### PR TITLE
feat: taskbar progress via OSC 9;4

### DIFF
--- a/src/Agwinterm.Core/TerminalEmulator.cs
+++ b/src/Agwinterm.Core/TerminalEmulator.cs
@@ -379,6 +379,11 @@ public sealed class TerminalEmulator : IParserPerformer
     /// (title, body). Fires on the feed/pump thread — consumers must marshal to their UI thread.</summary>
     public event Action<string, string>? Notified;
 
+    /// <summary>Raised for OSC 9;4 progress reports (ConEmu/Windows Terminal convention):
+    /// (state, value) where state = 0 clear | 1 normal | 2 error | 3 indeterminate | 4 paused,
+    /// value = 0–100 for state 1/2/4. Fires on the feed/pump thread.</summary>
+    public event Action<int, int>? Progress;
+
     /// <summary>Strip C0/C1 control characters (and DEL) from an OSC payload. OSC strings feed the
     /// window title, the tracked cwd (later expanded into custom-command text), and notification
     /// toasts — embedded control bytes there are a terminal/shell-injection vector, so they are
@@ -407,7 +412,17 @@ public sealed class TerminalEmulator : IParserPerformer
             case 7:
                 Cwd = text;
                 break;
-            case 9: // OSC 9 ; <message>  — body-only desktop notification
+            case 9: // OSC 9 ; <message> — body-only desktop notification; OSC 9;4 = ConEmu/WT progress
+                if (text.StartsWith("4;", StringComparison.Ordinal))
+                {
+                    // 9;4;<state>;<value> — state: 0 clear, 1 normal (value 0-100), 2 error,
+                    // 3 indeterminate, 4 paused. Progress, not a notification.
+                    var pp = text.Split(';');
+                    int pState = pp.Length > 1 && int.TryParse(pp[1], out int s9) ? s9 : 0;
+                    int pValue = pp.Length > 2 && int.TryParse(pp[2], out int v9) ? Math.Clamp(v9, 0, 100) : 0;
+                    Progress?.Invoke(pState, pValue);
+                    break;
+                }
                 Notified?.Invoke("", text);
                 break;
             case 777: // OSC 777 ; notify ; <title> ; <body>

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -635,6 +635,7 @@ internal partial class Program : ISessionHost, IWindowHost
         // An explicit --sound on session.status: play its spec (null => default alert).
         session.SoundRequested += PlayStatusSound;
         session.Emulator.Notified += (title, body) => Post(() => OnNotified(pane, title, body));
+        session.Emulator.Progress += (st, val) => Post(() => OnProgress(st, val));   // OSC 9;4 -> taskbar
         var env = new Dictionary<string, string>
         {
             ["AGWINTERM"] = "1",
@@ -5179,6 +5180,27 @@ internal partial class Program : ISessionHost, IWindowHost
     }
 
     private static void ClearUnread(Ses s) { foreach (var p in s.Panes) p.Unread = 0; if (s.Scratch is not null) s.Scratch.Unread = 0; if (s.Overlay is not null) s.Overlay.Unread = 0; }
+
+    // ---- Taskbar progress (OSC 9;4, ConEmu/Windows Terminal convention) ----
+    // Last-writer-wins across sessions: the most recent report drives the window's taskbar icon.
+    private ITaskbarList3? _taskbar;
+
+    private void OnProgress(int state, int value)
+    {
+        try
+        {
+            if (_taskbar is null)
+            {
+                _taskbar = (ITaskbarList3)new TaskbarListCom();
+                _taskbar.HrInit();
+            }
+            int flags = state switch { 1 => TBPF_NORMAL, 2 => TBPF_ERROR, 3 => TBPF_INDETERMINATE, 4 => TBPF_PAUSED, _ => TBPF_NOPROGRESS };
+            _taskbar.SetProgressState(_hwnd, flags);
+            if (flags is TBPF_NORMAL or TBPF_ERROR or TBPF_PAUSED)
+                _taskbar.SetProgressValue(_hwnd, (ulong)value, 100);
+        }
+        catch { /* taskbar progress is cosmetic */ }
+    }
 
     /// <summary>Show an OS desktop notification via a Shell_NotifyIcon tray balloon (no AUMID/shortcut needed).</summary>
     private void TrayNotify(string title, string body)

--- a/src/Agwinterm.Win32/Win32.cs
+++ b/src/Agwinterm.Win32/Win32.cs
@@ -229,6 +229,28 @@ internal static class Win32
     [DllImport("shell32.dll")] public static extern bool DragQueryPoint(IntPtr hDrop, out POINT lppt);
     [DllImport("shell32.dll")] public static extern void DragFinish(IntPtr hDrop);
 
+    // ---- Taskbar progress (ITaskbarList3.SetProgressState/Value for OSC 9;4) ----
+    public const int TBPF_NOPROGRESS = 0, TBPF_INDETERMINATE = 0x1, TBPF_NORMAL = 0x2, TBPF_ERROR = 0x4, TBPF_PAUSED = 0x8;
+
+    [ComImport, Guid("56FDF344-FD6D-11d0-958A-006097C9A090"), ClassInterface(ClassInterfaceType.None)]
+    public class TaskbarListCom { }
+
+    [ComImport, Guid("EA1AFB91-9E28-4B86-90E9-9E9F8A5EEFAF"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface ITaskbarList3
+    {
+        // ITaskbarList
+        void HrInit();
+        void AddTab(IntPtr hwnd);
+        void DeleteTab(IntPtr hwnd);
+        void ActivateTab(IntPtr hwnd);
+        void SetActiveAlt(IntPtr hwnd);
+        // ITaskbarList2
+        void MarkFullscreenWindow(IntPtr hwnd, [MarshalAs(UnmanagedType.Bool)] bool fullscreen);
+        // ITaskbarList3 (only what we use; declaration order = vtable order)
+        void SetProgressValue(IntPtr hwnd, ulong completed, ulong total);
+        void SetProgressState(IntPtr hwnd, int flags);
+    }
+
     // ---- Popup menu window (a real top-level HWND for the themed context menu) ----
     public const uint WS_EX_TOPMOST = 0x00000008, WS_EX_TOOLWINDOW = 0x00000080, WS_EX_NOACTIVATE = 0x08000000;
     public const uint CS_DROPSHADOW = 0x00020000;

--- a/tests/Agwinterm.Core.Tests/OscTests.cs
+++ b/tests/Agwinterm.Core.Tests/OscTests.cs
@@ -105,6 +105,42 @@ public class OscTests
         Assert.Equal("line1line2", gotBody);
     }
 
+    // OSC 9;4 (ConEmu/Windows Terminal progress) must fire Progress, NOT a notification toast.
+
+    [Fact]
+    public void Osc9_4_FiresProgressNotNotification()
+    {
+        var t = new TerminalEmulator(40, 3);
+        int? st = null, val = null; bool notified = false;
+        t.Progress += (s, v) => { st = s; val = v; };
+        t.Notified += (_, _) => notified = true;
+        t.OscDispatch(9, "4;1;62");
+        Assert.Equal(1, st);
+        Assert.Equal(62, val);
+        Assert.False(notified);
+    }
+
+    [Fact]
+    public void Osc9_4_ClearAndClamp()
+    {
+        var t = new TerminalEmulator(40, 3);
+        var got = new List<(int, int)>();
+        t.Progress += (s, v) => got.Add((s, v));
+        t.OscDispatch(9, "4;1;250");   // clamped to 100
+        t.OscDispatch(9, "4;0");       // clear, no value
+        Assert.Equal(new[] { (1, 100), (0, 0) }, got.ToArray());
+    }
+
+    [Fact]
+    public void Osc9_PlainMessage_StillNotifies()
+    {
+        var t = new TerminalEmulator(40, 3);
+        string? body = null;
+        t.Notified += (_, b) => body = b;
+        t.OscDispatch(9, "42 done");   // not "4;" -> a normal notification
+        Assert.Equal("42 done", body);
+    }
+
     // Regression: the parser must UTF-8-decode OSC payloads (byte-as-char accumulation
     // mojibakes multibyte text and lets the C1 stripper eat continuation bytes).
 


### PR DESCRIPTION
**WT-5 of 6** (triaged backlog). The ConEmu/Windows Terminal progress convention:

```
ESC ] 9 ; 4 ; <state> ; <value> BEL     # 0 clear | 1 normal | 2 error | 3 indeterminate | 4 paused
```

- Emulator raises a `Progress` event (and **doesn't** leak these into the OSC 9 notification/toast path)
- `ITaskbarList3.SetProgressState/Value` drives the window's taskbar icon; last-writer-wins across sessions
- Agents/long tasks can surface progress on the taskbar — pairs naturally with the status-dot philosophy

## Verification
- ✅ 3 new Core tests: progress fires (not notification), value clamping, clear, plain OSC 9 still notifies — 97/97 pass
- ✅ **Live screenshot**: `9;4;1;70` emitted in a session → ~70% progress line under the agwinterm taskbar icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)