### PR TITLE
feat(config): enable copy-on-select by default

### DIFF
--- a/src/Agwinterm.Core/TerminalConfig.cs
+++ b/src/Agwinterm.Core/TerminalConfig.cs
@@ -36,8 +36,8 @@ public sealed class TerminalConfig
     public bool RightClickPaste { get; set; } = true;
 
     /// <summary>Auto-copy the selection to the clipboard the moment a selection is finished (mouse-up /
-    /// word / line select), without needing Ctrl+C. Off by default. The selection stays highlighted.</summary>
-    public bool CopyOnSelect { get; set; } = false;
+    /// word / line select), without needing Ctrl+C. On by default. The selection stays highlighted.</summary>
+    public bool CopyOnSelect { get; set; } = true;
 
     /// <summary>Show OS desktop notifications (tray balloon) for OSC 9/777 / notify. Off → in-app banner + badge only.</summary>
     public bool DesktopNotifications { get; set; } = true;
@@ -115,7 +115,7 @@ public sealed class TerminalConfig
         right-click-paste = true
 
         # Auto-copy the selection to the clipboard as soon as it's made (no Ctrl+C needed).
-        copy-on-select = false
+        copy-on-select = true
 
         # Desktop notifications: show an OS tray-balloon for OSC 9/777 / `agwintermctl notify`
         # (the in-app banner + sidebar badge always show regardless). Set false to suppress the OS toast.


### PR DESCRIPTION
## What

Enable **copy-on-select** by default. Mouse selections now auto-copy to the clipboard the moment a selection is finished (drag mouse-up / word-select / line-select) — no `Ctrl+C` needed. The selection stays highlighted after copying.

## Why

Auto-copy-on-select is the expected behavior in most terminals (and in the upstream agterm workflow). Previously the feature existed but shipped **off**, so mouse selections silently never reached the clipboard unless the user discovered the toggle.

## Change

Flip both the `CopyOnSelect` property default and the seeded `agwinterm.conf` template from `false` → `true` in `TerminalConfig.cs`.

Users who prefer the old behavior can still opt out with `copy-on-select = false` in `agwinterm.conf` (or the Settings dialog → "Copy selection automatically").

## Notes

- No test changes needed — no tests assert the old default.
- `Ctrl+C` / `Ctrl+Shift+C` continue to work regardless of this setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)