### PR TITLE
feat: buffer-content restore on relaunch (opt-in)

### DIFF
--- a/src/Agwinterm.Core/TerminalConfig.cs
+++ b/src/Agwinterm.Core/TerminalConfig.cs
@@ -32,6 +32,10 @@ public sealed class TerminalConfig
     /// Off by default; honors restore-denylist.conf. Best-effort (Windows foreground-command capture).</summary>
     public bool RestoreCommands { get; set; } = false;
 
+    /// <summary>Persist each pane's scrollback text and re-display it (dimmed) above the fresh shell on
+    /// relaunch. WT's buffer-content restore. Off by default.</summary>
+    public bool RestoreBuffer { get; set; } = false;
+
     /// <summary>Paste the clipboard on a right-click in the terminal (when the app isn't grabbing the mouse).</summary>
     public bool RightClickPaste { get; set; } = true;
 
@@ -162,6 +166,9 @@ public sealed class TerminalConfig
         # opt-in restore-on-restart). Off by default. Edit restore-denylist.conf to exclude commands.
         restore-commands = false
 
+        # Restore each pane's scrollback text (dimmed) above the fresh shell on relaunch.
+        restore-buffer = false
+
         # Dim non-active panes in a split (0 = off, 100 = fully dark).
         inactive-pane-dim = 35
 
@@ -242,6 +249,7 @@ public sealed class TerminalConfig
                 case "theme": if (val.Length > 0) cfg.Theme = val; break;
                 case "shell-integration": cfg.ShellIntegration = ParseBool(val, cfg.ShellIntegration); break;
                 case "restore-commands": cfg.RestoreCommands = ParseBool(val, cfg.RestoreCommands); break;
+                case "restore-buffer": cfg.RestoreBuffer = ParseBool(val, cfg.RestoreBuffer); break;
                 case "right-click-paste": cfg.RightClickPaste = ParseBool(val, cfg.RightClickPaste); break;
                 case "copy-on-select": cfg.CopyOnSelect = ParseBool(val, cfg.CopyOnSelect); break;
                 case "word-delimiters": cfg.WordDelimiters = val; break;

--- a/src/Agwinterm.Core/TerminalEmulator.cs
+++ b/src/Agwinterm.Core/TerminalEmulator.cs
@@ -684,4 +684,45 @@ public sealed class TerminalEmulator : IParserPerformer
         }
         return sb.ToString().TrimEnd();
     }
+
+    /// <summary>The whole buffer as plain-text lines (history + visible), trailing blank rows dropped —
+    /// for buffer-content persistence.</summary>
+    public IReadOnlyList<string> DumpBuffer()
+    {
+        var lines = new List<string>();
+        for (int h = 0; h < _history.Count; h++)
+        {
+            var row = _history[h];
+            var sb = new System.Text.StringBuilder();
+            foreach (var cell in row)
+            {
+                if (cell.Width == 0) continue;
+                if (cell.Rune > 0xFFFF) sb.Append(char.ConvertFromUtf32(cell.Rune));
+                else sb.Append(cell.Rune == 0 ? ' ' : (char)cell.Rune);
+            }
+            lines.Add(sb.ToString().TrimEnd());
+        }
+        for (int r = 0; r < Screen.Rows; r++) lines.Add(DumpRow(r));
+        while (lines.Count > 0 && lines[^1].Length == 0) lines.RemoveAt(lines.Count - 1);
+        return lines;
+    }
+
+    /// <summary>Seed the scrollback with plain-text lines (dimmed) — restores a prior session's buffer
+    /// above the fresh shell without touching the live screen.</summary>
+    public void SeedScrollback(IReadOnlyList<string> lines)
+    {
+        int cols = Screen.Cols;
+        foreach (var line in lines)
+        {
+            var row = new Cell[cols];
+            for (int c = 0; c < cols; c++)
+            {
+                char ch = c < line.Length ? line[c] : ' ';
+                row[c] = new Cell(ch, Color.DefaultForeground, Color.DefaultBackground, CellAttributes.Dim);
+            }
+            _history.Add(row);
+        }
+        if (_history.Count > ScrollbackMax + TrimSlack)
+            _history.RemoveRange(0, _history.Count - ScrollbackMax);
+    }
 }

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -6047,7 +6047,7 @@ internal partial class Program : ISessionHost, IWindowHost
         "font-family", "font-size", "cursor-style", "cursor-blink", "cursor-blink-ms", "theme",
         "scrollback-lines", "inactive-pane-dim", "unfocused-dim", "builtin-glyphs", "window-opacity", "sidebar-tint", "scroll-speed",
         "new-session-dir", "right-click-paste", "copy-on-select", "word-delimiters", "desktop-notifications", "shell-integration",
-        "restore-commands", "blocked-sound", "omp-theme", "omp-integration", "prompt-engine", "starship-theme",
+        "restore-commands", "restore-buffer", "blocked-sound", "omp-theme", "omp-integration", "prompt-engine", "starship-theme",
         "new-session-dir-mode", "confirm-close-session", "compact-toolbar", "notification-badges",
         "attention-button", "status-color-active", "status-color-blocked", "status-color-completed",
     };
@@ -6093,6 +6093,7 @@ internal partial class Program : ISessionHost, IWindowHost
         "desktop-notifications" => _config.DesktopNotifications ? "true" : "false",
         "shell-integration" => _config.ShellIntegration ? "true" : "false",
         "restore-commands" => _config.RestoreCommands ? "true" : "false",
+        "restore-buffer" => _config.RestoreBuffer ? "true" : "false",
         "blocked-sound" => _config.BlockedSound,
         "omp-theme" => _config.OmpTheme,
         "omp-integration" => _config.OmpIntegration ? "true" : "false",
@@ -6257,7 +6258,7 @@ internal partial class Program : ISessionHost, IWindowHost
 
     // ---- Persistence: workspace/session tree + selection + sidebar state ----
 
-    private sealed class PaneState { public string Id { get; set; } = ""; public string Cwd { get; set; } = ""; public float FontSize { get; set; } public float Ratio { get; set; } = 1f; public string Command { get; set; } = ""; }
+    private sealed class PaneState { public string Id { get; set; } = ""; public string Cwd { get; set; } = ""; public float FontSize { get; set; } public float Ratio { get; set; } = 1f; public string Command { get; set; } = ""; public List<string>? Buffer { get; set; } }
     // Cwd/FontSize kept for backward-compat with pre-splits state.json (one pane per session).
     private sealed class SessionState { public string Id { get; set; } = ""; public string Name { get; set; } = ""; public string? CustomName { get; set; } public string? Profile { get; set; } public int Active { get; set; } public bool Flagged { get; set; } public List<PaneState> Panes { get; set; } = new(); public string Cwd { get; set; } = ""; public float FontSize { get; set; }
         // Wave F2: background watermark (BgFile = the copied file's name under backgrounds\; null = none).
@@ -6496,7 +6497,10 @@ internal partial class Program : ISessionHost, IWindowHost
                         string live = PrettyCwd(SafeCwd(p));                       // OSC 7 cwd if the shell reports it
                         string cwd = live.Length > 0 ? live : (p.StartCwd ?? ""); // else the launch dir
                         string cmd = (p.S.ChildProcessId is int pid && cmdByPid.TryGetValue(pid, out var c)) ? c : "";
-                        ss.Panes.Add(new PaneState { Id = p.Id, Cwd = cwd, FontSize = p.FontSize, Ratio = p.Ratio, Command = cmd });
+                        List<string>? buf = null;
+                        if (_config.RestoreBuffer)
+                            try { lock (p.S.SyncRoot) buf = p.S.Emulator.DumpBuffer().TakeLast(500).ToList(); } catch { }  // cap the saved lines
+                        ss.Panes.Add(new PaneState { Id = p.Id, Cwd = cwd, FontSize = p.FontSize, Ratio = p.Ratio, Command = cmd, Buffer = buf });
                     }
                     wss.Sessions.Add(ss);
                 }
@@ -6627,6 +6631,16 @@ internal partial class Program : ISessionHost, IWindowHost
                             ses.Panes[i].Ratio = pl[i].Ratio > 0 ? pl[i].Ratio : 1f;
                         ses.Active = Math.Clamp(s.Active, 0, ses.Panes.Count - 1);
                     }
+                    // Buffer-content restore: seed each pane's scrollback (dimmed) above the fresh shell.
+                    if (_config.RestoreBuffer)
+                        lock (_workspaces)
+                            for (int i = 0; i < pl.Count && i < ses.Panes.Count; i++)
+                                if (pl[i].Buffer is { Count: > 0 } b)
+                                {
+                                    var seed = new List<string>(b) { "──── restored ────" };
+                                    var pane = ses.Panes[i];
+                                    lock (pane.S.SyncRoot) pane.S.Emulator.SeedScrollback(seed);
+                                }
                     ses.Flagged = s.Flagged;
                     ses.CustomName = string.IsNullOrWhiteSpace(s.CustomName) ? null : s.CustomName;
                     if (!string.IsNullOrEmpty(s.BgFile)) // restore the watermark if its copied file still exists

--- a/tests/Agwinterm.Core.Tests/BufferRestoreTests.cs
+++ b/tests/Agwinterm.Core.Tests/BufferRestoreTests.cs
@@ -1,0 +1,38 @@
+using System.Text;
+using Agwinterm.Core;
+
+namespace Agwinterm.Core.Tests;
+
+public class BufferRestoreTests
+{
+    [Fact]
+    public void DumpBuffer_CapturesScrollbackAndVisible()
+    {
+        var t = new TerminalEmulator(20, 3);
+        // Print 5 lines into a 3-row screen: 2 scroll into history, 3 stay visible.
+        for (int i = 1; i <= 5; i++) t.Feed(Encoding.UTF8.GetBytes($"line{i}\r\n"));
+        var buf = t.DumpBuffer();
+        Assert.Contains("line1", buf);
+        Assert.Contains("line5", buf);
+        Assert.True(buf.Count >= 5);
+    }
+
+    [Fact]
+    public void SeedScrollback_AddsToHistoryAboveLiveScreen()
+    {
+        var t = new TerminalEmulator(20, 3);
+        t.SeedScrollback(new[] { "restored-A", "restored-B" });
+        Assert.Equal(2, t.HistoryCount);
+        Assert.Equal("restored-A", t.GetHistoryCell(0, 0) is var c0 ? RowText(t, 0) : "");
+        Assert.Equal("restored-B", RowText(t, 1));
+        // Live screen is untouched (blank).
+        Assert.Equal("", t.DumpRow(0));
+    }
+
+    private static string RowText(TerminalEmulator t, int historyRow)
+    {
+        var sb = new StringBuilder();
+        for (int c = 0; c < 20; c++) { var ch = t.GetHistoryCell(historyRow, c).Rune; if (ch == 0) break; sb.Append((char)ch); }
+        return sb.ToString().TrimEnd();
+    }
+}


### PR DESCRIPTION
**Tier 2 backlog (T2-9)** — WT's buffer-content persistence.

New `restore-buffer` config (default **off**): each pane's scrollback text is saved to `state.json` and re-displayed **dimmed** above the fresh shell on relaunch, under a `──── restored ────` separator. Pairs with the existing `restore-commands`.

- **Core**: `DumpBuffer()` (history + visible, trailing blanks trimmed) + `SeedScrollback(lines)` (adds dimmed rows to history without touching the live screen)
- **Save**: up to 500 lines/pane captured when enabled
- **Restore**: each pane's scrollback seeded right after creation (before the new shell scrolls), so restored content stays at the top

## Verification
- ✅ 2 new Core tests (DumpBuffer scrollback+visible; SeedScrollback above blank live screen) — 101/101
- ✅ **Live**: `echo RESTORE-MARKER-9876` → close → relaunch → the command + its output reappear as **dimmed scrollback** above `──── restored ────`, fresh prompt below

🤖 Generated with [Claude Code](https://claude.com/claude-code)