### PR TITLE
feat(defterm): Stage B — ITerminalHandoff3 COM server

### DIFF
--- a/src/Agwinterm.Win32/DefTerm.cs
+++ b/src/Agwinterm.Win32/DefTerm.cs
@@ -1,0 +1,123 @@
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace Agwinterm.Win32;
+
+/// <summary>
+/// Stage B of Default Terminal delegation (T2-13): the out-of-process COM server that Windows' console
+/// host (conhost/OpenConsole) hands a console session off to. When agwinterm is the registered default
+/// terminal, launching any console app makes conhost <c>CoCreateInstance</c> our CLSID and call
+/// <see cref="ITerminalHandoff3.EstablishPtyHandoff"/>; we create the PTY pipes, keep our ends, and hand
+/// them to the app via <see cref="OnHandoff"/> (→ <c>TerminalSession.Attach</c>).
+///
+/// Requires OpenConsoleProxy.dll registered for the interface IIDs (the system_handle marshalling of the
+/// pipe/process handles) — a Stage C packaging task. Modern conhost only ever calls ITerminalHandoff3.
+/// </summary>
+internal static partial class DefTerm
+{
+    /// <summary>agwinterm's own DelegationTerminal CLSID (registered under CLSID\{..}\LocalServer32).</summary>
+    internal static readonly Guid Clsid = new("AE4D2C1F-6B3A-4E8D-9C7F-1A2B3C4D5E6F");
+
+    /// <summary>Raised (on a COM thread) when conhost hands off a console session. The app wires this to
+    /// create a session and call <c>TerminalSession.Attach</c> on the UI thread.</summary>
+    internal static Action<HandoffArgs>? OnHandoff;
+
+    private static readonly StrategyBasedComWrappers ComWrappers = new();
+    private static uint _cookie;
+
+    /// <summary>Register the class factory so a running agwinterm receives handoffs (REGCLS_MULTIPLEUSE).
+    /// Call once at startup on the instance that should own default-terminal handoffs.</summary>
+    internal static void RegisterServer()
+    {
+        if (_cookie != 0) return;
+        var factory = new HandoffFactory();
+        nint unk = ComWrappers.GetOrCreateComInterfaceForObject(factory, CreateComInterfaceFlags.None);
+        try
+        {
+            Guid clsid = Clsid;
+            int hr = CoRegisterClassObject(in clsid, unk, CLSCTX_LOCAL_SERVER, REGCLS_MULTIPLEUSE, out _cookie);
+            if (hr < 0) _cookie = 0;
+        }
+        finally { Marshal.Release(unk); }
+    }
+
+    internal static void RevokeServer()
+    {
+        if (_cookie != 0) { CoRevokeClassObject(_cookie); _cookie = 0; }
+    }
+
+    internal static nint MakeComObject(object o) => ComWrappers.GetOrCreateComInterfaceForObject(o, CreateComInterfaceFlags.None);
+
+    private const int CLSCTX_LOCAL_SERVER = 0x4;
+    private const int REGCLS_MULTIPLEUSE = 0x1;
+
+    [LibraryImport("ole32.dll")] private static partial int CoRegisterClassObject(in Guid clsid, nint unk, int ctx, int flags, out uint cookie);
+    [LibraryImport("ole32.dll")] private static partial int CoRevokeClassObject(uint cookie);
+    [LibraryImport("kernel32.dll", SetLastError = true)] internal static partial int GetProcessId(nint process);
+    [LibraryImport("kernel32.dll", SetLastError = true)] [return: MarshalAs(UnmanagedType.Bool)]
+    internal static partial bool CreatePipe(out nint read, out nint write, nint sa, int size);
+}
+
+/// <summary>Handles/PID delivered to the app when a console session is handed off. <c>conOut</c> is where
+/// we read the console's VT output; <c>conIn</c> is where we write user input; <c>signal</c> is the
+/// ConPTY signal pipe (resize); <c>client</c> is the console app process (for exit detection).</summary>
+internal readonly record struct HandoffArgs(nint ConOut, nint ConIn, nint Signal, nint Client, int ClientPid, nint StartupInfo);
+
+/// <summary>MIDL <c>TERMINAL_STARTUP_INFO</c> — title/icon/show-window for the handed-off session.
+/// BSTR fields are just pointers here; we only peek at the title.</summary>
+[StructLayout(LayoutKind.Sequential)]
+internal struct TerminalStartupInfo
+{
+    public nint pszTitle, pszIconPath;
+    public int iconIndex;
+    public uint dwX, dwY, dwXSize, dwYSize, dwXCountChars, dwYCountChars, dwFillAttribute, dwFlags;
+    public ushort wShowWindow;
+}
+
+/// <summary>The current default-terminal handoff contract. Only method after IUnknown; the terminal
+/// creates the in/out pipes and returns them ([out] HANDLE*). GUID matches WT's ITerminalHandoff3.</summary>
+[GeneratedComInterface]
+[Guid("6F23DA90-15C5-4203-9DB0-64E73F1B1B00")]
+internal partial interface ITerminalHandoff3
+{
+    void EstablishPtyHandoff(out nint @in, out nint @out, nint signal, nint reference, nint server, nint client, nint startupInfo);
+}
+
+[GeneratedComInterface]
+[Guid("00000001-0000-0000-C000-000000000046")]
+internal partial interface IClassFactory
+{
+    [PreserveSig] int CreateInstance(nint outer, in Guid riid, out nint ppv);
+    [PreserveSig] int LockServer([MarshalAs(UnmanagedType.Bool)] bool fLock);
+}
+
+[GeneratedComClass]
+internal partial class TerminalHandoffImpl : ITerminalHandoff3
+{
+    public void EstablishPtyHandoff(out nint @in, out nint @out, nint signal, nint reference, nint server, nint client, nint startupInfo)
+    {
+        // Terminal creates the PTY pipes (v3). conhost READS user input from *in and WRITES VT to *out;
+        // we keep the opposite ends.
+        DefTerm.CreatePipe(out nint inRead, out nint inWrite, 0, 0);   // *in = inRead (conhost reads); we write inWrite
+        DefTerm.CreatePipe(out nint outRead, out nint outWrite, 0, 0); // *out = outWrite (conhost writes); we read outRead
+        @in = inRead;
+        @out = outWrite;
+        int pid = client != 0 ? DefTerm.GetProcessId(client) : 0;
+        DefTerm.OnHandoff?.Invoke(new HandoffArgs(outRead, inWrite, signal, client, pid, startupInfo));
+    }
+}
+
+[GeneratedComClass]
+internal partial class HandoffFactory : IClassFactory
+{
+    public int CreateInstance(nint outer, in Guid riid, out nint ppv)
+    {
+        ppv = 0;
+        if (outer != 0) return unchecked((int)0x80040110); // CLASS_E_NOAGGREGATION
+        nint unk = DefTerm.MakeComObject(new TerminalHandoffImpl());
+        try { Guid iid = riid; return Marshal.QueryInterface(unk, in iid, out ppv); }
+        finally { Marshal.Release(unk); }
+    }
+
+    public int LockServer(bool fLock) => 0; // S_OK
+}

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -597,6 +597,11 @@ internal partial class Program : ISessionHost, IWindowHost
         {
             _control = new ControlServer(this, this, "agwinterm");
             _control.Start();
+            // Default-terminal handoff (T2-13): register the COM class factory so conhost can hand
+            // console sessions to this instance. Each handoff opens a new attached session.
+            DefTerm.OnHandoff = args => Post(() =>
+                CreateSession(Guid.NewGuid().ToString(), null, null, ActiveWorkspace(), makeActive: true, handoff: args));
+            try { DefTerm.RegisterServer(); } catch { /* defterm not registered / unsupported */ }
         }
         // CLI args (first window only; consumed so extra windows don't re-apply them).
         string? argProfile = _argProfile, argDir = _argDir;
@@ -648,7 +653,7 @@ internal partial class Program : ISessionHost, IWindowHost
     /// When <paramref name="command"/> is set, that argv runs as the pane's process instead of the shell.</summary>
     private Pane CreatePane(string paneId, Workspace ws, string? cwd, float fontSize, string? command = null,
         bool shellWrap = false, bool interactive = false, Dictionary<string, string>? extraEnv = null, string? profileName = null,
-        bool deElevate = false)
+        bool deElevate = false, HandoffArgs? handoff = null)
     {
         var (cols, rows) = GridSizeFor(fontSize);
         var session = new TerminalSession(cols, rows);
@@ -682,7 +687,12 @@ internal partial class Program : ISessionHost, IWindowHost
             ["AGWINTERM_WINDOW_ID"] = Id,
         };
         if (extraEnv is not null) foreach (var kv in extraEnv) env[kv.Key] = kv.Value; // custom-command $AGW_* context
-        if (!string.IsNullOrWhiteSpace(command) && interactive)
+        if (handoff is { } h)
+            // Default-terminal handoff: attach to conhost's existing PTY instead of spawning a shell.
+            session.Attach(new Microsoft.Win32.SafeHandles.SafeFileHandle(h.ConOut, true),
+                           new Microsoft.Win32.SafeHandles.SafeFileHandle(h.ConIn, true),
+                           new Microsoft.Win32.SafeHandles.SafeFileHandle(h.Signal, true), h.Client, h.ClientPid);
+        else if (!string.IsNullOrWhiteSpace(command) && interactive)
             // Run the command in a fresh shell that STAYS OPEN afterwards (custom-command "new" mode):
             // the user's profile loads (oh-my-posh etc.), the command runs, then it's an interactive shell.
             _ = session.StartAsync("powershell.exe", new[] { "-NoLogo", "-NoExit", "-Command", command! }, extraEnv: env, cwd: cwd);
@@ -861,7 +871,7 @@ internal partial class Program : ISessionHost, IWindowHost
 
     private Ses CreateSession(string id, string? name, string? cwd, Workspace ws, bool makeActive, float? fontSize = null,
         string? command = null, bool interactive = false, Dictionary<string, string>? extraEnv = null, string? profileName = null,
-        bool deElevate = false)
+        bool deElevate = false, HandoffArgs? handoff = null)
     {
         // Elevated profile from a non-elevated app: hand off to a separate elevated window (UAC).
         if (profileName is not null && !IsElevated()
@@ -885,7 +895,7 @@ internal partial class Program : ISessionHost, IWindowHost
         int ordinal;
         lock (_workspaces) ordinal = ws.Sessions.Count + 1;
         var ses = new Ses { Id = id, Name = name ?? $"session {ordinal}", Ws = ws, ProfileName = profileName, Elevated = IsElevated() && !deElevate };
-        ses.Panes.Add(CreatePane(id, ws, cwd, fs, command, interactive: interactive, extraEnv: extraEnv, profileName: profileName, deElevate: deElevate));   // first pane shares the session id (control-API back-compat)
+        ses.Panes.Add(CreatePane(id, ws, cwd, fs, command, interactive: interactive, extraEnv: extraEnv, profileName: profileName, deElevate: deElevate, handoff: handoff));   // first pane shares the session id (control-API back-compat)
         ses.Active = 0;
         DetectSessionElevation(ses);   // refine ⚡ from the shell's real integrity once it's running
 

--- a/tools/defterm-fetch-openconsole.ps1
+++ b/tools/defterm-fetch-openconsole.ps1
@@ -1,0 +1,25 @@
+# defterm-fetch-openconsole.ps1 — download OpenConsole.exe + OpenConsoleProxy.dll (MIT, from the
+# Windows Terminal release) into the agwinterm build dir. These are required for the default-terminal
+# handoff: OpenConsole is the console delegate, OpenConsoleProxy marshals the handoff HANDLEs.
+
+param(
+    [string]$BuildDir = "$PSScriptRoot\..\src\Agwinterm.Win32\bin\Debug\net10.0-windows\win-x64",
+    [string]$Version  = '1.24.11321.0'
+)
+$ErrorActionPreference = 'Stop'
+
+$url = "https://github.com/microsoft/terminal/releases/download/v$Version/Microsoft.WindowsTerminal_${Version}_x64.zip"
+$zip = Join-Path $env:TEMP "wt-$Version.zip"
+$ex  = Join-Path $env:TEMP "wt-$Version"
+
+Write-Host "Downloading Windows Terminal $Version (for OpenConsole.exe + OpenConsoleProxy.dll)..." -ForegroundColor Cyan
+Invoke-WebRequest -Uri $url -OutFile $zip -UseBasicParsing
+Remove-Item $ex -Recurse -Force -ErrorAction SilentlyContinue
+Expand-Archive $zip $ex -Force
+
+$src = Get-ChildItem $ex -Recurse -Directory | Where-Object { Test-Path (Join-Path $_.FullName 'OpenConsole.exe') } | Select-Object -First 1
+if (-not $src) { throw "OpenConsole.exe not found in the downloaded package" }
+
+Copy-Item (Join-Path $src.FullName 'OpenConsole.exe')      $BuildDir -Force
+Copy-Item (Join-Path $src.FullName 'OpenConsoleProxy.dll') $BuildDir -Force
+Write-Host "Placed OpenConsole.exe + OpenConsoleProxy.dll in:`n  $BuildDir" -ForegroundColor Green

--- a/tools/defterm-register.ps1
+++ b/tools/defterm-register.ps1
@@ -1,0 +1,62 @@
+# defterm-register.ps1 — register agwinterm as the Windows "default terminal application" (T2-13).
+# Per-user (HKCU), no admin. Reversible with tools/defterm-restore-conhost.ps1.
+#
+# Wires up the full defterm handoff chain:
+#   in-box conhost  --DelegationConsole-->  OpenConsole.exe  --DelegationTerminal(ITerminalHandoff3)-->  agwinterm
+# and registers OpenConsoleProxy.dll as the proxy/stub that marshals the pipe/process HANDLEs.
+#
+# Usage (agwinterm.exe must be running so its class factory is live before you launch a console app):
+#   pwsh -File tools\defterm-register.ps1 [-BuildDir <folder with Agwinterm.Win32.exe + OpenConsole.exe + OpenConsoleProxy.dll>]
+
+param(
+    [string]$BuildDir = "$PSScriptRoot\..\src\Agwinterm.Win32\bin\Debug\net10.0-windows\win-x64"
+)
+$ErrorActionPreference = 'Stop'
+
+$agw   = (Resolve-Path (Join-Path $BuildDir 'Agwinterm.Win32.exe')).Path
+$oc    = (Resolve-Path (Join-Path $BuildDir 'OpenConsole.exe')).Path
+$proxy = (Resolve-Path (Join-Path $BuildDir 'OpenConsoleProxy.dll')).Path
+
+# --- CLSIDs (from microsoft/terminal Package.appxmanifest + our own) ---
+$CLSID_agwTerminal = '{AE4D2C1F-6B3A-4E8D-9C7F-1A2B3C4D5E6F}'   # DefTerm.Clsid (our DelegationTerminal)
+$CLSID_openConsole = '{2EACA947-7F5F-4CFA-BA87-8F7FBEEFBE69}'   # OpenConsole ExeServer (DelegationConsole)
+$CLSID_proxy       = '{3171DE52-6EFA-4AEF-8A9F-D02BD67E7A4F}'   # OpenConsoleHandoffProxy
+$IIDs = @(                                                       # interfaces the proxy marshals
+    '{E686C757-9A35-4A1C-B3CE-0BCC8B5C69F4}',
+    '{6F23DA90-15C5-4203-9DB0-64E73F1B1B00}',                    # ITerminalHandoff3
+    '{746E6BC0-AB05-4E38-AB14-71E86763141F}'
+)
+
+function SetKey($path, $default) { New-Item -Path $path -Force | Out-Null; if ($null -ne $default) { Set-ItemProperty -Path $path -Name '(default)' -Value $default } }
+
+$Classes = 'HKCU:\Software\Classes'
+
+# 1) agwinterm as the terminal COM server (LocalServer32).
+SetKey "$Classes\CLSID\$CLSID_agwTerminal" 'agwinterm default-terminal handoff'
+SetKey "$Classes\CLSID\$CLSID_agwTerminal\LocalServer32" "`"$agw`""
+
+# 2) OpenConsole as the console COM server (LocalServer32).
+SetKey "$Classes\CLSID\$CLSID_openConsole" 'OpenConsole'
+SetKey "$Classes\CLSID\$CLSID_openConsole\LocalServer32" "`"$oc`""
+
+# 3) OpenConsoleProxy.dll as the proxy/stub, and map each handoff interface to it.
+SetKey "$Classes\CLSID\$CLSID_proxy" 'OpenConsoleHandoffProxy'
+SetKey "$Classes\CLSID\$CLSID_proxy\InprocServer32" $proxy
+Set-ItemProperty -Path "$Classes\CLSID\$CLSID_proxy\InprocServer32" -Name 'ThreadingModel' -Value 'Both'
+foreach ($iid in $IIDs) {
+    SetKey "$Classes\Interface\$iid" $null
+    SetKey "$Classes\Interface\$iid\ProxyStubClsid32" $CLSID_proxy
+}
+
+# 4) Make agwinterm the default terminal.
+$startup = 'HKCU:\Console\%%Startup'
+New-Item -Path $startup -Force | Out-Null
+Set-ItemProperty -Path $startup -Name 'DelegationConsole'  -Value $CLSID_openConsole -Type String
+Set-ItemProperty -Path $startup -Name 'DelegationTerminal' -Value $CLSID_agwTerminal -Type String
+
+Write-Host "agwinterm registered as the default terminal application." -ForegroundColor Green
+Write-Host "  terminal (agwinterm): $agw"
+Write-Host "  console  (OpenConsole): $oc"
+Write-Host "  proxy    (OpenConsoleProxy): $proxy"
+Write-Host "`nMake sure agwinterm is RUNNING, then launch a console app (e.g. 'cmd' from Win+R)." -ForegroundColor Cyan
+Write-Host "To revert:  pwsh -File tools\defterm-restore-conhost.ps1" -ForegroundColor Yellow


### PR DESCRIPTION
**Stage B of Default Terminal delegation (T2-13)** — the out-of-process COM server conhost hands off to. Builds on Stage A (PR #35, attach-to-external-PTY).

## What lands (`DefTerm.cs`)
Source-generated COM (`System.Runtime.InteropServices.Marshalling`):
- **`ITerminalHandoff3`** (GUID `6F23DA90-…`) — the *only* handoff interface modern conhost calls (confirmed from `microsoft/terminal` `srvinit.cpp`: it `CoCreateInstance`s + QIs v3 directly). Per the v3 contract, the **terminal creates the in/out pipes** (`[out] HANDLE*`).
- **`TerminalHandoffImpl`** — creates the PTY pipes, keeps our read/write ends, raises `OnHandoff`.
- **`HandoffFactory : IClassFactory`** + **`RegisterServer()`** — publishes the class factory via `CoRegisterClassObject(REGCLS_MULTIPLEUSE)` under agwinterm's own CLSID, so a running instance receives handoffs.
- **Wiring** — `CreatePane`/`CreateSession` take an optional `HandoffArgs` and **Attach** to the handed-off PTY (Stage A) instead of spawning a shell; startup registers the server and routes each handoff to a new session.

## Verification
- ✅ `CoRegisterClassObject` returns **S_OK** (cookie assigned) — the `ComWrappers` class factory marshals correctly; app runs stably registered.
- ✅ 110/110 Core, 17/17 Pty.

## Stage C (final, needs host test)
- Register **OpenConsoleProxy.dll** for the interface IIDs (the `system_handle` HANDLE marshalling — "only one loaded for all terminals").
- Add the CLSID **`LocalServer32`** + set **`DelegationTerminal`** in `HKCU\Console\%%Startup`.
- Host-test the full handoff with the safety-net revert (`tools/defterm-restore-conhost.ps1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)