### PR TITLE
feat(core): astral-plane glyphs — emoji & nerd-font icons render (no more �)

### DIFF
--- a/src/Agwinterm.Core/Cell.cs
+++ b/src/Agwinterm.Core/Cell.cs
@@ -1,11 +1,12 @@
 namespace Agwinterm.Core;
 
 /// <summary>
-/// A single grid cell. <see cref="Width"/> is 1 for normal cells, 2 for the leading
-/// cell of a double-width (CJK) glyph, and 0 for the trailing spacer that follows it.
+/// A single grid cell. <see cref="Rune"/> is a full Unicode codepoint (astral glyphs — emoji,
+/// nerd-font plane-15/16 icons — fit in one cell). <see cref="Width"/> is 1 for normal cells,
+/// 2 for the leading cell of a double-width (CJK/emoji) glyph, and 0 for the trailing spacer.
 /// </summary>
 public readonly record struct Cell(
-    char Rune, Color Foreground, Color Background, CellAttributes Attributes, byte Width = 1,
+    int Rune, Color Foreground, Color Background, CellAttributes Attributes, byte Width = 1,
     ColorSpec FgSpec = default, ColorSpec BgSpec = default)
 {
     public static Cell Empty => new(' ', Color.DefaultForeground, Color.DefaultBackground, CellAttributes.None);

--- a/src/Agwinterm.Core/TerminalEmulator.cs
+++ b/src/Agwinterm.Core/TerminalEmulator.cs
@@ -109,9 +109,25 @@ public sealed class TerminalEmulator : IParserPerformer
         if (CursorCol >= cols) CursorCol = cols - 1;
     }
 
+    private char _pendingHighSurrogate;
+
     public void Print(char ch)
     {
-        int w = Wcwidth.Of(ch);
+        // Astral codepoints arrive as a surrogate pair (two Print calls); re-pair into one cell.
+        if (char.IsHighSurrogate(ch)) { _pendingHighSurrogate = ch; return; }
+        if (char.IsLowSurrogate(ch))
+        {
+            if (_pendingHighSurrogate != '\0') PrintScalar(char.ConvertToUtf32(_pendingHighSurrogate, ch));
+            _pendingHighSurrogate = '\0';
+            return;
+        }
+        _pendingHighSurrogate = '\0';
+        PrintScalar(ch);
+    }
+
+    private void PrintScalar(int cp)
+    {
+        int w = Wcwidth.Of(cp);
         if (w == 0) return; // combining/zero-width: dropped in v1 (see spec non-goals)
 
         if (CursorCol >= Screen.Cols)
@@ -127,7 +143,7 @@ public sealed class TerminalEmulator : IParserPerformer
             Index();
         }
 
-        Screen[CursorRow, CursorCol] = new Cell(ch, _fg, _bg, _attrs, (byte)w, _fgSpec, _bgSpec);
+        Screen[CursorRow, CursorCol] = new Cell(cp, _fg, _bg, _attrs, (byte)w, _fgSpec, _bgSpec);
         if (w == 2)
             Screen[CursorRow, CursorCol + 1] = new Cell('\0', _fg, _bg, _attrs, 0, _fgSpec, _bgSpec); // trailing spacer
         CursorCol += w;
@@ -584,7 +600,8 @@ public sealed class TerminalEmulator : IParserPerformer
         {
             Cell cell = Screen[row, c];
             if (cell.Width == 0) continue; // trailing spacer of a wide glyph
-            sb.Append(cell.Rune);
+            if (cell.Rune > 0xFFFF) sb.Append(char.ConvertFromUtf32(cell.Rune));
+            else sb.Append((char)cell.Rune);
         }
         return sb.ToString().TrimEnd();
     }

--- a/src/Agwinterm.Core/VtParser.cs
+++ b/src/Agwinterm.Core/VtParser.cs
@@ -139,11 +139,21 @@ public sealed class VtParser(IParserPerformer performer)
 
     private void EmitScalar(int scalar)
     {
-        // v1 limitation: BMP only. Astral codepoints and surrogates -> replacement.
-        if (scalar is >= 0xD800 and <= 0xDFFF or > 0xFFFF)
+        // Raw surrogates / out-of-range -> replacement.
+        if (scalar is >= 0xD800 and <= 0xDFFF or > 0x10FFFF or < 0)
+        {
             performer.Print(Replacement);
-        else
-            performer.Print((char)scalar);
+            return;
+        }
+        if (scalar > 0xFFFF)
+        {
+            // Astral (emoji, nerd-font plane-15/16 icons): hand the performer the surrogate pair;
+            // the emulator re-pairs it into a single cell.
+            performer.Print((char)(0xD800 + ((scalar - 0x10000) >> 10)));
+            performer.Print((char)(0xDC00 + ((scalar - 0x10000) & 0x3FF)));
+            return;
+        }
+        performer.Print((char)scalar);
     }
 
     private void FlushIncompleteUtf8()

--- a/src/Agwinterm.Core/Wcwidth.cs
+++ b/src/Agwinterm.Core/Wcwidth.cs
@@ -43,6 +43,12 @@ public static class Wcwidth
     public static int Of(int codepoint)
     {
         if (codepoint == 0) return 0;
+        if (codepoint > 0xFFFF)   // astral: emoji/CJK extensions are wide; plane-15/16 PUA (nerd-font icons) are single
+        {
+            if (codepoint is >= 0x1F300 and <= 0x1FAFF) return 2;   // emoji & pictographs
+            if (codepoint is >= 0x20000 and <= 0x3FFFD) return 2;   // CJK Extensions B..H
+            return 1;
+        }
         if (InRanges(codepoint, ZeroWidth)) return 0;
         if (InRanges(codepoint, Wide)) return 2;
         return 1;

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -2697,10 +2697,10 @@ internal partial class Program : ISessionHost, IWindowHost
             lock (h.pane.S.SyncRoot)
             {
                 int cols = em.Screen.Cols, rows = em.Screen.Rows, hist = em.HistoryCount;
-                for (int c = 0; c < cols; c++)   // string index == screen column (wide-char spacers -> ' ')
+                for (int c = 0; c < cols; c++)   // string index == screen column (spacers/astral -> ' '; URLs are ASCII)
                 {
                     Cell cell = CellAbs(em, hist, rows, cols, ln, c);
-                    sb.Append(cell.Width == 0 || cell.Rune == '\0' ? ' ' : cell.Rune);
+                    sb.Append(cell.Width == 0 || cell.Rune == '\0' || cell.Rune > 0xFFFF ? ' ' : (char)cell.Rune);
                 }
             }
             string row = sb.ToString();
@@ -2812,7 +2812,8 @@ internal partial class Program : ISessionHost, IWindowHost
                 {
                     Cell cell = CellAbs(em, hist, rows, cols, line, c);
                     if (cell.Width == 0) continue; // trailing spacer of a wide glyph
-                    row.Append(cell.Rune == '\0' ? ' ' : cell.Rune);
+                    if (cell.Rune > 0xFFFF) row.Append(char.ConvertFromUtf32(cell.Rune));   // full fidelity for copy
+                    else row.Append(cell.Rune == '\0' ? ' ' : (char)cell.Rune);
                 }
                 sb.Append(row.ToString().TrimEnd(' '));
                 if (line != l1) sb.Append("\r\n");
@@ -2838,7 +2839,7 @@ internal partial class Program : ISessionHost, IWindowHost
         lock (p.S.SyncRoot)
         {
             int cols = em.Screen.Cols, rows = em.Screen.Rows, hist = em.HistoryCount;
-            bool Word(int c) { char ch = CellAbs(em, hist, rows, cols, line, c).Rune; return ch != ' ' && ch != '\0'; }
+            bool Word(int c) { int ch = CellAbs(em, hist, rows, cols, line, c).Rune; return ch != ' ' && ch != '\0'; }
             if (col < 0 || col >= cols || !Word(col)) return;
             int a = col, b = col;
             while (a > 0 && Word(a - 1)) a--;
@@ -2944,7 +2945,8 @@ internal partial class Program : ISessionHost, IWindowHost
                 for (int c = 0; c < cols; c++)
                 {
                     Cell cell = CellAbs(em, hist, rows, cols, line, c);
-                    sb.Append(cell.Rune == '\0' ? ' ' : cell.Rune);
+                    // astral -> one replacement char so string index keeps matching the column
+                    sb.Append(cell.Rune == '\0' ? ' ' : cell.Rune > 0xFFFF ? '�' : (char)cell.Rune);
                 }
                 string text = sb.ToString().ToLowerInvariant();
                 int idx = 0;
@@ -3570,11 +3572,13 @@ internal partial class Program : ISessionHost, IWindowHost
                     Cell cell = CellAt(r, c);
                     if (cell.Width == 0 || cell.Rune == ' ' || cell.Rune == '\0') { c++; continue; }
                     Color runFg = EffectiveFg(cell);
-                    if (cell.Width == 2)
+                    if (cell.Width == 2 || cell.Rune > 0xFFFF)
                     {
+                        // Wide and astral glyphs draw individually: runs assume string index ==
+                        // column, and an astral codepoint is two UTF-16 units in one column.
                         brush.Color = C4(runFg);
                         float wx = ox + c * cw;
-                        rt.DrawText(cell.Rune.ToString(), fmt, new Rect(wx, y, wx + 2 * cw, y + ch), brush);
+                        rt.DrawText(RuneStr(cell.Rune), fmt, new Rect(wx, y, wx + cell.Width * cw, y + ch), brush);
                         c++;
                         continue;
                     }
@@ -3584,10 +3588,10 @@ internal partial class Program : ISessionHost, IWindowHost
                     while (c < cols)
                     {
                         Cell cc = CellAt(r, c);
-                        if (cc.Width == 2 || cc.Width == 0) break;
+                        if (cc.Width == 2 || cc.Width == 0 || cc.Rune > 0xFFFF) break;
                         bool blank = cc.Rune == ' ' || cc.Rune == '\0';
                         if (!blank && EffectiveFg(cc) != runFg) break;
-                        _run.Append(blank ? ' ' : cc.Rune);
+                        _run.Append(blank ? ' ' : (char)cc.Rune);
                         c++;
                         if (!blank) lastNonBlank = _run.Length;
                     }
@@ -4863,6 +4867,9 @@ internal partial class Program : ISessionHost, IWindowHost
         PalBorder = Mix(PalBg, fg, dark ? 0.28f : 0.30f);
         PalSel = Mix(PalBg, accent, dark ? 0.45f : 0.32f);
     }
+
+    /// <summary>A cell codepoint as a drawable string (astral -> surrogate pair).</summary>
+    private static string RuneStr(int cp) => cp > 0xFFFF ? char.ConvertFromUtf32(cp) : ((char)cp).ToString();
 
     private int ClientW() { GetClientRect(_hwnd, out RECT rc); return rc.right - rc.left; }
     private int ClientH() { GetClientRect(_hwnd, out RECT rc); return rc.bottom - rc.top; }

--- a/tests/Agwinterm.Core.Tests/ScrollbackTests.cs
+++ b/tests/Agwinterm.Core.Tests/ScrollbackTests.cs
@@ -10,7 +10,7 @@ public class ScrollbackTests
     private static string HistoryRow(TerminalEmulator t, int row, int cols)
     {
         var sb = new StringBuilder();
-        for (int c = 0; c < cols; c++) sb.Append(t.GetHistoryCell(row, c).Rune);
+        for (int c = 0; c < cols; c++) sb.Append((char)t.GetHistoryCell(row, c).Rune);
         return sb.ToString().TrimEnd();
     }
 

--- a/tests/Agwinterm.Core.Tests/VtParserTests.cs
+++ b/tests/Agwinterm.Core.Tests/VtParserTests.cs
@@ -89,10 +89,11 @@ public class VtParserTests
     }
 
     [Fact]
-    public void AstralCodepoint_BecomesReplacement()
+    public void AstralCodepoint_EmitsSurrogatePair()
     {
-        // U+1F600 😀 = 0xF0 0x9F 0x98 0x80 -> outside BMP -> U+FFFD (v1 BMP-only limitation)
-        Assert.Equal(new[] { "print:�" }, RunBytes(0xF0, 0x9F, 0x98, 0x80));
+        // U+1F600 😀 = 0xF0 0x9F 0x98 0x80 -> the performer receives the surrogate pair
+        // (the emulator re-pairs it into a single cell).
+        Assert.Equal(new[] { "print:\uD83D", "print:\uDE00" }, RunBytes(0xF0, 0x9F, 0x98, 0x80));
     }
 
     [Fact]

--- a/tests/Agwinterm.Core.Tests/WideCharTests.cs
+++ b/tests/Agwinterm.Core.Tests/WideCharTests.cs
@@ -50,6 +50,28 @@ public class WideCharTests
     }
 
     [Fact]
+    public void AstralEmoji_OneWideCellPlusSpacer()
+    {
+        var t = Feed(10, 2, "😀x");                 // U+1F600: wide (2 cols) + trailing spacer
+        Assert.Equal(0x1F600, t.Screen[0, 0].Rune); // full codepoint in ONE cell
+        Assert.Equal(2, t.Screen[0, 0].Width);
+        Assert.Equal(0, t.Screen[0, 1].Width);      // spacer
+        Assert.Equal('x', t.Screen[0, 2].Rune);
+        Assert.Equal(3, t.CursorCol);
+        Assert.Equal("😀x", t.DumpRow(0).TrimEnd());
+    }
+
+    [Fact]
+    public void AstralNerdFontIcon_SingleCell()
+    {
+        var t = Feed(10, 2, "\U000F0CB2x");         // plane-15 PUA (nf-md icon): single-width
+        Assert.Equal(0xF0CB2, t.Screen[0, 0].Rune);
+        Assert.Equal(1, t.Screen[0, 0].Width);
+        Assert.Equal('x', t.Screen[0, 1].Rune);
+        Assert.Equal(2, t.CursorCol);
+    }
+
+    [Fact]
     public void WideChar_AtRightEdge_WrapsToNextLine()
     {
         // 3 cols: "ab" fills the first two; the wide char can't fit the last column -> wraps.


### PR DESCRIPTION
Backlog item 3/3 — removes the VT engine's documented "v1 BMP-only" limitation that turned nerd-font `nf-md-*` icons (plane-15 PUA) and emoji into `�`.

## Design

- **`Cell.Rune`: `char` → `int`** — a full codepoint lives in one cell (grid semantics unchanged: wide glyphs keep their trailing spacer)
- **Parser → emulator**: astral scalars emit their surrogate pair; the emulator re-pairs consecutive surrogates into a single `PrintScalar(int)`
- **Widths**: emoji/pictographs (U+1F300–1FAFF) and CJK Ext B–H are wide (2 cols); plane-15/16 PUA (nerd-font icons) are single — matching how nerd mono fonts actually advance
- **Renderer**: the coalesced-run fast path relies on *string index == column*, so astral glyphs draw individually (same path wide CJK already used) — zero cost to the common case
- **Copy fidelity**: selection/`DumpRow` emit real surrogate pairs; search/link-hover row builders substitute one placeholder to preserve column mapping

## Verification
- ✅ 110/110 tests (2 new: astral emoji = wide cell + spacer at the right columns; nf icon = single cell)
- ✅ Parser test updated from asserting the old limitation to asserting the pair
- ✅ **Screenshot**: starship gruvbox-rainbow — previously `� boris ~ …` — now renders every glyph (OS logo, clock icon, chevrons), zero `�`

🤖 Generated with [Claude Code](https://claude.com/claude-code)