### PR TITLE
fix(win32): make copy-to-clipboard reliable

### DIFF
--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -2860,27 +2860,42 @@ internal partial class Program : ISessionHost, IWindowHost
         return true; // consume all keys while the find bar is open
     }
 
+    /// <summary>Open the clipboard with retries: clipboard history / cloud sync / managers briefly
+    /// hold it open on every change, so a single failed OpenClipboard is common and transient.</summary>
+    private bool OpenClipboardRetry()
+    {
+        for (int i = 0; ; i++)
+        {
+            if (OpenClipboard(_hwnd)) return true;
+            if (i >= 9) return false;
+            System.Threading.Thread.Sleep(10);
+        }
+    }
+
     private void ClipboardSet(string text)
     {
-        if (!OpenClipboard(_hwnd)) return;
+        // Build the handle before touching the clipboard so a failed alloc never leaves it emptied.
+        byte[] buf = Encoding.Unicode.GetBytes(text + "\0");
+        IntPtr h = GlobalAlloc(GMEM_MOVEABLE, (UIntPtr)(uint)buf.Length);
+        if (h == IntPtr.Zero) return;
+        IntPtr p = GlobalLock(h);
+        if (p == IntPtr.Zero) { GlobalFree(h); return; }
+        Marshal.Copy(buf, 0, p, buf.Length);
+        GlobalUnlock(h);
+
+        if (!OpenClipboardRetry()) { GlobalFree(h); return; }
         try
         {
             EmptyClipboard();
-            byte[] buf = Encoding.Unicode.GetBytes(text + "\0");
-            IntPtr h = GlobalAlloc(GMEM_MOVEABLE, (UIntPtr)(uint)buf.Length);
-            if (h == IntPtr.Zero) return;
-            IntPtr p = GlobalLock(h);
-            if (p == IntPtr.Zero) return;
-            Marshal.Copy(buf, 0, p, buf.Length);
-            GlobalUnlock(h);
-            SetClipboardData(CF_UNICODETEXT, h); // clipboard takes ownership of h
+            if (SetClipboardData(CF_UNICODETEXT, h) == IntPtr.Zero)
+                GlobalFree(h); // ownership only transfers to the clipboard on success
         }
         finally { CloseClipboard(); }
     }
 
     private string ClipboardGet()
     {
-        if (!OpenClipboard(_hwnd)) return "";
+        if (!OpenClipboardRetry()) return "";
         try
         {
             IntPtr h = GetClipboardData(CF_UNICODETEXT);
@@ -2957,9 +2972,10 @@ internal partial class Program : ISessionHost, IWindowHost
         }
 
         // Clipboard: Ctrl+Shift+C / Ctrl+C-with-selection copies; Ctrl+V / Ctrl+Shift+V pastes.
-        if (ctrl && !alt && _active is not null)
+        // Uses ActiveSurface() (not _active.ActivePane) so selections in a cover — quick terminal,
+        // scratch, overlay — copy too instead of falling through and interrupting the shell.
+        if (ctrl && !alt && ActiveSurface() is { } ap)
         {
-            var ap = _active.ActivePane;
             if (vk == 0x43) // C
             {
                 if (ap.HasSel) { CopySelection(ap); return true; }

--- a/src/Agwinterm.Win32/Win32.cs
+++ b/src/Agwinterm.Win32/Win32.cs
@@ -417,6 +417,7 @@ internal static class Win32
     [DllImport("user32.dll")] public static extern IntPtr SetClipboardData(uint uFormat, IntPtr hMem);
     [DllImport("user32.dll")] public static extern IntPtr GetClipboardData(uint uFormat);
     [DllImport("kernel32.dll")] public static extern IntPtr GlobalAlloc(uint uFlags, UIntPtr dwBytes);
+    [DllImport("kernel32.dll")] public static extern IntPtr GlobalFree(IntPtr hMem);
     [DllImport("kernel32.dll")] public static extern IntPtr GlobalLock(IntPtr hMem);
     [DllImport("kernel32.dll")] public static extern bool GlobalUnlock(IntPtr hMem);
 


### PR DESCRIPTION
## Problem

Copying selected text sometimes silently failed. Three distinct causes:

### 1. Ctrl+C didn't see selections made in a cover (the big one)
Mouse selection correctly targets whatever pane is under the cursor — including the **quick terminal (Ctrl+`), scratch pane, and overlays** (`_cover`). But the hardcoded Ctrl+C/Ctrl+V path checked `_active.ActivePane.HasSel` — the pane *underneath* the cover. Result: select text in the quick terminal, press Ctrl+C → the selection is missed **and a ^C interrupt is sent to the shell instead**. The keymap-dispatched `copy_selection` already used the correct `ActiveSurface()`; only this path was wrong.

### 2. Clipboard contention → silent drop
`ClipboardSet` bailed on the first failed `OpenClipboard`. On modern Windows something briefly holds the clipboard open on *every* change (Win+V clipboard history, cloud sync, clipboard managers), so single-shot opens fail sporadically. Now retried up to 10× with 10 ms backoff (paste/`ClipboardGet` too) — same approach as Windows Terminal.

### 3. Error-path hygiene
`EmptyClipboard()` ran before allocation, so a failed `GlobalAlloc`/`GlobalLock` left the clipboard *cleared*; a failed `SetClipboardData` leaked the `HGLOBAL`. Now: build the handle first (failed alloc never touches the clipboard), `GlobalFree` on every failure path (ownership only transfers on success).

## Defaults (unchanged — Windows Terminal behavior)

| Behavior | Default | Customizable |
|---|---|---|
| Copy on select | **off** | `copy-on-select` in agwinterm.conf / Settings dialog |
| Right-click pastes | **on** | `right-click-paste` in agwinterm.conf / Settings dialog |
| Ctrl+C copies when a selection exists (else ^C) | on | `copy_selection` chord in keymap.conf |
| Shift forces selection when an app grabs the mouse | on | — (same as WT) |

## Verification

- ✅ Build clean, 87/87 Core tests pass; CI green (build + test, windows).
- ✅ End-to-end via the control API: seeded clipboard with a sentinel → `selection all` + `selection copy` → clipboard contains the terminal text (`copied 146 chars`).
- ✅ Manually confirmed on the running build: mouse selection + Ctrl+C copy works (previously failed intermittently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)