### PR TITLE
feat(win32): quick terminal ✕ + context menu in a real themed popup window

### DIFF
--- a/src/Agwinterm.Win32/Keymap.cs
+++ b/src/Agwinterm.Win32/Keymap.cs
@@ -50,7 +50,7 @@ internal static class Keymap
         "focus_left_pane", "focus_right_pane", "next_session", "previous_session",
         "toggle_sidebar", "rename_session", "delete_workspace", "session_palette", "action_palette",
         "attention_list", "custom_palette", "next_attention", "previous_attention", "reload_keymap",
-        "toggle_search", "toggle_scratch", "quick_terminal",
+        "toggle_search", "toggle_scratch", "quick_terminal", "close_cover",
         "toggle_flag", "toggle_flagged_view", "focus_workspace",
         "select_all", "copy_selection", "paste",
         "new_window", "close_window", "switch_window",
@@ -81,9 +81,10 @@ internal static class Keymap
         #          toggle_sidebar rename_session delete_workspace session_palette
         #          action_palette attention_list custom_palette next_attention
         #          previous_attention reload_keymap toggle_flag focus_workspace
-        #          select_all copy_selection paste
+        #          select_all copy_selection paste close_cover
         #
         # Examples (uncomment to use):
+        # map escape = close_cover        # Esc hides the quick/scratch/overlay cover (falls through otherwise)
         # map ctrl+shift+g = command:Greet
         # command Greet = echo hello from {AGW_SESSION}
         # command [new] Log = echo running in {AGW_CWD}

--- a/src/Agwinterm.Win32/Menu.cs
+++ b/src/Agwinterm.Win32/Menu.cs
@@ -1,0 +1,227 @@
+using System.Runtime.InteropServices;
+using Vortice.Direct2D1;
+using Vortice.DCommon;
+using Vortice.Mathematics;
+using static Agwinterm.Win32.Win32;
+
+namespace Agwinterm.Win32;
+
+/// <summary>
+/// Popup context menu hosted in a REAL top-level window (WS_POPUP + drop shadow), so it can
+/// extend beyond the main window's bounds like a native menu — but rendered with the app theme
+/// (Direct2D + the chrome palette). Input model mirrors native menus: the popup captures the
+/// mouse while open (click inside runs, click outside dismisses and is swallowed, losing capture
+/// dismisses); the main window keeps keyboard focus (WS_EX_NOACTIVATE) and forwards
+/// Up/Down/Enter/Esc via <see cref="MenuKeyDown"/>.
+/// </summary>
+internal partial class Program
+{
+    private const string MenuClassName = "agwinterm-menu";
+    private static bool _menuClassReady;
+    private static WndProc? _menuProcKeep;                            // GC-rooted class wndproc
+    private static readonly Dictionary<IntPtr, Program> _menuByHwnd = new();
+
+    private IntPtr _menuHwnd;
+    private ID2D1HwndRenderTarget? _menuRt;
+    private ID2D1SolidColorBrush? _menuBrush;
+    private List<PalItem> _menuItems = new();
+    private int _menuSel = -1;                                        // hover/keyboard selection
+    private float _menuW, _menuH;
+    private bool _menuClosing;
+
+    private const float MenuRowH = 30f, MenuSepH = 9f, MenuPadY = 5f, MenuPadX = 12f;
+
+    /// <summary>A visual separator row (drawn as a hairline; never selectable).</summary>
+    private static PalItem MenuSeparator() => new() { Label = "-" };
+    private static bool IsSep(PalItem it) => it.Label == "-" && it.Run is null;
+
+    /// <summary>Show <paramref name="items"/> as a popup menu at screen point (sx, sy).</summary>
+    private void ShowMenuWindow(List<PalItem> items, int sx, int sy)
+    {
+        CloseMenuWindow();
+        if (items.Count == 0) return;
+        _menuItems = items; _menuSel = -1;
+
+        // Size to content, clamped; height is exact (a context menu is short by construction).
+        float maxW = 0f;
+        foreach (var it in items)
+        {
+            if (IsSep(it)) continue;
+            float w = MeasureText(it.Label, _uiFont) + (it.Hint.Length > 0 ? MeasureText(it.Hint, _uiSmall) + 28f : 0f);
+            maxW = MathF.Max(maxW, w);
+        }
+        _menuW = Math.Clamp(maxW + MenuPadX * 2f + 8f, 180f, 480f);
+        _menuH = MenuPadY * 2f;
+        foreach (var it in items) _menuH += IsSep(it) ? MenuSepH : MenuRowH;
+
+        // Clamp to the monitor work area; open upward when there's no room below (native behavior).
+        var mi = new MONITORINFO { cbSize = Marshal.SizeOf<MONITORINFO>() };
+        GetMonitorInfoW(MonitorFromPoint(new POINT { x = sx, y = sy }, MONITOR_DEFAULTTONEAREST), ref mi);
+        int x = Math.Clamp(sx, mi.rcWork.left, Math.Max(mi.rcWork.left, mi.rcWork.right - (int)_menuW));
+        int y = sy + (int)_menuH <= mi.rcWork.bottom ? sy : Math.Max(mi.rcWork.top, sy - (int)_menuH);
+
+        if (!_menuClassReady)
+        {
+            _menuProcKeep = MenuProc;
+            var wc = new WNDCLASSEXW
+            {
+                cbSize = (uint)Marshal.SizeOf<WNDCLASSEXW>(),
+                style = CS_HREDRAW | CS_VREDRAW | CS_DROPSHADOW,
+                lpfnWndProc = _menuProcKeep,
+                hInstance = _hInstance,
+                hCursor = LoadCursorW(IntPtr.Zero, IDC_ARROW),
+                lpszClassName = MenuClassName,
+            };
+            if (RegisterClassExW(ref wc) == 0) return;
+            _menuClassReady = true;
+        }
+
+        _menuHwnd = CreateWindowExW(WS_EX_TOPMOST | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE, MenuClassName, "",
+            WS_POPUP, x, y, (int)_menuW, (int)_menuH, _hwnd, IntPtr.Zero, _hInstance, IntPtr.Zero);
+        if (_menuHwnd == IntPtr.Zero) return;
+        _menuByHwnd[_menuHwnd] = this;
+
+        var props = new RenderTargetProperties
+        {
+            Type = RenderTargetType.Default,
+            PixelFormat = new PixelFormat(Vortice.DXGI.Format.B8G8R8A8_UNorm, Vortice.DCommon.AlphaMode.Ignore),
+            DpiX = 96f,
+            DpiY = 96f,
+        };
+        var hp = new HwndRenderTargetProperties { Hwnd = _menuHwnd, PixelSize = new SizeI((int)_menuW, (int)_menuH), PresentOptions = PresentOptions.None };
+        _menuRt = _d2d.CreateHwndRenderTarget(props, hp);
+        _menuRt.TextAntialiasMode = Vortice.Direct2D1.TextAntialiasMode.Grayscale;
+        _menuBrush = _menuRt.CreateSolidColorBrush(ChromeText);
+
+        ShowWindow(_menuHwnd, SW_SHOWNOACTIVATE);
+        SetCapture(_menuHwnd);   // native-menu input model: all mouse routes here until dismissed
+    }
+
+    private void CloseMenuWindow()
+    {
+        if (_menuHwnd == IntPtr.Zero || _menuClosing) return;
+        _menuClosing = true;
+        var h = _menuHwnd; _menuHwnd = IntPtr.Zero;
+        _menuByHwnd.Remove(h);
+        ReleaseCapture();
+        _menuBrush?.Dispose(); _menuBrush = null;
+        _menuRt?.Dispose(); _menuRt = null;
+        DestroyWindow(h);
+        _menuClosing = false;
+    }
+
+    /// <summary>Actionable row index at a popup-client point, or -1 (separators/disabled aren't hits).</summary>
+    private int MenuIndexAt(int mx, int my)
+    {
+        if (mx < 0 || mx >= _menuW) return -1;
+        float y = MenuPadY;
+        for (int i = 0; i < _menuItems.Count; i++)
+        {
+            float h = IsSep(_menuItems[i]) ? MenuSepH : MenuRowH;
+            if (my >= y && my < y + h) return _menuItems[i].Run is null ? -1 : i;
+            y += h;
+        }
+        return -1;
+    }
+
+    /// <summary>Keyboard while the menu is up (the main window keeps focus and forwards here):
+    /// ↑/↓ move, Enter runs, Esc closes; everything else is swallowed like a native menu.</summary>
+    private bool MenuKeyDown(int vk)
+    {
+        switch (vk)
+        {
+            case VK_ESCAPE: CloseMenuWindow(); return true;
+            case VK_UP:
+            case VK_DOWN:
+            {
+                int dir = vk == VK_DOWN ? 1 : -1, n = _menuItems.Count, i = _menuSel;
+                for (int step = 0; step < n; step++)
+                {
+                    i = ((i + dir) % n + n) % n;
+                    if (_menuItems[i].Run is not null) { _menuSel = i; break; }
+                }
+                if (_menuHwnd != IntPtr.Zero) InvalidateRect(_menuHwnd, IntPtr.Zero, false);
+                return true;
+            }
+            case VK_RETURN:
+                if (_menuSel >= 0 && _menuSel < _menuItems.Count && _menuItems[_menuSel].Run is { } run)
+                { CloseMenuWindow(); run(); }
+                return true;
+            default: return true;
+        }
+    }
+
+    private void RenderMenu()
+    {
+        if (_menuRt is null || _menuBrush is null) return;
+        var rt = _menuRt; var brush = _menuBrush;
+        rt.BeginDraw();
+        rt.Clear(PalBg);
+        float y = MenuPadY;
+        for (int i = 0; i < _menuItems.Count; i++)
+        {
+            var it = _menuItems[i];
+            if (IsSep(it))
+            {
+                brush.Color = ChromeBorder;
+                rt.DrawLine(new System.Numerics.Vector2(MenuPadX - 4f, y + MenuSepH / 2f),
+                            new System.Numerics.Vector2(_menuW - MenuPadX + 4f, y + MenuSepH / 2f), brush, 1f);
+                y += MenuSepH;
+                continue;
+            }
+            if (i == _menuSel) { brush.Color = PalSel; rt.FillRectangle(new Rect(3f, y, _menuW - 6f, MenuRowH), brush); }
+            brush.Color = it.Run is null ? ChromeDim : (i == _menuSel ? SbActiveText : ChromeText);
+            rt.DrawText(it.Label, _uiFont, new Rect(MenuPadX, y + (MenuRowH - 18f) / 2f, _menuW - MenuPadX * 2f - (it.Hint.Length > 0 ? 60f : 0f), 18f), brush, DrawTextOptions.Clip);
+            if (it.Hint.Length > 0)
+            {
+                float hw = MeasureText(it.Hint, _uiSmall);
+                brush.Color = ChromeDim;
+                rt.DrawText(it.Hint, _uiSmall, new Rect(_menuW - MenuPadX - hw, y + (MenuRowH - 15f) / 2f, hw + 2f, 15f), brush);
+            }
+            y += MenuRowH;
+        }
+        brush.Color = PalBorder;
+        rt.DrawRectangle(new Rect(0.5f, 0.5f, _menuW - 1f, _menuH - 1f), brush, 1f);
+        rt.EndDraw();
+    }
+
+    private static IntPtr MenuProc(IntPtr hwnd, uint msg, IntPtr wParam, IntPtr lParam)
+    {
+        if (!_menuByHwnd.TryGetValue(hwnd, out var self)) return DefWindowProcW(hwnd, msg, wParam, lParam);
+        switch (msg)
+        {
+            case WM_MOUSEACTIVATE: return (IntPtr)MA_NOACTIVATE;   // never steal focus from the main window
+            case WM_PAINT:
+            {
+                BeginPaint(hwnd, out PAINTSTRUCT ps);
+                try { self.RenderMenu(); } catch { /* rendering is best-effort; the menu closes on any click */ }
+                EndPaint(hwnd, ref ps);
+                return IntPtr.Zero;
+            }
+            case WM_MOUSEMOVE:
+            {
+                int i = self.MenuIndexAt(LoWord(lParam), HiWord(lParam));
+                if (i != self._menuSel) { self._menuSel = i; InvalidateRect(hwnd, IntPtr.Zero, false); }
+                return IntPtr.Zero;
+            }
+            case WM_LBUTTONDOWN:
+            case WM_RBUTTONDOWN:
+            {
+                // Outside the menu (coords can be negative under capture): dismiss and swallow.
+                int mx = LoWord(lParam), my = HiWord(lParam);
+                if (mx < 0 || my < 0 || mx >= self._menuW || my >= self._menuH) self.CloseMenuWindow();
+                return IntPtr.Zero;
+            }
+            case WM_LBUTTONUP:
+            {
+                int i = self.MenuIndexAt(LoWord(lParam), HiWord(lParam));
+                if (i >= 0 && self._menuItems[i].Run is { } run) { self.CloseMenuWindow(); run(); }
+                return IntPtr.Zero;
+            }
+            case WM_CAPTURECHANGED:
+                if (!self._menuClosing) self.CloseMenuWindow();   // capture stolen (alt-tab, other app) — dismiss
+                return IntPtr.Zero;
+        }
+        return DefWindowProcW(hwnd, msg, wParam, lParam);
+    }
+}

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -4005,6 +4005,7 @@ internal partial class Program : ISessionHost, IWindowHost
     {
         _ctxItem = item;
         _palAnchor = (cx, cy);
+        if (_palette == PaletteKind.Context) ClosePalette();   // right-click while open: reopen at the new row/point
         TogglePalette(PaletteKind.Context);
     }
 
@@ -4540,7 +4541,10 @@ internal partial class Program : ISessionHost, IWindowHost
         const int maxRows = 12;
         float pw = MathF.Min(_palette == PaletteKind.Context ? 340f : 560f, cw - 80f);
         float px = (cw - pw) / 2f;
-        int shown = Math.Min(_palItems.Count, maxRows);
+        // Cap the row count so the panel always fits inside the window (the list scrolls with the
+        // selection when there are more items than fit).
+        int fitRows = Math.Max(1, (int)((ch - TitleBarH - 16f - queryH - 8f) / rowH));
+        int shown = Math.Min(_palItems.Count, Math.Min(maxRows, fitRows));
         float ph = queryH + Math.Max(1, shown) * rowH + 8f;
         float py = MathF.Max(TitleBarH + 16f, ch * 0.14f);
         if (_palette == PaletteKind.Context && _palAnchor is { } an)   // context menu: at the click point, clamped on-window
@@ -4548,6 +4552,7 @@ internal partial class Program : ISessionHost, IWindowHost
             px = Math.Clamp(an.x, 8f, MathF.Max(8f, cw - pw - 8f));
             py = Math.Clamp(an.y, TitleBarH + 8f, MathF.Max(TitleBarH + 8f, ch - ph - 8f));
         }
+        else py = MathF.Min(py, MathF.Max(TitleBarH + 8f, ch - ph - 8f));   // short window: pull the centered panel up
         _palPanel = new Rect(px, py, pw, ph);
 
         brush.Color = PalBg;
@@ -4568,7 +4573,7 @@ internal partial class Program : ISessionHost, IWindowHost
         brush.Color = ChromeBorder;
         rt.DrawLine(new System.Numerics.Vector2(px + 8f, py + queryH), new System.Numerics.Vector2(px + pw - 8f, py + queryH), brush, 1f);
 
-        int start = _palSel >= maxRows ? _palSel - maxRows + 1 : 0;
+        int start = _palSel >= shown ? _palSel - shown + 1 : 0;
         for (int i = 0; i < shown; i++)
         {
             int idx = start + i;
@@ -4580,8 +4585,9 @@ internal partial class Program : ISessionHost, IWindowHost
             if (it.Dot is AgentStatus ds) { brush.Color = StatusDot(ds); rt.FillEllipse(new Ellipse(new System.Numerics.Vector2(px + 16f, ry + rowH / 2f), 4.5f, 4.5f), brush); tx = px + 30f; }
             bool hasSub = it.Secondary.Length > 0;
             brush.Color = it.Run is null ? ChromeDim : (idx == _palSel ? SbActiveText : ChromeText);
-            rt.DrawText(it.Label, _uiFont, new Rect(tx, ry + (hasSub ? 3f : 0f), pw - (tx - px) - 80f, hasSub ? 20f : rowH), brush);
-            if (hasSub) { brush.Color = ChromeDim; rt.DrawText(it.Secondary, _uiSmall, new Rect(tx, ry + 20f, pw - (tx - px) - 20f, 16f), brush); }
+            float lw = pw - (tx - px) - (it.Hint.Length > 0 ? 80f : 20f);
+            rt.DrawText(it.Label, _uiFont, new Rect(tx, ry + (hasSub ? 3f : 0f), lw, hasSub ? 20f : rowH), brush, DrawTextOptions.Clip);
+            if (hasSub) { brush.Color = ChromeDim; rt.DrawText(it.Secondary, _uiSmall, new Rect(tx, ry + 20f, pw - (tx - px) - 20f, 16f), brush, DrawTextOptions.Clip); }
             if (it.Hint.Length > 0) { brush.Color = ChromeDim; float hw = MeasureText(it.Hint, _uiSmall); rt.DrawText(it.Hint, _uiSmall, new Rect(px + pw - 16f - hw, ry + (rowH - 16f) / 2f, hw + 2f, 16f), brush); }
             _palRows.Add((ry, ry + rowH, idx));
         }

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -156,7 +156,7 @@ internal partial class Program : ISessionHost, IWindowHost
     private const int SelAutoTimer = 7;   // WM_TIMER id for drag-autoscroll ticks
 
     // Command palette overlay (⌃P sessions / ⌃⇧P actions / ⌃⇧I attention).
-    private enum PaletteKind { None, Sessions, Actions, Attention, Themes, Custom, Windows, Omp, NewSession, Context }
+    private enum PaletteKind { None, Sessions, Actions, Attention, Themes, Custom, Windows, Omp, NewSession }
     private sealed class PalItem
     {
         public required string Label;
@@ -1934,7 +1934,7 @@ internal partial class Program : ISessionHost, IWindowHost
                     if (pt.x < (int)_sidebarW && pt.y >= (int)TitleBarH)
                     {
                         var item = RowAt(pt.y);
-                        if (item is not null) ShowContextPalette(item, pt.x, pt.y);
+                        if (item is not null) ShowContextMenuWindow(item, sx, sy);   // screen coords
                         return IntPtr.Zero;
                     }
                     break;
@@ -2932,6 +2932,10 @@ internal partial class Program : ISessionHost, IWindowHost
     private bool OnKeyDown(int vk)
     {
         bool ctrl = KeyDown(VK_CONTROL), shift = KeyDown(VK_SHIFT), alt = KeyDown(VK_MENU);
+
+        // While the popup context menu is up it owns the keyboard (↑↓ Enter Esc; the popup window
+        // never takes focus, so keys arrive here and are forwarded).
+        if (_menuHwnd != IntPtr.Zero) return MenuKeyDown(vk);
 
         // A --wait overlay whose program has exited hangs around; any key dismisses it.
         if (_coverKind == 3 && _ovlOwner is { OverlayExited: true }) { CloseActiveOverlay(); return true; }
@@ -3996,17 +4000,45 @@ internal partial class Program : ISessionHost, IWindowHost
 
     // ---- Context menus ----
 
-    // Sidebar right-click menu: a themed palette anchored at the click point (replaces the native
-    // Win32 popup, which ignores the app theme). _ctxItem is the row (Ses/Workspace) it acts on.
-    private object? _ctxItem;
-    private (float x, float y)? _palAnchor;
+    /// <summary>Sidebar right-click menu at screen point (sx, sy): a themed popup window (Menu.cs)
+    /// that — like a native menu — can extend beyond the main window's bounds.</summary>
+    private void ShowContextMenuWindow(object item, int sx, int sy) => ShowMenuWindow(BuildContextItems(item), sx, sy);
 
-    private void ShowContextPalette(object item, int cx, int cy)
+    /// <summary>The context-menu items for a sidebar row (mirrors agterm's session/workspace menus).</summary>
+    private List<PalItem> BuildContextItems(object item)
     {
-        _ctxItem = item;
-        _palAnchor = (cx, cy);
-        if (_palette == PaletteKind.Context) ClosePalette();   // right-click while open: reopen at the new row/point
-        TogglePalette(PaletteKind.Context);
+        var list = new List<PalItem>();
+        void A(string label, string hint, Action run) => list.Add(new PalItem { Label = label, Hint = hint, Search = label, Run = run });
+        if (item is Ses ses)
+        {
+            if (_profileCfg.Profiles.Count > 1)
+                foreach (var p in _profileCfg.Profiles)
+                { var nm = p.Name; A($"New Session — {nm}", "", () => CreateSession(Guid.NewGuid().ToString(), null, null, ses.Ws, true, profileName: nm)); }
+            else A("New Session", "", () => CreateSession(Guid.NewGuid().ToString(), null, null, ses.Ws, true));
+            A("Open Directory…", "", () => { var d = PickFolder(); if (d is not null) CreateSession(Guid.NewGuid().ToString(), null, d, ses.Ws, true); });
+            A("Rename", "F2", () => StartRename(ses));
+            A(ses.Flagged ? "Unflag Session" : "Flag Session", "", () => FlagOp(ses, "toggle"));
+            List<Workspace> targets;
+            lock (_workspaces) targets = _workspaces.Where(w => !ReferenceEquals(w, ses.Ws)).ToList();
+            foreach (var t in targets) A($"Move to — {t.Name}", "", () => MoveSession(ses, t));
+            if (ses.S.Status != AgentStatus.Idle) A("Clear Status", "", () => { ses.S.SetStatus(AgentStatus.Idle); RequestRedraw(); });
+            list.Add(MenuSeparator());
+            A("Close Session", "", () => { if (ConfirmCloseOk()) CloseSessionInternal(ses); });
+        }
+        else if (item is Workspace cws)
+        {
+            bool wsFocused = _focusedWorkspaceId == cws.Id;
+            int wsCount; lock (_workspaces) wsCount = _workspaces.Count;
+            if (_profileCfg.Profiles.Count > 1)
+                foreach (var p in _profileCfg.Profiles)
+                { var nm = p.Name; A($"New Session — {nm}", "", () => CreateSession(Guid.NewGuid().ToString(), null, null, cws, true, profileName: nm)); }
+            else A("New Session", "", () => CreateSession(Guid.NewGuid().ToString(), null, null, cws, true));
+            A("Open Directory…", "", () => { var d = PickFolder(); if (d is not null) CreateSession(Guid.NewGuid().ToString(), null, d, cws, true); });
+            A("Rename", "", () => StartRename(cws));
+            A(wsFocused ? "Unfocus" : "Focus", "", () => WorkspaceFocusOp(wsFocused ? "off" : "on", cws.Id));
+            if (wsCount > 1) { list.Add(MenuSeparator()); A("Delete Workspace", "", () => DeleteWorkspace(cws)); }
+        }
+        return list;
     }
 
     private void MoveSession(Ses ses, Workspace target)
@@ -4406,39 +4438,6 @@ internal partial class Program : ISessionHost, IWindowHost
                 });
                 break;
             }
-            case PaletteKind.Context:
-            {
-                void A(string label, string hint, Action run) => _palAll.Add(new PalItem { Label = label, Hint = hint, Search = label, Run = run });
-                if (_ctxItem is Ses ses)
-                {
-                    if (_profileCfg.Profiles.Count > 1)
-                        foreach (var p in _profileCfg.Profiles)
-                        { var nm = p.Name; A($"New Session — {nm}", "", () => CreateSession(Guid.NewGuid().ToString(), null, null, ses.Ws, true, profileName: nm)); }
-                    else A("New Session", "", () => CreateSession(Guid.NewGuid().ToString(), null, null, ses.Ws, true));
-                    A("Open Directory…", "", () => { var d = PickFolder(); if (d is not null) CreateSession(Guid.NewGuid().ToString(), null, d, ses.Ws, true); });
-                    A("Rename", "F2", () => StartRename(ses));
-                    A(ses.Flagged ? "Unflag Session" : "Flag Session", "", () => FlagOp(ses, "toggle"));
-                    List<Workspace> targets;
-                    lock (_workspaces) targets = _workspaces.Where(w => !ReferenceEquals(w, ses.Ws)).ToList();
-                    foreach (var t in targets) A($"Move to — {t.Name}", "", () => MoveSession(ses, t));
-                    if (ses.S.Status != AgentStatus.Idle) A("Clear Status", "", () => { ses.S.SetStatus(AgentStatus.Idle); RequestRedraw(); });
-                    A("Close Session", "", () => { if (ConfirmCloseOk()) CloseSessionInternal(ses); });
-                }
-                else if (_ctxItem is Workspace cws)
-                {
-                    bool wsFocused = _focusedWorkspaceId == cws.Id;
-                    int wsCount; lock (_workspaces) wsCount = _workspaces.Count;
-                    if (_profileCfg.Profiles.Count > 1)
-                        foreach (var p in _profileCfg.Profiles)
-                        { var nm = p.Name; A($"New Session — {nm}", "", () => CreateSession(Guid.NewGuid().ToString(), null, null, cws, true, profileName: nm)); }
-                    else A("New Session", "", () => CreateSession(Guid.NewGuid().ToString(), null, null, cws, true));
-                    A("Open Directory…", "", () => { var d = PickFolder(); if (d is not null) CreateSession(Guid.NewGuid().ToString(), null, d, cws, true); });
-                    A("Rename", "", () => StartRename(cws));
-                    A(wsFocused ? "Unfocus" : "Focus", "", () => WorkspaceFocusOp(wsFocused ? "off" : "on", cws.Id));
-                    if (wsCount > 1) A("Delete Workspace", "", () => DeleteWorkspace(cws));
-                }
-                break;
-            }
             case PaletteKind.Attention:
             {
                 var att = AllSessions().Where(s => s.S.Status != AgentStatus.Idle)
@@ -4539,7 +4538,7 @@ internal partial class Program : ISessionHost, IWindowHost
 
         const float queryH = 42f, rowH = 40f;
         const int maxRows = 12;
-        float pw = MathF.Min(_palette == PaletteKind.Context ? 340f : 560f, cw - 80f);
+        float pw = MathF.Min(560f, cw - 80f);
         float px = (cw - pw) / 2f;
         // Cap the row count so the panel always fits inside the window (the list scrolls with the
         // selection when there are more items than fit).
@@ -4547,12 +4546,7 @@ internal partial class Program : ISessionHost, IWindowHost
         int shown = Math.Min(_palItems.Count, Math.Min(maxRows, fitRows));
         float ph = queryH + Math.Max(1, shown) * rowH + 8f;
         float py = MathF.Max(TitleBarH + 16f, ch * 0.14f);
-        if (_palette == PaletteKind.Context && _palAnchor is { } an)   // context menu: at the click point, clamped on-window
-        {
-            px = Math.Clamp(an.x, 8f, MathF.Max(8f, cw - pw - 8f));
-            py = Math.Clamp(an.y, TitleBarH + 8f, MathF.Max(TitleBarH + 8f, ch - ph - 8f));
-        }
-        else py = MathF.Min(py, MathF.Max(TitleBarH + 8f, ch - ph - 8f));   // short window: pull the centered panel up
+        py = MathF.Min(py, MathF.Max(TitleBarH + 8f, ch - ph - 8f));   // short window: pull the panel up
         _palPanel = new Rect(px, py, pw, ph);
 
         brush.Color = PalBg;
@@ -4561,7 +4555,7 @@ internal partial class Program : ISessionHost, IWindowHost
         rt.DrawRoundedRectangle(new RoundedRectangle { Rect = _palPanel, RadiusX = 10f, RadiusY = 10f }, brush, 1f);
 
         // Query line (placeholder when empty) + blinking caret.
-        string placeholder = _palette switch { PaletteKind.Sessions => "Go to session…", PaletteKind.Actions => "Run action…", PaletteKind.Themes => "Select theme…", PaletteKind.Omp => "oh-my-posh theme…", PaletteKind.Custom => "Run command…", PaletteKind.Windows => "Switch window…", PaletteKind.NewSession => "New session — pick a shell…", PaletteKind.Context => _ctxItem is Workspace ? "Workspace…" : "Session…", _ => "Attention" };
+        string placeholder = _palette switch { PaletteKind.Sessions => "Go to session…", PaletteKind.Actions => "Run action…", PaletteKind.Themes => "Select theme…", PaletteKind.Omp => "oh-my-posh theme…", PaletteKind.Custom => "Run command…", PaletteKind.Windows => "Switch window…", PaletteKind.NewSession => "New session — pick a shell…", _ => "Attention" };
         brush.Color = _palQuery.Length > 0 ? ChromeText : ChromeDim;
         rt.DrawText(_palQuery.Length > 0 ? _palQuery : placeholder, _uiFont, new Rect(px + 16f, py + 9f, pw - 32f, queryH - 10f), brush);
         if (_cursorOn && _palQuery.Length > 0)

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -156,7 +156,7 @@ internal partial class Program : ISessionHost, IWindowHost
     private const int SelAutoTimer = 7;   // WM_TIMER id for drag-autoscroll ticks
 
     // Command palette overlay (⌃P sessions / ⌃⇧P actions / ⌃⇧I attention).
-    private enum PaletteKind { None, Sessions, Actions, Attention, Themes, Custom, Windows, Omp, NewSession }
+    private enum PaletteKind { None, Sessions, Actions, Attention, Themes, Custom, Windows, Omp, NewSession, Context }
     private sealed class PalItem
     {
         public required string Label;
@@ -1934,7 +1934,7 @@ internal partial class Program : ISessionHost, IWindowHost
                     if (pt.x < (int)_sidebarW && pt.y >= (int)TitleBarH)
                     {
                         var item = RowAt(pt.y);
-                        if (item is not null) ShowContextMenu(item, sx, sy);
+                        if (item is not null) ShowContextPalette(item, pt.x, pt.y);
                         return IntPtr.Zero;
                     }
                     break;
@@ -3994,108 +3994,18 @@ internal partial class Program : ISessionHost, IWindowHost
         SetFocus(_hwnd);
     }
 
-    // ---- Context menus (native Win32 popup) ----
+    // ---- Context menus ----
 
-    private const uint IDM_NEW_SESSION = 1, IDM_OPEN_DIR = 2, IDM_RENAME = 3, IDM_CLOSE = 4, IDM_CLEAR = 5, IDM_DELETE_WS = 6, IDM_FLAG = 7, IDM_FOCUS_WS = 8;
-    private const uint IDM_MOVE_BASE = 1000;
-    private const uint IDM_PROFILE_BASE = 2000;   // "New Session ▸ <profile>" items: IDM_PROFILE_BASE + index
+    // Sidebar right-click menu: a themed palette anchored at the click point (replaces the native
+    // Win32 popup, which ignores the app theme). _ctxItem is the row (Ses/Workspace) it acts on.
+    private object? _ctxItem;
+    private (float x, float y)? _palAnchor;
 
-    /// <summary>A popup menu listing the shell profiles (item id = IDM_PROFILE_BASE + index).</summary>
-    private static IntPtr BuildProfilesMenu()
+    private void ShowContextPalette(object item, int cx, int cy)
     {
-        IntPtr m = CreatePopupMenu();
-        var profs = _profileCfg.Profiles;
-        for (int i = 0; i < profs.Count; i++) AppendMenuW(m, MF_STRING, (UIntPtr)(IDM_PROFILE_BASE + (uint)i), profs[i].Name);
-        return m;
-    }
-
-    /// <summary>If cmd is a profile item, create a session with that profile in <paramref name="ws"/>. Returns true if handled.</summary>
-    private bool TryCreateSessionForProfileCmd(int cmd, Workspace ws, string? cwd)
-    {
-        int idx = cmd - (int)IDM_PROFILE_BASE;
-        if (idx < 0 || idx >= _profileCfg.Profiles.Count) return false;
-        CreateSession(Guid.NewGuid().ToString(), null, cwd, ws, makeActive: true, profileName: _profileCfg.Profiles[idx].Name);
-        return true;
-    }
-
-    private void ShowContextMenu(object item, int sx, int sy)
-    {
-        IntPtr menu = CreatePopupMenu();
-        if (item is Ses ses)
-        {
-            if (_profileCfg.Profiles.Count > 1) AppendMenuW(menu, MF_POPUP, (UIntPtr)(ulong)BuildProfilesMenu(), "New Session");
-            else AppendMenuW(menu, MF_STRING, (UIntPtr)IDM_NEW_SESSION, "New Session");
-            AppendMenuW(menu, MF_STRING, (UIntPtr)IDM_OPEN_DIR, "Open Directory…");
-            AppendMenuW(menu, MF_STRING, (UIntPtr)IDM_RENAME, "Rename");
-            AppendMenuW(menu, MF_STRING, (UIntPtr)IDM_FLAG, ses.Flagged ? "Unflag Session" : "Flag Session");
-            List<Workspace> targets;
-            lock (_workspaces) targets = _workspaces.Where(w => !ReferenceEquals(w, ses.Ws)).ToList();
-            IntPtr sub = CreatePopupMenu();
-            for (int i = 0; i < targets.Count; i++) AppendMenuW(sub, MF_STRING, (UIntPtr)(IDM_MOVE_BASE + (uint)i), targets[i].Name);
-            AppendMenuW(menu, MF_POPUP | (targets.Count == 0 ? MF_GRAYED : 0), (UIntPtr)(ulong)sub, "Move to");
-            if (ses.S.Status != AgentStatus.Idle) AppendMenuW(menu, MF_STRING, (UIntPtr)IDM_CLEAR, "Clear Status");
-            AppendMenuW(menu, MF_SEPARATOR, UIntPtr.Zero, "");
-            AppendMenuW(menu, MF_STRING, (UIntPtr)IDM_CLOSE, "Close Session");
-            int cmd = TrackPopupMenuEx(menu, TPM_RETURNCMD | TPM_RIGHTBUTTON | TPM_LEFTALIGN, sx, sy, _hwnd, IntPtr.Zero);
-            DestroyMenu(menu);
-            switch ((uint)cmd)
-            {
-                case IDM_NEW_SESSION: CreateSession(Guid.NewGuid().ToString(), null, null, ses.Ws, true); break;
-                case IDM_OPEN_DIR: { var d = PickFolder(); if (d is not null) CreateSession(Guid.NewGuid().ToString(), null, d, ses.Ws, true); break; }
-                case IDM_RENAME: StartRename(ses); break;
-                case IDM_FLAG: FlagOp(ses, "toggle"); break;
-                case IDM_CLEAR: ses.S.SetStatus(AgentStatus.Idle); RequestRedraw(); break;
-                case IDM_CLOSE: if (ConfirmCloseOk()) CloseSessionInternal(ses); break;
-                default:
-                    if (cmd >= (int)IDM_MOVE_BASE && cmd < (int)IDM_MOVE_BASE + targets.Count)
-                        MoveSession(ses, targets[cmd - (int)IDM_MOVE_BASE]);
-                    else TryCreateSessionForProfileCmd(cmd, ses.Ws, null);   // "New Session ▸ <profile>"
-                    break;
-            }
-        }
-        else if (item is Workspace ws)
-        {
-            bool wsFocused = _focusedWorkspaceId == ws.Id;
-            int wsCount; lock (_workspaces) wsCount = _workspaces.Count;
-            if (_profileCfg.Profiles.Count > 1) AppendMenuW(menu, MF_POPUP, (UIntPtr)(ulong)BuildProfilesMenu(), "New Session");
-            else AppendMenuW(menu, MF_STRING, (UIntPtr)IDM_NEW_SESSION, "New Session");
-            AppendMenuW(menu, MF_STRING, (UIntPtr)IDM_OPEN_DIR, "Open Directory…");
-            AppendMenuW(menu, MF_STRING, (UIntPtr)IDM_RENAME, "Rename");
-            AppendMenuW(menu, MF_STRING, (UIntPtr)IDM_FOCUS_WS, wsFocused ? "Unfocus" : "Focus");
-            AppendMenuW(menu, MF_SEPARATOR, UIntPtr.Zero, "");
-            AppendMenuW(menu, MF_STRING | (wsCount <= 1 ? MF_GRAYED : 0), (UIntPtr)IDM_DELETE_WS, "Delete Workspace");
-            int cmd = TrackPopupMenuEx(menu, TPM_RETURNCMD | TPM_RIGHTBUTTON | TPM_LEFTALIGN, sx, sy, _hwnd, IntPtr.Zero);
-            DestroyMenu(menu);
-            switch ((uint)cmd)
-            {
-                case IDM_NEW_SESSION: CreateSession(Guid.NewGuid().ToString(), null, null, ws, true); break;
-                case IDM_OPEN_DIR: { var d = PickFolder(); if (d is not null) CreateSession(Guid.NewGuid().ToString(), null, d, ws, true); break; }
-                case IDM_RENAME: StartRename(ws); break;
-                case IDM_FOCUS_WS: WorkspaceFocusOp(wsFocused ? "off" : "on", ws.Id); break;
-                case IDM_DELETE_WS: DeleteWorkspace(ws); break;
-                default: TryCreateSessionForProfileCmd(cmd, ws, null); break;   // "New Session ▸ <profile>"
-            }
-        }
-        else DestroyMenu(menu);
-    }
-
-    /// <summary>Footer add-session button: popup menu (New Session / Open Directory…) above the button.</summary>
-    private void ShowAddSessionMenu()
-    {
-        float bx0 = 6f;
-        foreach (var b in _footerButtons) if (b.action == "add-session") { bx0 = b.x0; break; }
-        var pt = new POINT { x = (int)bx0, y = ClientH() - (int)FooterH };
-        ClientToScreen(_hwnd, ref pt);
-        IntPtr menu = CreatePopupMenu();
-        var profs = _profileCfg.Profiles;                       // one "New <profile>" item per shell profile
-        for (int i = 0; i < profs.Count; i++) AppendMenuW(menu, MF_STRING, (UIntPtr)(IDM_PROFILE_BASE + (uint)i), profs[i].Name);
-        AppendMenuW(menu, MF_SEPARATOR, UIntPtr.Zero, "");
-        AppendMenuW(menu, MF_STRING, (UIntPtr)IDM_OPEN_DIR, "Open Directory…");
-        int cmd = TrackPopupMenuEx(menu, TPM_RETURNCMD | TPM_LEFTALIGN | TPM_BOTTOMALIGN, pt.x, pt.y, _hwnd, IntPtr.Zero);
-        DestroyMenu(menu);
-        var ws = ActiveWorkspace();
-        if (cmd == (int)IDM_OPEN_DIR) { var d = PickFolder(); if (d is not null) CreateSession(Guid.NewGuid().ToString(), null, d, ws, true); }
-        else TryCreateSessionForProfileCmd(cmd, ws, null);
+        _ctxItem = item;
+        _palAnchor = (cx, cy);
+        TogglePalette(PaletteKind.Context);
     }
 
     private void MoveSession(Ses ses, Workspace target)
@@ -4495,6 +4405,39 @@ internal partial class Program : ISessionHost, IWindowHost
                 });
                 break;
             }
+            case PaletteKind.Context:
+            {
+                void A(string label, string hint, Action run) => _palAll.Add(new PalItem { Label = label, Hint = hint, Search = label, Run = run });
+                if (_ctxItem is Ses ses)
+                {
+                    if (_profileCfg.Profiles.Count > 1)
+                        foreach (var p in _profileCfg.Profiles)
+                        { var nm = p.Name; A($"New Session — {nm}", "", () => CreateSession(Guid.NewGuid().ToString(), null, null, ses.Ws, true, profileName: nm)); }
+                    else A("New Session", "", () => CreateSession(Guid.NewGuid().ToString(), null, null, ses.Ws, true));
+                    A("Open Directory…", "", () => { var d = PickFolder(); if (d is not null) CreateSession(Guid.NewGuid().ToString(), null, d, ses.Ws, true); });
+                    A("Rename", "F2", () => StartRename(ses));
+                    A(ses.Flagged ? "Unflag Session" : "Flag Session", "", () => FlagOp(ses, "toggle"));
+                    List<Workspace> targets;
+                    lock (_workspaces) targets = _workspaces.Where(w => !ReferenceEquals(w, ses.Ws)).ToList();
+                    foreach (var t in targets) A($"Move to — {t.Name}", "", () => MoveSession(ses, t));
+                    if (ses.S.Status != AgentStatus.Idle) A("Clear Status", "", () => { ses.S.SetStatus(AgentStatus.Idle); RequestRedraw(); });
+                    A("Close Session", "", () => { if (ConfirmCloseOk()) CloseSessionInternal(ses); });
+                }
+                else if (_ctxItem is Workspace cws)
+                {
+                    bool wsFocused = _focusedWorkspaceId == cws.Id;
+                    int wsCount; lock (_workspaces) wsCount = _workspaces.Count;
+                    if (_profileCfg.Profiles.Count > 1)
+                        foreach (var p in _profileCfg.Profiles)
+                        { var nm = p.Name; A($"New Session — {nm}", "", () => CreateSession(Guid.NewGuid().ToString(), null, null, cws, true, profileName: nm)); }
+                    else A("New Session", "", () => CreateSession(Guid.NewGuid().ToString(), null, null, cws, true));
+                    A("Open Directory…", "", () => { var d = PickFolder(); if (d is not null) CreateSession(Guid.NewGuid().ToString(), null, d, cws, true); });
+                    A("Rename", "", () => StartRename(cws));
+                    A(wsFocused ? "Unfocus" : "Focus", "", () => WorkspaceFocusOp(wsFocused ? "off" : "on", cws.Id));
+                    if (wsCount > 1) A("Delete Workspace", "", () => DeleteWorkspace(cws));
+                }
+                break;
+            }
             case PaletteKind.Attention:
             {
                 var att = AllSessions().Where(s => s.S.Status != AgentStatus.Idle)
@@ -4595,11 +4538,16 @@ internal partial class Program : ISessionHost, IWindowHost
 
         const float queryH = 42f, rowH = 40f;
         const int maxRows = 12;
-        float pw = MathF.Min(560f, cw - 80f);
+        float pw = MathF.Min(_palette == PaletteKind.Context ? 340f : 560f, cw - 80f);
         float px = (cw - pw) / 2f;
         int shown = Math.Min(_palItems.Count, maxRows);
         float ph = queryH + Math.Max(1, shown) * rowH + 8f;
         float py = MathF.Max(TitleBarH + 16f, ch * 0.14f);
+        if (_palette == PaletteKind.Context && _palAnchor is { } an)   // context menu: at the click point, clamped on-window
+        {
+            px = Math.Clamp(an.x, 8f, MathF.Max(8f, cw - pw - 8f));
+            py = Math.Clamp(an.y, TitleBarH + 8f, MathF.Max(TitleBarH + 8f, ch - ph - 8f));
+        }
         _palPanel = new Rect(px, py, pw, ph);
 
         brush.Color = PalBg;
@@ -4608,7 +4556,7 @@ internal partial class Program : ISessionHost, IWindowHost
         rt.DrawRoundedRectangle(new RoundedRectangle { Rect = _palPanel, RadiusX = 10f, RadiusY = 10f }, brush, 1f);
 
         // Query line (placeholder when empty) + blinking caret.
-        string placeholder = _palette switch { PaletteKind.Sessions => "Go to session…", PaletteKind.Actions => "Run action…", PaletteKind.Themes => "Select theme…", PaletteKind.Omp => "oh-my-posh theme…", PaletteKind.Custom => "Run command…", PaletteKind.Windows => "Switch window…", PaletteKind.NewSession => "New session — pick a shell…", _ => "Attention" };
+        string placeholder = _palette switch { PaletteKind.Sessions => "Go to session…", PaletteKind.Actions => "Run action…", PaletteKind.Themes => "Select theme…", PaletteKind.Omp => "oh-my-posh theme…", PaletteKind.Custom => "Run command…", PaletteKind.Windows => "Switch window…", PaletteKind.NewSession => "New session — pick a shell…", PaletteKind.Context => _ctxItem is Workspace ? "Workspace…" : "Session…", _ => "Attention" };
         brush.Color = _palQuery.Length > 0 ? ChromeText : ChromeDim;
         rt.DrawText(_palQuery.Length > 0 ? _palQuery : placeholder, _uiFont, new Rect(px + 16f, py + 9f, pw - 32f, queryH - 10f), brush);
         if (_cursorOn && _palQuery.Length > 0)

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -904,6 +904,14 @@ internal partial class Program : ISessionHost, IWindowHost
         RequestRedraw();
     }
 
+    /// <summary>Dismiss whatever cover is up (the "close_cover" keymap action): overlays close
+    /// (their program is ephemeral), scratch/quick just hide (their shells stay alive).</summary>
+    private void CloseCover()
+    {
+        if (_cover is null) return;
+        if (_coverKind == 3) CloseActiveOverlay(); else HideCover();
+    }
+
     /// <summary>The rect (px) the current cover occupies: the full content region, or — for a floating overlay — a centered panel sized by percent.</summary>
     private (float x, float y, float w, float h) CoverRect()
     {
@@ -2033,11 +2041,13 @@ internal partial class Program : ISessionHost, IWindowHost
                         SetActive(t);
                         return IntPtr.Zero;
                     }
-                    // Quick terminal is a floating panel: a left-click anywhere in the "main window area"
-                    // outside the panel dismisses it (like a tool window that hides on focus loss).
+                    // Quick terminal is a floating panel: its corner ✕ hides it, and a left-click anywhere
+                    // in the "main window area" outside the panel also dismisses it (like a tool window).
                     if (_coverKind == 2)
                     {
                         var (qx, qy, qw, qh) = CoverRect();
+                        var (bx, by, bw, bh) = CoverCloseRect(qx + qw, qy);
+                        if (mx >= bx && mx < bx + bw && my >= by && my < by + bh) { HideCover(); return IntPtr.Zero; }
                         if (mx < qx || mx >= qx + qw || my < qy || my >= qy + qh) { HideCover(); return IntPtr.Zero; }
                     }
                     if (my < (int)TitleBarH)
@@ -2326,6 +2336,7 @@ internal partial class Program : ISessionHost, IWindowHost
             case "toggle_flag": if (_active is not null) FlagOp(_active, "toggle"); break;
             case "toggle_flagged_view": ToggleFlaggedView(); break;
             case "focus_workspace": WorkspaceFocusOp("toggle"); break;
+            case "close_cover": CloseCover(); break;
             case "select_all": if (ActiveSurface() is { } sa) SelectAll(sa); break;
             case "copy_selection": if (ActiveSurface() is { } sc && sc.HasSel) CopySelection(sc); break;
             case "paste": if (ActiveSurface() is { } sp2) PasteInto(sp2); break;
@@ -3004,7 +3015,12 @@ internal partial class Program : ISessionHost, IWindowHost
         // Keymap dispatch: build the chord and run its bound action (defaults overlaid by keymap.conf).
         // Unbound chords fall through to terminal input below.
         string? chord = Keymap.ChordFor(vk, ctrl, alt, shift);
-        if (chord is not null && _keymap.TryGetValue(chord, out var action)) { RunAction(action); return true; }
+        if (chord is not null && _keymap.TryGetValue(chord, out var action))
+        {
+            // close_cover only applies while a cover is up — otherwise its chord (typically a bare
+            // Escape) falls through so the key still reaches the terminal.
+            if (action is not "close_cover" || _cover is not null) { RunAction(action); return true; }
+        }
 
         if (_session is null) return false;
 
@@ -3608,10 +3624,22 @@ internal partial class Program : ISessionHost, IWindowHost
     }
 
     /// <summary>Corner badge naming the current cover (scratch / quick / overlay); rightX/topY = cover top-right.</summary>
+    /// <summary>The quick terminal's ✕ close box, anchored to the panel's top-right corner.</summary>
+    private static (float x, float y, float w, float h) CoverCloseRect(float rightX, float topY) => (rightX - 26f, topY + 4f, 20f, 20f);
+
     private void DrawCoverBadge(ID2D1HwndRenderTarget rt, ID2D1SolidColorBrush brush, float rightX, float topY)
     {
         string badge = _coverKind switch { 1 => "scratch", 2 => "quick", 3 => "overlay", _ => "" };
         if (badge.Length == 0) return;
+        if (_coverKind == 2)   // quick terminal: ✕ close box in the corner; the badge pill sits left of it
+        {
+            var (cx, cy, cw2, ch2) = CoverCloseRect(rightX, topY);
+            brush.Color = WithA(SbHighlight, 0.92f);
+            rt.FillRoundedRectangle(new RoundedRectangle { Rect = new Rect(cx, cy, cw2, ch2), RadiusX = 5f, RadiusY = 5f }, brush);
+            brush.Color = ChromeText;
+            rt.DrawText(GlyphClose, _iconFont, new Rect(cx + 4f, cy + 3f, cw2 - 4f, ch2 - 3f), brush);
+            rightX = cx - 2f;
+        }
         float bw = MeasureText(badge, _uiSmall) + 16f;
         brush.Color = WithA(SbHighlight, 0.92f);
         rt.FillRoundedRectangle(new RoundedRectangle { Rect = new Rect(rightX - bw - 6f, topY + 4f, bw, 20f), RadiusX = 5f, RadiusY = 5f }, brush);

--- a/src/Agwinterm.Win32/Win32.cs
+++ b/src/Agwinterm.Win32/Win32.cs
@@ -219,6 +219,20 @@ internal static class Win32
         public byte rgbReserved28; public byte rgbReserved29; public byte rgbReserved30; public byte rgbReserved31;
     }
 
+    // ---- Popup menu window (a real top-level HWND for the themed context menu) ----
+    public const uint WS_EX_TOPMOST = 0x00000008, WS_EX_TOOLWINDOW = 0x00000080, WS_EX_NOACTIVATE = 0x08000000;
+    public const uint CS_DROPSHADOW = 0x00020000;
+    public const int SW_SHOWNOACTIVATE = 4;
+    public const uint WM_MOUSEACTIVATE = 0x0021, WM_CAPTURECHANGED = 0x0215;
+    public const int MA_NOACTIVATE = 3;
+    public const uint MONITOR_DEFAULTTONEAREST = 2;
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct MONITORINFO { public int cbSize; public RECT rcMonitor; public RECT rcWork; public uint dwFlags; }
+
+    [DllImport("user32.dll")] public static extern IntPtr MonitorFromPoint(POINT pt, uint dwFlags);
+    [DllImport("user32.dll")] public static extern bool GetMonitorInfoW(IntPtr hMonitor, ref MONITORINFO lpmi);
+
     public const uint CS_HREDRAW = 0x0002, CS_VREDRAW = 0x0001;
     public const uint WS_OVERLAPPEDWINDOW = 0x00CF0000, WS_VISIBLE = 0x10000000;
     public const int CW_USEDEFAULT = unchecked((int)0x80000000);


### PR DESCRIPTION
Three related UI features, all verified visually on the running app.

## 1. Quick terminal close button (+ bindable Esc)

- A **✕ close box** in the quick terminal panel's corner (chrome `GlyphClose` style, next to the "quick" badge). Clicking hides the panel — shell stays alive, same semantics as click-outside/toggle.
- New keymap action **`close_cover`** (no default binding): dismisses the active cover — overlays close, scratch/quick hide. Bind `map escape = close_cover` for Esc-to-close; when no cover is up the chord **falls through**, so a bare Esc still reaches the terminal (vim/TUIs unaffected).

Upstream agterm's quick terminal closes via toggle / margin-click / ⌘W only — no ✕, no Esc. Both additions are opt-in-friendly supersets.

## 2. Context menu in a REAL popup window (Menu.cs)

The sidebar right-click menu is now hosted in its own top-level `WS_POPUP` window — **it can extend beyond the main window's bounds like a native menu**, while staying fully themed (Direct2D + chrome palette, drop shadow, hover highlight, separators, right-aligned hints).

- **Native-menu input model**: the popup captures the mouse — click inside runs, click outside dismisses (and is swallowed), losing capture (alt-tab) dismisses. It never takes focus (`WS_EX_NOACTIVATE`); the main window forwards ↑/↓/Enter/Esc.
- Positioned at the cursor, clamped to the monitor work area, opens upward when there's no room below.
- Same items as the old native menu: per-profile New Session, Open Directory…, Rename (F2), Flag/Unflag, Move to ⟨workspace⟩, Clear Status, ── separator, Close Session / Focus, Delete Workspace.
- The transitional palette-based context menu was replaced; the dead native `TrackPopupMenuEx` block was removed earlier in this PR.

## 3. Palette overflow fixes (benefit all palettes)

- Labels no longer paint past the panel border (D2D `DrawText` doesn't clip by default → `DrawTextOptions.Clip`).
- The panel caps its row count to the window height (the list scrolls with the selection); centered palettes pull up on short windows.

## Verification (all screenshot-verified)

- ✅ ✕ renders in the panel corner; synthetic click dismisses the panel
- ✅ Menu opens themed at the cursor in a 300px-tall window and **extends well past the main window's bottom edge** over the desktop
- ✅ Esc (forwarded through the main window) dismisses the menu
- ✅ Long labels clip at the menu border; separator hairline before Close Session
- ✅ Bonus: re-verified Ctrl+V pastes into the quick terminal (v0.4.0 fix) — marker landed in the cover, not the main pane
- ✅ Build clean; 87/87 Core tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)