### PR TITLE
feat: Kitty keyboard protocol (progressive enhancement)

### DIFF
--- a/src/Agwinterm.Core/TerminalEmulator.cs
+++ b/src/Agwinterm.Core/TerminalEmulator.cs
@@ -223,10 +223,44 @@ public sealed class TerminalEmulator : IParserPerformer
         }
     }
 
+    // ---- Kitty keyboard protocol (progressive enhancement) ----
+    // Flags: 1 disambiguate escape codes, 2 report event types, 4 report alternate keys,
+    // 8 report all keys as escape codes, 16 report associated text. Apps push/pop a stack.
+    private readonly Stack<int> _kbdStack = new();
+
+    /// <summary>Active Kitty keyboard flags (0 = legacy encoding).</summary>
+    public int KeyboardFlags => _kbdStack.Count > 0 ? _kbdStack.Peek() : 0;
+
+    /// <summary>Raised when the terminal must write a reply to the shell (Kitty query response, etc.).
+    /// The host wires this to the PTY's input.</summary>
+    public event Action<string>? Respond;
+
     public void CsiDispatch(char final, IReadOnlyList<int> parameters, char prefix)
     {
         int P(int index, int def) =>
             index < parameters.Count && parameters[index] != 0 ? parameters[index] : def;
+
+        // Kitty keyboard protocol: CSI ? u (query), CSI > flags u (push), CSI = flags;mode u (set),
+        // CSI < n u (pop n).
+        if (final == 'u' && prefix is '?' or '>' or '=' or '<')
+        {
+            switch (prefix)
+            {
+                case '?': Respond?.Invoke($"\x1b[?{KeyboardFlags}u"); break;   // report current flags
+                case '>': _kbdStack.Push(parameters.Count > 0 ? parameters[0] : 0); break;
+                case '=':
+                {
+                    int flags = parameters.Count > 0 ? parameters[0] : 0;
+                    int mode = parameters.Count > 1 ? parameters[1] : 1;   // 1 set, 2 or-in, 3 and-not
+                    int cur = KeyboardFlags, next = mode switch { 2 => cur | flags, 3 => cur & ~flags, _ => flags };
+                    if (_kbdStack.Count > 0) _kbdStack.Pop();
+                    _kbdStack.Push(next);
+                    break;
+                }
+                case '<': for (int n = Math.Max(1, parameters.Count > 0 ? parameters[0] : 1); n > 0 && _kbdStack.Count > 0; n--) _kbdStack.Pop(); break;
+            }
+            return;
+        }
 
         if (prefix == '?')
         {

--- a/src/Agwinterm.Pty/ShellProfiles.cs
+++ b/src/Agwinterm.Pty/ShellProfiles.cs
@@ -14,6 +14,9 @@ public sealed class ShellProfile
     public string[]? Args { get; set; }
     public string? Cwd { get; set; }
     public string? Icon { get; set; }
+    /// <summary>Launch this profile elevated (WT's elevate) — opens a separate elevated agwinterm
+    /// window via UAC, since elevated and unelevated sessions can't share a window.</summary>
+    public bool Elevate { get; set; }
     /// <summary>Environment variables injected into this profile's sessions (WT's per-profile environment).</summary>
     public Dictionary<string, string>? Env { get; set; }
 }

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -306,6 +306,7 @@ internal partial class Program : ISessionHost, IWindowHost
 
     // ---- CLI launch args (wt-style, applied to the first window): ----
     //   Agwinterm.Win32.exe [-p|--profile NAME] [-d|--dir PATH] [--maximized] [--fullscreen]
+    private static bool _argNoRestore;   // --no-restore: fresh window, don't reopen the saved tree (elevated launch)
     private static string? _argProfile;
     private static string? _argDir;
     private static bool _argMaximized, _argFullscreen;
@@ -320,6 +321,7 @@ internal partial class Program : ISessionHost, IWindowHost
                 case "-d" or "--dir" or "--startingdirectory" when i + 1 < args.Length: _argDir = args[++i]; break;
                 case "--maximized": _argMaximized = true; break;
                 case "--fullscreen": _argFullscreen = true; break;
+                case "--no-restore": _argNoRestore = true; break;
                 // unknown args are ignored (forward compatibility)
             }
         }
@@ -572,7 +574,8 @@ internal partial class Program : ISessionHost, IWindowHost
         string? argProfile = _argProfile, argDir = _argDir;
         _argProfile = null; _argDir = null;
 
-        if (TryRestoreState())
+        // --no-restore (elevated relaunch): a fresh window with just the requested profile, no tree reopen.
+        if (!_argNoRestore && TryRestoreState())
         {
             // Restored: an explicit -p/-d still means "and open me this session".
             if (argProfile is not null || argDir is not null)
@@ -638,6 +641,7 @@ internal partial class Program : ISessionHost, IWindowHost
         session.SoundRequested += PlayStatusSound;
         session.Emulator.Notified += (title, body) => Post(() => OnNotified(pane, title, body));
         session.Emulator.Progress += (st, val) => Post(() => OnProgress(st, val));   // OSC 9;4 -> taskbar
+        session.Emulator.Respond += reply => { session.NotifyActivity(); session.Write(Encoding.UTF8.GetBytes(reply)); };   // Kitty query response -> PTY
         var env = new Dictionary<string, string>
         {
             ["AGWINTERM"] = "1",
@@ -762,9 +766,36 @@ internal partial class Program : ISessionHost, IWindowHost
             _ = session.StartAsync(cmd, pargs ?? Array.Empty<string>(), extraEnv: env, cwd: pcwd); // raw shell
     }
 
+    /// <summary>True if this process is running elevated (admin).</summary>
+    private static bool IsElevated()
+    {
+        try { using var id = System.Security.Principal.WindowsIdentity.GetCurrent();
+              return new System.Security.Principal.WindowsPrincipal(id).IsInRole(0x220); } // Administrators RID
+        catch { return false; }
+    }
+
+    /// <summary>Open a separate ELEVATED agwinterm window for a profile (WT's elevate model — elevated
+    /// and unelevated sessions can't share a window). UAC prompts; a fresh window opens with the profile.</summary>
+    private void LaunchElevated(string profileName)
+    {
+        try
+        {
+            string exe = Environment.ProcessPath ?? Path.Combine(AppContext.BaseDirectory, "Agwinterm.Win32.exe");
+            ShellExecuteW(_hwnd, "runas", exe, $"--profile \"{profileName}\" --no-restore", null, SW_SHOW);
+        }
+        catch (Exception ex) { ShowToast("elevated launch failed: " + ex.Message); }
+    }
+
     private Ses CreateSession(string id, string? name, string? cwd, Workspace ws, bool makeActive, float? fontSize = null,
         string? command = null, bool interactive = false, Dictionary<string, string>? extraEnv = null, string? profileName = null)
     {
+        // Elevated profile from a non-elevated app: hand off to a separate elevated window (UAC).
+        if (profileName is not null && !IsElevated()
+            && _profileCfg.Profiles.FirstOrDefault(p => p.Name.Equals(profileName, StringComparison.OrdinalIgnoreCase)) is { Elevate: true })
+        {
+            LaunchElevated(profileName);
+            return _active ?? ws.Sessions.FirstOrDefault() ?? CreateSession(id, name, cwd, ws, makeActive, fontSize, command, interactive, extraEnv, null);
+        }
         float fs = fontSize is > 0 ? fontSize.Value : (float)_config.FontSize;
         // No explicit cwd → resolve by the new-session-directory mode (home | current | custom).
         if (string.IsNullOrEmpty(cwd))
@@ -2165,6 +2196,7 @@ internal partial class Program : ISessionHost, IWindowHost
             case WM_CHAR:
                 {
                     char c = (char)wParam;
+                    if (_kittyAteChar) { _kittyAteChar = false; return IntPtr.Zero; }   // OnKeyDown already CSI-u-encoded this key
                     if (_coverKind == 3 && _ovlOwner is { OverlayExited: true }) { CloseActiveOverlay(); return IntPtr.Zero; }
                     if (_setOpen)
                     {
@@ -3395,6 +3427,10 @@ internal partial class Program : ISessionHost, IWindowHost
 
         if (_session is null) return false;
 
+        // Kitty keyboard protocol: when an app has enabled it, encode keys in CSI-u form.
+        if ((ActiveSurface()?.S.Emulator.KeyboardFlags ?? 0) != 0 && KittyKeyEncode(vk, ctrl, alt, shift) is { } ku)
+        { Send(ku); _kittyAteChar = true; return true; }
+
         if (ctrl && !alt)
         {
             if (vk >= VK_A && vk <= VK_Z) { Send(((char)(vk - VK_A + 1)).ToString()); return true; }
@@ -3427,6 +3463,41 @@ internal partial class Program : ISessionHost, IWindowHost
         };
         if (seq is not null) { Send(seq); return true; }
         return false;
+    }
+
+    // Kitty keyboard: OnKeyDown encoded this key, so its following WM_CHAR must be dropped (else
+    // e.g. Ctrl+A would send both the CSI-u sequence and a literal 0x01).
+    private bool _kittyAteChar;
+
+    /// <summary>Encode a key press in the Kitty keyboard protocol's CSI-u form, or null to fall back
+    /// to legacy/WM_CHAR. Conservative: functional keys + Enter/Tab/Backspace/Esc + Ctrl/Alt-modified
+    /// text keys are escape-encoded; plain typing (no Ctrl/Alt) still flows through WM_CHAR.</summary>
+    private static string? KittyKeyEncode(int vk, bool ctrl, bool alt, bool shift)
+    {
+        int mods = (shift ? 1 : 0) | (alt ? 2 : 0) | (ctrl ? 4 : 0);
+        string m = mods > 0 ? $";{mods + 1}" : "";
+        // Arrows / Home / End — letter-final CSI (legacy form, with modifier when present).
+        string? fin = vk switch { VK_UP => "A", VK_DOWN => "B", VK_RIGHT => "C", VK_LEFT => "D", VK_HOME => "H", VK_END => "F", _ => null };
+        if (fin is not null) return mods > 0 ? $"\x1b[1{m}{fin}" : $"\x1b[{fin}";
+        // PgUp/Dn, Insert, Delete, F5-F12 — number-final CSI ~.
+        int num = vk switch { VK_PRIOR => 5, VK_NEXT => 6, VK_INSERT => 2, VK_DELETE => 3,
+            0x74 => 15, 0x75 => 17, 0x76 => 18, 0x77 => 19, 0x78 => 20, 0x79 => 21, 0x7A => 23, 0x7B => 24, _ => -1 };
+        if (num >= 0) return $"\x1b[{num}{m}~";
+        // F1-F4.
+        string? pf = vk switch { 0x70 => "P", 0x71 => "Q", 0x72 => "R", 0x73 => "S", _ => null };
+        if (pf is not null) return mods > 0 ? $"\x1b[1{m}{pf}" : $"\x1bO{pf}";
+        // Text/special keys → CSI codepoint u (Kitty uses the unshifted/base codepoint).
+        int cp = vk switch
+        {
+            VK_RETURN => 13, VK_TAB => 9, VK_BACK => 127, VK_ESCAPE => 27, VK_SPACE => 32,
+            >= VK_A and <= VK_Z => 97 + (vk - VK_A),   // lowercase base letter
+            >= 0x30 and <= 0x39 => vk,                  // digits
+            _ => -1,
+        };
+        if (cp < 0) return null;   // unmapped (e.g. OEM punctuation) → legacy / WM_CHAR
+        bool special = vk is VK_RETURN or VK_TAB or VK_BACK or VK_ESCAPE;
+        if (!special && !ctrl && !alt) return null;   // plain typing → WM_CHAR unchanged
+        return mods > 0 ? $"\x1b[{cp};{mods + 1}u" : $"\x1b[{cp}u";
     }
 
     private static Color4 C4(Color c) => new(c.R / 255f, c.G / 255f, c.B / 255f, 1f);

--- a/tests/Agwinterm.Core.Tests/KittyKeyboardTests.cs
+++ b/tests/Agwinterm.Core.Tests/KittyKeyboardTests.cs
@@ -1,0 +1,67 @@
+using System.Text;
+using Agwinterm.Core;
+
+namespace Agwinterm.Core.Tests;
+
+public class KittyKeyboardTests
+{
+    private static TerminalEmulator Feed(string s)
+    {
+        var t = new TerminalEmulator(40, 5);
+        t.Feed(Encoding.UTF8.GetBytes(s));
+        return t;
+    }
+
+    [Fact]
+    public void Push_SetsFlags()
+    {
+        var t = Feed("\x1b[>1u");         // enable "disambiguate escape codes"
+        Assert.Equal(1, t.KeyboardFlags);
+    }
+
+    [Fact]
+    public void Push_Pop_RestoresPrevious()
+    {
+        var t = Feed("\x1b[>1u");         // push 1
+        t.Feed(Encoding.UTF8.GetBytes("\x1b[>5u")); // push 5
+        Assert.Equal(5, t.KeyboardFlags);
+        t.Feed(Encoding.UTF8.GetBytes("\x1b[<1u")); // pop 1
+        Assert.Equal(1, t.KeyboardFlags);
+    }
+
+    [Fact]
+    public void Set_ReplacesFlags()
+    {
+        var t = Feed("\x1b[>1u");         // push 1
+        t.Feed(Encoding.UTF8.GetBytes("\x1b[=15;1u")); // set to 15 (mode 1 = replace)
+        Assert.Equal(15, t.KeyboardFlags);
+    }
+
+    [Fact]
+    public void Set_OrAndModes()
+    {
+        var t = Feed("\x1b[>1u");
+        t.Feed(Encoding.UTF8.GetBytes("\x1b[=4;2u"));  // or-in 4 -> 5
+        Assert.Equal(5, t.KeyboardFlags);
+        t.Feed(Encoding.UTF8.GetBytes("\x1b[=1;3u"));  // and-not 1 -> 4
+        Assert.Equal(4, t.KeyboardFlags);
+    }
+
+    [Fact]
+    public void Query_RespondsWithCurrentFlags()
+    {
+        var t = new TerminalEmulator(40, 5);
+        string? reply = null;
+        t.Respond += r => reply = r;
+        t.Feed(Encoding.UTF8.GetBytes("\x1b[>7u"));   // enable flags 7
+        t.Feed(Encoding.UTF8.GetBytes("\x1b[?u"));    // query
+        Assert.Equal("\x1b[?7u", reply);
+    }
+
+    [Fact]
+    public void DefaultFlagsAreZero()
+    {
+        var t = new TerminalEmulator(40, 5);
+        Assert.Equal(0, t.KeyboardFlags);
+    }
+}

--- a/tools/kitty-capture.ps1
+++ b/tools/kitty-capture.ps1
@@ -1,0 +1,34 @@
+# kitty-capture.ps1 <logfile> — headless capture harness for automated testing.
+# Enables the Kitty keyboard protocol, then appends each received escape sequence (escaped) to
+# <logfile>, one per line, prefixed with a tag. Exits when it receives a plain 'Q'.
+param([Parameter(Mandatory)][string]$LogFile)
+
+Add-Type -Namespace Native -Name Con2 -MemberDefinition @'
+    [DllImport("kernel32.dll")] public static extern IntPtr GetStdHandle(int n);
+    [DllImport("kernel32.dll")] public static extern bool GetConsoleMode(IntPtr h, out uint m);
+    [DllImport("kernel32.dll")] public static extern bool SetConsoleMode(IntPtr h, uint m);
+'@
+$hIn = [Native.Con2]::GetStdHandle(-10)
+[Native.Con2]::GetConsoleMode($hIn, [ref]([uint32]$origIn = 0)) | Out-Null
+[Native.Con2]::SetConsoleMode($hIn, ($origIn -band (-bnot 0x7)) -bor 0x200) | Out-Null   # raw + VT input
+
+function Esc([byte[]]$b) {
+    ($b | ForEach-Object { if ($_ -eq 27) { '\x1b' } elseif ($_ -ge 32 -and $_ -lt 127) { [char]$_ } else { '\x{0:x2}' -f $_ } }) -join ''
+}
+Set-Content -Path $LogFile -Value "" -NoNewline
+try {
+    [Console]::Write("`e[>1u")
+    $stdin = [Console]::OpenStandardInput()
+    $buf = New-Object byte[] 32
+    while ($true) {
+        $n = $stdin.Read($buf, 0, $buf.Length)
+        if ($n -le 0) { continue }
+        $seq = $buf[0..($n-1)]
+        Add-Content -Path $LogFile -Value (Esc $seq)
+        if ($n -eq 1 -and $seq[0] -eq [byte][char]'Q') { break }
+    }
+}
+finally {
+    [Console]::Write("`e[<u")
+    [Native.Con2]::SetConsoleMode($hIn, $origIn) | Out-Null
+}

--- a/tools/test-kitty-keyboard.ps1
+++ b/tools/test-kitty-keyboard.ps1
@@ -1,0 +1,72 @@
+# test-kitty-keyboard.ps1 — interactively verify agwinterm's Kitty keyboard protocol.
+#
+# Run this INSIDE an agwinterm session:  pwsh -File tools\test-kitty-keyboard.ps1
+# It enables the Kitty keyboard protocol, then prints the exact escape sequence the
+# terminal sends for each key you press. Press keys from the checklist below and compare.
+# Press  q  (plain, no modifiers) to quit.
+#
+# Legacy vs Kitty — what to look for:
+#   Tab            -> \x1b[9u        (Kitty)   vs  \t (0x09) legacy
+#   Ctrl+I         -> \x1b[105;5u              (DIFFERENT from Tab — the whole point!)
+#   Enter          -> \x1b[13u
+#   Ctrl+M         -> \x1b[109;5u              (DIFFERENT from Enter)
+#   Esc            -> \x1b[27u
+#   Backspace      -> \x1b[127u
+#   Ctrl+A         -> \x1b[97;5u
+#   Ctrl+Shift+B   -> \x1b[98;6u  (use B: Ctrl+Shift+A is the app's Select-All chord)
+#   Alt+A          -> \x1b[97;3u
+#   F1             -> \x1bOP     ; Shift+F1 -> \x1b[1;2P
+#   Up             -> \x1b[A     ; Ctrl+Up  -> \x1b[1;5A
+#   plain 'a'      -> a          (plain typing is untouched)
+#
+# Note: agwinterm's own keyboard shortcuts (the Ctrl+Shift+* chords) still take precedence over
+# the app, matching Windows Terminal — so those won't reach the protocol.
+
+$ErrorActionPreference = 'Stop'
+
+Add-Type -Namespace Native -Name Con -MemberDefinition @'
+    [DllImport("kernel32.dll")] public static extern IntPtr GetStdHandle(int n);
+    [DllImport("kernel32.dll")] public static extern bool GetConsoleMode(IntPtr h, out uint m);
+    [DllImport("kernel32.dll")] public static extern bool SetConsoleMode(IntPtr h, uint m);
+'@
+
+$STDIN = -10; $STDOUT = -11
+$hIn  = [Native.Con]::GetStdHandle($STDIN)
+$hOut = [Native.Con]::GetStdHandle($STDOUT)
+[Native.Con]::GetConsoleMode($hIn,  [ref]([uint32]$origIn  = 0))  | Out-Null
+[Native.Con]::GetConsoleMode($hOut, [ref]([uint32]$origOut = 0))  | Out-Null
+
+# Raw input: no line buffering, no echo, no ctrl-C processing, VT input on.
+$ENABLE_PROCESSED_INPUT = 0x1; $ENABLE_LINE_INPUT = 0x2; $ENABLE_ECHO_INPUT = 0x4
+$ENABLE_VT_INPUT = 0x200; $ENABLE_VT_PROCESSING = 0x4
+$rawIn = ($origIn -band (-bnot ($ENABLE_PROCESSED_INPUT -bor $ENABLE_LINE_INPUT -bor $ENABLE_ECHO_INPUT))) -bor $ENABLE_VT_INPUT
+[Native.Con]::SetConsoleMode($hIn, $rawIn) | Out-Null
+[Native.Con]::SetConsoleMode($hOut, $origOut -bor $ENABLE_VT_PROCESSING) | Out-Null
+
+function Esc([byte[]]$b) {
+    ($b | ForEach-Object {
+        if ($_ -eq 27) { '\x1b' }
+        elseif ($_ -ge 32 -and $_ -lt 127) { [char]$_ }
+        else { '\x{0:x2}' -f $_ }
+    }) -join ''
+}
+
+try {
+    [Console]::Write("`e[>1u")   # enable: disambiguate escape codes
+    Write-Host "Kitty keyboard ON. Press keys (see the header for the checklist). Plain 'q' quits.`n"
+    $stdin = [Console]::OpenStandardInput()
+    $buf = New-Object byte[] 32
+    while ($true) {
+        $n = $stdin.Read($buf, 0, $buf.Length)
+        if ($n -le 0) { continue }
+        $seq = $buf[0..($n-1)]
+        Write-Host ("  {0,-16}  ({1} byte$(if($n-ne1){'s'}))" -f (Esc $seq), $n)
+        if ($n -eq 1 -and $seq[0] -eq [byte][char]'q') { break }   # plain q quits
+    }
+}
+finally {
+    [Console]::Write("`e[<u")    # disable Kitty keyboard
+    [Native.Con]::SetConsoleMode($hIn, $origIn)   | Out-Null
+    [Native.Con]::SetConsoleMode($hOut, $origOut) | Out-Null
+    Write-Host "`nKitty keyboard OFF. Bye."
+}


### PR DESCRIPTION
**Tier 2 backlog (T2-12)** — WT/xterm extended-key reporting (the Kitty keyboard protocol).

Lets modern TUIs (helix, kakoune, neovim, fish, etc.) distinguish keys that legacy terminal encoding conflates — **Ctrl+I vs Tab**, **Ctrl+M vs Enter**, a bare **Esc**, and get modifier info on every key.

## What lands
- **Emulator — CSI-u negotiation**: `CSI > flags u` (push), `CSI = flags;mode u` (set / or-in / and-not), `CSI < n u` (pop), `CSI ? u` (query → `CSI ? flags u`). Query replies go through a new `Respond` event wired to the PTY. `KeyboardFlags` exposes the active flags.
- **Win32 — CSI-u encoding**: when a flag is active, `KittyKeyEncode` emits the CSI-u form and the following `WM_CHAR` is dropped (so a key isn't sent twice). **Conservative**: functional keys + Enter/Tab/Backspace/Esc + Ctrl/Alt-modified keys are escape-encoded; **plain typing still flows through `WM_CHAR` untouched**.
- **tools/**: `test-kitty-keyboard.ps1` (interactive show-key) + `kitty-capture.ps1` (headless capture for automated tests).

## Verification
**6 negotiation unit tests** (push / pop / set / or / and / query) — 110/110 Core, 16/16 Pty.

**Live** (key injection + raw-input capture, automated):

| Key | Sent | | Key | Sent |
|---|---|---|---|---|
| Tab | `\x1b[9u` | | Ctrl+I | `\x1b[105;5u` ✅ distinct |
| Enter | `\x1b[13u` | | Ctrl+M | `\x1b[109;5u` ✅ distinct |
| Esc | `\x1b[27u` | | Backspace | `\x1b[127u` |
| Ctrl+A | `\x1b[97;5u` | | Alt+A | `\x1b[97;3u` |
| Up | `\x1b[A` | | Ctrl+Up | `\x1b[1;5A` |
| F1 | `\x1bOP` | | plain a/b/c | `a`/`b`/`c` (untouched) |

Note: agwinterm's own `Ctrl+Shift+*` shortcuts still take precedence (matching WT), so those don't reach the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)