### PR TITLE
feat(win32): 'Update themes pack…' entry in the omp theme picker

### DIFF
--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -4551,6 +4551,11 @@ internal partial class Program : ISessionHost, IWindowHost
                     var p = pth; // applies live + persists so new sessions keep it
                     _palAll.Add(new PalItem { Label = nm, Search = nm, Data = p, Run = () => ApplyOmp(p, persist: true) });
                 }
+                // Our downloaded pack in use: offer a refresh (new omp releases add/update themes).
+                if (Directory.Exists(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "agwinterm", "omp-themes")))
+                    _palAll.Add(new PalItem { Label = "Update themes pack…",
+                        Secondary = "re-download the official themes from the latest oh-my-posh release",
+                        Search = "update refresh download themes pack", Run = DownloadOmpThemes });
                 break;
             }
             case PaletteKind.Starship:


### PR DESCRIPTION
Backlog item 1/3. When the agwinterm-downloaded themes pack is in use, the oh-my-posh theme picker gains a final **"Update themes pack…"** entry that re-downloads the official `themes.zip` from the latest release — same flow as the initial download, refreshes in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)