### PR TITLE
test: control-API suite (+21) + free build-provenance attestation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write        # for build-provenance attestation (free, keyless via Sigstore)
+  attestations: write
 
 jobs:
   installer:
@@ -31,6 +33,16 @@ jobs:
       - name: Build portable exe
         shell: pwsh
         run: ./installer/build-portable.ps1
+
+      # Free, certless supply-chain signing: a Sigstore-backed attestation binding each artifact to
+      # this commit + workflow. Verify with:  gh attestation verify <file> --repo yeroo/agwinterm
+      # (Doesn't remove SmartScreen — that needs Authenticode, e.g. a SignPath Foundation OSS cert.)
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: |
+            installer/Output/agwinterm-setup-*.exe
+            installer/Output/agwinterm-portable-*.exe
 
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2

--- a/tests/Agwinterm.Pty.Tests/ControlApiTests.cs
+++ b/tests/Agwinterm.Pty.Tests/ControlApiTests.cs
@@ -1,0 +1,270 @@
+using System.Text.Json;
+using Agwinterm.Core;
+using Agwinterm.Pty;
+
+namespace Agwinterm.Pty.Tests;
+
+/// <summary>End-to-end control-API contract tests: JSON command in → JSON response out, driving a realistic
+/// in-memory <see cref="FakeSessionHost"/>. This is the regression net for the control surface that the
+/// Win32 UI otherwise only exercises by hand. Covers the tree/window read-back, session &amp; workspace
+/// lifecycle, config, overlay, toggles, and error handling.</summary>
+public class ControlApiTests
+{
+    private static (ControlServer server, FakeSessionHost host) New()
+    {
+        var host = new FakeSessionHost();
+        return (new ControlServer(host), host);
+    }
+
+    // `target` is a top-level field in the command envelope (not inside args); size-percent etc. are hyphenated
+    // arg keys, so args that need them are passed as dictionaries.
+    private static JsonElement Dispatch(ControlServer server, string cmd, object? args = null, string? target = null)
+    {
+        var sb = new System.Text.StringBuilder("{\"cmd\":").Append(JsonSerializer.Serialize(cmd));
+        if (target is not null) sb.Append(",\"target\":").Append(JsonSerializer.Serialize(target));
+        if (args is not null) sb.Append(",\"args\":").Append(JsonSerializer.Serialize(args));
+        sb.Append('}');
+        return JsonDocument.Parse(server.Dispatch(sb.ToString())).RootElement;
+    }
+
+    private static Dictionary<string, object> Overlay(string action, int sizePercent, string? command = null)
+    {
+        var d = new Dictionary<string, object> { ["action"] = action, ["size-percent"] = sizePercent };
+        if (command is not null) d["command"] = command;
+        return d;
+    }
+
+    private static bool Ok(JsonElement r) => r.TryGetProperty("ok", out var o) && o.GetBoolean();
+    private static string Result(JsonElement r) => r.GetProperty("result").GetString() ?? "";
+    // tree / window.state return raw JSON nested under "result".
+    private static JsonElement Tree(ControlServer s) => Dispatch(s, "tree").GetProperty("result");
+    private static JsonElement Sessions0(ControlServer s) => Tree(s).GetProperty("workspaces")[0].GetProperty("sessions")[0];
+    private static JsonElement WinState(ControlServer s) => Dispatch(s, "window.state").GetProperty("result");
+
+    // ---- tree read-back ----
+
+    [Fact]
+    public void Tree_ReportsWorkspacesAndSessions()
+    {
+        var (server, _) = New();
+        var ws = Tree(server).GetProperty("workspaces");
+        Assert.Equal(1, ws.GetArrayLength());
+        Assert.Equal("workspace 1", ws[0].GetProperty("name").GetString());
+        Assert.True(ws[0].GetProperty("active").GetBoolean());
+        Assert.Equal("session 1", ws[0].GetProperty("sessions")[0].GetProperty("name").GetString());
+    }
+
+    [Fact]
+    public void Tree_ExposesSplitReadBack_AfterSplit()
+    {
+        var (server, host) = New();
+        host.Split("on");   // 2 panes, 0.5/0.5
+        host.FocusPaneDir("right");
+        var s = Sessions0(server);
+        Assert.Equal(2, s.GetProperty("paneCount").GetInt32());
+        Assert.Equal(1, s.GetProperty("focusedPane").GetInt32());
+        var ratios = s.GetProperty("splitRatios");
+        Assert.Equal(2, ratios.GetArrayLength());
+        Assert.Equal(0.5, ratios[0].GetDouble(), 3);
+    }
+
+    [Fact]
+    public void Tree_OmitsSplitFields_ForSinglePane()
+    {
+        var (server, _) = New();
+        var s = Sessions0(server);
+        Assert.False(s.TryGetProperty("paneCount", out _));   // single-pane sessions stay lean
+        Assert.False(s.TryGetProperty("splitRatios", out _));
+    }
+
+    [Fact]
+    public void Tree_ExposesOverlaySize_WhenOverlayOpen()
+    {
+        var (server, _) = New();
+        Dispatch(server, "session.overlay", Overlay("open", 40, "cmd"));
+        var s = Sessions0(server);
+        Assert.True(s.GetProperty("overlay").GetBoolean());
+        Assert.Equal(40, s.GetProperty("overlaySize").GetInt32());
+    }
+
+    // ---- window.state ----
+
+    [Fact]
+    public void WindowState_ReportsFlagsAndActive()
+    {
+        var (server, _) = New();
+        var r = WinState(server);
+        Assert.True(r.GetProperty("sidebarVisible").GetBoolean());
+        Assert.False(r.GetProperty("fullscreen").GetBoolean());
+        Assert.False(r.GetProperty("maximized").GetBoolean());
+        Assert.False(r.GetProperty("quickTerminalVisible").GetBoolean());
+        Assert.Equal("workspace 1", r.GetProperty("activeWorkspace").GetString());
+        Assert.Equal("session 1", r.GetProperty("activeSession").GetString());
+    }
+
+    [Fact]
+    public void WindowState_SidebarVisible_FollowsSidebarOp()
+    {
+        var (server, _) = New();
+        Dispatch(server, "sidebar", new { op = "hide" });
+        Assert.False(WinState(server).GetProperty("sidebarVisible").GetBoolean());
+        Dispatch(server, "sidebar", new { op = "show" });
+        Assert.True(WinState(server).GetProperty("sidebarVisible").GetBoolean());
+    }
+
+    // ---- session lifecycle ----
+
+    [Fact]
+    public void NewSession_AppearsInTree_AndBecomesActive()
+    {
+        var (server, host) = New();
+        var r = Dispatch(server, "session.new", new { name = "built" });
+        Assert.True(Ok(r));
+        Assert.Equal(2, host.ActiveWs.Sessions.Count);
+        Assert.Equal("built", host.ActiveSess!.Name);
+    }
+
+    [Fact]
+    public void SessionRename_ChangesName()
+    {
+        var (server, host) = New();
+        Dispatch(server, "session.rename", new { name = "renamed" });
+        Assert.Equal("renamed", host.ActiveSess!.Name);
+    }
+
+    [Fact]
+    public void SessionFlag_TogglesFlag()
+    {
+        var (server, host) = New();
+        Dispatch(server, "session.flag", new { op = "on" });
+        Assert.True(host.ActiveSess!.Flagged);
+        Dispatch(server, "session.flag", new { op = "toggle" });
+        Assert.False(host.ActiveSess.Flagged);
+    }
+
+    [Fact]
+    public void CloseSession_RemovesIt()
+    {
+        var (server, host) = New();
+        string id = Dispatch(server, "session.new", new { name = "temp" }).GetProperty("result").GetString()!;
+        Assert.Equal(2, host.ActiveWs.Sessions.Count);
+        var r = Dispatch(server, "session.close", target: id);
+        Assert.True(Ok(r));
+        Assert.Single(host.ActiveWs.Sessions);
+    }
+
+    [Fact]
+    public void SelectSession_SetsActive()
+    {
+        var (server, host) = New();
+        string id = Dispatch(server, "session.new", new { name = "b" }).GetProperty("result").GetString()!;
+        Dispatch(server, "session.select", target: "s1");
+        Assert.Equal("session 1", host.ActiveSess!.Name);
+        Dispatch(server, "session.select", target: id);
+        Assert.Equal("b", host.ActiveSess.Name);
+    }
+
+    // ---- workspace lifecycle ----
+
+    [Fact]
+    public void NewWorkspace_ThenRename_ThenDelete()
+    {
+        var (server, host) = New();
+        string wid = Dispatch(server, "workspace.new", new { name = "extra" }).GetProperty("result").GetString()!;
+        Assert.Equal(2, host.Workspaces.Count);
+        Dispatch(server, "workspace.rename", new { name = "renamed-ws" }, target: wid);
+        Assert.Contains(host.Workspaces, w => w.Name == "renamed-ws");
+        Dispatch(server, "workspace.delete", target: wid);
+        Assert.Single(host.Workspaces);
+    }
+
+    [Fact]
+    public void WorkspaceDelete_RefusesLastWorkspace()
+    {
+        var (server, host) = New();
+        var r = Dispatch(server, "workspace.delete", target: "w1");
+        Assert.False(Ok(r));            // can't delete the only workspace
+        Assert.Single(host.Workspaces);
+    }
+
+    // ---- config ----
+
+    [Fact]
+    public void ConfigSet_ThenGet_RoundTrips()
+    {
+        var (server, _) = New();
+        Dispatch(server, "config.set", new { key = "toolbar-mode", value = "hidden" });
+        Assert.Equal("hidden", Result(Dispatch(server, "config.get", new { key = "toolbar-mode" })));
+    }
+
+    // ---- overlay ----
+
+    [Fact]
+    public void Overlay_Open_Resize_Close()
+    {
+        var (server, host) = New();
+        Dispatch(server, "session.overlay", Overlay("open", 30, "cmd"));
+        Assert.True(host.ActiveSess!.Overlay);
+        Assert.Equal("resized 75%", Result(Dispatch(server, "session.overlay", Overlay("resize", 75))));
+        Assert.Equal(75, host.ActiveSess.OverlaySize);
+        Dispatch(server, "session.overlay", new { action = "close" });
+        Assert.False(host.ActiveSess.Overlay);
+    }
+
+    [Fact]
+    public void Overlay_Resize_WithNoOverlay_ReturnsNoOverlay()
+    {
+        var (server, _) = New();
+        Assert.Equal("no overlay", Result(Dispatch(server, "session.overlay", Overlay("resize", 50))));
+    }
+
+    // ---- toggles ----
+
+    [Fact]
+    public void Broadcast_And_ReadOnly_And_Quick_Toggle()
+    {
+        var (server, host) = New();
+        Assert.Equal("on", Result(Dispatch(server, "broadcast", new { op = "on" })));
+        Assert.True(host.Broadcast);
+        Assert.Equal("on", Result(Dispatch(server, "session.readonly", new { op = "on" })));
+        Assert.True(host.ActiveSess!.ReadOnly);
+        Dispatch(server, "quick", new { op = "on" });
+        Assert.True(host.QuickVisible);
+    }
+
+    // ---- notifications ----
+
+    [Fact]
+    public void Notify_ThenSeen_ClearsBadge()
+    {
+        var (server, host) = New();
+        Dispatch(server, "notify", new { title = "t", body = "b" });
+        Assert.Equal(1, host.ActiveSess!.Notifications);
+        Assert.Equal(1, Sessions0(server).GetProperty("notifications").GetInt32());
+        Dispatch(server, "session.seen");
+        Assert.Equal(0, host.ActiveSess.Notifications);
+    }
+
+    // ---- error handling ----
+
+    [Fact]
+    public void UnknownCommand_IsError()
+    {
+        var (server, _) = New();
+        Assert.False(Ok(Dispatch(server, "does.not.exist")));
+    }
+
+    [Fact]
+    public void InvalidJson_IsError()
+    {
+        var (server, _) = New();
+        Assert.False(Ok(JsonDocument.Parse(server.Dispatch("}{ not json")).RootElement));
+    }
+
+    [Fact]
+    public void CloseUnknownSession_IsError()
+    {
+        var (server, _) = New();
+        Assert.False(Ok(Dispatch(server, "session.close", target: "nope-does-not-exist")));
+    }
+}

--- a/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
+++ b/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
@@ -1,0 +1,130 @@
+using Agwinterm.Core;
+using Agwinterm.Pty;
+
+namespace Agwinterm.Pty.Tests;
+
+/// <summary>An in-memory <see cref="ISessionHost"/> for testing the control-API JSON contract without the
+/// Win32 UI: real workspace→session state + window flags, so tree/window.state/lifecycle verbs can be
+/// asserted end-to-end. Peripheral verbs return sensible constants.</summary>
+internal sealed class FakeSessionHost : ISessionHost
+{
+    internal sealed class Sess
+    {
+        public string Id = "", Name = "";
+        public AgentStatus Status = AgentStatus.Idle;
+        public bool Flagged, Overlay, ReadOnly;
+        public int Notifications, PaneCount = 1, FocusedPane, OverlaySize;
+        public List<double> Ratios = new() { 1.0 };
+    }
+    internal sealed class Ws { public string Id = "", Name = ""; public List<Sess> Sessions = new(); }
+
+    internal readonly List<Ws> Workspaces = new();
+    internal Ws ActiveWs;
+    internal Sess? ActiveSess;
+    internal bool SidebarVisible = true, Fullscreen, Maximized, QuickVisible, Broadcast;
+    internal readonly Dictionary<string, string> Config = new();
+    private readonly TerminalSession _session = new(80, 24);
+    private int _idSeq;
+
+    public FakeSessionHost()
+    {
+        var w = new Ws { Id = "w1", Name = "workspace 1" };
+        var s = new Sess { Id = "s1", Name = "session 1" };
+        w.Sessions.Add(s);
+        Workspaces.Add(w);
+        ActiveWs = w; ActiveSess = s;
+    }
+
+    private Sess? Find(string? t) =>
+        t is null or "active" ? ActiveSess
+        : Workspaces.SelectMany(w => w.Sessions).FirstOrDefault(s => s.Id == t || s.Id.StartsWith(t));
+    private Ws? FindWs(string? t) =>
+        t is null or "active" ? ActiveWs
+        : Workspaces.FirstOrDefault(w => w.Id == t || w.Id.StartsWith(t) || string.Equals(w.Name, t, StringComparison.OrdinalIgnoreCase));
+
+    public TerminalSession? Resolve(string? target) => Find(target) is not null ? _session : null;
+
+    public IReadOnlyList<WorkspaceSnapshot> Tree() => Workspaces.Select(w => new WorkspaceSnapshot(
+        w.Id, w.Name, ReferenceEquals(w, ActiveWs),
+        w.Sessions.Select(s => new SessionSnapshot(s.Id, s.Name, ReferenceEquals(s, ActiveSess), s.Status,
+            s.Overlay, s.Notifications, s.Flagged, false, s.FocusedPane, s.PaneCount, false, s.OverlaySize, s.Ratios)).ToList())).ToList();
+
+    public WindowStateSnapshot WindowState() =>
+        new(SidebarVisible, Fullscreen, Maximized, QuickVisible, ActiveWs.Name, ActiveSess?.Name);
+
+    public string NewSession(string? name, string? cwd, string? workspace, string? command = null,
+        string? workspaceName = null, bool createWorkspace = false, string? profile = null)
+    {
+        var w = FindWs(workspace) ?? ActiveWs;
+        var s = new Sess { Id = "s" + (++_idSeq + 100), Name = string.IsNullOrEmpty(name) ? $"session {w.Sessions.Count + 1}" : name };
+        w.Sessions.Add(s); ActiveSess = s; ActiveWs = w;
+        return s.Id;
+    }
+
+    public bool SelectSession(string target) { var s = Find(target); if (s is null) return false; ActiveSess = s; ActiveWs = Workspaces.First(w => w.Sessions.Contains(s)); return true; }
+    public bool CloseSession(string target)
+    {
+        var s = Find(target); if (s is null) return false;
+        var w = Workspaces.First(x => x.Sessions.Contains(s)); w.Sessions.Remove(s);
+        if (ReferenceEquals(ActiveSess, s)) ActiveSess = Workspaces.SelectMany(x => x.Sessions).FirstOrDefault();
+        return true;
+    }
+    public string NewWorkspace(string? name) { var w = new Ws { Id = "w" + (++_idSeq + 100), Name = string.IsNullOrEmpty(name) ? $"workspace {Workspaces.Count + 1}" : name }; Workspaces.Add(w); return w.Id; }
+    public string ProfilesList() => "default";
+    public string ProfilesReload() => "1 profile loaded";
+    public bool SetFontSize(string? target, string op) => Find(target) is not null;
+
+    public void SessionGo(string dir) { }
+    public bool SessionReorder(string? target, string dir) => Find(target) is not null;
+    public bool SessionToWorkspace(string? target, string workspace) { var s = Find(target); var w = FindWs(workspace); if (s is null || w is null) return false; Workspaces.First(x => x.Sessions.Contains(s)).Sessions.Remove(s); w.Sessions.Add(s); return true; }
+    public bool SessionRename(string? target, string name) { var s = Find(target); if (s is null || string.IsNullOrWhiteSpace(name)) return false; s.Name = name; return true; }
+    public bool SessionSeen(string? target) { var s = Find(target); if (s is null) return false; s.Notifications = 0; return true; }
+    public string SidebarState() => SidebarVisible ? "visible tree" : "hidden tree";
+    public string BroadcastOp(string op) { Broadcast = op switch { "on" => true, "off" => false, "toggle" => !Broadcast, _ => Broadcast }; return Broadcast ? "on" : "off"; }
+    public string ReadOnlyOp(string? target, string op) { var s = Find(target); if (s is null) return "off"; s.ReadOnly = op switch { "on" => true, "off" => false, "toggle" => !s.ReadOnly, _ => s.ReadOnly }; return s.ReadOnly ? "on" : "off"; }
+    public string SessionOutput(string? target) => "";
+    public bool WorkspaceRename(string? target, string name) { var w = FindWs(target); if (w is null || string.IsNullOrWhiteSpace(name)) return false; w.Name = name; return true; }
+    public bool WorkspaceDelete(string? target) { var w = FindWs(target); if (w is null || Workspaces.Count <= 1) return false; Workspaces.Remove(w); if (ReferenceEquals(ActiveWs, w)) { ActiveWs = Workspaces[0]; ActiveSess = ActiveWs.Sessions.FirstOrDefault(); } return true; }
+    public bool WorkspaceSelect(string? target) { var w = FindWs(target); if (w is null) return false; ActiveWs = w; ActiveSess = w.Sessions.FirstOrDefault(); return true; }
+    public bool WorkspaceReorder(string? target, string dir) => FindWs(target) is not null;
+    public void Split(string op) { if (ActiveSess is null) return; ActiveSess.PaneCount = op == "off" ? 1 : 2; ActiveSess.Ratios = op == "off" ? new() { 1.0 } : new() { 0.5, 0.5 }; }
+    public void FocusPaneDir(string dir) { if (ActiveSess is { PaneCount: > 1 }) ActiveSess.FocusedPane ^= 1; }
+    public void ResizeSplit(double? ratio, int growLeft, int growRight) { if (ActiveSess is { PaneCount: > 1 } && ratio is { } r) ActiveSess.Ratios = new() { r, 1 - r }; }
+    public IReadOnlyList<string> ThemeList() => new[] { "dark", "light" };
+    public bool ThemeSet(string name) => name is "dark" or "light";
+    public string KeymapReload() => "reloaded";
+    public string RestoreClear() => "cleared";
+    public void SidebarOp(string op) { SidebarVisible = op switch { "show" => true, "hide" => false, "toggle" => !SidebarVisible, _ => SidebarVisible }; }
+    public string ConfigSet(string key, string value) { Config[key] = value; return "set"; }
+    public string ConfigGet(string key) => Config.TryGetValue(key, out var v) ? v : "";
+    public string ConfigList() => string.Join("\n", Config.Select(kv => $"{kv.Key} = {kv.Value}"));
+    public string SettingsOpen() => "opened";
+    public string SessionCopy(string? target) => "";
+    public string SelectionAll(string? target) => Find(target) is not null ? "selected" : "no session";
+    public string SelectionCopy(string? target) => "";
+    public string SelectionClear(string? target) => "cleared";
+    public string SelectionFinalize(string? target) => "";
+    public string SessionPaste(string? target, string? text) => Find(target) is not null ? "pasted" : "no session";
+    public string SessionSearch(string? target, string? query, string? action) => "no matches";
+    public bool SessionScratch(string? target, string op) => Find(target) is not null;
+    public void Quick(string op) { QuickVisible = op switch { "on" => true, "off" => false, "toggle" => !QuickVisible, _ => QuickVisible }; }
+    public string SessionOverlay(string? target, string action, string? command, int sizePercent, bool wait, bool block)
+    {
+        var s = Find(target); if (s is null) return "no session";
+        switch (action)
+        {
+            case "close": s.Overlay = false; s.OverlaySize = 0; return "closed";
+            case "resize": if (!s.Overlay) return "no overlay"; s.OverlaySize = Math.Clamp(sizePercent, 0, 100); return $"resized {s.OverlaySize}%";
+            default: if (string.IsNullOrWhiteSpace(command)) return "no command"; s.Overlay = true; s.OverlaySize = Math.Clamp(sizePercent, 0, 100); return s.Id;
+        }
+    }
+    public bool Notify(string? target, string? title, string body) { var s = Find(target); if (s is null) return false; s.Notifications++; return true; }
+    public bool SessionFlag(string? target, string op) { if (op == "clear") { foreach (var s in Workspaces.SelectMany(w => w.Sessions)) s.Flagged = false; return true; } var x = Find(target); if (x is null) return false; x.Flagged = op switch { "on" => true, "off" => false, "toggle" => !x.Flagged, _ => x.Flagged }; return true; }
+    public void WorkspaceFocus(string op) { }
+    public string SessionBackground(string? target, string action, string? path, int opacity, string? mode) => Find(target) is not null ? "ok" : "no session";
+    public string SessionSwitch(string op) => ActiveSess?.Name ?? "";
+    public string CommandRun(string nameOrCommand, string? mode) => $"{mode ?? "new"}: {nameOrCommand}";
+    public string CommandList() => "";
+    public string CommandLeader(string op) => "idle";
+    public string OmpSet(string nameOrPath, bool persist) => "ok";
+}


### PR DESCRIPTION
Addresses two of the maturity gaps: **no automated coverage of the control surface** and **no supply-chain signing**.

## Control-API test suite (+21 tests)
- **FakeSessionHost** — a realistic in-memory `ISessionHost` (workspaces→sessions, window flags, config) so the JSON contract is asserted end-to-end without the Win32 UI.
- **ControlApiTests** — tree read-back (splitRatios/paneCount/focusedPane/overlaySize), `window.state`, session + workspace lifecycle, config round-trip, overlay open/resize/close, toggles, notify+seen, error handling. Caught and documented the `OkRaw` `result`-wrapping contract.
- Pty tests **17 → 38**; 110/110 Core still green.

## Free build-provenance attestation
- `release.yml` now emits a **Sigstore-backed provenance attestation** for each release artifact (no cert, no cost) — verifiable with `gh attestation verify <file> --repo yeroo/agwinterm`. Pairs with the OpenSSF scorecard.
- SmartScreen removal still needs Authenticode; documented the affordable OSS path (SignPath Foundation free cert / Certum ~\$30) for when you want it.

Tests-only + CI — no runtime change, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)