### PR TITLE
feat(profiles): per-profile environment variables

### DIFF
--- a/src/Agwinterm.Pty/AgentSkill.cs
+++ b/src/Agwinterm.Pty/AgentSkill.cs
@@ -58,7 +58,7 @@ public static class AgentSkill
           — create a session (prints its id). `--command` runs that program as the session process (argv-style, no shell) instead of the shell.
           `--profile NAME` picks a shell profile (default = Windows PowerShell).
         - `agwintermctl profiles list` — shell profiles (cmd, Windows PowerShell, PowerShell 7, Git Bash, WSL:*, custom); `* ` marks the default.
-          Profiles live in `%LOCALAPPDATA%\agwinterm\profiles.json` (auto-seeded from detected shells; edit to add your own — name/command/args/cwd/icon); `agwintermctl profiles reload` re-reads it.
+          Profiles live in `%LOCALAPPDATA%\agwinterm\profiles.json` (auto-seeded from detected shells; edit to add your own — name/command/args/cwd/icon/env); `agwintermctl profiles reload` re-reads it.
         - `agwintermctl session select <id>` / `session close <id>`
         - `agwintermctl session rename <new-name> [--target ID]` — set a session's custom name (sidebar + title bar)
         - `agwintermctl session seen [--target ID]` — clear a session's unseen-notification badge headlessly

--- a/src/Agwinterm.Pty/ShellProfiles.cs
+++ b/src/Agwinterm.Pty/ShellProfiles.cs
@@ -14,6 +14,8 @@ public sealed class ShellProfile
     public string[]? Args { get; set; }
     public string? Cwd { get; set; }
     public string? Icon { get; set; }
+    /// <summary>Environment variables injected into this profile's sessions (WT's per-profile environment).</summary>
+    public Dictionary<string, string>? Env { get; set; }
 }
 
 /// <summary>

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -748,6 +748,10 @@ internal partial class Program : ISessionHost, IWindowHost
         string cmd = prof?.Command is { Length: > 0 } c ? c : "powershell.exe";
         string[]? pargs = prof?.Args;
         string? pcwd = string.IsNullOrEmpty(cwd) ? prof?.Cwd : cwd;
+        // Per-profile env vars (WT parity). AGWINTERM_* set by CreatePane win, so profile env can't
+        // clobber our identity vars; a custom-command's $AGW_* extraEnv still overrides last.
+        if (prof?.Env is { Count: > 0 } penv)
+            foreach (var kv in penv) if (!kv.Key.StartsWith("AGWINTERM", StringComparison.OrdinalIgnoreCase)) env[kv.Key] = kv.Value;
         string exe = Path.GetFileName(cmd).ToLowerInvariant();
         bool isPwsh = exe is "powershell.exe" or "pwsh.exe" or "pwsh";
         if (isPwsh && (pargs is null || pargs.Length == 0))


### PR DESCRIPTION
**Tier 2 backlog (T2-2)** — WT's per-profile `environment` analog.

`ShellProfile` gains an optional `env` dict; sessions launched from that profile get those variables. In `profiles.json`:
```json
{ "name": "Deploy", "command": "pwsh.exe", "env": { "AWS_PROFILE": "prod", "EDITOR": "code" } }
```
`AGWINTERM_*` identity vars are never clobbered by profile env.

**Verified live**: a profile with `env MY_AGW_VAR=hello-from-profile` → a new session using it has `$env:MY_AGW_VAR` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)