### PR TITLE
fix(profiles): WSL stub prompts seeded as fake distros

### DIFF
--- a/src/Agwinterm.Pty/ShellProfiles.cs
+++ b/src/Agwinterm.Pty/ShellProfiles.cs
@@ -85,6 +85,10 @@ public static class ShellProfiles
     private static Config Normalize(Config c)
     {
         c.Profiles.RemoveAll(p => string.IsNullOrWhiteSpace(p.Name) || string.IsNullOrWhiteSpace(p.Command));
+        // Repair earlier seeds that captured the wsl.exe stub's "install WSL?" message lines as
+        // distros (e.g. "WSL: Press any key to install …") — distro names never contain spaces.
+        c.Profiles.RemoveAll(p => p.Name.StartsWith("WSL: ", StringComparison.OrdinalIgnoreCase)
+                                  && p.Name["WSL: ".Length..].Contains(' '));
         if (c.Profiles.Count == 0) c.Profiles.Add(DefaultPowerShell());
         if (string.IsNullOrWhiteSpace(c.Default) ||
             !c.Profiles.Exists(p => p.Name.Equals(c.Default, StringComparison.OrdinalIgnoreCase)))
@@ -146,14 +150,18 @@ public static class ShellProfiles
             };
             using var p = Process.Start(psi);
             if (p is null) return result;
-            outp = p.StandardOutput.ReadToEnd();
-            p.WaitForExit(3000);
+            var read = p.StandardOutput.ReadToEndAsync();   // read async so a prompting stub can't deadlock us
+            if (!p.WaitForExit(3000)) { try { p.Kill(); } catch { } return result; }
+            // Without WSL installed, wsl.exe is a stub that prints "Press any key to install…"
+            // prompt lines and exits non-zero — those lines are NOT distros.
+            if (p.ExitCode != 0) return result;
+            outp = read.GetAwaiter().GetResult();
         }
         catch { return result; }
         foreach (var raw in outp.Split('\n'))
         {
             var d = raw.Trim().Trim('\0', '\r');
-            if (d.Length > 0) result.Add(d);
+            if (d.Length > 0 && !d.Contains(' ')) result.Add(d);   // real distro names never contain spaces
         }
         return result;
     }


### PR DESCRIPTION
Backlog item 2/3 — the bug behind the *"New Session — WSL: Press any key to install Windows Subsystem for Linux."* garbage in the pickers/context menu.

**Root cause:** without WSL installed, `wsl.exe` is a Store stub that prints install-prompt lines and exits non-zero; the distro enumeration treated every output line as a distro at first-run seed time.

**Fixes:**
- exit-code check (stub exits non-zero) + async stdout read (a prompting stub can't deadlock the wait) + drop lines with spaces (distro names never have them)
- `Normalize` repairs **existing** polluted `profiles.json` files on every load — no manual cleanup needed

**Verified live:** the 4 stub entries in the real profiles.json disappeared from `profiles list`; real shells (PS5/PS7/cmd/Git Bash) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)