### PR TITLE
feat: portable single-file exe — no installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,15 @@ jobs:
         shell: pwsh
         run: ./installer/build.ps1
 
+      - name: Build portable exe
+        shell: pwsh
+        run: ./installer/build-portable.ps1
+
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: installer/Output/agwinterm-setup-*.exe
+          files: |
+            installer/Output/agwinterm-setup-*.exe
+            installer/Output/agwinterm-portable-*.exe
           generate_release_notes: true
           fail_on_unmatched_files: true

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ obj/
 .vs/
 artifacts/
 installer/stage/
+installer/stage-portable/
 installer/Output/

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ the real thing: **[github.com/umputun/agterm](https://github.com/umputun/agterm)
 Grab the latest **`agwinterm-setup-<version>.exe`** from the
 [**Releases**](https://github.com/yeroo/agwinterm/releases) page and run it.
 
+Prefer no installer? Each release also ships **`agwinterm-portable-<version>-win-x64.exe`** — a
+single self-contained exe, run it from anywhere (settings still live under `%LOCALAPPDATA%\agwinterm`).
+
 - **Per-user, no admin required**, and **self-contained** — no .NET runtime needed on the target.
 - It's currently **unsigned**, so SmartScreen will warn on first run → *More info → Run anyway*.
 - The installer is deliberately minimal (copies files + shortcuts). The integrations

--- a/installer/build-portable.ps1
+++ b/installer/build-portable.ps1
@@ -1,0 +1,39 @@
+# Build the PORTABLE agwinterm: one self-contained single-file exe, no installer needed.
+# Output: installer\Output\agwinterm-portable-<ver>-win-x64.exe
+# Themes + the window icon are embedded in the assembly (see Agwinterm.Win32.csproj), so the
+# bare exe runs from anywhere. Settings still live under %LOCALAPPDATA%\agwinterm.
+$ErrorActionPreference = "Stop"
+$here   = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$root   = Split-Path -Parent $here
+$dotnet = if (Test-Path "C:\Program Files\dotnet\dotnet.exe") { "C:\Program Files\dotnet\dotnet.exe" } else { "dotnet" }
+$stage  = Join-Path $here "stage-portable"
+$outDir = Join-Path $here "Output"
+
+# version = the installer's AppVersion define (single source of truth)
+$iss = Get-Content (Join-Path $here "agwinterm.iss") -Raw
+if ($iss -notmatch '#define\s+AppVersion\s+"([^"]+)"') { throw "AppVersion not found in agwinterm.iss" }
+$ver = $Matches[1]
+
+Write-Host "== clean stage ==" -ForegroundColor Cyan
+if (Test-Path $stage) { Remove-Item -Recurse -Force $stage }
+New-Item -ItemType Directory -Force $stage, $outDir | Out-Null
+
+Write-Host "== publish single-file portable exe (v$ver) ==" -ForegroundColor Cyan
+& $dotnet publish (Join-Path $root "src\Agwinterm.Win32\Agwinterm.Win32.csproj") `
+  -c Release -r win-x64 --self-contained true `
+  -p:PublishSingleFile=true `
+  -p:EnableCompressionInSingleFile=true `
+  -p:IncludeNativeLibrariesForSelfExtract=true `
+  -p:SatelliteResourceLanguages=en `
+  -p:DebugType=none `
+  -o $stage
+if ($LASTEXITCODE -ne 0) { throw "portable publish failed" }
+
+$exe = Join-Path $stage "Agwinterm.Win32.exe"
+if (-not (Test-Path $exe)) { throw "publish produced no Agwinterm.Win32.exe" }
+
+# Ship ONLY the exe — themes/assets land next to it in the stage as loose copies, but the
+# embedded fallbacks make the bare exe self-sufficient.
+$dst = Join-Path $outDir "agwinterm-portable-$ver-win-x64.exe"
+Copy-Item $exe $dst -Force
+Write-Host ("== done: {0} ({1:N1} MB) ==" -f $dst, ((Get-Item $dst).Length/1MB)) -ForegroundColor Green

--- a/src/Agwinterm.Win32/Agwinterm.Win32.csproj
+++ b/src/Agwinterm.Win32/Agwinterm.Win32.csproj
@@ -30,4 +30,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <!-- Also embed the same themes in the assembly so the single-file portable exe works with no
+       on-disk themes\ dir (disk copies still win by name when present). -->
+  <ItemGroup>
+    <EmbeddedResource Include="..\..\themes\*.conf">
+      <LogicalName>theme:%(Filename)</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -392,16 +392,22 @@ internal partial class Program : ISessionHost, IWindowHost
         try { int pref = DWMWCP_ROUND; DwmSetWindowAttribute(_hwnd, DWMWA_WINDOW_CORNER_PREFERENCE, ref pref, sizeof(int)); } catch { }
 
         // App icon for the window (taskbar + alt-tab); the exe icon comes from <ApplicationIcon>.
+        // Single-file portable exe has no assets\ dir — extract the icon compiled into the exe instead.
         try
         {
+            IntPtr hIconBig = IntPtr.Zero, hIconSm = IntPtr.Zero;
             string icoPath = System.IO.Path.Combine(AppContext.BaseDirectory, "assets", "agwinterm.ico");
             if (System.IO.File.Exists(icoPath))
             {
-                IntPtr hIconBig = LoadImageW(IntPtr.Zero, icoPath, IMAGE_ICON, 0, 0, LR_LOADFROMFILE | LR_DEFAULTSIZE);
-                IntPtr hIconSm = LoadImageW(IntPtr.Zero, icoPath, IMAGE_ICON, 16, 16, LR_LOADFROMFILE);
-                if (hIconBig != IntPtr.Zero) SendMessageW(_hwnd, WM_SETICON, (IntPtr)ICON_BIG, hIconBig);
-                if (hIconSm != IntPtr.Zero) SendMessageW(_hwnd, WM_SETICON, (IntPtr)ICON_SMALL, hIconSm);
+                hIconBig = LoadImageW(IntPtr.Zero, icoPath, IMAGE_ICON, 0, 0, LR_LOADFROMFILE | LR_DEFAULTSIZE);
+                hIconSm = LoadImageW(IntPtr.Zero, icoPath, IMAGE_ICON, 16, 16, LR_LOADFROMFILE);
             }
+            else if (Environment.ProcessPath is { } exe)
+            {
+                ExtractIconExW(exe, 0, out hIconBig, out hIconSm, 1);
+            }
+            if (hIconBig != IntPtr.Zero) SendMessageW(_hwnd, WM_SETICON, (IntPtr)ICON_BIG, hIconBig);
+            if (hIconSm != IntPtr.Zero) SendMessageW(_hwnd, WM_SETICON, (IntPtr)ICON_SMALL, hIconSm);
         }
         catch { /* icon is cosmetic; ignore load failures */ }
 
@@ -5377,6 +5383,24 @@ internal partial class Program : ISessionHost, IWindowHost
             }
             catch { }
         }
+
+        // Single-file portable exe: no themes\ dir on disk — the same curated themes are embedded
+        // in the assembly (disk copies above win the name dedup when both exist).
+        try
+        {
+            var asm = typeof(Program).Assembly;
+            foreach (var res in asm.GetManifestResourceNames())
+            {
+                if (!res.StartsWith("theme:", StringComparison.Ordinal)) continue;
+                using var s = asm.GetManifestResourceStream(res);
+                if (s is null) continue;
+                using var r = new StreamReader(s);
+                var lines = new List<string>();
+                while (r.ReadLine() is { } ln) lines.Add(ln);
+                if (ParseGhosttyTheme(res["theme:".Length..], lines) is Theme th) Add(th);
+            }
+        }
+        catch { }
         return list;
     }
 
@@ -5401,11 +5425,17 @@ internal partial class Program : ISessionHost, IWindowHost
     /// <summary>Parse a ghostty-format theme file (palette = N=#rrggbb, background/foreground/cursor-color).</summary>
     private static Theme? ParseGhosttyTheme(string path)
     {
+        try { return ParseGhosttyTheme(Path.GetFileNameWithoutExtension(path), File.ReadAllLines(path)); }
+        catch { return null; }
+    }
+
+    private static Theme? ParseGhosttyTheme(string name, IEnumerable<string> lines)
+    {
         try
         {
             var pal = Theme.DefaultPalette();
             Color fg = Color.DefaultForeground, bg = Color.DefaultBackground, cur = new(222, 222, 230);
-            foreach (var raw in File.ReadAllLines(path))
+            foreach (var raw in lines)
             {
                 var line = raw.Trim();
                 if (line.Length == 0 || line[0] == '#') continue;
@@ -5419,7 +5449,7 @@ internal partial class Program : ISessionHost, IWindowHost
                     case "cursor-color": cur = Hex(val); break;
                 }
             }
-            return new Theme { Name = Path.GetFileNameWithoutExtension(path), Palette = pal, DefaultForeground = fg, DefaultBackground = bg, Cursor = cur };
+            return new Theme { Name = name, Palette = pal, DefaultForeground = fg, DefaultBackground = bg, Cursor = cur };
         }
         catch { return null; }
     }

--- a/src/Agwinterm.Win32/Win32.cs
+++ b/src/Agwinterm.Win32/Win32.cs
@@ -437,6 +437,9 @@ internal static class Win32
     [DllImport("shell32.dll", CharSet = CharSet.Unicode)]
     public static extern IntPtr ShellExecuteW(IntPtr hwnd, string? op, string file, string? args, string? dir, int show);
 
+    [DllImport("shell32.dll", CharSet = CharSet.Unicode)]
+    public static extern uint ExtractIconExW(string lpszFile, int nIconIndex, out IntPtr phiconLarge, out IntPtr phiconSmall, uint nIcons);
+
     [StructLayout(LayoutKind.Sequential)] public struct INITCOMMONCONTROLSEX { public int dwSize; public int dwICC; }
     [DllImport("comctl32.dll")] public static extern bool InitCommonControlsEx(ref INITCOMMONCONTROLSEX icc);
     public const int ICC_TAB_CLASSES = 0x8, ICC_BAR_CLASSES = 0x4, ICC_STANDARD_CLASSES = 0x4000;


### PR DESCRIPTION
Closes #1 — portable version, no installer (запрошено: portable версия без инсталятора ✓).

## What

Every release now also ships **`agwinterm-portable-<ver>-win-x64.exe`** — one self-contained 37.8 MB exe. Copy it anywhere (USB stick included), run it. No installer, no .NET runtime required.

## How

The app read two things from folders next to the exe, which a single-file build doesn't have:

| Dependency | Fix |
|---|---|
| `themes\*.conf` (575 curated ghostty themes) | Also **embedded in the assembly** (`theme:<name>` resources); `LoadThemes` reads them as a fallback source — on-disk copies still win the name dedup, so installed builds behave exactly as before |
| `assets\agwinterm.ico` (runtime window/taskbar icon) | When the file is missing, **extract the icon compiled into the exe** (`ExtractIconExW` on `Environment.ProcessPath`) |

`agwintermctl.exe` lookups were already `File.Exists`-guarded and degrade gracefully.

Safety check: the publish output contains **zero app-local native DLLs** (Vortice P/Invokes system `d2d1`/`dwrite`), so single-file bundling is robust — the old caution in `build.ps1` doesn't apply.

## Build & release plumbing

- `installer/build-portable.ps1` — compressed single-file publish → `Output/agwinterm-portable-<ver>-win-x64.exe`; version parsed from `agwinterm.iss` `AppVersion` (single source of truth)
- `release.yml` — builds and attaches the portable exe alongside the setup exe on every tag
- README — portable download mentioned under Install

Settings still live under `%LOCALAPPDATA%\agwinterm` (true USB-stick data portability was deliberately left out of scope).

## Verification

- ✅ Copied the bare exe alone to an empty directory, ran it: launches, renders, control API responds (`ping` → `agwinterm`)
- ✅ `theme.list` returns **580 themes** with no `themes\` folder on disk — embedded resources confirmed working
- ✅ 87/87 Core + 16/16 Pty tests pass; installed-build theme loading path unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)