### PR TITLE
feat(win32): broadcast input to all sessions in the workspace

### DIFF
--- a/src/Agwinterm.Ctl/Program.cs
+++ b/src/Agwinterm.Ctl/Program.cs
@@ -243,6 +243,10 @@ switch (area)
         cmd = "quick";
         cargs["op"] = sub.Length > 0 ? sub : "toggle"; // on|off|toggle; the window's throwaway shell
         break;
+    case "broadcast": // agwintermctl broadcast [on|off|toggle|state] — typing fans out to the whole workspace
+        cmd = "broadcast";
+        cargs["op"] = sub.Length > 0 ? sub : "toggle";
+        break;
     case "notify": // agwintermctl notify <body...> [--title T] [--target ID]
         cmd = "notify";
         target = DefaultTarget();

--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -145,6 +145,7 @@ public sealed class ControlServer : IDisposable
                         ? Ok("moved") : Err("not found");
                 case "session.rename": return host.SessionRename(target, GetString(args, "name") ?? "") ? Ok("renamed") : Err("session not found / blank name");
                 case "session.seen": return host.SessionSeen(target) ? Ok("seen") : Err("session not found");
+                case "broadcast": return Ok(host.BroadcastOp(GetString(args, "op") ?? "toggle"));
                 case "workspace.rename": return host.WorkspaceRename(target, GetString(args, "name") ?? "") ? Ok("renamed") : Err("workspace not found");
                 case "workspace.delete": return host.WorkspaceDelete(target) ? Ok("deleted") : Err("workspace not found");
                 case "workspace.select": return host.WorkspaceSelect(target) ? Ok("selected") : Err("workspace not found");

--- a/src/Agwinterm.Pty/ISessionHost.cs
+++ b/src/Agwinterm.Pty/ISessionHost.cs
@@ -62,6 +62,9 @@ public interface ISessionHost
     /// <summary>Sidebar state read-back: "visible tree" | "hidden flagged" | ….</summary>
     string SidebarState();
 
+    /// <summary>Broadcast-input toggle for the frontmost window: op = on|off|toggle|state. Returns "on"/"off".</summary>
+    string BroadcastOp(string op);
+
     bool WorkspaceRename(string? target, string name);
     bool WorkspaceDelete(string? target);
     bool WorkspaceSelect(string? target);
@@ -188,6 +191,7 @@ public sealed class SingleSessionHost : ISessionHost
     public bool SessionRename(string? target, string name) => false;
     public bool SessionSeen(string? target) => false;
     public string SidebarState() => "visible tree";
+    public string BroadcastOp(string op) => "off";
     public bool WorkspaceRename(string? target, string name) => false;
     public bool WorkspaceDelete(string? target) => false;
     public bool WorkspaceSelect(string? target) => false;

--- a/src/Agwinterm.Win32/Keymap.cs
+++ b/src/Agwinterm.Win32/Keymap.cs
@@ -51,7 +51,7 @@ internal static class Keymap
         "focus_left_pane", "focus_right_pane", "next_session", "previous_session",
         "toggle_sidebar", "rename_session", "delete_workspace", "session_palette", "action_palette",
         "attention_list", "custom_palette", "next_attention", "previous_attention", "reload_keymap",
-        "toggle_search", "toggle_scratch", "quick_terminal", "close_cover", "toggle_fullscreen",
+        "toggle_search", "toggle_scratch", "quick_terminal", "close_cover", "toggle_fullscreen", "toggle_broadcast",
         "toggle_flag", "toggle_flagged_view", "focus_workspace",
         "select_all", "copy_selection", "paste",
         "new_window", "close_window", "switch_window",

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -1713,6 +1713,13 @@ internal partial class Program : ISessionHost, IWindowHost
         public string SidebarState() => InvokeOnUi(() =>
             (_sidebarW > 0 ? "visible" : "hidden") + " " + (_sidebarMode == SidebarMode.Flagged ? "flagged" : "tree"));
 
+        public string BroadcastOp(string op) => InvokeOnUi(() =>
+        {
+            bool want = op switch { "on" => true, "off" => false, "state" or "get" => _broadcast, _ => !_broadcast };
+            if (op is not ("state" or "get") && want != _broadcast) ToggleBroadcast();
+            return _broadcast ? "on" : "off";
+        });
+
         public bool SessionSeen(string? target)
         {
             var ses = FindSesForTarget(target);
@@ -2328,10 +2335,29 @@ internal partial class Program : ISessionHost, IWindowHost
         return DefWindowProcW(hwnd, msg, wParam, lParam);
     }
 
+    // ---- Broadcast input (WT's toggleBroadcastInput analog): keyboard input mirrors to every
+    // pane of every session in the ACTIVE WORKSPACE. Paste stays targeted (safety). ----
+    private bool _broadcast;
+
+    private void ToggleBroadcast()
+    {
+        _broadcast = !_broadcast;
+        ShowToast(_broadcast ? "broadcast ON — typing goes to ALL sessions in this workspace" : "broadcast off");
+        RequestRedraw();
+    }
+
     private void Send(string s)
     {
         var surf = ActiveSurface();
         if (surf is not null) { surf.ScrollOffset = 0; surf.ClearSel(); } // typing snaps to bottom, clears selection
+        if (_broadcast && _cover is null && _active is not null)
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(s);
+            List<Pane> panes;
+            lock (_workspaces) panes = _active.Ws.Sessions.SelectMany(x => x.Panes).ToList();
+            foreach (var p in panes) { p.S.NotifyActivity(); p.S.Write(bytes); }
+            return;
+        }
         _session?.NotifyActivity();
         _session?.Write(Encoding.UTF8.GetBytes(s));
     }
@@ -2394,6 +2420,7 @@ internal partial class Program : ISessionHost, IWindowHost
             case "focus_workspace": WorkspaceFocusOp("toggle"); break;
             case "close_cover": CloseCover(); break;
             case "toggle_fullscreen": ToggleFullscreen(); break;
+            case "toggle_broadcast": ToggleBroadcast(); break;
             case "select_all": if (ActiveSurface() is { } sa) SelectAll(sa); break;
             case "copy_selection": if (ActiveSurface() is { } sc && sc.HasSel) CopySelection(sc); break;
             case "paste": if (ActiveSurface() is { } sp2) PasteInto(sp2); break;
@@ -4473,6 +4500,7 @@ internal partial class Program : ISessionHost, IWindowHost
                 A("New Workspace", "Ctrl+Shift+N", () => CreateWorkspace(Guid.NewGuid().ToString(), null));
                 A("New Window", "Ctrl+Alt+N", () => WindowNew(null));
                 A("Toggle Fullscreen", "F11", ToggleFullscreen);
+                A("Toggle Broadcast Input", "", ToggleBroadcast);   // typing fans out to the whole workspace
                 A("Close Window", "", () => DestroyWindow(_hwnd));
                 A("Switch Window…", "", () => TogglePalette(PaletteKind.Windows));
                 A("Rename Active Session", "F2", () => { if (_active is not null) StartRename(_active); });
@@ -5215,6 +5243,15 @@ internal partial class Program : ISessionHost, IWindowHost
         float titleW = MathF.Max(30f, MathF.Min(titleMeasured, titleAvail));
         brush.Color = ChromeText;
         rt.DrawText(title, _uiTitle, new Rect(titleX, 0f, titleW, TitleBarH), brush);  // one vertically-centered, ellipsized row
+        if (_broadcast)   // persistent danger pill: typing fans out to the whole workspace
+        {
+            float bx0 = titleX + titleW + 10f;
+            float bw0 = MeasureText("BROADCAST", _uiSmall) + 14f;
+            brush.Color = new Color4(0.85f, 0.25f, 0.25f, 0.95f);
+            rt.FillRoundedRectangle(new RoundedRectangle { Rect = new Rect(bx0, (TitleBarH - 20f) / 2f, bw0, 20f), RadiusX = 5f, RadiusY = 5f }, brush);
+            brush.Color = new Color4(1f, 1f, 1f, 1f);
+            rt.DrawText("BROADCAST", _uiSmall, new Rect(bx0 + 7f, (TitleBarH - 20f) / 2f + 2f, bw0, 16f), brush);
+        }
 
         // dim = nothing, plain = active/completed, blocked-color = any blocked (uses the configured status color).
         if (showBell)


### PR DESCRIPTION
**WT-4 of 6** (triaged backlog) — WT's `toggleBroadcastInput`, adapted to the sidebar model: broadcast scope is the **active workspace** (our tab-analog).

- While armed, typing fans out to **every pane of every session in the workspace**; paste stays targeted (safety); covers excluded
- **Red BROADCAST pill** in the title bar as a persistent danger indicator
- `toggle_broadcast` keymap action + action-palette entry
- **`agwintermctl broadcast on|off|toggle|state`** — orchestrators can arm it, then a single `session.type` to one pane… or plain typing drives the whole fleet

## Verification
- ✅ Two fresh sessions + broadcast on → one typed command (real `WM_CHAR` input path) appeared in **both** buffers
- ✅ `broadcast state` read-back; off restores single-target input
- ✅ Solution builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)