### PR TITLE
feat: ligatures toggle (ligatures config)

### DIFF
--- a/src/Agwinterm.Core/TerminalConfig.cs
+++ b/src/Agwinterm.Core/TerminalConfig.cs
@@ -66,6 +66,10 @@ public sealed class TerminalConfig
     /// and solid blocks at any size) instead of using the font's glyphs. WT's font.builtinGlyphs. On.</summary>
     public bool BuiltinGlyphs { get; set; } = true;
 
+    /// <summary>Render font ligatures (e.g. -&gt; ⇒ ≠ with Cascadia Code / Fira Code). On by default;
+    /// set false to disable the calt/liga/clig/dlig features so each character draws standalone.</summary>
+    public bool Ligatures { get; set; } = true;
+
     /// <summary>Whole-window opacity, 30–100 (%). 100 = opaque. Clamped so the window never disappears.</summary>
     public int WindowOpacity { get; set; } = 100;
 
@@ -178,6 +182,9 @@ public sealed class TerminalConfig
         # Draw box-drawing / block-element glyphs as vectors (crisp, seamless borders at any size).
         builtin-glyphs = true
 
+        # Render font ligatures (-> ⇒ ≠ …) with a ligature font. Set false to disable them.
+        ligatures = true
+
         # Whole-window opacity, 30-100 (%). 100 = opaque.
         window-opacity = 100
 
@@ -258,6 +265,7 @@ public sealed class TerminalConfig
                 case "inactive-pane-dim": if (int.TryParse(val, out var ipd)) cfg.InactivePaneDim = System.Math.Clamp(ipd, 0, 100); break;
                 case "unfocused-dim": if (int.TryParse(val, out var ufd)) cfg.UnfocusedDim = System.Math.Clamp(ufd, 0, 90); break;
                 case "builtin-glyphs": cfg.BuiltinGlyphs = ParseBool(val, cfg.BuiltinGlyphs); break;
+                case "ligatures": cfg.Ligatures = ParseBool(val, cfg.Ligatures); break;
                 case "window-opacity": if (int.TryParse(val, out var wo)) cfg.WindowOpacity = System.Math.Clamp(wo, 30, 100); break;
                 case "sidebar-tint": if (int.TryParse(val, out var st)) cfg.SidebarTint = System.Math.Clamp(st, -100, 100); break;
                 case "new-session-dir": cfg.NewSessionDir = val; break;

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -476,6 +476,33 @@ internal partial class Program : ISessionHost, IWindowHost
         return f;
     }
 
+    private IDWriteTypography? _noLig;
+    /// <summary>Typography disabling ligature-forming features (calt/liga/clig/dlig/hlig) — the
+    /// ligatures=off path. Cached; created lazily on first use.</summary>
+    private IDWriteTypography NoLigTypography()
+    {
+        if (_noLig is null)
+        {
+            _noLig = _dwrite.CreateTypography();
+            foreach (var tag in new[] { FontFeatureTag.StandardLigatures, FontFeatureTag.ContextualAlternates,
+                                        FontFeatureTag.ContextualLigatures, FontFeatureTag.DiscretionaryLigatures,
+                                        FontFeatureTag.HistoricalLigatures })
+                _noLig.AddFontFeature(new FontFeature { NameTag = tag, Parameter = 0 });
+        }
+        return _noLig;
+    }
+
+    /// <summary>Draw a same-colour text run — plain DrawText (font default: ligatures on), or a text
+    /// layout with ligature features disabled when <c>ligatures = false</c>.</summary>
+    private void DrawRun(ID2D1HwndRenderTarget rt, ID2D1SolidColorBrush brush, string text, IDWriteTextFormat fmt,
+        float rx, float y, float w, float h)
+    {
+        if (_config.Ligatures) { rt.DrawText(text, fmt, new Rect(rx, y, rx + w, y + h), brush); return; }
+        using var layout = _dwrite.CreateTextLayout(text, fmt, w, h);
+        layout.SetTypography(NoLigTypography(), new TextRange(0, (uint)text.Length));
+        rt.DrawTextLayout(new System.Numerics.Vector2(rx, y), layout, brush);
+    }
+
     private static IDWriteTextFormat NewChromeFormat(string family, float px, bool center)
     {
         IDWriteTextFormat f;
@@ -4027,7 +4054,7 @@ internal partial class Program : ISessionHost, IWindowHost
                         _run.Length = lastNonBlank;
                         brush.Color = C4(runFg);
                         float rx = ox + start * cw;
-                        rt.DrawText(_run.ToString(), fmt, new Rect(rx, y, rx + _run.Length * cw, y + ch), brush);
+                        DrawRun(rt, brush, _run.ToString(), fmt, rx, y, _run.Length * cw, ch);
                     }
                 }
             }
@@ -6229,7 +6256,7 @@ internal partial class Program : ISessionHost, IWindowHost
     private static readonly string[] ConfigKeys =
     {
         "font-family", "font-size", "cursor-style", "cursor-blink", "cursor-blink-ms", "theme",
-        "scrollback-lines", "inactive-pane-dim", "unfocused-dim", "builtin-glyphs", "window-opacity", "sidebar-tint", "scroll-speed",
+        "scrollback-lines", "inactive-pane-dim", "unfocused-dim", "builtin-glyphs", "ligatures", "window-opacity", "sidebar-tint", "scroll-speed",
         "new-session-dir", "right-click-paste", "copy-on-select", "word-delimiters", "desktop-notifications", "shell-integration",
         "restore-commands", "restore-buffer", "blocked-sound", "omp-theme", "omp-integration", "prompt-engine", "starship-theme",
         "new-session-dir-mode", "confirm-close-session", "compact-toolbar", "notification-badges",
@@ -6267,6 +6294,7 @@ internal partial class Program : ISessionHost, IWindowHost
         "inactive-pane-dim" => _config.InactivePaneDim.ToString(),
         "unfocused-dim" => _config.UnfocusedDim.ToString(),
         "builtin-glyphs" => _config.BuiltinGlyphs ? "true" : "false",
+        "ligatures" => _config.Ligatures ? "true" : "false",
         "window-opacity" => _config.WindowOpacity.ToString(),
         "sidebar-tint" => _config.SidebarTint.ToString(),
         "scroll-speed" => _config.ScrollSpeed.ToString(),


### PR DESCRIPTION
**Tier 2 backlog (T2-10)** — font ligatures / WT `font.features` analog.

## Finding
Ligatures **already render** in agwinterm — DirectWrite's `DrawText` shapes them. With a ligature font (Cascadia Code, Fira Code, JetBrains Mono…), `-> => != >= <=>` already draw as `→ ⇒ ≠ ≥ ⇔`. (The default font, MesloLGSDZ Nerd Font, has no ligatures, so it's opt-in via `font-family`.)

## What lands
A **`ligatures`** config (default **true**) to turn them **off** — a common terminal preference:
- **false** → same-colour runs draw via an `IDWriteTextLayout` + a cached `IDWriteTypography` that disables `calt`/`liga`/`clig`/`dlig`/`hlig`.
- **true** → the existing fast `DrawText` path, unchanged (zero perf cost for the default).
- Live-togglable (not a deferred/restart key).

## Verification (Cascadia Code, screenshots)
| `ligatures = true` | `ligatures = false` |
|---|---|
| `→ ⇒ ≠ ≥ ≤ ⇔` | `-> => != >= <= <=>` |

Toggled **live**; 110/110 Core, 16/16 Pty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)