### PR TITLE
feat(win32): Ctrl+wheel font zoom

### DIFF
--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -2264,6 +2264,12 @@ internal partial class Program : ISessionHost, IWindowHost
                     if (_setOpen) { SettingsWheel(HiWord(wParam) > 0 ? 1 : -1); return IntPtr.Zero; }
                     var pt = new POINT { x = LoWord(lParam), y = HiWord(lParam) }; // wheel gives screen coords
                     ScreenToClient(_hwnd, ref pt);
+                    // Ctrl+wheel: font zoom (Windows-wide convention), on the active surface.
+                    if (KeyDown(VK_CONTROL) && pt.x >= (int)_sidebarW && pt.y >= (int)TitleBarH)
+                    {
+                        ChangeFontSize(HiWord(wParam) > 0 ? 1 : -1);
+                        return IntPtr.Zero;
+                    }
                     var em = _session?.Emulator;
                     if (em is not null && em.MouseReporting) // app wants the wheel (forward to the active pane)
                     {


### PR DESCRIPTION
**WT-1 of 6** (triaged backlog). Ctrl+wheel over the terminal zooms the active surface's font — routes to the existing `ChangeFontSize` per-pane zoom (Ctrl+/-/0). Plain wheel and VT mouse-mode forwarding unchanged. Verified live: 3 Ctrl+wheel-up notches visibly enlarged the prompt (screenshot in session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)