### PR TITLE
feat(win32): clickable links — Ctrl+hover underline, Ctrl+click open

### DIFF
--- a/installer/build-portable.ps1
+++ b/installer/build-portable.ps1
@@ -26,6 +26,7 @@ Write-Host "== publish single-file portable exe (v$ver) ==" -ForegroundColor Cya
   -p:IncludeNativeLibrariesForSelfExtract=true `
   -p:SatelliteResourceLanguages=en `
   -p:DebugType=none `
+  -p:Version=$ver `
   -o $stage
 if ($LASTEXITCODE -ne 0) { throw "portable publish failed" }
 

--- a/installer/build.ps1
+++ b/installer/build.ps1
@@ -19,9 +19,14 @@ Write-Host "== clean stage ==" -ForegroundColor Cyan
 if (Test-Path $stage) { Remove-Item -Recurse -Force $stage }
 New-Item -ItemType Directory -Force $stage | Out-Null
 
+# version = the installer's AppVersion define (stamped into the assemblies so `ping` reports it)
+$issText = Get-Content (Join-Path $here "agwinterm.iss") -Raw
+if ($issText -notmatch '#define\s+AppVersion\s+"([^"]+)"') { throw "AppVersion not found in agwinterm.iss" }
+$ver = $Matches[1]
+
 # Self-contained, NON-single-file (a folder): most robust for Vortice native libs + the on-disk
 # themes\ / assets\ the app reads relative to the exe. The installer bundles the whole folder.
-$common = @("-c","Release","-r","win-x64","--self-contained","true","-p:PublishSingleFile=false","-o",$stage)
+$common = @("-c","Release","-r","win-x64","--self-contained","true","-p:PublishSingleFile=false","-p:Version=$ver","-o",$stage)
 
 Write-Host "== publish Agwinterm.Win32 (app) ==" -ForegroundColor Cyan
 & $dotnet publish (Join-Path $root "src\Agwinterm.Win32\Agwinterm.Win32.csproj") @common

--- a/src/Agwinterm.Ctl/Program.cs
+++ b/src/Agwinterm.Ctl/Program.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 //   agwintermctl session new [--cwd DIR] [--name NAME]
 //   agwintermctl session select <target>
 //   agwintermctl session close [target]
+//   agwintermctl session rename <new-name...> [--target ID]
 //   agwintermctl session status <idle|active|blocked|completed> [--sound [name]] [--blink] [--auto-reset] [--target ID]
 //   agwintermctl session type <text...> [--target ID]
 //   agwintermctl session write <text...> [--target ID]
@@ -115,6 +116,10 @@ switch (area)
             case "select":
             case "close":
                 target = rest.Count > 0 ? rest[0] : (Opt("target") ?? "active");
+                break;
+            case "rename": // session rename <new-name...> [--target ID]
+                if (rest.Count == 0 && Opt("name") is null) { Console.Error.WriteLine("session rename needs a name"); return 2; }
+                cargs["name"] = rest.Count > 0 ? string.Join(' ', rest) : Opt("name")!;
                 break;
             case "status":
                 if (rest.Count == 0) { Console.Error.WriteLine("session status needs a state"); return 2; }

--- a/src/Agwinterm.Ctl/Program.cs
+++ b/src/Agwinterm.Ctl/Program.cs
@@ -10,6 +10,8 @@ using System.Text.Json;
 //   agwintermctl session select <target>
 //   agwintermctl session close [target]
 //   agwintermctl session rename <new-name...> [--target ID]
+//   agwintermctl session seen [--target ID]        (clear the unseen-notification badge)
+//   agwintermctl sidebar state                      (read-back: "visible tree" | "hidden flagged" | ...)
 //   agwintermctl session status <idle|active|blocked|completed> [--sound [name]] [--blink] [--auto-reset] [--target ID]
 //   agwintermctl session type <text...> [--target ID]
 //   agwintermctl session write <text...> [--target ID]
@@ -135,6 +137,7 @@ switch (area)
                 break;
             case "text": break; // dump the buffer; target only
             case "copy": break;  // return the target's selection text; target only
+            case "seen": break;  // clear the unseen-notification badge; target only
             case "paste": // paste literal text (or the clipboard if none) into the target pane
                 cargs["text"] = rest.Count > 0 ? string.Join(' ', rest) : (Opt("text") ?? "");
                 break;

--- a/src/Agwinterm.Pty/AgentSkill.cs
+++ b/src/Agwinterm.Pty/AgentSkill.cs
@@ -59,6 +59,8 @@ public static class AgentSkill
           Profiles live in `%LOCALAPPDATA%\agwinterm\profiles.json` (auto-seeded from detected shells; edit to add your own — name/command/args/cwd/icon); `agwintermctl profiles reload` re-reads it.
         - `agwintermctl session select <id>` / `session close <id>`
         - `agwintermctl session rename <new-name> [--target ID]` — set a session's custom name (sidebar + title bar)
+        - `agwintermctl session seen [--target ID]` — clear a session's unseen-notification badge headlessly
+        - `agwintermctl sidebar state` — read-back: `visible tree` | `hidden flagged` | … (`ping` reports the app version)
         - `agwintermctl session go next|prev|first|last|next-attention|prev-attention` — move the active session
         - `agwintermctl session move --to up|down|top|bottom`     — reorder within its workspace
         - `agwintermctl session move <workspace-id>`             — relocate to another workspace

--- a/src/Agwinterm.Pty/AgentSkill.cs
+++ b/src/Agwinterm.Pty/AgentSkill.cs
@@ -58,6 +58,7 @@ public static class AgentSkill
         - `agwintermctl profiles list` — shell profiles (cmd, Windows PowerShell, PowerShell 7, Git Bash, WSL:*, custom); `* ` marks the default.
           Profiles live in `%LOCALAPPDATA%\agwinterm\profiles.json` (auto-seeded from detected shells; edit to add your own — name/command/args/cwd/icon); `agwintermctl profiles reload` re-reads it.
         - `agwintermctl session select <id>` / `session close <id>`
+        - `agwintermctl session rename <new-name> [--target ID]` — set a session's custom name (sidebar + title bar)
         - `agwintermctl session go next|prev|first|last|next-attention|prev-attention` — move the active session
         - `agwintermctl session move --to up|down|top|bottom`     — reorder within its workspace
         - `agwintermctl session move <workspace-id>`             — relocate to another workspace

--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -101,7 +101,7 @@ public sealed class ControlServer : IDisposable
             // App-level, window-agnostic verbs first.
             switch (cmd)
             {
-                case "ping": return Ok("agwinterm");
+                case "ping": return Ok("agwinterm " + AppVersion());
                 case "install.hooks": return Ok(AgentHooks.Install());
                 case "install.skill": return Ok(AgentSkill.Install());
                 case "install.shell": return Ok(ShellIntegrationInstaller.Install());
@@ -144,6 +144,7 @@ public sealed class ControlServer : IDisposable
                         : host.SessionReorder(target, GetString(args, "dir") ?? "down"))
                         ? Ok("moved") : Err("not found");
                 case "session.rename": return host.SessionRename(target, GetString(args, "name") ?? "") ? Ok("renamed") : Err("session not found / blank name");
+                case "session.seen": return host.SessionSeen(target) ? Ok("seen") : Err("session not found");
                 case "workspace.rename": return host.WorkspaceRename(target, GetString(args, "name") ?? "") ? Ok("renamed") : Err("workspace not found");
                 case "workspace.delete": return host.WorkspaceDelete(target) ? Ok("deleted") : Err("workspace not found");
                 case "workspace.select": return host.WorkspaceSelect(target) ? Ok("selected") : Err("workspace not found");
@@ -165,7 +166,12 @@ public sealed class ControlServer : IDisposable
                 case "config.get": return Ok(host.ConfigGet(GetString(args, "key") ?? ""));
                 case "config.list": return Ok(host.ConfigList());
                 case "settings.open": return Ok(host.SettingsOpen());
-                case "sidebar": host.SidebarOp(GetString(args, "op") ?? "toggle"); return Ok("sidebar");
+                case "sidebar":
+                {
+                    string op = GetString(args, "op") ?? "toggle";
+                    if (op is "state" or "get") return Ok(host.SidebarState());   // read-back, no mutation
+                    host.SidebarOp(op); return Ok("sidebar");
+                }
                 case "session.copy": return Ok(host.SessionCopy(target)); // selection text (host-side), "" if none
                 case "selection.all": return Ok(host.SelectionAll(target));
                 case "selection.copy": return Ok(host.SelectionCopy(target));      // -> Windows clipboard
@@ -424,6 +430,18 @@ public sealed class ControlServer : IDisposable
     private static bool GetBool(JsonElement args, string key)
         => args.ValueKind == JsonValueKind.Object && args.TryGetProperty(key, out var v)
            && (v.ValueKind == JsonValueKind.True || (v.ValueKind == JsonValueKind.String && v.GetString() is "true" or "1"));
+
+    /// <summary>App version for `ping` — the entry assembly's informational version (stamped by the
+    /// release build scripts via -p:Version; "1.0.0" in unstamped dev builds), without metadata.</summary>
+    private static string AppVersion()
+    {
+        string v = System.Reflection.Assembly.GetEntryAssembly()?
+            .GetCustomAttributes(typeof(System.Reflection.AssemblyInformationalVersionAttribute), false)
+            .OfType<System.Reflection.AssemblyInformationalVersionAttribute>()
+            .FirstOrDefault()?.InformationalVersion ?? "dev";
+        int plus = v.IndexOf('+');
+        return plus > 0 ? v[..plus] : v;
+    }
 
     private static string Ok(string result) => $"{{\"ok\":true,\"result\":{JsonSerializer.Serialize(result)}}}";
     private static string OkRaw(string rawResult) => $"{{\"ok\":true,\"result\":{rawResult}}}";

--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -143,6 +143,7 @@ public sealed class ControlServer : IDisposable
                         ? host.SessionToWorkspace(target, wsMove)
                         : host.SessionReorder(target, GetString(args, "dir") ?? "down"))
                         ? Ok("moved") : Err("not found");
+                case "session.rename": return host.SessionRename(target, GetString(args, "name") ?? "") ? Ok("renamed") : Err("session not found / blank name");
                 case "workspace.rename": return host.WorkspaceRename(target, GetString(args, "name") ?? "") ? Ok("renamed") : Err("workspace not found");
                 case "workspace.delete": return host.WorkspaceDelete(target) ? Ok("deleted") : Err("workspace not found");
                 case "workspace.select": return host.WorkspaceSelect(target) ? Ok("selected") : Err("workspace not found");

--- a/src/Agwinterm.Pty/ISessionHost.cs
+++ b/src/Agwinterm.Pty/ISessionHost.cs
@@ -56,6 +56,12 @@ public interface ISessionHost
     /// <summary>Rename a session: sets its custom name (shown in the sidebar and title bar).</summary>
     bool SessionRename(string? target, string name);
 
+    /// <summary>Clear a session's unseen-notification badge without visiting it (headless "seen").</summary>
+    bool SessionSeen(string? target);
+
+    /// <summary>Sidebar state read-back: "visible tree" | "hidden flagged" | ….</summary>
+    string SidebarState();
+
     bool WorkspaceRename(string? target, string name);
     bool WorkspaceDelete(string? target);
     bool WorkspaceSelect(string? target);
@@ -180,6 +186,8 @@ public sealed class SingleSessionHost : ISessionHost
     public bool SessionReorder(string? target, string dir) => false;
     public bool SessionToWorkspace(string? target, string workspace) => false;
     public bool SessionRename(string? target, string name) => false;
+    public bool SessionSeen(string? target) => false;
+    public string SidebarState() => "visible tree";
     public bool WorkspaceRename(string? target, string name) => false;
     public bool WorkspaceDelete(string? target) => false;
     public bool WorkspaceSelect(string? target) => false;

--- a/src/Agwinterm.Pty/ISessionHost.cs
+++ b/src/Agwinterm.Pty/ISessionHost.cs
@@ -53,6 +53,9 @@ public interface ISessionHost
     /// <summary>Relocate a session to another workspace (by id/prefix/active), appending.</summary>
     bool SessionToWorkspace(string? target, string workspace);
 
+    /// <summary>Rename a session: sets its custom name (shown in the sidebar and title bar).</summary>
+    bool SessionRename(string? target, string name);
+
     bool WorkspaceRename(string? target, string name);
     bool WorkspaceDelete(string? target);
     bool WorkspaceSelect(string? target);
@@ -176,6 +179,7 @@ public sealed class SingleSessionHost : ISessionHost
     public void SessionGo(string dir) { }
     public bool SessionReorder(string? target, string dir) => false;
     public bool SessionToWorkspace(string? target, string workspace) => false;
+    public bool SessionRename(string? target, string name) => false;
     public bool WorkspaceRename(string? target, string name) => false;
     public bool WorkspaceDelete(string? target) => false;
     public bool WorkspaceSelect(string? target) => false;

--- a/src/Agwinterm.Win32/Keymap.cs
+++ b/src/Agwinterm.Win32/Keymap.cs
@@ -42,6 +42,7 @@ internal static class Keymap
         ("ctrl+shift+f", "toggle_flag"),
         ("ctrl+shift+a", "select_all"),
         ("ctrl+alt+n", "new_window"),
+        ("f11", "toggle_fullscreen"),
     };
 
     public static readonly HashSet<string> ValidActions = new(StringComparer.OrdinalIgnoreCase)
@@ -50,7 +51,7 @@ internal static class Keymap
         "focus_left_pane", "focus_right_pane", "next_session", "previous_session",
         "toggle_sidebar", "rename_session", "delete_workspace", "session_palette", "action_palette",
         "attention_list", "custom_palette", "next_attention", "previous_attention", "reload_keymap",
-        "toggle_search", "toggle_scratch", "quick_terminal", "close_cover",
+        "toggle_search", "toggle_scratch", "quick_terminal", "close_cover", "toggle_fullscreen",
         "toggle_flag", "toggle_flagged_view", "focus_workspace",
         "select_all", "copy_selection", "paste",
         "new_window", "close_window", "switch_window",
@@ -68,7 +69,9 @@ internal static class Keymap
         #   map leader <chord> = <action|command:Label>        bind a leader sequence
         #
         # chords: ctrl+ alt+ shift+ then a key — a-z, 0-9, f1-f12,
-        #         tab enter escape space up down left right.  e.g. ctrl+shift+g
+        #         tab enter escape space up down left right,
+        #         comma period slash semicolon quote backtick minus equals
+        #         lbracket rbracket backslash (US layout).  e.g. shift+comma, ctrl+shift+g
         #
         # run modes: send (default; types into the active session) | new (fresh session's
         #            shell runs it) | overlay (ephemeral pane over the session) | detached
@@ -208,7 +211,10 @@ internal static class Keymap
     {
         if (t.Length == 1 && char.IsLetterOrDigit(t[0])) return true;
         if (t.Length is 2 or 3 && t[0] == 'f' && int.TryParse(t[1..], out int n) && n is >= 1 and <= 12) return true;
-        return t is "tab" or "enter" or "escape" or "space" or "up" or "down" or "left" or "right";
+        return t is "tab" or "enter" or "escape" or "space" or "up" or "down" or "left" or "right"
+            // OEM punctuation (US layout), so symbol chords like shift+comma ('<') bind too.
+            or "comma" or "period" or "slash" or "semicolon" or "quote" or "backtick"
+            or "minus" or "equals" or "lbracket" or "rbracket" or "backslash";
     }
 
     /// <summary>Build the canonical chord for a live keypress, or null if the key isn't bindable.</summary>
@@ -228,6 +234,10 @@ internal static class Keymap
         {
             VK_TAB => "tab", VK_RETURN => "enter", VK_ESCAPE => "escape", VK_SPACE => "space",
             VK_UP => "up", VK_DOWN => "down", VK_LEFT => "left", VK_RIGHT => "right",
+            // OEM punctuation VKs (US layout names)
+            0xBA => "semicolon", 0xBB => "equals", 0xBC => "comma", 0xBD => "minus",
+            0xBE => "period", 0xBF => "slash", 0xC0 => "backtick",
+            0xDB => "lbracket", 0xDC => "backslash", 0xDD => "rbracket", 0xDE => "quote",
             _ => null,
         };
     }

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -2021,6 +2021,12 @@ internal partial class Program : ISessionHost, IWindowHost
                 // Committing the MRU walk happens when Ctrl is finally released (any key-up where Ctrl
                 // is no longer held is exactly the Ctrl-up event; a Tab-up with Ctrl still down is ignored).
                 if (_mruWalking && !KeyDown(VK_CONTROL)) { MruCommit(); return IntPtr.Zero; }
+                if (!KeyDown(VK_CONTROL)) ClearLinkHover();   // Ctrl released: drop the link underline/cursor
+                break;
+
+            case WM_SETCURSOR:
+                if (_linkUrl is not null && LoWord(lParam) == HTCLIENT)
+                { SetCursor(LoadCursorW(IntPtr.Zero, IDC_HAND)); return (IntPtr)1; }   // hand over a hovered link
                 break;
 
             case WM_CHAR:
@@ -2095,6 +2101,8 @@ internal partial class Program : ISessionHost, IWindowHost
                     int di = _cover is null ? DividerAtX(mx, my) : -1;
                     if (di >= 0) { _divDragging = true; _divLeft = di; SetCapture(hwnd); return IntPtr.Zero; }
                     if (_cover is null) FocusPaneAtX(mx); // covers capture the whole content region
+                    // Ctrl+click on a hovered link opens it (never starts a selection or reaches the app).
+                    if (KeyDown(VK_CONTROL) && _linkUrl is { } lurl) { OpenLink(lurl); return IntPtr.Zero; }
                     bool shiftDn = KeyDown(VK_SHIFT);
                     var em0 = _session?.Emulator;
                     if (em0 is not null && em0.MouseReporting && !shiftDn) { SendMousePx(0, lParam, true); SetCapture(hwnd); return IntPtr.Zero; }
@@ -2188,6 +2196,11 @@ internal partial class Program : ISessionHost, IWindowHost
                         TrackMouseEvent(ref tme); _mouseTracking = true;
                     }
                     if (!_divDragging && !_sbPress && !_selecting) UpdateChromeHover(LoWord(lParam), HiWord(lParam));
+                    if (!_divDragging && !_sbPress && !_selecting)
+                    {
+                        if (KeyDown(VK_CONTROL)) UpdateLinkHover(LoWord(lParam), HiWord(lParam));   // Ctrl+hover: link detection
+                        else ClearLinkHover();
+                    }
                     if (_divDragging && ((long)wParam & MK_LBUTTON) != 0) { DragDivider(LoWord(lParam)); return IntPtr.Zero; }
                     if (_sbPress && ((long)wParam & MK_LBUTTON) != 0)
                     {
@@ -2630,6 +2643,67 @@ internal partial class Program : ISessionHost, IWindowHost
             ? $"\x1b[<{btn};{col + 1};{row + 1}{(press ? 'M' : 'm')}"
             : "\x1b[M" + (char)(32 + (press ? btn : 3)) + (char)(33 + col) + (char)(33 + row);
         _session?.Write(Encoding.UTF8.GetBytes(seq));
+    }
+
+    // ---- Clickable links: Ctrl+hover underlines a URL (hand cursor); Ctrl+click opens it ----
+
+    private static readonly System.Text.RegularExpressions.Regex LinkRx = new(
+        @"https?://[^\s""'<>\[\]{}|\\^`]+", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    private string? _linkUrl;      // hovered link (null = none); drawn underlined in RenderTerminal
+    private Pane? _linkPane;
+    private int _linkLine, _linkC0, _linkC1;   // absolute line + column span
+
+    /// <summary>Trailing punctuation is almost never part of a URL pasted into terminal output.</summary>
+    private static string TrimLink(string s)
+    {
+        while (s.Length > 0 && s[^1] is '.' or ',' or ';' or ':' or '!' or '?' or ')' or '\'' or '"') s = s[..^1];
+        return s;
+    }
+
+    /// <summary>Refresh the Ctrl+hover link state for the mouse point; true when over a link.</summary>
+    private bool UpdateLinkHover(int mx, int my)
+    {
+        string? url = null; Pane? pane = null; int line = 0, c0 = 0, c1 = 0;
+        if (PaneAt(mx, my) is { } h)
+        {
+            var (ln, col) = CellAtPx(h.pane, h.ox, h.oy, h.cw, h.ch, mx, my);
+            var em = h.pane.S.Emulator;
+            var sb = new StringBuilder();
+            lock (h.pane.S.SyncRoot)
+            {
+                int cols = em.Screen.Cols, rows = em.Screen.Rows, hist = em.HistoryCount;
+                for (int c = 0; c < cols; c++)   // string index == screen column (wide-char spacers -> ' ')
+                {
+                    Cell cell = CellAbs(em, hist, rows, cols, ln, c);
+                    sb.Append(cell.Width == 0 || cell.Rune == '\0' ? ' ' : cell.Rune);
+                }
+            }
+            string row = sb.ToString();
+            foreach (System.Text.RegularExpressions.Match m in LinkRx.Matches(row))
+            {
+                int end = m.Index + TrimLink(m.Value).Length;
+                if (col >= m.Index && col < end)
+                { url = row[m.Index..end]; pane = h.pane; line = ln; c0 = m.Index; c1 = end - 1; break; }
+            }
+        }
+        if (url != _linkUrl || !ReferenceEquals(pane, _linkPane) || line != _linkLine || c0 != _linkC0)
+        { _linkUrl = url; _linkPane = pane; _linkLine = line; _linkC0 = c0; _linkC1 = c1; RequestRedraw(); }
+        return _linkUrl is not null;
+    }
+
+    private void ClearLinkHover()
+    {
+        if (_linkUrl is null) return;
+        _linkUrl = null; _linkPane = null; RequestRedraw();
+    }
+
+    /// <summary>Validated open: absolute http/https only, handed to the shell.</summary>
+    private void OpenLink(string url)
+    {
+        if (Uri.TryCreate(url, UriKind.Absolute, out var u) && u.Scheme is "http" or "https")
+            ShellExecuteW(IntPtr.Zero, "open", url, null, null, SW_SHOW);
+        else ShowToast("blocked non-http(s) link");
     }
 
     // ---- Text selection + clipboard ----
@@ -3458,6 +3532,13 @@ internal partial class Program : ISessionHost, IWindowHost
                                                        : new Color4(150 / 255f, 110 / 255f, 25 / 255f, 1f);
                         rt.FillRectangle(new Rect(ox + from * cw, y, (to - from + 1) * cw, ch), brush);
                     }
+                }
+                if (_linkUrl is not null && selPane is not null && ReferenceEquals(selPane, _linkPane) && abs == _linkLine)
+                {   // Ctrl+hovered link: accent underline under its column span
+                    brush.Color = ChromeAccent;
+                    float uy = y + ch - 1.5f;
+                    rt.DrawLine(new System.Numerics.Vector2(ox + _linkC0 * cw, uy),
+                                new System.Numerics.Vector2(ox + (_linkC1 + 1) * cw, uy), brush, 1.4f);
                 }
                 c = 0;
                 while (c < cols)  // Pass 2: coalesced same-colour text runs

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -1687,6 +1687,17 @@ internal partial class Program : ISessionHost, IWindowHost
 
         public void SidebarOp(string op) => Post(() => SidebarOpInternal(op));
 
+        public string SidebarState() => InvokeOnUi(() =>
+            (_sidebarW > 0 ? "visible" : "hidden") + " " + (_sidebarMode == SidebarMode.Flagged ? "flagged" : "tree"));
+
+        public bool SessionSeen(string? target)
+        {
+            var ses = FindSesForTarget(target);
+            if (ses is null) return false;
+            Post(() => { ClearUnread(ses); RequestRedraw(); });
+            return true;
+        }
+
         public string SessionCopy(string? target)
         {
             var s = Resolve(target);

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -2356,6 +2356,7 @@ internal partial class Program : ISessionHost, IWindowHost
             case "toggle_flagged_view": ToggleFlaggedView(); break;
             case "focus_workspace": WorkspaceFocusOp("toggle"); break;
             case "close_cover": CloseCover(); break;
+            case "toggle_fullscreen": ToggleFullscreen(); break;
             case "select_all": if (ActiveSurface() is { } sa) SelectAll(sa); break;
             case "copy_selection": if (ActiveSurface() is { } sc && sc.HasSel) CopySelection(sc); break;
             case "paste": if (ActiveSurface() is { } sp2) PasteInto(sp2); break;
@@ -4355,6 +4356,7 @@ internal partial class Program : ISessionHost, IWindowHost
                 A("New Session…", "", () => TogglePalette(PaletteKind.NewSession));   // pick a shell profile
                 A("New Workspace", "Ctrl+Shift+N", () => CreateWorkspace(Guid.NewGuid().ToString(), null));
                 A("New Window", "Ctrl+Alt+N", () => WindowNew(null));
+                A("Toggle Fullscreen", "F11", ToggleFullscreen);
                 A("Close Window", "", () => DestroyWindow(_hwnd));
                 A("Switch Window…", "", () => TogglePalette(PaletteKind.Windows));
                 A("Rename Active Session", "F2", () => { if (_active is not null) StartRename(_active); });
@@ -5472,6 +5474,8 @@ internal partial class Program : ISessionHost, IWindowHost
         // Wave D1: sidebar view mode ("tree"|"flagged") + focused workspace id (null = show all).
         public string SidebarMode { get; set; } = "tree";
         public string? FocusedWorkspaceId { get; set; }
+        // Ctrl+Tab MRU session order (most recent first); restored on relaunch.
+        public List<string> Mru { get; set; } = new();
     }
 
     private static readonly JsonSerializerOptions _stateJson = new() { WriteIndented = true };
@@ -5671,6 +5675,7 @@ internal partial class Program : ISessionHost, IWindowHost
                 SidebarVisible = _sidebarW > 0,
                 SidebarMode = _sidebarMode == SidebarMode.Flagged ? "flagged" : "tree",
                 FocusedWorkspaceId = _focusedWorkspaceId,
+                Mru = _mru.ToList(),   // Ctrl+Tab recency order survives relaunch
             };
             CaptureGeometry(st);
             foreach (var (id, name, expanded, sessions) in rows)
@@ -5721,6 +5726,35 @@ internal partial class Program : ISessionHost, IWindowHost
     private int _geoX, _geoY, _geoW, _geoH;
     private bool _geoMax;
     private bool _wasMaximized;
+
+    // ---- Fullscreen (F11 / toggle_fullscreen): borderless over the whole monitor ----
+    private bool _fullscreen;
+    private WINDOWPLACEMENT _fsPrev;
+
+    private void ToggleFullscreen()
+    {
+        long style = (long)GetWindowLongPtrW(_hwnd, GWL_STYLE);
+        if (!_fullscreen)
+        {
+            _fsPrev = new WINDOWPLACEMENT { length = System.Runtime.InteropServices.Marshal.SizeOf<WINDOWPLACEMENT>() };
+            GetWindowPlacement(_hwnd, ref _fsPrev);
+            var mi = new MONITORINFO { cbSize = System.Runtime.InteropServices.Marshal.SizeOf<MONITORINFO>() };
+            GetMonitorInfoW(MonitorFromWindow(_hwnd, MONITOR_DEFAULTTONEAREST), ref mi);
+            SetWindowLongPtrW(_hwnd, GWL_STYLE, (IntPtr)((style & ~(long)WS_OVERLAPPEDWINDOW) | WS_POPUP));
+            SetWindowPos(_hwnd, IntPtr.Zero, mi.rcMonitor.left, mi.rcMonitor.top,
+                mi.rcMonitor.right - mi.rcMonitor.left, mi.rcMonitor.bottom - mi.rcMonitor.top,
+                SWP_FRAMECHANGED | SWP_SHOWWINDOW | SWP_NOZORDER);
+            _fullscreen = true;
+        }
+        else
+        {
+            SetWindowLongPtrW(_hwnd, GWL_STYLE, (IntPtr)((style & ~(long)WS_POPUP) | WS_OVERLAPPEDWINDOW));
+            SetWindowPlacement(_hwnd, ref _fsPrev);
+            SetWindowPos(_hwnd, IntPtr.Zero, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
+            _fullscreen = false;
+        }
+        RequestRedraw();
+    }
 
     /// <summary>Fill AppState with the window's restore rect + maximized flag (GetWindowPlacement).</summary>
     private void CaptureGeometry(AppState st)
@@ -5828,6 +5862,7 @@ internal partial class Program : ISessionHost, IWindowHost
         // Restore sidebar mode + workspace focus (Wave D1). Focus that no longer resolves is dropped.
         _sidebarMode = string.Equals(st.SidebarMode, "flagged", StringComparison.OrdinalIgnoreCase) ? SidebarMode.Flagged : SidebarMode.Tree;
         _focusedWorkspaceId = st.FocusedWorkspaceId;
+        if (st.Mru is { Count: > 0 }) { _mru.Clear(); _mru.AddRange(st.Mru); } // EnsureMru prunes dead ids on first walk
         if (_focusedWorkspaceId is not null)
             lock (_workspaces) if (!_workspaces.Any(w => w.Id == _focusedWorkspaceId)) _focusedWorkspaceId = null;
 

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -1603,6 +1603,14 @@ internal partial class Program : ISessionHost, IWindowHost
             return true;
         }
 
+        public bool SessionRename(string? target, string name)
+        {
+            var ses = FindSesForTarget(target);
+            if (ses is null || string.IsNullOrWhiteSpace(name)) return false;
+            Post(() => { ses.Name = name; ses.CustomName = name; RequestRedraw(); SaveState(); }); // CustomName drives the title bar
+            return true;
+        }
+
         public bool WorkspaceRename(string? target, string name)
         {
             var ws = FindWs(target);

--- a/src/Agwinterm.Win32/Win32.cs
+++ b/src/Agwinterm.Win32/Win32.cs
@@ -231,7 +231,12 @@ internal static class Win32
     public struct MONITORINFO { public int cbSize; public RECT rcMonitor; public RECT rcWork; public uint dwFlags; }
 
     [DllImport("user32.dll")] public static extern IntPtr MonitorFromPoint(POINT pt, uint dwFlags);
+    [DllImport("user32.dll")] public static extern IntPtr MonitorFromWindow(IntPtr hwnd, uint dwFlags);
     [DllImport("user32.dll")] public static extern bool GetMonitorInfoW(IntPtr hMonitor, ref MONITORINFO lpmi);
+    [DllImport("user32.dll")] public static extern bool SetWindowPlacement(IntPtr hWnd, ref WINDOWPLACEMENT lpwndpl);
+
+    public const int GWL_STYLE = -16;
+    public const uint SWP_SHOWWINDOW = 0x0040;
 
     public const uint CS_HREDRAW = 0x0002, CS_VREDRAW = 0x0001;
     public const uint WS_OVERLAPPEDWINDOW = 0x00CF0000, WS_VISIBLE = 0x10000000;

--- a/src/Agwinterm.Win32/Win32.cs
+++ b/src/Agwinterm.Win32/Win32.cs
@@ -242,6 +242,10 @@ internal static class Win32
     public const uint WS_OVERLAPPEDWINDOW = 0x00CF0000, WS_VISIBLE = 0x10000000;
     public const int CW_USEDEFAULT = unchecked((int)0x80000000);
     public static readonly IntPtr IDC_ARROW = (IntPtr)32512;
+    public static readonly IntPtr IDC_HAND = (IntPtr)32649;
+    public const uint WM_SETCURSOR = 0x0020;
+
+    [DllImport("user32.dll")] public static extern IntPtr SetCursor(IntPtr hCursor);
     public static readonly IntPtr DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 = (IntPtr)(-4);
 
     [DllImport("user32.dll", SetLastError = true)]


### PR DESCRIPTION
**Gap-analysis item 5 of 6** (P2 — the most user-visible remaining gap; agterm [#126](https://github.com/umputun/agterm/pull/126) analog). Windows Terminal-style interaction.

> **Note: stacked on #9** (→ #8 → #7) — merge in order.

## Behavior

- **Ctrl+hover** over terminal text detects `http(s)://` URLs on the hovered row (regex with trailing-punctuation trimming: `https://x.com/a).` → `https://x.com/a`)
- Hovered link gets an **accent underline** under its exact column span + the **hand cursor**
- **Ctrl+click opens it** — validated (absolute http/https only; anything else toasts "blocked") via `ShellExecuteW`. The click is consumed: never starts a selection, never reaches a mouse-mode app
- Releasing Ctrl or moving off clears the state; plain hover/click behavior is completely unchanged

## Implementation notes

- Row text is built with string-index == screen-column (wide-char trailing spacers pad as spaces), so match spans map directly to cell columns
- Underline renders in `RenderTerminal` after the selection/search highlights; detection is one row-scan per mouse-move while Ctrl is held
- Works in history/scrollback (absolute line addressing) and in covers (quick/scratch/overlay) since it goes through `PaneAt`

## Not in scope (follow-ups)
Multi-row wrapped URLs, OSC 8 explicit hyperlinks, `file://` reveal (agterm #162 is still open on their side too).

## Verification
- ✅ Screenshot: Ctrl+hover over `https://example.com/test-link-target` draws the accent underline exactly under the URL span
- ✅ Underline clears on Ctrl release
- ✅ Build clean (click-open not auto-tested — it would pop a browser mid-session; the path is 3 lines of validated ShellExecute)

🤖 Generated with [Claude Code](https://claude.com/claude-code)