### PR TITLE
feat(config): word-delimiters — configurable double-click word boundaries

### DIFF
--- a/src/Agwinterm.Core/TerminalConfig.cs
+++ b/src/Agwinterm.Core/TerminalConfig.cs
@@ -39,6 +39,10 @@ public sealed class TerminalConfig
     /// word / line select), without needing Ctrl+C. Off by default. The selection stays highlighted.</summary>
     public bool CopyOnSelect { get; set; } = false;
 
+    /// <summary>Characters that DELIMIT words for double-click selection (in addition to whitespace).
+    /// Empty = whitespace only (double-click grabs a whole path/URL). WT's wordDelimiters analog.</summary>
+    public string WordDelimiters { get; set; } = "";
+
     /// <summary>Show OS desktop notifications (tray balloon) for OSC 9/777 / notify. Off → in-app banner + badge only.</summary>
     public bool DesktopNotifications { get; set; } = true;
 
@@ -127,6 +131,10 @@ public sealed class TerminalConfig
 
         # Auto-copy the selection to the clipboard as soon as it's made (no Ctrl+C needed).
         copy-on-select = false
+
+        # Extra word-delimiter characters for double-click selection (besides whitespace).
+        # Empty = whitespace only, so double-click grabs a whole path or URL. Example: /\.:;,="'()[]{}
+        word-delimiters =
 
         # Desktop notifications: show an OS tray-balloon for OSC 9/777 / `agwintermctl notify`
         # (the in-app banner + sidebar badge always show regardless). Set false to suppress the OS toast.
@@ -222,6 +230,7 @@ public sealed class TerminalConfig
                 case "restore-commands": cfg.RestoreCommands = ParseBool(val, cfg.RestoreCommands); break;
                 case "right-click-paste": cfg.RightClickPaste = ParseBool(val, cfg.RightClickPaste); break;
                 case "copy-on-select": cfg.CopyOnSelect = ParseBool(val, cfg.CopyOnSelect); break;
+                case "word-delimiters": cfg.WordDelimiters = val; break;
                 case "desktop-notifications": cfg.DesktopNotifications = ParseBool(val, cfg.DesktopNotifications); break;
                 case "blocked-sound": cfg.BlockedSound = val; break;
                 case "inactive-pane-dim": if (int.TryParse(val, out var ipd)) cfg.InactivePaneDim = System.Math.Clamp(ipd, 0, 100); break;

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -3007,7 +3007,12 @@ internal partial class Program : ISessionHost, IWindowHost
         lock (p.S.SyncRoot)
         {
             int cols = em.Screen.Cols, rows = em.Screen.Rows, hist = em.HistoryCount;
-            bool Word(int c) { int ch = CellAbs(em, hist, rows, cols, line, c).Rune; return ch != ' ' && ch != '\0'; }
+            string delims = _config.WordDelimiters;
+            bool Word(int c)
+            {
+                int ch = CellAbs(em, hist, rows, cols, line, c).Rune;
+                return ch != ' ' && ch != '\0' && (delims.Length == 0 || ch > 0xFFFF || delims.IndexOf((char)ch) < 0);
+            }
             if (col < 0 || col >= cols || !Word(col)) return;
             int a = col, b = col;
             while (a > 0 && Word(a - 1)) a--;
@@ -5897,7 +5902,7 @@ internal partial class Program : ISessionHost, IWindowHost
     {
         "font-family", "font-size", "cursor-style", "cursor-blink", "cursor-blink-ms", "theme",
         "scrollback-lines", "inactive-pane-dim", "window-opacity", "sidebar-tint", "scroll-speed",
-        "new-session-dir", "right-click-paste", "copy-on-select", "desktop-notifications", "shell-integration",
+        "new-session-dir", "right-click-paste", "copy-on-select", "word-delimiters", "desktop-notifications", "shell-integration",
         "restore-commands", "blocked-sound", "omp-theme", "omp-integration", "prompt-engine", "starship-theme",
         "new-session-dir-mode", "confirm-close-session", "compact-toolbar", "notification-badges",
         "attention-button", "status-color-active", "status-color-blocked", "status-color-completed",
@@ -5938,6 +5943,7 @@ internal partial class Program : ISessionHost, IWindowHost
         "new-session-dir" => _config.NewSessionDir,
         "right-click-paste" => _config.RightClickPaste ? "true" : "false",
         "copy-on-select" => _config.CopyOnSelect ? "true" : "false",
+        "word-delimiters" => _config.WordDelimiters,
         "desktop-notifications" => _config.DesktopNotifications ? "true" : "false",
         "shell-integration" => _config.ShellIntegration ? "true" : "false",
         "restore-commands" => _config.RestoreCommands ? "true" : "false",


### PR DESCRIPTION
**Tier 2 backlog (T2-1)** — WT's `wordDelimiters` analog.

New `word-delimiters` config key: characters that break words for double-click selection, on top of whitespace. Empty (default, unchanged behavior) = whitespace only, so double-click grabs a whole path or URL. `SelectWord` consults it instead of the old hardcoded space/NUL check.

**Verified live** (synthesized double-clicks + `session copy`):
- `word-delimiters = /\.:` → double-click a path segment selects just `usr`
- empty → selects the whole `/usr/local/bin/tool`

🤖 Generated with [Claude Code](https://claude.com/claude-code)