### PR TITLE
feat(win32): drag & drop file paths onto the terminal

### DIFF
--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -411,6 +411,8 @@ internal partial class Program : ISessionHost, IWindowHost
         }
         catch { /* icon is cosmetic; ignore load failures */ }
 
+        DragAcceptFiles(_hwnd, true);   // drop files/folders onto a pane -> quoted paths pasted
+
         CreateRenderTarget();
         StartSession();
 
@@ -1966,6 +1968,35 @@ internal partial class Program : ISessionHost, IWindowHost
                 SetTextColor(wParam, RGB(255, 255, 255));
                 SetBkColor(wParam, RGB(41, 51, 64));
                 return _editBrush;
+
+            case WM_DROPFILES:
+                {
+                    // Files/folders dropped onto the window: paste their quoted paths (space-joined)
+                    // into the pane under the drop point — via PasteTextInto, so bracketed paste
+                    // applies and the text can't auto-execute.
+                    IntPtr hDrop = wParam;
+                    try
+                    {
+                        DragQueryPoint(hDrop, out POINT dp);
+                        uint n = DragQueryFileW(hDrop, 0xFFFFFFFF, null, 0);
+                        var paths = new List<string>();
+                        for (uint i = 0; i < n; i++)
+                        {
+                            uint len = DragQueryFileW(hDrop, i, null, 0);
+                            if (len == 0) continue;
+                            var sb = new StringBuilder((int)len + 1);
+                            if (DragQueryFileW(hDrop, i, sb, len + 1) > 0) paths.Add(sb.ToString());
+                        }
+                        if (paths.Count > 0)
+                        {
+                            string text = string.Join(" ", paths.Select(p => p.IndexOfAny(new[] { ' ', '\'', '(', ')', '&', ';' }) >= 0 ? "\"" + p + "\"" : p));
+                            var target = PaneAt(dp.x, dp.y)?.pane ?? ActiveSurface();
+                            if (target is not null) PasteTextInto(target, text);
+                        }
+                    }
+                    finally { DragFinish(hDrop); }
+                    return IntPtr.Zero;
+                }
 
             case WM_CONTEXTMENU:
                 {

--- a/src/Agwinterm.Win32/Win32.cs
+++ b/src/Agwinterm.Win32/Win32.cs
@@ -219,6 +219,16 @@ internal static class Win32
         public byte rgbReserved28; public byte rgbReserved29; public byte rgbReserved30; public byte rgbReserved31;
     }
 
+    // ---- Drag & drop: file paths onto the terminal ----
+    public const uint WM_DROPFILES = 0x0233;
+    public const int WS_EX_ACCEPTFILES = 0x00000010;
+
+    [DllImport("shell32.dll")] public static extern void DragAcceptFiles(IntPtr hWnd, bool fAccept);
+    [DllImport("shell32.dll", CharSet = CharSet.Unicode)]
+    public static extern uint DragQueryFileW(IntPtr hDrop, uint iFile, System.Text.StringBuilder? lpszFile, uint cch);
+    [DllImport("shell32.dll")] public static extern bool DragQueryPoint(IntPtr hDrop, out POINT lppt);
+    [DllImport("shell32.dll")] public static extern void DragFinish(IntPtr hDrop);
+
     // ---- Popup menu window (a real top-level HWND for the themed context menu) ----
     public const uint WS_EX_TOPMOST = 0x00000008, WS_EX_TOOLWINDOW = 0x00000080, WS_EX_NOACTIVATE = 0x08000000;
     public const uint CS_DROPSHADOW = 0x00020000;


### PR DESCRIPTION
**WT-3 of 6** (triaged backlog; also closes the agterm-list drag-drop item).

Drop files/folders onto any pane → their paths paste at the drop point, **quoted** when containing spaces/shell-specials and space-joined for multiple files. Routed through `PasteTextInto`, so **bracketed paste** applies — dropped text can't auto-execute (the exact injection class agterm patched in #96/#102). Works over covers (quick/scratch/overlay) too.

Verification: `WS_EX_ACCEPTFILES` confirmed set on the live window; the handler is a thin shell around the already-verified paste path. **One manual drag-drop recommended at review time** — real HDROPs can't be synthesized cross-process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)