### PR TITLE
feat(core): sixel graphics — DCS parser, decoder, out-of-band delivery

### DIFF
--- a/src/Agwinterm.Core/IParserPerformer.cs
+++ b/src/Agwinterm.Core/IParserPerformer.cs
@@ -8,4 +8,6 @@ public interface IParserPerformer
     void EscDispatch(char final);
     void OscDispatch(int command, string text);
     void ApcDispatch(string data);
+    /// <summary>A completed DCS string (ESC P … ST), raw bytes without the introducer/terminator.</summary>
+    void DcsDispatch(byte[] data);
 }

--- a/src/Agwinterm.Core/ParserState.cs
+++ b/src/Agwinterm.Core/ParserState.cs
@@ -12,4 +12,6 @@ internal enum ParserState
     OscEsc,
     ApcString,
     ApcEsc,
+    DcsString,
+    DcsEsc,
 }

--- a/src/Agwinterm.Core/Sixel.cs
+++ b/src/Agwinterm.Core/Sixel.cs
@@ -1,0 +1,142 @@
+namespace Agwinterm.Core;
+
+/// <summary>
+/// Decodes a DCS sixel payload (the bytes between <c>ESC P … q</c> and <c>ST</c>) into an RGBA
+/// bitmap. Handles the color introducer (<c>#</c>, RGB/HLS define + select), raster attributes
+/// (<c>"</c>), repeat (<c>!</c>), carriage return (<c>$</c>), line feed (<c>-</c>), and the sixel
+/// data bytes (0x3F–0x7E, six vertical pixels each). Background stays transparent.
+/// </summary>
+public static class Sixel
+{
+    /// <summary>Result of decoding: RGBA pixels (width*height*4) or null if not a sixel payload.</summary>
+    public static (int Width, int Height, byte[] Rgba)? Decode(byte[] dcs)
+    {
+        // The DCS payload is "P1;P2;P3 q <sixel-data>". Skip params up to and including 'q'.
+        int i = 0;
+        while (i < dcs.Length && dcs[i] != (byte)'q') i++;
+        if (i >= dcs.Length) return null;   // no sixel introducer
+        i++;
+
+        // The VT-241 default 16-color palette (indices 0..15); apps usually redefine what they use.
+        var palette = new (byte R, byte G, byte B)[256];
+        int[] defaults = { 0x000000, 0x3333CC, 0xCC2121, 0x33CC33, 0xCC33CC, 0x33CCCC, 0xCCCC33, 0x878787,
+                           0x424242, 0x545499, 0x994242, 0x549954, 0x995499, 0x549999, 0x999954, 0xCCCCCC };
+        for (int p = 0; p < 256; p++)
+        {
+            int d = p < defaults.Length ? defaults[p] : 0xFFFFFF;
+            palette[p] = ((byte)(d >> 16), (byte)(d >> 8), (byte)d);
+        }
+
+        // Grow-as-needed RGBA canvas (sixel doesn't have to declare its size up front).
+        int cap = 64;
+        int width = 0, height = 0;              // used extent
+        byte[] rgba = new byte[cap * cap * 4];
+        int canvasW = cap, canvasH = cap;
+        int curColor = 0, x = 0, y = 0;         // y = top of the current 6-pixel band
+
+        void EnsureSize(int needW, int needH)
+        {
+            if (needW <= canvasW && needH <= canvasH) return;
+            int nw = canvasW, nh = canvasH;
+            while (nw < needW) nw *= 2;
+            while (nh < needH) nh *= 2;
+            var ng = new byte[nw * nh * 4];
+            for (int row = 0; row < canvasH; row++)
+                System.Array.Copy(rgba, row * canvasW * 4, ng, row * nw * 4, canvasW * 4);
+            rgba = ng; canvasW = nw; canvasH = nh;
+        }
+
+        int ReadInt(ref int j)
+        {
+            int v = 0; bool any = false;
+            while (j < dcs.Length && dcs[j] >= (byte)'0' && dcs[j] <= (byte)'9') { v = v * 10 + (dcs[j] - '0'); j++; any = true; }
+            return any ? v : -1;
+        }
+
+        try
+        {
+            while (i < dcs.Length)
+            {
+                byte b = dcs[i];
+                if (b == (byte)'#')   // color: #Pc  (select)  or  #Pc;Pu;Px;Py;Pz  (define)
+                {
+                    i++;
+                    int idx = ReadInt(ref i);
+                    if (idx < 0 || idx > 255) { continue; }
+                    if (i < dcs.Length && dcs[i] == (byte)';')
+                    {
+                        i++; int space = ReadInt(ref i);
+                        Skip(ref i, ';'); int a = ReadInt(ref i);
+                        Skip(ref i, ';'); int bb = ReadInt(ref i);
+                        Skip(ref i, ';'); int cc = ReadInt(ref i);
+                        if (space == 2)   // RGB, components 0..100
+                            palette[idx] = ((byte)(a * 255 / 100), (byte)(bb * 255 / 100), (byte)(cc * 255 / 100));
+                        else if (space == 1)   // HLS (hue 0..360, light/sat 0..100)
+                            palette[idx] = HlsToRgb(a, bb, cc);
+                    }
+                    curColor = idx;
+                }
+                else if (b == (byte)'"')   // raster attributes: "Pan;Pad;Ph;Pv  (aspect + declared size)
+                {
+                    i++; ReadInt(ref i); Skip(ref i, ';'); ReadInt(ref i);
+                    Skip(ref i, ';'); int ph = ReadInt(ref i); Skip(ref i, ';'); int pv = ReadInt(ref i);
+                    if (ph > 0 && pv > 0) EnsureSize(ph, pv);
+                }
+                else if (b == (byte)'!')   // repeat: !Pn <sixel>
+                {
+                    i++; int n = ReadInt(ref i);
+                    if (i < dcs.Length && dcs[i] >= 0x3F && dcs[i] <= 0x7E)
+                    { PutSixel(dcs[i] - 0x3F, System.Math.Max(1, n)); i++; }
+                }
+                else if (b == (byte)'$') { x = 0; i++; }              // CR: back to left, same band
+                else if (b == (byte)'-') { x = 0; y += 6; i++; }      // LF: next 6-pixel band
+                else if (b >= 0x3F && b <= 0x7E) { PutSixel(b - 0x3F, 1); i++; }
+                else i++;   // ignore anything else (whitespace, stray bytes)
+            }
+        }
+        catch { /* be forgiving: return whatever decoded so far */ }
+
+        if (width <= 0 || height <= 0) return null;
+
+        // Crop the canvas to the used extent.
+        var outp = new byte[width * height * 4];
+        for (int row = 0; row < height; row++)
+            System.Array.Copy(rgba, row * canvasW * 4, outp, row * width * 4, width * 4);
+        return (width, height, outp);
+
+        void Skip(ref int j, char ch) { if (j < dcs.Length && dcs[j] == (byte)ch) j++; }
+
+        void PutSixel(int bits, int repeat)
+        {
+            EnsureSize(x + repeat, y + 6);
+            var (r, g, bl) = palette[curColor];
+            for (int rep = 0; rep < repeat; rep++, x++)
+                for (int row = 0; row < 6; row++)
+                    if ((bits & (1 << row)) != 0)
+                    {
+                        int px = x, py = y + row;
+                        int o = (py * canvasW + px) * 4;
+                        rgba[o] = r; rgba[o + 1] = g; rgba[o + 2] = bl; rgba[o + 3] = 255;
+                        if (px + 1 > width) width = px + 1;
+                        if (py + 1 > height) height = py + 1;
+                    }
+        }
+    }
+
+    private static (byte, byte, byte) HlsToRgb(int h, int l, int s)
+    {
+        double L = l / 100.0, S = s / 100.0, H = ((h % 360) + 360) % 360 / 360.0;
+        if (S == 0) { byte v = (byte)(L * 255); return (v, v, v); }
+        double q = L < 0.5 ? L * (1 + S) : L + S - L * S, p = 2 * L - q;
+        double R = Hue(p, q, H + 1.0 / 3), G = Hue(p, q, H), B = Hue(p, q, H - 1.0 / 3);
+        return ((byte)(R * 255), (byte)(G * 255), (byte)(B * 255));
+        static double Hue(double p, double q, double t)
+        {
+            if (t < 0) t += 1; if (t > 1) t -= 1;
+            if (t < 1.0 / 6) return p + (q - p) * 6 * t;
+            if (t < 1.0 / 2) return q;
+            if (t < 2.0 / 3) return p + (q - p) * (2.0 / 3 - t) * 6;
+            return p;
+        }
+    }
+}

--- a/src/Agwinterm.Core/TerminalEmulator.cs
+++ b/src/Agwinterm.Core/TerminalEmulator.cs
@@ -365,6 +365,33 @@ public sealed class TerminalEmulator : IParserPerformer
         _placements.Add(new ImagePlacement(id, row, col, cols, rows, srcX, srcY, srcW, srcH));
     }
 
+    /// <summary>Cell size in pixels (set by the host from its font metrics) — used to lay a sixel
+    /// image onto the grid and advance the cursor below it. Sane defaults for headless use.</summary>
+    public int CellPixelWidth { get; set; } = 8;
+    public int CellPixelHeight { get; set; } = 18;
+
+    /// <summary>Next free image id for host-generated (sixel) images; negative to avoid clashing with
+    /// Kitty ids (which are app-chosen positive numbers).</summary>
+    private int _sixelSeq = -1;
+
+    public void DcsDispatch(byte[] data) => PlaceSixel(data);
+
+    /// <summary>Decode a sixel DCS payload and place it at the cursor (advancing below it). Returns
+    /// false if it isn't a valid sixel. Reused by the out-of-band control path (ConPTY strips DCS
+    /// through the shell, so sixel is also deliverable via the control pipe, like Kitty images).</summary>
+    public bool PlaceSixel(byte[] data)
+    {
+        if (Sixel.Decode(data) is not { } s || s.Width <= 0 || s.Height <= 0) return false;
+        int id = _sixelSeq--;
+        _images[id] = new KittyImage(id, KittyFormat.Rgba, s.Width, s.Height, s.Rgba);
+        int cols = Math.Max(1, (s.Width + CellPixelWidth - 1) / CellPixelWidth);
+        int rows = Math.Max(1, (s.Height + CellPixelHeight - 1) / CellPixelHeight);
+        _placements.Add(new ImagePlacement(id, CursorRow, CursorCol, cols, rows));   // visible grid row
+        for (int k = 0; k < rows; k++) Index();   // advance the cursor below the image (sixel scrolling)
+        CursorCol = 0;
+        return true;
+    }
+
     public void ApcDispatch(string data)
     {
         if (data.Length == 0 || data[0] != 'G') return; // only Kitty graphics (_G...)
@@ -616,6 +643,15 @@ public sealed class TerminalEmulator : IParserPerformer
         // A full-height scroll on the main screen pushes the top row into scrollback.
         if (!IsAltScreen && ScrollbackMax > 0 && _scrollTop == 0 && _scrollBottom == Screen.Rows - 1)
             PushHistory();
+        // Sixel images (negative ids; not host-managed like Kitty) scroll up with the text.
+        if (_placements.Count > 0)
+            for (int i = _placements.Count - 1; i >= 0; i--)
+                if (_placements[i].ImageId < 0)
+                {
+                    var np = _placements[i] with { Row = _placements[i].Row - 1 };
+                    if (np.Row + Math.Max(1, np.Rows) <= 0) { _placements.RemoveAt(i); _images.Remove(np.ImageId); }
+                    else _placements[i] = np;
+                }
         for (int r = _scrollTop + 1; r <= _scrollBottom; r++)
             for (int c = 0; c < Screen.Cols; c++)
                 Screen[r - 1, c] = Screen[r, c];

--- a/src/Agwinterm.Core/VtParser.cs
+++ b/src/Agwinterm.Core/VtParser.cs
@@ -16,6 +16,7 @@ public sealed class VtParser(IParserPerformer performer)
 
     // OSC / APC string accumulators.
     private readonly List<byte> _osc = new();   // raw payload bytes; UTF-8-decoded at dispatch
+    private readonly List<byte> _dcs = new();   // DCS payload bytes (sixel etc.)
     private readonly System.Text.StringBuilder _apc = new();
 
     public void Feed(ReadOnlySpan<byte> bytes)
@@ -26,9 +27,10 @@ public sealed class VtParser(IParserPerformer performer)
 
     private void Step(byte b)
     {
-        // ESC inside an OSC/APC string may be the start of a String Terminator (ESC \).
+        // ESC inside an OSC/APC/DCS string may be the start of a String Terminator (ESC \).
         if (b == 0x1b && _state == ParserState.OscString) { _state = ParserState.OscEsc; return; }
         if (b == 0x1b && _state == ParserState.ApcString) { _state = ParserState.ApcEsc; return; }
+        if (b == 0x1b && _state == ParserState.DcsString) { _state = ParserState.DcsEsc; return; }
 
         // ESC otherwise restarts an escape sequence from any state.
         if (b == 0x1b) { FlushIncompleteUtf8(); EnterEscape(); return; }
@@ -43,6 +45,7 @@ public sealed class VtParser(IParserPerformer performer)
                 if (b == (byte)'[') { _state = ParserState.CsiEntry; ResetParams(); }
                 else if (b == (byte)']') { _state = ParserState.OscString; _osc.Clear(); }
                 else if (b == (byte)'_') { _state = ParserState.ApcString; _apc.Clear(); }
+                else if (b == (byte)'P') { _state = ParserState.DcsString; _dcs.Clear(); }   // DCS (sixel etc.)
                 else if (b is >= 0x30 and <= 0x7e) { performer.EscDispatch((char)b); _state = ParserState.Ground; }
                 else if (IsControl(b)) performer.Execute(b);
                 else _state = ParserState.Ground;
@@ -66,6 +69,17 @@ public sealed class VtParser(IParserPerformer performer)
 
             case ParserState.ApcEsc:
                 DispatchApc();
+                _state = ParserState.Ground;
+                if (b != (byte)'\\') Step(b);
+                break;
+
+            case ParserState.DcsString:
+                if (b == 0x07) { DispatchDcs(); _state = ParserState.Ground; } // BEL terminator
+                else if (_dcs.Count < 8_000_000) _dcs.Add(b);                  // cap runaway payloads
+                break;
+
+            case ParserState.DcsEsc:
+                DispatchDcs();
                 _state = ParserState.Ground;
                 if (b != (byte)'\\') Step(b);
                 break;
@@ -135,6 +149,12 @@ public sealed class VtParser(IParserPerformer performer)
     {
         if (_apc.Length > 0)
             performer.ApcDispatch(_apc.ToString());
+    }
+
+    private void DispatchDcs()
+    {
+        if (_dcs.Count > 0)
+            performer.DcsDispatch(_dcs.ToArray());
     }
 
     private void EmitScalar(int scalar)

--- a/src/Agwinterm.Ctl/Program.cs
+++ b/src/Agwinterm.Ctl/Program.cs
@@ -300,6 +300,14 @@ switch (area)
         if (int.TryParse(Opt("col"), out var col)) cargs["col"] = col;
         if (int.TryParse(Opt("id"), out var id)) cargs["id"] = id;
         break;
+    case "image" when sub == "sixel":
+        cmd = "image.sixel";
+        target = DefaultTarget();
+        if (rest.Count == 0) { Console.Error.WriteLine("image sixel needs a path"); return 2; }
+        cargs["path"] = System.IO.Path.GetFullPath(rest[0]);
+        if (int.TryParse(Opt("row"), out var srow)) cargs["row"] = srow;
+        if (int.TryParse(Opt("col"), out var scol)) cargs["col"] = scol;
+        break;
     default:
         Console.Error.WriteLine($"unknown command '{area} {sub}'"); return 2;
 }

--- a/src/Agwinterm.Pty/AgentSkill.cs
+++ b/src/Agwinterm.Pty/AgentSkill.cs
@@ -177,6 +177,8 @@ public static class AgentSkill
 
         ## Show an image inline
         - `agwintermctl image show C:\path\pic.png --row 2 --col 4`
+        - `agwintermctl image sixel C:\path\pic.six [--row R --col C]` — render a sixel file (delivered
+          out-of-band; ConPTY strips sixel through the shell, so use this to display one)
         Note: Windows ConPTY strips inline terminal-graphics sequences, so images MUST be delivered
         through this control channel — not by printing escape codes to stdout.
 

--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -219,6 +219,7 @@ public sealed class ControlServer : IDisposable
                 "session.text" => HandleText(s),
                 "session.status" => HandleStatus(s, args),
                 "image.show" => HandleImageShow(s, args),
+                "image.sixel" => HandleImageSixel(s, args),
                 "image.clear" => HandleImageClear(s),
                 "image.frame" => HandleImageFrame(s, args),
                 _ => Err($"unknown command '{cmd}'"),
@@ -342,6 +343,18 @@ public sealed class ControlServer : IDisposable
         sb.Append('\x1b').Append('[').Append(row + 1).Append(';').Append(col + 1).Append('H');
         sb.Append('\x1b').Append("_Gf=100,a=T,i=").Append(id).Append(';').Append(b64).Append('\x1b').Append('\\');
         s.Inject(Encoding.ASCII.GetBytes(sb.ToString()));
+        return Ok("shown");
+    }
+
+    private static string HandleImageSixel(TerminalSession s, JsonElement args)
+    {
+        string? path = GetString(args, "path");
+        if (path is null || !File.Exists(path)) return Err("sixel file not found: " + (path ?? "<null>"));
+        int row = GetInt(args, "row", -1), col = GetInt(args, "col", -1);
+        // Inject straight into the emulator's parser — ConPTY strips DCS through the shell, so sixel is
+        // delivered out-of-band here (same as Kitty images). Optional CUP positions it first.
+        if (row >= 0 && col >= 0) s.Inject(Encoding.ASCII.GetBytes($"\x1b[{row + 1};{col + 1}H"));
+        s.Inject(File.ReadAllBytes(path));
         return Ok("shown");
     }
 

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -3746,6 +3746,7 @@ internal partial class Program : ISessionHost, IWindowHost
         lock (session.SyncRoot)
         {
             var em = session.Emulator;
+            em.CellPixelWidth = Math.Max(1, (int)cw); em.CellPixelHeight = Math.Max(1, (int)ch);  // for sixel cell-span
             var screen = em.Screen;
             int cols = screen.Cols, rows = screen.Rows;
             int hist = em.HistoryCount;

--- a/tests/Agwinterm.Core.Tests/KittyGraphicsTests.cs
+++ b/tests/Agwinterm.Core.Tests/KittyGraphicsTests.cs
@@ -94,5 +94,6 @@ public class KittyGraphicsTests
         public void EscDispatch(char final) { }
         public void OscDispatch(int command, string text) { }
         public void ApcDispatch(string data) => LastApc = data;
+        public void DcsDispatch(byte[] data) { }
     }
 }

--- a/tests/Agwinterm.Core.Tests/SixelTests.cs
+++ b/tests/Agwinterm.Core.Tests/SixelTests.cs
@@ -1,0 +1,49 @@
+using System.Text;
+using Agwinterm.Core;
+
+namespace Agwinterm.Core.Tests;
+
+public class SixelTests
+{
+    [Fact]
+    public void Decode_SimpleTwoColorSixel()
+    {
+        // "#0;2;100;0;0" defines color 0 = red (RGB 100%,0,0); "@" (0x40) = bit 0 set (top pixel);
+        // then color 1 green, "~" (0x7E) = bits 0..5 all set (full 6-pixel column).
+        var payload = "#0;2;100;0;0#0@#1;2;0;100;0#1~";
+        var (w, h, rgba) = Sixel.Decode(ToDcs(payload))!.Value;
+        Assert.True(w >= 2 && h >= 6);
+        // Col 0, row 0 = red (from '@' with color 0).
+        int o0 = (0 * w + 0) * 4;
+        Assert.Equal(255, rgba[o0]); Assert.Equal(0, rgba[o0 + 1]); Assert.Equal(0, rgba[o0 + 2]); Assert.Equal(255, rgba[o0 + 3]);
+        // Col 1, rows 0..5 = green (from '~' with color 1).
+        for (int row = 0; row < 6; row++)
+        {
+            int o = (row * w + 1) * 4;
+            Assert.Equal(0, rgba[o]); Assert.Equal(255, rgba[o + 1]); Assert.Equal(0, rgba[o + 2]);
+        }
+    }
+
+    [Fact]
+    public void Decode_RepeatAndNewline()
+    {
+        // "!5~" repeats a full column 5 times; "-" moves to the next band; then another column.
+        var (w, h, _) = Sixel.Decode(ToDcs("#0;2;0;0;100!5~-@"))!.Value;
+        Assert.True(w >= 5);
+        Assert.True(h >= 7);   // band 0 (6px) + band 1 has a pixel -> at least 7
+    }
+
+    [Fact]
+    public void Emulator_SixelPlacesAnImage()
+    {
+        var t = new TerminalEmulator(40, 10);
+        t.Feed(Encoding.UTF8.GetBytes("\x1bP0;0;0q#0;2;100;0;0~~~~\x1b\\"));
+        Assert.Single(t.Placements);
+        var pl = t.Placements[0];
+        Assert.True(t.Images.ContainsKey(pl.ImageId));
+        Assert.True(pl.ImageId < 0);   // sixel-generated id
+    }
+
+    private static byte[] ToDcs(string sixelBody)
+        => Encoding.ASCII.GetBytes("0;0;0q" + sixelBody);   // params + 'q' + body (as DcsDispatch receives)
+}

--- a/tests/Agwinterm.Core.Tests/VtParserTests.cs
+++ b/tests/Agwinterm.Core.Tests/VtParserTests.cs
@@ -15,6 +15,7 @@ public class VtParserTests
         public void EscDispatch(char final) => Events.Add($"esc:{final}");
         public void OscDispatch(int command, string text) => Events.Add($"osc:{command}:{text}");
         public void ApcDispatch(string data) => Events.Add($"apc:{data}");
+        public void DcsDispatch(byte[] data) => Events.Add($"dcs:{data.Length}");
     }
 
     private static Recorder Run(string input)


### PR DESCRIPTION
**Tier 2 backlog (T2-11)** — WT/xterm sixel graphics.

## What lands
- **VtParser**: DCS string handling (`ESC P … ST`) → new `IParserPerformer.DcsDispatch`; `ParserState.DcsString/DcsEsc`
- **`Sixel.cs`**: decodes a sixel payload to RGBA — color introducer (`#`, RGB + HLS define/select), raster attributes (`"`), repeat (`!`), CR (`$`), LF (`-`), and the 6-pixel data bytes; grow-as-needed canvas
- **Emulator**: `PlaceSixel` decodes + places at the cursor (advancing below it), **reusing the existing Kitty image render path** (RGBA → premultiplied-BGRA → `DrawBitmap`); sixel placements scroll up with the text
- Cell pixel size fed from the renderer's font metrics so the image spans the right cell count

## Delivery — the ConPTY wall
**ConPTY strips DCS/sixel before it reaches our emulator** — the same reason Kitty graphics already go **out-of-band via the control pipe** (the code comments "ConPTY strips APC"). So sixel is delivered the same way: new **`image.sixel`** control verb + **`agwintermctl image sixel <file> [--row R --col C]`** inject the sixel straight into the emulator's parser. (Through-the-shell sixel would additionally need a ConPTY *passthrough* mode in the PTY layer — a separate investigation.)

## Verification
- ✅ 3 new tests: sixel decode (2-color; repeat/newline), emulator placement — 104/104 Core, 16/16 Pty
- ✅ **Live**: a 6-band RGB sixel file → `agwintermctl image sixel` → renders as a **striped color image** (screenshot); confirmed ConPTY silently drops the same bytes when emitted through the shell (root-caused, not guessed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)