### PR TITLE
feat(defterm): Stage A — attach to an externally-created PTY

### DIFF
--- a/src/Agwinterm.Pty/AttachedPty.cs
+++ b/src/Agwinterm.Pty/AttachedPty.cs
@@ -1,0 +1,77 @@
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+using Porta.Pty;
+
+namespace Agwinterm.Pty;
+
+/// <summary>
+/// An <see cref="IPtyConnection"/> over an <b>externally-created</b> pseudoconsole — agwinterm does NOT
+/// spawn the child; it's handed the pipe/signal handles that another process (conhost/OpenConsole in the
+/// Windows "default terminal" handoff, or a test harness) already set up. Stage A of defterm (T2-13):
+/// this is what lets agwinterm host a console session it didn't start.
+/// </summary>
+internal sealed class AttachedPty : IPtyConnection
+{
+    private readonly FileStream _reader;   // console VT output → we read
+    private readonly FileStream _writer;   // user input → we write
+    private readonly SafeFileHandle _signal;
+    private IntPtr _clientProcess;         // the console client, for exit/wait (IntPtr.Zero if unknown)
+
+    public Stream ReaderStream => _reader;
+    public Stream WriterStream => _writer;
+    public int Pid { get; }
+    public int ExitCode { get { if (_clientProcess != IntPtr.Zero && GetExitCodeProcess(_clientProcess, out int c)) return c; return 0; } }
+#pragma warning disable CS0067 // IPtyConnection member; exit is driven via WaitForExit, not the event
+    public event EventHandler<PtyExitedEventArgs>? ProcessExited;
+#pragma warning restore CS0067
+
+    /// <param name="conOut">Handle the terminal READS console VT output from.</param>
+    /// <param name="conIn">Handle the terminal WRITES user input to.</param>
+    /// <param name="signal">The ConPTY signal pipe (resize etc.); may be invalid/closed.</param>
+    /// <param name="clientProcess">The console client process handle for exit detection (optional).</param>
+    /// <param name="pid">The client PID (0 if unknown).</param>
+    public AttachedPty(SafeFileHandle conOut, SafeFileHandle conIn, SafeFileHandle signal, IntPtr clientProcess, int pid)
+    {
+        _reader = new FileStream(conOut, FileAccess.Read);
+        _writer = new FileStream(conIn, FileAccess.Write);
+        _signal = signal;
+        _clientProcess = clientProcess;
+        Pid = pid;
+    }
+
+    public void Resize(int cols, int rows)
+    {
+        // ConPTY signal-pipe resize packet: [PTY_SIGNAL_RESIZE_WINDOW=8][cols][rows] as little-endian UINT16s.
+        if (_signal is null || _signal.IsInvalid || _signal.IsClosed) return;
+        Span<byte> pkt = stackalloc byte[6];
+        pkt[0] = 8; pkt[1] = 0;
+        pkt[2] = (byte)(cols & 0xFF); pkt[3] = (byte)((cols >> 8) & 0xFF);
+        pkt[4] = (byte)(rows & 0xFF); pkt[5] = (byte)((rows >> 8) & 0xFF);
+        try { uint written; WriteFile(_signal, pkt, (uint)pkt.Length, out written, IntPtr.Zero); } catch { }
+    }
+
+    public bool WaitForExit(int milliseconds)
+    {
+        if (_clientProcess == IntPtr.Zero) return false;   // no handle → caller falls back to EOF on the reader
+        return WaitForSingleObject(_clientProcess, milliseconds < 0 ? 0xFFFFFFFF : (uint)milliseconds) == 0;
+    }
+
+    public void Kill()
+    {
+        if (_clientProcess != IntPtr.Zero) try { TerminateProcess(_clientProcess, 1); } catch { }
+    }
+
+    public void Dispose()
+    {
+        try { _writer.Dispose(); } catch { }
+        try { _reader.Dispose(); } catch { }
+        try { _signal?.Dispose(); } catch { }
+        if (_clientProcess != IntPtr.Zero) { CloseHandle(_clientProcess); _clientProcess = IntPtr.Zero; }
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern bool WriteFile(SafeFileHandle h, ReadOnlySpan<byte> buf, uint n, out uint written, IntPtr overlapped);
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern uint WaitForSingleObject(IntPtr h, uint ms);
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern bool GetExitCodeProcess(IntPtr h, out int code);
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern bool TerminateProcess(IntPtr h, uint code);
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern bool CloseHandle(IntPtr h);
+}

--- a/src/Agwinterm.Pty/TerminalSession.cs
+++ b/src/Agwinterm.Pty/TerminalSession.cs
@@ -1,4 +1,5 @@
 using Agwinterm.Core;
+using Microsoft.Win32.SafeHandles;
 using Porta.Pty;
 
 namespace Agwinterm.Pty;
@@ -207,6 +208,27 @@ public sealed class TerminalSession : IDisposable
             ExitCode = code; HasExited = true;
             try { Exited?.Invoke(code); } catch { }
         }, ct);
+    }
+
+    /// <summary>Attach to an <b>externally-created</b> pseudoconsole (the Windows default-terminal handoff,
+    /// or a test harness) instead of spawning our own. <paramref name="conOut"/> is where console VT output
+    /// is read; <paramref name="conIn"/> is where user input is written; <paramref name="signal"/> is the
+    /// ConPTY signal pipe; <paramref name="clientProcess"/> is the console client's handle (optional, for
+    /// exit detection). Pumps output into the emulator and reports exit on client death or output EOF.</summary>
+    public void Attach(SafeFileHandle conOut, SafeFileHandle conIn, SafeFileHandle signal, IntPtr clientProcess, int pid)
+    {
+        var conn = new AttachedPty(conOut, conIn, signal, clientProcess, pid);
+        _connection = conn;
+        var pump = Task.Run(() => InteractivePumpAsync(conn.ReaderStream));
+        _ = Task.Run(async () =>
+        {
+            if (clientProcess != IntPtr.Zero) await Task.Run(() => conn.WaitForExit(Timeout.Infinite)).ConfigureAwait(false);
+            else await pump.ConfigureAwait(false);   // no client handle → exit when the output pipe hits EOF
+            int code = 0; try { code = conn.ExitCode; } catch { }
+            ExitCode = code; HasExited = true;
+            try { Exited?.Invoke(code); } catch { }
+        });
+        conn.Resize(Cols, Rows);   // tell the console our initial size
     }
 
     /// <summary>The child's exit code once <see cref="HasExited"/> is true (null while still running).</summary>

--- a/tests/Agwinterm.Pty.Tests/PtyAttachTests.cs
+++ b/tests/Agwinterm.Pty.Tests/PtyAttachTests.cs
@@ -1,0 +1,52 @@
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Win32.SafeHandles;
+using Agwinterm.Pty;
+
+namespace Agwinterm.Pty.Tests;
+
+/// <summary>Stage A of defterm (T2-13): agwinterm attaching to an externally-created PTY. Uses raw pipes
+/// (no real ConPTY/child needed) to prove Attach pumps external output into the emulator and routes
+/// input back out.</summary>
+public class PtyAttachTests
+{
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern bool CreatePipe(out IntPtr r, out IntPtr w, IntPtr sa, int size);
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern bool WriteFile(SafeFileHandle h, byte[] b, uint n, out uint written, IntPtr o);
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern bool ReadFile(SafeFileHandle h, byte[] b, uint n, out uint read, IntPtr o);
+
+    [Fact]
+    public async Task Attach_PumpsExternalOutputIntoEmulator()
+    {
+        Assert.True(CreatePipe(out IntPtr outR, out IntPtr outW, IntPtr.Zero, 0)); // console output → session reads outR
+        Assert.True(CreatePipe(out IntPtr inR, out IntPtr inW, IntPtr.Zero, 0));   // session writes inW → user input
+
+        var session = new TerminalSession(40, 10);
+        session.Attach(new SafeFileHandle(outR, true), new SafeFileHandle(inW, true),
+                       new SafeFileHandle(IntPtr.Zero, false), IntPtr.Zero, 0);
+
+        var outWrite = new SafeFileHandle(outW, true);
+        var bytes = Encoding.ASCII.GetBytes("ATTACH_WORKS\r\n");
+        Assert.True(WriteFile(outWrite, bytes, (uint)bytes.Length, out _, IntPtr.Zero));
+
+        for (int i = 0; i < 100 && !RowsContain(session, "ATTACH_WORKS"); i++) await Task.Delay(20);
+        Assert.True(RowsContain(session, "ATTACH_WORKS"), "attached output should reach the emulator");
+
+        // Input written to the session must come out the conIn pipe (what a real console would read as stdin).
+        var inRead = new SafeFileHandle(inR, true);
+        session.Write(Encoding.ASCII.GetBytes("xy"));
+        var buf = new byte[8];
+        Assert.True(ReadFile(inRead, buf, 2, out uint got, IntPtr.Zero));
+        Assert.Equal(2u, got);
+        Assert.Equal("xy", Encoding.ASCII.GetString(buf, 0, (int)got));
+
+        outWrite.Dispose(); inRead.Dispose(); session.Dispose();
+    }
+
+    private static bool RowsContain(TerminalSession s, string text)
+    {
+        lock (s.SyncRoot)
+            for (int r = 0; r < s.Emulator.Screen.Rows; r++)
+                if (s.Emulator.DumpRow(r).Contains(text)) return true;
+        return false;
+    }
+}


### PR DESCRIPTION
**Stage A of Default Terminal delegation (T2-13)** — see `docs/defterm-feasibility.md` for the full staged plan.

Adds the ability for agwinterm to host a console session it **did not spawn** — the prerequisite for the Windows default-terminal handoff, where conhost/OpenConsole hands the terminal the pipe + signal handles of an already-running console client.

## What lands
- **`AttachedPty : IPtyConnection`** over externally-provided handles: `conOut` (read console VT output), `conIn` (write user input), a **signal pipe** (resize via the ConPTY resize packet), and an optional **client process handle** for exit detection.
- **`TerminalSession.Attach(...)`** wires it into the existing emulator pump + input path; exit reports on client death or output-pipe EOF.

## Safe & self-contained
No COM, no registry, nothing system-wide. This is pure plumbing that's independently testable.

## Verification
New raw-pipe test (no real ConPTY/child needed): external output **pumps into the emulator** and input **routes back out** the conIn pipe. **110/110 Core, 17/17 Pty.**

## Next stages (need sandbox testing)
- **B** — out-of-proc `ITerminalHandoff3` COM server (CLSID + handoff → `Attach`)
- **C** — "set as default terminal" registry (`HKCU\Console\%%Startup`) + OpenConsole delegation, with a one-click revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)