### PR TITLE
feat(win32): unfocused-window dim

### DIFF
--- a/src/Agwinterm.Core/TerminalConfig.cs
+++ b/src/Agwinterm.Core/TerminalConfig.cs
@@ -54,6 +54,10 @@ public sealed class TerminalConfig
     /// <summary>How much to dim non-active panes in a split (0 = no dimming, 100 = fully dark). Default 35.</summary>
     public int InactivePaneDim { get; set; } = 35;
 
+    /// <summary>Dim the whole content region when the window isn't focused (0 = off … 90). WT's
+    /// unfocusedAppearance analog. Off by default.</summary>
+    public int UnfocusedDim { get; set; } = 0;
+
     /// <summary>Whole-window opacity, 30–100 (%). 100 = opaque. Clamped so the window never disappears.</summary>
     public int WindowOpacity { get; set; } = 100;
 
@@ -157,6 +161,9 @@ public sealed class TerminalConfig
         # Dim non-active panes in a split (0 = off, 100 = fully dark).
         inactive-pane-dim = 35
 
+        # Dim the terminal content when this window isn't focused (0 = off .. 90).
+        unfocused-dim = 0
+
         # Whole-window opacity, 30-100 (%). 100 = opaque.
         window-opacity = 100
 
@@ -234,6 +241,7 @@ public sealed class TerminalConfig
                 case "desktop-notifications": cfg.DesktopNotifications = ParseBool(val, cfg.DesktopNotifications); break;
                 case "blocked-sound": cfg.BlockedSound = val; break;
                 case "inactive-pane-dim": if (int.TryParse(val, out var ipd)) cfg.InactivePaneDim = System.Math.Clamp(ipd, 0, 100); break;
+                case "unfocused-dim": if (int.TryParse(val, out var ufd)) cfg.UnfocusedDim = System.Math.Clamp(ufd, 0, 90); break;
                 case "window-opacity": if (int.TryParse(val, out var wo)) cfg.WindowOpacity = System.Math.Clamp(wo, 30, 100); break;
                 case "sidebar-tint": if (int.TryParse(val, out var st)) cfg.SidebarTint = System.Math.Clamp(st, -100, 100); break;
                 case "new-session-dir": cfg.NewSessionDir = val; break;

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -2408,7 +2408,9 @@ internal partial class Program : ISessionHost, IWindowHost
                 }
 
             case WM_ACTIVATE:
-                if (LoWord(wParam) != 0 && _frontmostId != Id) // WA_ACTIVE/WA_CLICKACTIVE -> this window is frontmost
+                _windowActive = LoWord(wParam) != 0;   // WA_ACTIVE/WA_CLICKACTIVE vs WA_INACTIVE (drives unfocused dim)
+                if (_config.UnfocusedDim > 0) RequestRedraw();
+                if (_windowActive && _frontmostId != Id) // this window is frontmost
                 {
                     Frontmost = this; _frontmostId = Id; SaveIndex();
                 }
@@ -3877,6 +3879,12 @@ internal partial class Program : ISessionHost, IWindowHost
                 DrawCoverBadge(rt, brush, fx + fw, fy);
                 if (_coverKind == 3) DrawOverlayFooter(rt, brush);          // overlay-only footer
             }
+        }
+        if (!_windowActive && _config.UnfocusedDim > 0)   // dim the content region when the window isn't focused
+        {
+            var (dx, dy, dw, dh) = ContentArea();
+            brush.Color = new Color4(0f, 0f, 0f, Math.Clamp(_config.UnfocusedDim, 0, 90) / 100f);
+            rt.FillRectangle(new Rect(dx, dy, dw, dh), brush);
         }
         DrawSidebar(rt, brush);
         DrawTitleBar(rt, brush);
@@ -5921,7 +5929,7 @@ internal partial class Program : ISessionHost, IWindowHost
     private static readonly string[] ConfigKeys =
     {
         "font-family", "font-size", "cursor-style", "cursor-blink", "cursor-blink-ms", "theme",
-        "scrollback-lines", "inactive-pane-dim", "window-opacity", "sidebar-tint", "scroll-speed",
+        "scrollback-lines", "inactive-pane-dim", "unfocused-dim", "window-opacity", "sidebar-tint", "scroll-speed",
         "new-session-dir", "right-click-paste", "copy-on-select", "word-delimiters", "desktop-notifications", "shell-integration",
         "restore-commands", "blocked-sound", "omp-theme", "omp-integration", "prompt-engine", "starship-theme",
         "new-session-dir-mode", "confirm-close-session", "compact-toolbar", "notification-badges",
@@ -5957,6 +5965,7 @@ internal partial class Program : ISessionHost, IWindowHost
         "theme" => _config.Theme,
         "scrollback-lines" => _config.Scrollback.ToString(),
         "inactive-pane-dim" => _config.InactivePaneDim.ToString(),
+        "unfocused-dim" => _config.UnfocusedDim.ToString(),
         "window-opacity" => _config.WindowOpacity.ToString(),
         "sidebar-tint" => _config.SidebarTint.ToString(),
         "scroll-speed" => _config.ScrollSpeed.ToString(),
@@ -6404,6 +6413,7 @@ internal partial class Program : ISessionHost, IWindowHost
     private int _geoX, _geoY, _geoW, _geoH;
     private bool _geoMax;
     private bool _wasMaximized;
+    private bool _windowActive = true;   // window focus state (drives unfocused-dim)
 
     // ---- Fullscreen (F11 / toggle_fullscreen): borderless over the whole monitor ----
     private bool _fullscreen;


### PR DESCRIPTION
**Tier 2 backlog (T2-4)** — WT's `unfocusedAppearance` (dim form).

New `unfocused-dim` config (0 = off … 90): darkens the terminal **content region** when the window isn't focused, so the active window stands out with several open. Sidebar + chrome stay bright. Off by default. Tracked via `WM_ACTIVATE`.

**Verified live**: posting `WA_INACTIVE` dims the content (muted text + powerline colors), `WA_ACTIVE` restores full brightness — screenshots in session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)