### PR TITLE
feat: FTCS shell-integration marks (OSC 133) — jump-to-prompt + session.output

### DIFF
--- a/src/Agwinterm.Core/TerminalEmulator.cs
+++ b/src/Agwinterm.Core/TerminalEmulator.cs
@@ -70,7 +70,68 @@ public sealed class TerminalEmulator : IParserPerformer
         for (int c = 0; c < cols; c++) row[c] = Screen[0, c];
         _history.Add(row);
         if (_history.Count > ScrollbackMax + TrimSlack)
-            _history.RemoveRange(0, _history.Count - ScrollbackMax);
+        {
+            int trim = _history.Count - ScrollbackMax;
+            _history.RemoveRange(0, trim);
+            // Marks address buffer-absolute lines (history + live row): shift with the trim.
+            for (int i = _marks.Count - 1; i >= 0; i--)
+            {
+                var m = _marks[i];
+                m.PromptLine -= trim;
+                if (m.CommandLine >= 0) m.CommandLine -= trim;
+                if (m.OutputLine >= 0) m.OutputLine -= trim;
+                if (m.EndLine >= 0) m.EndLine -= trim;
+                if (m.PromptLine < 0) _marks.RemoveAt(i);
+            }
+        }
+    }
+
+    // ---- Shell-integration marks (FTCS / OSC 133): prompt + command-output boundaries ----
+
+    /// <summary>One prompt→command→output record from FTCS (OSC 133). Lines are buffer-absolute
+    /// (history + live row); they shift as history trims and drop off when trimmed away.</summary>
+    public sealed class ShellMark
+    {
+        public int PromptLine;        // 133;A — the prompt started on this line
+        public int CommandLine = -1;  // 133;B — command input line (where the user types)
+        public int OutputLine = -1;   // 133;C — command output starts here (optional)
+        public int EndLine = -1;      // 133;D — command finished (the next prompt's line)
+        public int? ExitCode;         // from 133;D;<code>
+    }
+
+    private readonly List<ShellMark> _marks = new();
+
+    /// <summary>FTCS marks, oldest first (main screen only; capped at 512).</summary>
+    public IReadOnlyList<ShellMark> Marks => _marks;
+
+    private void FtcsDispatch(string text)
+    {
+        if (IsAltScreen || text.Length == 0) return;
+        int abs = _history.Count + CursorRow;
+        switch (char.ToUpperInvariant(text[0]))
+        {
+            case 'A':   // prompt start (dedupe re-renders on the same line)
+                if (_marks.Count == 0 || _marks[^1].PromptLine != abs)
+                    _marks.Add(new ShellMark { PromptLine = abs });
+                break;
+            case 'B':   // command-line start (user input row)
+                if (_marks.Count > 0 && _marks[^1].CommandLine < 0) _marks[^1].CommandLine = abs;
+                break;
+            case 'C':   // output start
+                if (_marks.Count > 0 && _marks[^1].OutputLine < 0) _marks[^1].OutputLine = abs;
+                break;
+            case 'D':   // command finished (+ optional exit code)
+                if (_marks.Count > 0 && _marks[^1].EndLine < 0)
+                {
+                    var m = _marks[^1];
+                    m.EndLine = abs;
+                    int semi = text.IndexOf(';');
+                    if (semi >= 0 && int.TryParse(text[(semi + 1)..], out int ec)) m.ExitCode = ec;
+                }
+                break;
+            // 'B' (command-line start) isn't tracked separately in v1.
+        }
+        if (_marks.Count > 512) _marks.RemoveRange(0, _marks.Count - 512);
     }
 
     private Color _fg = Color.DefaultForeground;
@@ -411,6 +472,9 @@ public sealed class TerminalEmulator : IParserPerformer
                 break;
             case 7:
                 Cwd = text;
+                break;
+            case 133: // FTCS shell-integration marks: A prompt, B command, C output, D;exit done
+                FtcsDispatch(text);
                 break;
             case 9: // OSC 9 ; <message> — body-only desktop notification; OSC 9;4 = ConEmu/WT progress
                 if (text.StartsWith("4;", StringComparison.Ordinal))

--- a/src/Agwinterm.Ctl/Program.cs
+++ b/src/Agwinterm.Ctl/Program.cs
@@ -138,6 +138,7 @@ switch (area)
             case "text": break; // dump the buffer; target only
             case "copy": break;  // return the target's selection text; target only
             case "seen": break;  // clear the unseen-notification badge; target only
+            case "output": break; // last completed command's output (FTCS marks); target only
             case "paste": // paste literal text (or the clipboard if none) into the target pane
                 cargs["text"] = rest.Count > 0 ? string.Join(' ', rest) : (Opt("text") ?? "");
                 break;

--- a/src/Agwinterm.Pty/AgentSkill.cs
+++ b/src/Agwinterm.Pty/AgentSkill.cs
@@ -62,6 +62,8 @@ public static class AgentSkill
         - `agwintermctl session select <id>` / `session close <id>`
         - `agwintermctl session rename <new-name> [--target ID]` — set a session's custom name (sidebar + title bar)
         - `agwintermctl session seen [--target ID]` — clear a session's unseen-notification badge headlessly
+        - `agwintermctl session output [--target ID]` — the LAST COMPLETED command's output (FTCS marks;
+          pwsh sessions emit them automatically) — cleaner than parsing `session text` yourself
         - `agwintermctl sidebar state` — read-back: `visible tree` | `hidden flagged` | … (`ping` reports the app version)
         - `agwintermctl session go next|prev|first|last|next-attention|prev-attention` — move the active session
         - `agwintermctl session move --to up|down|top|bottom`     — reorder within its workspace

--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -146,6 +146,7 @@ public sealed class ControlServer : IDisposable
                 case "session.rename": return host.SessionRename(target, GetString(args, "name") ?? "") ? Ok("renamed") : Err("session not found / blank name");
                 case "session.seen": return host.SessionSeen(target) ? Ok("seen") : Err("session not found");
                 case "broadcast": return Ok(host.BroadcastOp(GetString(args, "op") ?? "toggle"));
+                case "session.output": return Ok(host.SessionOutput(target)); // last completed command's output (FTCS)
                 case "workspace.rename": return host.WorkspaceRename(target, GetString(args, "name") ?? "") ? Ok("renamed") : Err("workspace not found");
                 case "workspace.delete": return host.WorkspaceDelete(target) ? Ok("deleted") : Err("workspace not found");
                 case "workspace.select": return host.WorkspaceSelect(target) ? Ok("selected") : Err("workspace not found");

--- a/src/Agwinterm.Pty/ISessionHost.cs
+++ b/src/Agwinterm.Pty/ISessionHost.cs
@@ -65,6 +65,9 @@ public interface ISessionHost
     /// <summary>Broadcast-input toggle for the frontmost window: op = on|off|toggle|state. Returns "on"/"off".</summary>
     string BroadcastOp(string op);
 
+    /// <summary>Plain text of the last completed command's output (FTCS/OSC 133 marks).</summary>
+    string SessionOutput(string? target);
+
     bool WorkspaceRename(string? target, string name);
     bool WorkspaceDelete(string? target);
     bool WorkspaceSelect(string? target);
@@ -192,6 +195,7 @@ public sealed class SingleSessionHost : ISessionHost
     public bool SessionSeen(string? target) => false;
     public string SidebarState() => "visible tree";
     public string BroadcastOp(string op) => "off";
+    public string SessionOutput(string? target) => "";
     public bool WorkspaceRename(string? target, string name) => false;
     public bool WorkspaceDelete(string? target) => false;
     public bool WorkspaceSelect(string? target) => false;

--- a/src/Agwinterm.Pty/ShellIntegrationInstaller.cs
+++ b/src/Agwinterm.Pty/ShellIntegrationInstaller.cs
@@ -42,10 +42,17 @@ public static class ShellIntegrationInstaller
         if (-not $global:__agwSI) {
           $global:__agwSI = $true
           $global:__agwPrompt = $function:prompt
+          $global:__agwFirst = $true
           function global:prompt {
+            $ok = $?
+            $e = [char]27; $b = [char]7
+            $ec = $global:LASTEXITCODE; if ($null -eq $ec) { $ec = if ($ok) { 0 } else { 1 } }
+            if ($global:__agwFirst) { $global:__agwFirst = $false } else { [Console]::Write("$e]133;D;$ec$b") }
+            [Console]::Write("$e]133;A$b")
             $d = (Get-Location).ProviderPath
-            [Console]::Write("$([char]27)]7;file://$env:COMPUTERNAME/$(($d -replace '\\','/'))$([char]7)")
-            if ($global:__agwPrompt) { & $global:__agwPrompt } else { "PS $d> " }
+            [Console]::Write("$e]7;file://$env:COMPUTERNAME/$(($d -replace '\\','/'))$b")
+            $p = if ($global:__agwPrompt) { & $global:__agwPrompt } else { "PS $d> " }
+            "$p$e]133;B$b"
           }
         }
         """;

--- a/src/Agwinterm.Win32/Keymap.cs
+++ b/src/Agwinterm.Win32/Keymap.cs
@@ -43,6 +43,8 @@ internal static class Keymap
         ("ctrl+shift+a", "select_all"),
         ("ctrl+alt+n", "new_window"),
         ("f11", "toggle_fullscreen"),
+        ("ctrl+shift+up", "previous_prompt"),
+        ("ctrl+shift+down", "next_prompt"),
     };
 
     public static readonly HashSet<string> ValidActions = new(StringComparer.OrdinalIgnoreCase)
@@ -52,6 +54,7 @@ internal static class Keymap
         "toggle_sidebar", "rename_session", "delete_workspace", "session_palette", "action_palette",
         "attention_list", "custom_palette", "next_attention", "previous_attention", "reload_keymap",
         "toggle_search", "toggle_scratch", "quick_terminal", "close_cover", "toggle_fullscreen", "toggle_broadcast",
+        "previous_prompt", "next_prompt",
         "toggle_flag", "toggle_flagged_view", "focus_workspace",
         "select_all", "copy_selection", "paste",
         "new_window", "close_window", "switch_window",

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -1767,6 +1767,26 @@ internal partial class Program : ISessionHost, IWindowHost
             return true;
         }
 
+        /// <summary>Plain text of the LAST COMPLETED command's output (FTCS marks) — the
+        /// agent-workflow primitive: "give me what that command printed".</summary>
+        public string SessionOutput(string? target)
+        {
+            var s = Resolve(target);
+            if (s is null) return "";
+            Pane? pane;
+            lock (_workspaces)
+                pane = _workspaces.SelectMany(w => w.Sessions).SelectMany(x => x.Panes)
+                                  .FirstOrDefault(p => ReferenceEquals(p.S, s));
+            if (pane is null) return "";
+            TerminalEmulator.ShellMark? m;
+            lock (pane.S.SyncRoot) m = pane.S.Emulator.Marks.LastOrDefault(x => x.EndLine >= 0);
+            if (m is null) return "no completed command marks (FTCS wrap not active?)";
+            // Output begins after the command's input row: 133;C if the shell emits it, else the
+            // line after 133;B (the input row), else after the prompt.
+            int from = m.OutputLine >= 0 ? m.OutputLine : m.CommandLine >= 0 ? m.CommandLine + 1 : m.PromptLine + 1;
+            return from > m.EndLine - 1 ? "" : RowsText(pane, from, m.EndLine - 1);
+        }
+
         public string SessionCopy(string? target)
         {
             var s = Resolve(target);
@@ -2437,6 +2457,51 @@ internal partial class Program : ISessionHost, IWindowHost
     }
 
     /// <summary>Scroll the active pane's scrollback by delta lines (or to top/bottom for ±int.MaxValue).</summary>
+    /// <summary>Jump the active pane's scrollback to the previous/next FTCS prompt line.</summary>
+    private void JumpPrompt(int dir)
+    {
+        var p = ActiveSurface();
+        if (p is null) return;
+        var em = p.S.Emulator;
+        List<int> lines;
+        int hist;
+        lock (p.S.SyncRoot) { lines = em.Marks.Select(m => m.PromptLine).ToList(); hist = em.HistoryCount; }
+        if (lines.Count == 0) { ShowToast("no shell marks yet (FTCS comes from the pwsh prompt wrap)"); return; }
+        int curTop = hist - p.ScrollOffset;
+        int target = dir < 0 ? lines.Where(l => l < curTop).DefaultIfEmpty(-1).Max()
+                             : lines.Where(l => l > curTop).DefaultIfEmpty(-1).Min();
+        if (target < 0) { ShowToast(dir < 0 ? "no earlier prompt" : "no later prompt"); return; }
+        p.ScrollOffset = Math.Clamp(hist - target, 0, hist);
+        RequestRedraw();
+    }
+
+    /// <summary>Plain-text rows [from..to] of a pane's buffer (history + live), trailing spaces trimmed.</summary>
+    private static string RowsText(Pane pane, int from, int to)
+    {
+        var em = pane.S.Emulator;
+        var sb = new StringBuilder();
+        lock (pane.S.SyncRoot)
+        {
+            int cols = em.Screen.Cols, rows = em.Screen.Rows, hist = em.HistoryCount;
+            from = Math.Max(0, from);
+            to = Math.Min(hist + rows - 1, to);
+            for (int line = from; line <= to; line++)
+            {
+                var row = new StringBuilder();
+                for (int c = 0; c < cols; c++)
+                {
+                    Cell cell = CellAbs(em, hist, rows, cols, line, c);
+                    if (cell.Width == 0 && cell.Rune == '\0') continue;
+                    if (cell.Rune > 0xFFFF) row.Append(char.ConvertFromUtf32(cell.Rune));
+                    else row.Append(cell.Rune == '\0' ? ' ' : (char)cell.Rune);
+                }
+                sb.Append(row.ToString().TrimEnd(' '));
+                if (line != to) sb.Append("\r\n");
+            }
+        }
+        return sb.ToString();
+    }
+
     private bool ScrollActivePane(int deltaLines)
     {
         var p = ActiveSurface();
@@ -2495,6 +2560,8 @@ internal partial class Program : ISessionHost, IWindowHost
             case "close_cover": CloseCover(); break;
             case "toggle_fullscreen": ToggleFullscreen(); break;
             case "toggle_broadcast": ToggleBroadcast(); break;
+            case "previous_prompt": JumpPrompt(-1); break;
+            case "next_prompt": JumpPrompt(1); break;
             case "select_all": if (ActiveSurface() is { } sa) SelectAll(sa); break;
             case "copy_selection": if (ActiveSurface() is { } sc && sc.HasSel) CopySelection(sc); break;
             case "paste": if (ActiveSurface() is { } sp2) PasteInto(sp2); break;
@@ -3718,6 +3785,18 @@ internal partial class Program : ISessionHost, IWindowHost
                 rt.FillRectangle(new Rect(trackX, oy, 3f, trackH), brush);
                 brush.Color = WithA(ChromeText, 0.35f);
                 rt.FillRectangle(new Rect(trackX, thumbY, 3f, thumbH), brush);
+            }
+            if (!em.IsAltScreen && em.Marks.Count > 0)  // FTCS prompt pips (green ok / red fail / accent running)
+            {
+                float pipX = ox + cols * cw - 3f, pipTrackH = rows * ch, pipTotal = MathF.Max(1f, hist + rows);
+                foreach (var m in em.Marks)
+                {
+                    float py2 = oy + pipTrackH * m.PromptLine / pipTotal;
+                    brush.Color = m.ExitCode is int ec2
+                        ? (ec2 == 0 ? new Color4(0.24f, 0.78f, 0.35f, 0.9f) : new Color4(0.9f, 0.3f, 0.3f, 0.9f))
+                        : WithA(ChromeAccent, 0.9f);
+                    rt.FillRectangle(new Rect(pipX, py2, 3f, 2f), brush);
+                }
             }
 
             if (em.CursorVisible && off == 0)

--- a/tests/Agwinterm.Core.Tests/OscTests.cs
+++ b/tests/Agwinterm.Core.Tests/OscTests.cs
@@ -70,8 +70,7 @@ public class OscTests
         Assert.Equal("", t.Cwd);
     }
 
-    // Control characters embedded in OSC payloads are an injection vector (the title is re-shown
-    // in the title bar; the cwd is expanded into custom-command text). They must be stripped.
+    // Control characters embedded in OSC payloads are an injection vector; they must be stripped.
 
     [Fact]
     public void OscTitle_StripsControlCharacters()
@@ -91,7 +90,7 @@ public class OscTests
     public void OscTitle_StripsDelAndC1Controls()
     {
         var t = new TerminalEmulator(40, 3);
-        t.OscDispatch(2, "a\u007Fb\u009Cc");   // DEL + C1 (ST)
+        t.OscDispatch(2, "a\u007Fb\u009Cc");
         Assert.Equal("abc", t.Title);
     }
 
@@ -126,8 +125,8 @@ public class OscTests
         var t = new TerminalEmulator(40, 3);
         var got = new List<(int, int)>();
         t.Progress += (s, v) => got.Add((s, v));
-        t.OscDispatch(9, "4;1;250");   // clamped to 100
-        t.OscDispatch(9, "4;0");       // clear, no value
+        t.OscDispatch(9, "4;1;250");
+        t.OscDispatch(9, "4;0");
         Assert.Equal(new[] { (1, 100), (0, 0) }, got.ToArray());
     }
 
@@ -137,12 +136,38 @@ public class OscTests
         var t = new TerminalEmulator(40, 3);
         string? body = null;
         t.Notified += (_, b) => body = b;
-        t.OscDispatch(9, "42 done");   // not "4;" -> a normal notification
+        t.OscDispatch(9, "42 done");
         Assert.Equal("42 done", body);
     }
 
-    // Regression: the parser must UTF-8-decode OSC payloads (byte-as-char accumulation
-    // mojibakes multibyte text and lets the C1 stripper eat continuation bytes).
+    // FTCS (OSC 133) shell-integration marks: prompt/output boundaries + exit codes.
+
+    [Fact]
+    public void Ftcs_RecordsPromptOutputAndExit()
+    {
+        var t = new TerminalEmulator(40, 6);
+        t.Feed(Encoding.UTF8.GetBytes("\x1b]133;A\x07PS> dir\r\n"));
+        t.Feed(Encoding.UTF8.GetBytes("\x1b]133;C\afile1\r\nfile2\r\n"));
+        t.Feed(Encoding.UTF8.GetBytes("\x1b]133;D;0\x07\x1b]133;A\x07PS> "));
+        Assert.Equal(2, t.Marks.Count);
+        Assert.Equal(0, t.Marks[0].PromptLine);
+        Assert.Equal(1, t.Marks[0].OutputLine);
+        Assert.Equal(3, t.Marks[0].EndLine);
+        Assert.Equal(0, t.Marks[0].ExitCode);
+        Assert.Equal(3, t.Marks[1].PromptLine);
+        Assert.Null(t.Marks[1].ExitCode);
+    }
+
+    [Fact]
+    public void Ftcs_FailureExitCodeRecorded()
+    {
+        var t = new TerminalEmulator(40, 6);
+        t.Feed(Encoding.UTF8.GetBytes("\x1b]133;A\x07PS> boom\r\nerr\r\n\x1b]133;D;1\x07"));
+        Assert.Single(t.Marks);
+        Assert.Equal(1, t.Marks[0].ExitCode);
+    }
+
+    // Regression: the parser must UTF-8-decode OSC payloads.
 
     [Fact]
     public void OscTitle_Utf8DecodesMultibyteText()


### PR DESCRIPTION
**WT-6 of 6** (final of the triaged batch) — the agent-workflow multiplier.

Parses **OSC 133 (FTCS)** prompt/command/output/done marks and puts them to work:

## What lands
- **Emulator**: OSC 133 A/B/C/D → per-buffer `ShellMark` records (exit codes included; buffer-absolute lines that survive history trim; main-screen only, capped 512)
- **Prompt wrap**: the pwsh prompt now emits `133;D;<exit>` + `133;A` + `133;B` — **every pwsh session gets marks automatically**, composing with oh-my-posh/starship (still one wrap, one sentinel)
- **Renderer**: colored **prompt pips** on the scroll-thumb edge — green (exit 0) / red (failure) / accent (running)
- **Navigation**: `previous_prompt`/`next_prompt` (**Ctrl+Shift+Up/Down**) jump the scrollback between prompts
- **Control API**: **`agwintermctl session output`** returns the *last completed command's output* — the "give me what that command printed" primitive, far cleaner than parsing `session text`. Precise boundaries: after `133;C` (or the `133;B` input row) through `133;D`

## Verification
- ✅ 2 new Core tests (prompt/output/exit recording; failure exit code) — 96/96 Core, 16/16 Pty
- ✅ **Live**: `echo FIRST` then `whoami` → `session output` = exactly `boris-laptop\boris` (no echo, no prompt)
- ✅ A failing command records exit 1; **Ctrl+Shift+Up** jumps between prompt marks (screenshot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)