### PR TITLE
fix: PTY connection leak — one thread + ConPTY handles per closed session

### DIFF
--- a/docs/memory-profile-2026-07-09.md
+++ b/docs/memory-profile-2026-07-09.md
@@ -1,0 +1,49 @@
+# Memory & leak profile — 2026-07-09
+
+First systematic leak hunt. Method: `tools/profile-memory.ps1` drives the app through two identical
+rounds of churn (30× session create/close, 15× overlay open/close, 30× split on/off, 20× theme
+switches, 30× window resizes, one 60k-line output blast) via the control API, sampling working set,
+private bytes, kernel handles, GDI/USER handles and thread count between phases. **Round-2 growth over
+the round-1 idle point is the leak signal** — round-1 growth alone is warm caches + lazy GC.
+
+## Finding 1 (real, fixed): every closed session leaked a thread + ConPTY handles
+
+`TerminalSession.Dispose()` called `_connection?.Kill()` but never **disposed** the connection.
+ConPTY semantics: killing the child does NOT EOF the pseudoconsole's output pipe — only closing the
+pseudoconsole does. So each closed session/overlay/split-pane left its output pump blocked in
+`ReadAsync` forever: one pinned thread-pool thread (~1 MB stack) + the ConPTY/pipe/process handles.
+
+Measured round-2 delta, before → after the fix:
+
+| signal | before | after |
+|---|---|---|
+| threads | **+76** | **0** |
+| kernel handles | **+1,227** | **0** |
+| USER handles | **+78** | **0** |
+| working set | +64.9 MB | +9.7 MB |
+
+Fix: `Dispose()` now kills **and disposes** the connection (closes pseudoconsole + pipes, unblocking
+the pump), and the pump treats `ObjectDisposedException` as normal shutdown. Both `DeElevatedPty` and
+`AttachedPty` already had correct `Dispose()` implementations — they were simply never invoked.
+
+## Finding 2 (not a leak): residual ~10 MB after heavy output
+
+Three consecutive 60k-line blasts: 128 → 133 → 132 MB. Plateau, not linear growth — the first big
+scrollback sizes the GC heap segments and later rounds reuse them. Normal .NET heap behaviour.
+
+## Clean bills of health (static audit)
+
+- All `IDWriteTextLayout`s are `using`-scoped; the ligature typography object is cached once.
+- Kitty image + watermark bitmap caches evict with `Dispose()`; device-loss (`RecreateTarget`)
+  disposes every device-bound resource before rebuilding.
+- `WM_SIZE` uses `rt.Resize` (no target churn). GDI count is flat at 15 through all phases (Direct2D
+  doesn't consume GDI handles).
+- Theme churn ×20: +0.6 MB, nothing retained.
+- `_metrics` (per-font-size TextFormat cache) is never cleared, but font family/size changes are
+  restart-deferred, so entries can't go stale in-process; bounded by distinct zoom levels. Watch item.
+
+## Steady state after fix
+
+Baseline ~88 MB WS / 644 handles / 42 threads; a full double churn round ends at ~139 MB / 675 / 42
+with handles/threads returning exactly to baseline. Re-run the harness after any PTY/session-lifecycle
+change: `pwsh tools/profile-memory.ps1`.

--- a/src/Agwinterm.Pty/TerminalSession.cs
+++ b/src/Agwinterm.Pty/TerminalSession.cs
@@ -257,6 +257,7 @@ public sealed class TerminalSession : IDisposable
         }
         catch (IOException) { }
         catch (OperationCanceledException) { }
+        catch (ObjectDisposedException) { }   // Dispose() closed the stream mid-read — normal shutdown
     }
 
     /// <summary>
@@ -305,6 +306,13 @@ public sealed class TerminalSession : IDisposable
 
     public void Dispose()
     {
-        try { _connection?.Kill(); } catch { /* already exited */ }
+        var c = _connection;
+        _connection = null;
+        try { c?.Kill(); } catch { /* already exited */ }
+        // Dispose closes the pseudoconsole + pipes. Without it the ConPTY output pipe never EOFs
+        // (killing the child is not enough), so the pump task stays blocked in ReadAsync forever —
+        // leaking one thread-pool thread (~1MB stack) plus the ConPTY/pipe/process handles per
+        // closed session. Found by tools/profile-memory.ps1.
+        try { c?.Dispose(); } catch { }
     }
 }

--- a/tools/profile-memory.ps1
+++ b/tools/profile-memory.ps1
@@ -1,0 +1,103 @@
+# Memory-leak churn harness for agwinterm.
+#
+# Drives the app through repeated create/destroy cycles (sessions, overlays, splits, themes,
+# window resizes, heavy output) via agwintermctl, sampling working set, private bytes, kernel
+# handles, and GDI/USER handles between phases. A leak shows up as monotonic growth that
+# repeats on a SECOND round of the same churn (round 1 growth alone can be warm caches / lazy GC).
+#
+# Usage:  pwsh tools/profile-memory.ps1 [-Exe <path>] [-Ctl <path>] [-Cycles 30]
+param(
+    [string]$Exe = "$PSScriptRoot\..\src\Agwinterm.Win32\bin\Debug\net10.0-windows\win-x64\Agwinterm.Win32.exe",
+    [string]$Ctl = "$PSScriptRoot\..\src\Agwinterm.Ctl\bin\Debug\net10.0-windows\agwintermctl.exe",
+    [int]$Cycles = 30
+)
+$ErrorActionPreference = 'SilentlyContinue'
+
+Add-Type -MemberDefinition '[DllImport("user32.dll")] public static extern uint GetGuiResources(IntPtr hProcess, uint uiFlags);' -Name Gui -Namespace Prof
+
+$script:Samples = @()
+function Sample([string]$label) {
+    $p = Get-Process Agwinterm.Win32 | Select-Object -First 1
+    if (-not $p) { Write-Warning "app gone at '$label'"; return }
+    $p.Refresh()
+    $s = [pscustomobject]@{
+        Phase    = $label
+        WS_MB    = [math]::Round($p.WorkingSet64 / 1MB, 1)
+        Priv_MB  = [math]::Round($p.PrivateMemorySize64 / 1MB, 1)
+        Handles  = $p.HandleCount
+        GDI      = [Prof.Gui]::GetGuiResources($p.Handle, 0)
+        USER     = [Prof.Gui]::GetGuiResources($p.Handle, 1)
+        Threads  = $p.Threads.Count
+    }
+    $script:Samples += $s
+    Write-Host ("{0,-28} WS={1,7}MB priv={2,7}MB handles={3,5} gdi={4,4} user={5,4} thr={6,3}" -f
+        $s.Phase, $s.WS_MB, $s.Priv_MB, $s.Handles, $s.GDI, $s.USER, $s.Threads)
+}
+
+function ChurnSessions([string]$tag) {
+    for ($i = 0; $i -lt $Cycles; $i++) {
+        $id = (& $Ctl session new --name "churn$i" | Out-String).Trim()
+        & $Ctl session close --target $id 2>$null | Out-Null
+    }
+    Start-Sleep -Seconds 2; Sample "sessions x$Cycles $tag"
+}
+function ChurnOverlays([string]$tag) {
+    for ($i = 0; $i -lt [math]::Max(10, $Cycles / 2); $i++) {
+        & $Ctl session overlay open 'cmd /c echo overlay' --size-percent 40 2>$null | Out-Null
+        Start-Sleep -Milliseconds 120
+        & $Ctl session overlay close 2>$null | Out-Null
+    }
+    Start-Sleep -Seconds 2; Sample "overlays $tag"
+}
+function ChurnSplits([string]$tag) {
+    for ($i = 0; $i -lt $Cycles; $i++) {
+        & $Ctl session split on 2>$null | Out-Null
+        & $Ctl session split off 2>$null | Out-Null
+    }
+    Start-Sleep -Seconds 2; Sample "splits x$Cycles $tag"
+}
+function ChurnThemes([string]$tag) {
+    $themes = (& $Ctl theme list | Out-String) -split "`n" | Where-Object { $_.Trim() } | Select-Object -First 10
+    for ($i = 0; $i -lt 20; $i++) { & $Ctl theme set $themes[$i % $themes.Count].Trim() 2>$null | Out-Null }
+    Start-Sleep -Seconds 2; Sample "themes x20 $tag"
+}
+function ChurnResize([string]$tag) {
+    for ($i = 0; $i -lt $Cycles; $i++) {
+        $w = 900 + ($i % 6) * 120; $h = 600 + ($i % 5) * 90
+        & $Ctl window resize active $w $h 2>$null | Out-Null
+    }
+    Start-Sleep -Seconds 2; Sample "resize x$Cycles $tag"
+}
+function HeavyOutput([string]$tag) {
+    # ~60k lines through one PTY: scrollback fills to its cap; growth beyond one buffer = leak.
+    $id = (& $Ctl session new --name blaster --command 'powershell -NoProfile -Command "1..60000 | ForEach-Object { \"line $_ with some padding text to make it wider\" }; Start-Sleep 2"' | Out-String).Trim()
+    Start-Sleep -Seconds 14
+    Sample "heavy output (open) $tag"
+    & $Ctl session close --target $id 2>$null | Out-Null
+    Start-Sleep -Seconds 2; Sample "heavy output (closed) $tag"
+}
+
+# ---- run ----
+Get-Process Agwinterm.Win32 | Stop-Process -Force; Start-Sleep 1
+Start-Process $Exe
+for ($i = 0; $i -lt 15; $i++) { Start-Sleep 1; if ((& $Ctl ping) -match 'agwinterm') { break } }
+Start-Sleep -Seconds 3
+Sample "baseline"
+
+ChurnSessions "R1"; ChurnOverlays "R1"; ChurnSplits "R1"; ChurnThemes "R1"; ChurnResize "R1"; HeavyOutput "R1"
+Write-Host "`n-- idle 15s (GC settle) --"; Start-Sleep -Seconds 15; Sample "idle after R1"
+
+# Round 2: growth here (over 'idle after R1') is the leak signal — caches are already warm.
+ChurnSessions "R2"; ChurnOverlays "R2"; ChurnSplits "R2"; ChurnThemes "R2"; ChurnResize "R2"; HeavyOutput "R2"
+Write-Host "`n-- idle 15s --"; Start-Sleep -Seconds 15; Sample "idle after R2"
+
+Write-Host "`n===== summary ====="
+$script:Samples | Format-Table -AutoSize
+$r1 = $script:Samples | Where-Object Phase -eq "idle after R1"
+$r2 = $script:Samples | Where-Object Phase -eq "idle after R2"
+if ($r1 -and $r2) {
+    Write-Host ("round-2 delta (leak signal): WS {0:+0.0;-0.0}MB priv {1:+0.0;-0.0}MB handles {2:+0;-0} gdi {3:+0;-0} user {4:+0;-0} thr {5:+0;-0}" -f
+        ($r2.WS_MB - $r1.WS_MB), ($r2.Priv_MB - $r1.Priv_MB), ($r2.Handles - $r1.Handles),
+        ($r2.GDI - $r1.GDI), ($r2.USER - $r1.USER), ($r2.Threads - $r1.Threads))
+}
+Get-Process Agwinterm.Win32 | Stop-Process -Force


### PR DESCRIPTION
First systematic memory/leak profile ([findings](../blob/fix/pty-dispose-leak/docs/memory-profile-2026-07-09.md)). One real leak found and fixed.

## The leak
`TerminalSession.Dispose()` called `Kill()` but never **disposed** the connection. ConPTY's output pipe only EOFs when the *pseudoconsole* is closed — killing the child is not enough — so every closed session/overlay/split-pane left its pump blocked in `ReadAsync` forever: **one pinned thread-pool thread (~1 MB stack) + ConPTY/pipe/process handles**.

## Evidence (round-2 churn delta, before → after)
| signal | before | after |
|---|---|---|
| threads | **+76** | **0** |
| kernel handles | **+1,227** | **0** |
| USER handles | **+78** | **0** |
| working set | +64.9 MB | +9.7 MB |

Residual ~10 MB verified as GC heap sizing (3× 60k-line blasts plateau 128→133→132 MB), not a leak.

## Also in this PR
- **`tools/profile-memory.ps1`** — reusable churn harness (sessions/overlays/splits/themes/resizes/heavy output, sampling WS/private/handles/GDI/USER/threads); re-run after any PTY-lifecycle change.
- **`docs/memory-profile-2026-07-09.md`** — findings + static-audit clean bills of health (render path `using` discipline, cache eviction, device-loss recreate, flat GDI).

110/110 Core, 38/38 Pty. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)