### PR TITLE
feat(uia): screen-reader accessibility — Document provider (T2-14 Stage 1)

### DIFF
--- a/docs/windows-terminal-gap-analysis.md
+++ b/docs/windows-terminal-gap-analysis.md
@@ -112,13 +112,13 @@ opaque→alpha-composited render-pipeline rework. Not worth it; owner doesn't wa
   ITerminalHandoff3 COM server, registration tooling). CoRegisterClassObject returns S_OK. Remaining:
   the host handoff test (tools/defterm-register.ps1 → launch cmd → tools/defterm-restore-conhost.ps1);
   needs OpenConsole.exe + OpenConsoleProxy.dll (tools/defterm-fetch-openconsole.ps1).
-- UIA accessibility (T2-14): first attempt (raw source-gen COM IRawElementProviderSimple via
-  WM_GETOBJECT + UiaReturnRawElementProvider, VARIANT via Marshal.GetNativeVariantForObject) built
-  cleanly but **crashed natively** when a UIA client queried it (crash persisted with a null host
-  provider, so it's in the return-provider / property-VARIANT marshalling, not the host round-trip).
-  Reverted — a crashing a11y provider is worse than none. Needs a dedicated debugger-driven session;
-  consider a separate assembly with DisableRuntimeMarshalling + ComVariant, or the managed
-  UIAutomationProvider API (WPF-stack size cost). inspect via scripted UIAutomationClient / Narrator.
+- UIA accessibility (T2-14): **Stage 1 done** (PR #37). Raw source-gen COM IRawElementProviderSimple via
+  WM_GETOBJECT — WPF-free. Reports ControlType=Document, LocalizedControlType "terminal", Name = the
+  visible screen text. The first attempt crashed natively because it handed UiaReturnRawElementProvider
+  the CCW's raw IUnknown* instead of a QueryInterface'd IRawElementProviderSimple* (different vtables) —
+  fixed. Verified via scripted UIAutomationClient (no screen reader needed). **Stage 2 (remaining):**
+  ITextProvider/ITextRangeProvider for line/caret navigation + selection — big (≈20 range methods,
+  SAFEARRAY/VARIANT marshalling), best validated against a live Narrator/NVDA.
 
 **Rejected**: search regex/case toggle, global summon hotkey, hidden profiles,
 one-keystroke duplicate session.

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -602,6 +602,18 @@ internal partial class Program : ISessionHost, IWindowHost
             DefTerm.OnHandoff = args => Post(() =>
                 CreateSession(Guid.NewGuid().ToString(), null, null, ActiveWorkspace(), makeActive: true, handoff: args));
             try { DefTerm.RegisterServer(); } catch { /* defterm not registered / unsupported */ }
+            // UIA (T2-14): expose the active pane's visible text to screen readers.
+            Uia.GetVisibleText = () =>
+            {
+                var p = ActiveSurface();
+                if (p is null) return "terminal";
+                lock (p.S.SyncRoot)
+                {
+                    var em = p.S.Emulator; var sb = new StringBuilder();
+                    for (int r = 0; r < em.Screen.Rows; r++) sb.Append(em.DumpRow(r)).Append('\n');
+                    return sb.ToString().TrimEnd() is { Length: > 0 } t ? t : "terminal";
+                }
+            };
         }
         // CLI args (first window only; consumed so extra windows don't re-apply them).
         string? argProfile = _argProfile, argDir = _argDir;
@@ -2159,6 +2171,9 @@ internal partial class Program : ISessionHost, IWindowHost
     {
         switch (msg)
         {
+            case 0x003D: // WM_GETOBJECT — expose the terminal to screen readers (UIA, T2-14)
+                { nint r = Uia.OnGetObject(hwnd, wParam, lParam); if (r != 0) return r; break; }
+
             case WM_NCCALCSIZE:
                 if (wParam != IntPtr.Zero) { AdjustClientRect(hwnd, lParam); return IntPtr.Zero; }
                 break;

--- a/src/Agwinterm.Win32/Uia.cs
+++ b/src/Agwinterm.Win32/Uia.cs
@@ -1,0 +1,95 @@
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace Agwinterm.Win32;
+
+/// <summary>
+/// UIA accessibility (T2-14): a minimal UI Automation provider so screen readers (Narrator, NVDA) can
+/// see agwinterm as a document control and read the visible terminal content. Exposed via WM_GETOBJECT.
+/// Raw source-generated COM — NO WPF/UIAutomationProvider dependency (which would bloat the exe). A full
+/// ITextProvider (line/caret navigation) is the follow-on stage.
+/// </summary>
+internal static partial class Uia
+{
+    private static readonly StrategyBasedComWrappers ComWrappers = new();
+    private static UiaProvider? _provider;   // keep a managed ref alive
+    private static nint _providerSimple;     // QI'd IRawElementProviderSimple* handed to UIA
+
+    /// <summary>Supplies the current visible terminal text (set by the app) for the provider's Name.</summary>
+    internal static Func<string>? GetVisibleText;
+
+    /// <summary>Handle WM_GETOBJECT: return our root UIA provider when UIA asks for it.</summary>
+    internal static nint OnGetObject(nint hwnd, nint wParam, nint lParam)
+    {
+        if ((int)lParam != UiaRootObjectId) return 0;
+        if (_providerSimple == 0)
+        {
+            _provider = new UiaProvider(hwnd);
+            nint unk = ComWrappers.GetOrCreateComInterfaceForObject(_provider, CreateComInterfaceFlags.None);
+            try
+            {
+                // Hand UIA a real IRawElementProviderSimple* (not the raw IUnknown* — vtables differ).
+                Guid iid = IID_IRawElementProviderSimple;
+                if (Marshal.QueryInterface(unk, in iid, out _providerSimple) < 0) _providerSimple = 0;
+            }
+            finally { Marshal.Release(unk); }
+        }
+        return _providerSimple != 0 ? UiaReturnRawElementProvider(hwnd, wParam, lParam, _providerSimple) : 0;
+    }
+
+    private static readonly Guid IID_IRawElementProviderSimple = new("d6dd68d1-86fd-4332-8666-9abedea2d24c");
+    private const int UiaRootObjectId = -25;
+    [LibraryImport("uiautomationcore.dll")] private static partial nint UiaReturnRawElementProvider(nint hwnd, nint wParam, nint lParam, nint provider);
+}
+
+[Flags]
+internal enum ProviderOptions { ClientSideProvider = 0x1, ServerSideProvider = 0x2, NonClientAreaProvider = 0x4, OverrideProvider = 0x8, ProviderOwnsSetFocus = 0x10, UseComThreading = 0x20 }
+
+/// <summary>Minimal server-side UIA element: IRawElementProviderSimple only (control type + name). The
+/// GUID is the standard IRawElementProviderSimple IID; method order matches its COM vtable exactly.</summary>
+[GeneratedComInterface]
+[Guid("d6dd68d1-86fd-4332-8666-9abedea2d24c")]
+internal partial interface IRawElementProviderSimple
+{
+    ProviderOptions GetProviderOptions();
+    nint GetPatternProvider(int patternId);
+    void GetPropertyValue(int propertyId, nint pRetVal);   // pRetVal is a caller-allocated VARIANT*
+    nint GetHostRawElementProvider();                       // IRawElementProviderSimple** (null = none)
+}
+
+[GeneratedComClass]
+internal partial class UiaProvider : IRawElementProviderSimple
+{
+    private readonly nint _hwnd;
+    public UiaProvider(nint hwnd) => _hwnd = hwnd;
+
+    // Direct (non-marshalled) calls on UIA's thread; our reads are guarded by the session lock.
+    public ProviderOptions GetProviderOptions() => ProviderOptions.ServerSideProvider;
+
+    public nint GetPatternProvider(int patternId) => 0; // no control patterns yet (ITextProvider next)
+
+    public nint GetHostRawElementProvider() => 0;        // no host provider in this stage
+
+    public void GetPropertyValue(int propertyId, nint pRetVal)
+    {
+        VariantInit(pRetVal);   // default VT_EMPTY (= "not supported", UIA falls back)
+        object? val = propertyId switch
+        {
+            UIA_ControlTypePropertyId => UIA_DocumentControlTypeId,
+            UIA_NamePropertyId => SafeText(),
+            UIA_IsContentElementPropertyId or UIA_IsControlElementPropertyId or UIA_IsKeyboardFocusablePropertyId => true,
+            UIA_LocalizedControlTypePropertyId => "terminal",
+            _ => null,
+        };
+        if (val is not null) Marshal.GetNativeVariantForObject(val, pRetVal);
+    }
+
+    private static string SafeText() { try { return Uia.GetVisibleText?.Invoke() ?? "terminal"; } catch { return "terminal"; } }
+
+    [LibraryImport("oleaut32.dll")] private static partial void VariantInit(nint pvarg);
+
+    private const int UIA_ControlTypePropertyId = 30003, UIA_NamePropertyId = 30005,
+        UIA_IsControlElementPropertyId = 30016, UIA_IsContentElementPropertyId = 30017,
+        UIA_IsKeyboardFocusablePropertyId = 30009, UIA_LocalizedControlTypePropertyId = 30004;
+    private const int UIA_DocumentControlTypeId = 50030;
+}


### PR DESCRIPTION
**T2-14 Stage 1** — the last WT backlog item. A minimal UI Automation provider so **Narrator/NVDA can see agwinterm as a terminal document and read its visible content**. Exposed via `WM_GETOBJECT`.

## WPF-free by design
Raw **source-generated COM** (`System.Runtime.InteropServices.Marshalling`) — deliberately **no** `UIAutomationProvider`/WPF dependency (that would drag in the whole desktop stack and bloat the exe). VARIANT filled via `Marshal.GetNativeVariantForObject` to avoid the assembly-wide `DisableRuntimeMarshalling` that `ComVariant` would force.

## What it exposes
`IRawElementProviderSimple` → ControlType **Document**, LocalizedControlType **"terminal"**, **Name = the visible screen text**, IsContent/IsControl/IsKeyboardFocusable = true.

## The crash fix
The earlier attempt crashed natively because it handed `UiaReturnRawElementProvider` the CCW's raw **`IUnknown*`**; UIA expects an **`IRawElementProviderSimple*`** (different vtable). Fix: `QueryInterface` for the exact IID first, and keep a managed ref to the provider alive.

## Verification (no screen reader needed)
Scripted **`UIAutomationClient`** (`AutomationElement.FromHandle`): the app **survives** the query and reports **ControlType=Document**, LocalizedControlType **"terminal"**, and **Name = the on-screen text** (test marker found). 110/110 Core, 17/17 Pty.

## Next (Stage 2)
`ITextProvider`/`ITextRangeProvider` for line/caret navigation and selection — best landed when it can be checked against a live screen reader (Narrator/NVDA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)