### PR TITLE
feat(control): session.rename verb

### DIFF
--- a/src/Agwinterm.Ctl/Program.cs
+++ b/src/Agwinterm.Ctl/Program.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 //   agwintermctl session new [--cwd DIR] [--name NAME]
 //   agwintermctl session select <target>
 //   agwintermctl session close [target]
+//   agwintermctl session rename <new-name...> [--target ID]
 //   agwintermctl session status <idle|active|blocked|completed> [--sound [name]] [--blink] [--auto-reset] [--target ID]
 //   agwintermctl session type <text...> [--target ID]
 //   agwintermctl session write <text...> [--target ID]
@@ -115,6 +116,10 @@ switch (area)
             case "select":
             case "close":
                 target = rest.Count > 0 ? rest[0] : (Opt("target") ?? "active");
+                break;
+            case "rename": // session rename <new-name...> [--target ID]
+                if (rest.Count == 0 && Opt("name") is null) { Console.Error.WriteLine("session rename needs a name"); return 2; }
+                cargs["name"] = rest.Count > 0 ? string.Join(' ', rest) : Opt("name")!;
                 break;
             case "status":
                 if (rest.Count == 0) { Console.Error.WriteLine("session status needs a state"); return 2; }

--- a/src/Agwinterm.Pty/AgentSkill.cs
+++ b/src/Agwinterm.Pty/AgentSkill.cs
@@ -58,6 +58,7 @@ public static class AgentSkill
         - `agwintermctl profiles list` — shell profiles (cmd, Windows PowerShell, PowerShell 7, Git Bash, WSL:*, custom); `* ` marks the default.
           Profiles live in `%LOCALAPPDATA%\agwinterm\profiles.json` (auto-seeded from detected shells; edit to add your own — name/command/args/cwd/icon); `agwintermctl profiles reload` re-reads it.
         - `agwintermctl session select <id>` / `session close <id>`
+        - `agwintermctl session rename <new-name> [--target ID]` — set a session's custom name (sidebar + title bar)
         - `agwintermctl session go next|prev|first|last|next-attention|prev-attention` — move the active session
         - `agwintermctl session move --to up|down|top|bottom`     — reorder within its workspace
         - `agwintermctl session move <workspace-id>`             — relocate to another workspace

--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -143,6 +143,7 @@ public sealed class ControlServer : IDisposable
                         ? host.SessionToWorkspace(target, wsMove)
                         : host.SessionReorder(target, GetString(args, "dir") ?? "down"))
                         ? Ok("moved") : Err("not found");
+                case "session.rename": return host.SessionRename(target, GetString(args, "name") ?? "") ? Ok("renamed") : Err("session not found / blank name");
                 case "workspace.rename": return host.WorkspaceRename(target, GetString(args, "name") ?? "") ? Ok("renamed") : Err("workspace not found");
                 case "workspace.delete": return host.WorkspaceDelete(target) ? Ok("deleted") : Err("workspace not found");
                 case "workspace.select": return host.WorkspaceSelect(target) ? Ok("selected") : Err("workspace not found");

--- a/src/Agwinterm.Pty/ISessionHost.cs
+++ b/src/Agwinterm.Pty/ISessionHost.cs
@@ -53,6 +53,9 @@ public interface ISessionHost
     /// <summary>Relocate a session to another workspace (by id/prefix/active), appending.</summary>
     bool SessionToWorkspace(string? target, string workspace);
 
+    /// <summary>Rename a session: sets its custom name (shown in the sidebar and title bar).</summary>
+    bool SessionRename(string? target, string name);
+
     bool WorkspaceRename(string? target, string name);
     bool WorkspaceDelete(string? target);
     bool WorkspaceSelect(string? target);
@@ -176,6 +179,7 @@ public sealed class SingleSessionHost : ISessionHost
     public void SessionGo(string dir) { }
     public bool SessionReorder(string? target, string dir) => false;
     public bool SessionToWorkspace(string? target, string workspace) => false;
+    public bool SessionRename(string? target, string name) => false;
     public bool WorkspaceRename(string? target, string name) => false;
     public bool WorkspaceDelete(string? target) => false;
     public bool WorkspaceSelect(string? target) => false;

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -1603,6 +1603,14 @@ internal partial class Program : ISessionHost, IWindowHost
             return true;
         }
 
+        public bool SessionRename(string? target, string name)
+        {
+            var ses = FindSesForTarget(target);
+            if (ses is null || string.IsNullOrWhiteSpace(name)) return false;
+            Post(() => { ses.Name = name; ses.CustomName = name; RequestRedraw(); SaveState(); }); // CustomName drives the title bar
+            return true;
+        }
+
         public bool WorkspaceRename(string? target, string name)
         {
             var ws = FindWs(target);


### PR DESCRIPTION
**Gap-analysis item 2 of 6** (P0 — the community's most load-bearing missing verb).

The [quickloc recipe](https://github.com/umputun/agterm/discussions/153) (harpoon-style session slots) encodes its entire state as `[N]` tags in session *names* — `agtermctl session rename` is its core primitive. We only had F2/inline rename; this adds the headless verb, unblocking that recipe pattern on Windows.

- **host**: `SessionRename` resolves by session id / pane id / prefix / `active`, sets `Name` + `CustomName` (drives the title bar, same as inline rename), persists via `SaveState`
- **server**: `session.rename` (blank names rejected)
- **ctl**: `agwintermctl session rename <new-name...> [--target ID]`
- agent-skill doc updated so agents discover the verb

## Verification
- ✅ `agwintermctl session rename "quickloc-test [3]"` → `renamed`; `tree --json` shows the new name
- ✅ blank name → `session not found / blank name`
- ✅ solution builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)