### PR TITLE
perf: 10x sustained-output throughput (block-move scroll + frame cap + snapshot render + sync pump)

### DIFF
--- a/docs/memory-profile-2026-07-09.md
+++ b/docs/memory-profile-2026-07-09.md
@@ -47,3 +47,42 @@ scrollback sizes the GC heap segments and later rounds reuse them. Normal .NET h
 Baseline ~88 MB WS / 644 handles / 42 threads; a full double churn round ends at ~139 MB / 675 / 42
 with handles/threads returning exactly to baseline. Re-run the harness after any PTY/session-lifecycle
 change: `pwsh tools/profile-memory.ps1`.
+
+---
+
+# Performance profile (same session)
+
+Headline numbers (Debug build, maximized window):
+- **Startup → control-API responsive: 0.38 s.** Idle CPU: **0.47 %** of one core (cursor-blink timer).
+- **Sustained output throughput: 18.5 s → 1.84 s for a 60k-line / 4 MB `type`** (3.2k → **32.6k lines/s**,
+  ~87 % of a bare conhost window at 37.5k). App CPU for the blast: 19.1 s → **1.3 s**.
+
+## Finding 3 (the big one, fixed): per-cell scroll dominated sustained output
+
+`dotnet-stack` on the one hot thread (99 % of a core) showed the pump inside
+`TerminalEmulator.ScrollRegionUp()` → `ScreenBuffer.get_Item`. Every LF at the bottom row scrolled the
+grid **cell-by-cell through a bounds-checked indexer** (~rows×cols calls per line; hundreds of millions
+for the blast). Fix: `ScreenBuffer.MoveRows/FillRow/CopyRowTo` — one `Array.Copy` (memmove) per scroll —
+used by ScrollRegionUp/Down, InsertLines, DeleteLines, PushHistory. This alone was the 10× win.
+
+## Supporting fixes (landed with it)
+
+- **Output-driven frame cap** (`RedrawMinIntervalMs` = 15 ms): floods render at ~66 fps instead of
+  per-chunk back-to-back frames; the first frame after a quiet period still paints immediately.
+- **Snapshot rendering**: `RenderTerminal` now copies the visible viewport under the session lock
+  (sub-ms) and draws outside it, so a slow frame no longer blocks the PTY pump (`Monitor.Enter`
+  convoy seen in stacks).
+- **Dedicated sync pump thread**: the ConPTY read pipe is a synchronous handle, so `ReadAsync` went
+  through the async-over-sync layer (visible as `AsyncOverSyncWithIoCancellation` in traces). The pump
+  is now a plain blocking `Read` on a `LongRunning` task with a 64 KB buffer.
+
+## Method notes (for the next profiling pass)
+
+- Emitter choice matters: `cmd for /L` and PowerShell pipelines are themselves slow (~0.5–1k lines/s)
+  and will mask terminal-side wins — benchmark with `type <pregenerated file>`.
+- A quoting mistake in `session new --command` fails fast inside cmd and looks exactly like a hang;
+  screenshot the pane before trusting a timing number.
+- `dotnet-stack report` (per-thread) beat `dotnet-trace` percentages here: find the hot thread by
+  per-thread CPU delta first, then read its stack.
+- Leak harness re-run after all perf changes: round-2 delta ≈ 0 (WS −0.5 MB, +1 thread, +7 handles —
+  noise). The dedicated pump threads exit on dispose.

--- a/src/Agwinterm.Core/ScreenBuffer.cs
+++ b/src/Agwinterm.Core/ScreenBuffer.cs
@@ -33,6 +33,32 @@ public sealed class ScreenBuffer
 
     public void Clear() => Array.Fill(_cells, Cell.Empty);
 
+    /// <summary>Block-move <paramref name="count"/> whole rows from <paramref name="srcRow"/> to
+    /// <paramref name="dstRow"/> (memmove semantics — overlapping regions are safe). Scrolling with
+    /// this is one Array.Copy instead of rows×cols bounds-checked indexer calls, which dominated
+    /// the profile under sustained output.</summary>
+    public void MoveRows(int srcRow, int dstRow, int count)
+    {
+        if (count <= 0) return;
+        if ((uint)srcRow >= (uint)Rows || (uint)dstRow >= (uint)Rows) throw new ArgumentOutOfRangeException(nameof(srcRow));
+        if (srcRow + count > Rows || dstRow + count > Rows) throw new ArgumentOutOfRangeException(nameof(count));
+        Array.Copy(_cells, srcRow * Cols, _cells, dstRow * Cols, count * Cols);
+    }
+
+    /// <summary>Fill one whole row with <paramref name="cell"/> in a single span fill.</summary>
+    public void FillRow(int row, Cell cell)
+    {
+        if ((uint)row >= (uint)Rows) throw new ArgumentOutOfRangeException(nameof(row));
+        _cells.AsSpan(row * Cols, Cols).Fill(cell);
+    }
+
+    /// <summary>Copy one whole row into <paramref name="dest"/> (used by scrollback capture).</summary>
+    public void CopyRowTo(int row, Cell[] dest)
+    {
+        if ((uint)row >= (uint)Rows) throw new ArgumentOutOfRangeException(nameof(row));
+        Array.Copy(_cells, row * Cols, dest, 0, Math.Min(Cols, dest.Length));
+    }
+
     public void Resize(int cols, int rows)
     {
         if (cols <= 0) throw new ArgumentOutOfRangeException(nameof(cols));

--- a/src/Agwinterm.Core/TerminalEmulator.cs
+++ b/src/Agwinterm.Core/TerminalEmulator.cs
@@ -67,7 +67,7 @@ public sealed class TerminalEmulator : IParserPerformer
     {
         int cols = Screen.Cols;
         var row = new Cell[cols];
-        for (int c = 0; c < cols; c++) row[c] = Screen[0, c];
+        Screen.CopyRowTo(0, row);
         _history.Add(row);
         if (_history.Count > ScrollbackMax + TrimSlack)
         {
@@ -686,46 +686,34 @@ public sealed class TerminalEmulator : IParserPerformer
                     if (np.Row + Math.Max(1, np.Rows) <= 0) { _placements.RemoveAt(i); _images.Remove(np.ImageId); }
                     else _placements[i] = np;
                 }
-        for (int r = _scrollTop + 1; r <= _scrollBottom; r++)
-            for (int c = 0; c < Screen.Cols; c++)
-                Screen[r - 1, c] = Screen[r, c];
-        for (int c = 0; c < Screen.Cols; c++)
-            Screen[_scrollBottom, c] = Blank();
+        // One memmove for the region, not rows×cols indexer calls (this is the hottest path
+        // under sustained output — every LF at the bottom row lands here).
+        Screen.MoveRows(_scrollTop + 1, _scrollTop, _scrollBottom - _scrollTop);
+        Screen.FillRow(_scrollBottom, Blank());
     }
 
     private void ScrollRegionDown()
     {
-        for (int r = _scrollBottom; r > _scrollTop; r--)
-            for (int c = 0; c < Screen.Cols; c++)
-                Screen[r, c] = Screen[r - 1, c];
-        for (int c = 0; c < Screen.Cols; c++)
-            Screen[_scrollTop, c] = Blank();
+        Screen.MoveRows(_scrollTop, _scrollTop + 1, _scrollBottom - _scrollTop);
+        Screen.FillRow(_scrollTop, Blank());
     }
 
     private void InsertLines(int n) // IL: insert n blank lines at cursor row, within scroll region
     {
         if (CursorRow < _scrollTop || CursorRow > _scrollBottom) return;
-        for (int i = 0; i < n; i++)
-        {
-            for (int r = _scrollBottom; r > CursorRow; r--)
-                for (int c = 0; c < Screen.Cols; c++)
-                    Screen[r, c] = Screen[r - 1, c];
-            for (int c = 0; c < Screen.Cols; c++)
-                Screen[CursorRow, c] = Blank();
-        }
+        n = Math.Min(n, _scrollBottom - CursorRow + 1);
+        int shift = _scrollBottom - CursorRow + 1 - n;
+        if (shift > 0) Screen.MoveRows(CursorRow, CursorRow + n, shift);
+        for (int r = CursorRow; r < CursorRow + n; r++) Screen.FillRow(r, Blank());
     }
 
     private void DeleteLines(int n) // DL: delete n lines at cursor row, pulling region up
     {
         if (CursorRow < _scrollTop || CursorRow > _scrollBottom) return;
-        for (int i = 0; i < n; i++)
-        {
-            for (int r = CursorRow; r < _scrollBottom; r++)
-                for (int c = 0; c < Screen.Cols; c++)
-                    Screen[r, c] = Screen[r + 1, c];
-            for (int c = 0; c < Screen.Cols; c++)
-                Screen[_scrollBottom, c] = Blank();
-        }
+        n = Math.Min(n, _scrollBottom - CursorRow + 1);
+        int shift = _scrollBottom - CursorRow + 1 - n;
+        if (shift > 0) Screen.MoveRows(CursorRow + n, CursorRow, shift);
+        for (int r = _scrollBottom - n + 1; r <= _scrollBottom; r++) Screen.FillRow(r, Blank());
     }
 
     private void InsertChars(int n) // ICH: shift cells right at cursor, blank the gap

--- a/src/Agwinterm.Pty/TerminalSession.cs
+++ b/src/Agwinterm.Pty/TerminalSession.cs
@@ -164,7 +164,7 @@ public sealed class TerminalSession : IDisposable
                 return;
             }
             _connection = dc;
-            _ = Task.Run(() => InteractivePumpAsync(dc.ReaderStream), ct);
+            _ = StartPump(dc.ReaderStream);
             _ = Task.Run(() =>
             {
                 try { dc.WaitForExit(Timeout.Infinite); } catch { }
@@ -198,7 +198,7 @@ public sealed class TerminalSession : IDisposable
 
         _connection = await PtyProvider.SpawnAsync(options, ct).ConfigureAwait(false);
         var conn = _connection;
-        _ = Task.Run(() => InteractivePumpAsync(conn.ReaderStream), ct);
+        _ = StartPump(conn.ReaderStream);
         // Watch for the child exiting so overlays (and anyone else) get the real ConPTY exit code,
         // reliably even for programs that finish faster than a PID poll could catch them.
         _ = Task.Run(() =>
@@ -219,7 +219,7 @@ public sealed class TerminalSession : IDisposable
     {
         var conn = new AttachedPty(conOut, conIn, signal, clientProcess, pid);
         _connection = conn;
-        var pump = Task.Run(() => InteractivePumpAsync(conn.ReaderStream));
+        var pump = StartPump(conn.ReaderStream);
         _ = Task.Run(async () =>
         {
             if (clientProcess != IntPtr.Zero) await Task.Run(() => conn.WaitForExit(Timeout.Infinite)).ConfigureAwait(false);
@@ -240,14 +240,22 @@ public sealed class TerminalSession : IDisposable
     private static readonly string? DumpPath =
         Environment.GetEnvironmentVariable("AGWINTERM_DUMP") is { Length: > 0 } d ? d : null;
 
-    private async Task InteractivePumpAsync(Stream stream)
+    /// <summary>Run the output pump on a dedicated thread (LongRunning → not a pool thread, still awaitable).
+    /// The ConPTY read pipe is a synchronous handle, so Stream.ReadAsync on it goes through the
+    /// async-over-sync layer — profiling showed that machinery dominating CPU under sustained output
+    /// (~3k lines/s). A plain blocking Read on a dedicated thread is a bare syscall per chunk.</summary>
+    private Task StartPump(Stream stream) =>
+        Task.Factory.StartNew(() => PumpLoop(stream), CancellationToken.None,
+            TaskCreationOptions.LongRunning, TaskScheduler.Default);
+
+    private void PumpLoop(Stream stream)
     {
-        var buffer = new byte[8192];
+        var buffer = new byte[64 * 1024];
         try
         {
             while (true)
             {
-                int n = await stream.ReadAsync(buffer).ConfigureAwait(false);
+                int n = stream.Read(buffer, 0, buffer.Length);
                 if (n <= 0) break;
                 if (DumpPath is not null)
                     lock (_sync) System.IO.File.AppendAllBytes(DumpPath, buffer.AsSpan(0, n).ToArray());

--- a/src/Agwinterm.Win32/Program.Render.cs
+++ b/src/Agwinterm.Win32/Program.Render.cs
@@ -310,32 +310,59 @@ internal partial class Program
     }
 
     /// <summary>Draw one terminal surface (cells, images, cursor) at origin (ox,oy) with its font metrics.</summary>
+    private Cell[] _cellSnap = Array.Empty<Cell>();   // reusable viewport snapshot; drawing reads it lock-free
+
     private void RenderTerminal(TerminalSession session, float ox, float oy, IDWriteTextFormat fmt, float cw, float ch, int scrollOffset, Pane? selPane = null)
     {
         var rt = _rt!;
         var brush = _brush!;
+        // Snapshot the visible viewport under the session lock (sub-ms), then draw OUTSIDE it.
+        // Holding the lock for the whole frame serializes rendering against the PTY pump's Feed,
+        // capping sustained-output throughput (dotnet-stack showed the UI thread in Monitor.Enter
+        // here while the pump held the lock — see docs/memory-profile-2026-07-09.md).
+        var em = session.Emulator;
+        int cols, rows, hist, off;
+        bool cursorVisible; int cursorCol, cursorRow;
+        bool drawImages;
+        (int PromptLine, int? ExitCode)[] marks;
         lock (session.SyncRoot)
         {
-            var em = session.Emulator;
             em.CellPixelWidth = Math.Max(1, (int)cw); em.CellPixelHeight = Math.Max(1, (int)ch);  // for sixel cell-span
             var screen = em.Screen;
-            int cols = screen.Cols, rows = screen.Rows;
-            int hist = em.HistoryCount;
-            int off = em.IsAltScreen ? 0 : Math.Clamp(scrollOffset, 0, hist);
+            cols = screen.Cols; rows = screen.Rows;
+            hist = em.HistoryCount;
+            bool isAlt = em.IsAltScreen;
+            off = isAlt ? 0 : Math.Clamp(scrollOffset, 0, hist);
+            cursorVisible = em.CursorVisible; cursorCol = em.CursorCol; cursorRow = em.CursorRow;
+            drawImages = !_noImages && em.Placements.Count > 0 && off == 0;
+            marks = !isAlt && em.Marks.Count > 0
+                ? em.Marks.Select(m => (m.PromptLine, m.ExitCode)).ToArray()
+                : Array.Empty<(int, int?)>();
+            if (_cellSnap.Length < rows * cols) _cellSnap = new Cell[rows * cols];
+            for (int r = 0; r < rows; r++)
+                for (int c = 0; c < cols; c++)
+                {
+                    // Visible row r maps into [history ++ live grid], shifted up by `off`.
+                    Cell v;
+                    if (off <= 0) v = screen[r, c];
+                    else
+                    {
+                        int vi = hist - off + r;
+                        if (vi < 0) v = Cell.Empty;
+                        else if (vi < hist) v = em.GetHistoryCell(vi, c);
+                        else { int live = vi - hist; v = live < rows ? screen[live, c] : Cell.Empty; }
+                    }
+                    _cellSnap[r * cols + c] = v;
+                }
+        }
+        // Drawing below reads only the snapshot + UI-thread state — no session lock held.
+        {
+            var snap = _cellSnap;
+            Cell CellAt(int r, int c) => snap[r * cols + c];
             bool hasSel = selPane is { HasSel: true };
             int sl0 = 0, sc0 = 0, sl1 = 0, sc1 = 0;
             if (hasSel) NormSel(selPane!, out sl0, out sc0, out sl1, out sc1);
             bool searchHere = _searchActive && selPane is not null && ReferenceEquals(selPane, ActiveSurface());
-            // Visible row r maps into [history ++ live grid], shifted up by `off`.
-            Cell CellAt(int r, int c)
-            {
-                if (off <= 0) return screen[r, c];
-                int vi = hist - off + r;
-                if (vi < 0) return Cell.Empty;
-                if (vi < hist) return em.GetHistoryCell(vi, c);
-                int live = vi - hist;
-                return live < rows ? screen[live, c] : Cell.Empty;
-            }
             for (int r = 0; r < rows; r++)
             {
                 float y = oy + r * ch;
@@ -437,8 +464,8 @@ internal partial class Program
                 }
             }
 
-            if (!_noImages && em.Placements.Count > 0 && off == 0)
-                DrawImages(em, ox, oy, cw, ch);
+            if (drawImages)
+                lock (session.SyncRoot) DrawImages(em, ox, oy, cw, ch);   // image placements read emulator state
 
             if (off > 0) // scrollback position indicator on the pane's right edge
             {
@@ -450,10 +477,10 @@ internal partial class Program
                 brush.Color = WithA(ChromeText, 0.35f);
                 rt.FillRectangle(new Rect(trackX, thumbY, 3f, thumbH), brush);
             }
-            if (!em.IsAltScreen && em.Marks.Count > 0)  // FTCS prompt pips (green ok / red fail / accent running)
+            if (marks.Length > 0)  // FTCS prompt pips (green ok / red fail / accent running)
             {
                 float pipX = ox + cols * cw - 3f, pipTrackH = rows * ch, pipTotal = MathF.Max(1f, hist + rows);
-                foreach (var m in em.Marks)
+                foreach (var m in marks)
                 {
                     float py2 = oy + pipTrackH * m.PromptLine / pipTotal;
                     brush.Color = m.ExitCode is int ec2
@@ -463,9 +490,9 @@ internal partial class Program
                 }
             }
 
-            if (em.CursorVisible && off == 0)
+            if (cursorVisible && off == 0)
             {
-                float cx = ox + em.CursorCol * cw, cy = oy + em.CursorRow * ch;
+                float cx = ox + cursorCol * cw, cy = oy + cursorRow * ch;
                 brush.Color = C4(_theme.Cursor);
                 if (!_config.CursorBlink || _cursorOn)
                 {

--- a/src/Agwinterm.Win32/Program.WndProc.cs
+++ b/src/Agwinterm.Win32/Program.WndProc.cs
@@ -140,13 +140,24 @@ internal partial class Program
             case WM_PAINT:
                 BeginPaint(hwnd, out PAINTSTRUCT ps);
                 Render();
+                _lastPaintTick = Environment.TickCount64;
                 EndPaint(hwnd, ref ps);
                 return IntPtr.Zero;
 
             case WM_APP_REDRAW:
+            {
                 System.Threading.Interlocked.Exchange(ref _redrawPending, 0);
-                InvalidateRect(hwnd, IntPtr.Zero, false);
+                // Frame cap (RedrawMinIntervalMs): paint immediately when quiet; under sustained
+                // output defer to a one-shot timer so floods render at ~66fps instead of per chunk.
+                long since = Environment.TickCount64 - _lastPaintTick;
+                if (since >= RedrawMinIntervalMs) InvalidateRect(hwnd, IntPtr.Zero, false);
+                else if (!_redrawTimerArmed)
+                {
+                    _redrawTimerArmed = true;
+                    SetTimer(hwnd, (IntPtr)RedrawTimer, (uint)Math.Max(1, RedrawMinIntervalMs - (int)since), IntPtr.Zero);
+                }
                 return IntPtr.Zero;
+            }
 
             case WM_APP_ACTION:
                 while (_uiActions.TryDequeue(out var act))
@@ -162,6 +173,12 @@ internal partial class Program
                 if ((int)wParam == SelAutoTimer) { SelAutoscrollTick(); return IntPtr.Zero; }
                 if ((int)wParam == HoverTimer) { HoverTick(); return IntPtr.Zero; }
                 if ((int)wParam == PromptPreviewTimer) { PromptPreviewTick(); return IntPtr.Zero; }
+                if ((int)wParam == RedrawTimer)
+                {
+                    KillTimer(hwnd, (IntPtr)RedrawTimer); _redrawTimerArmed = false;
+                    InvalidateRect(hwnd, IntPtr.Zero, false);
+                    return IntPtr.Zero;
+                }
                 _cursorOn = !_cursorOn;
                 InvalidateRect(hwnd, IntPtr.Zero, false);
                 return IntPtr.Zero;

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -293,6 +293,13 @@ internal partial class Program : ISessionHost, IWindowHost
     private bool _cursorOn = true;
     private readonly StringBuilder _run = new(256);   // reused per text run (no per-cell alloc)
     private int _redrawPending;                       // coalesces redraw requests into one paint
+    // Frame cap for output-driven repaints: under sustained PTY output, paint at most ~66fps instead
+    // of back-to-back full renders (which saturate a core and starve the pump via grid-lock contention).
+    // The first frame after a quiet period still paints immediately — no interactive latency cost.
+    private const int RedrawTimer = 10;               // WM_TIMER id for the deferred frame
+    private const int RedrawMinIntervalMs = 15;
+    private long _lastPaintTick;                      // Environment.TickCount64 of the last WM_PAINT render
+    private bool _redrawTimerArmed;
 
     // Decoded Kitty images, keyed by the current KittyImage instance so a retransmit
     // (new bytes, same id) re-decodes and the stale texture is pruned/disposed.


### PR DESCRIPTION
Performance half of the profiling pass ([full findings](../blob/perf/scroll-blockmove-and-pump/docs/memory-profile-2026-07-09.md)).

## Headline
| metric | before | after |
|---|---|---|
| 60k-line / 4MB `type` blast | 18.5 s | **1.84 s** |
| throughput | 3.2k lines/s | **32.6k lines/s** (~87% of bare conhost) |
| app CPU during blast | 19.1 s | **1.3 s** |
| startup → API responsive | — | 0.38 s |
| idle CPU | — | 0.47% |

## Root cause (found via dotnet-stack)
The pump thread burned 99% of a core inside `ScrollRegionUp()` → `ScreenBuffer.get_Item`: **every LF at the bottom row scrolled the grid cell-by-cell through a bounds-checked indexer**. Now `ScreenBuffer.MoveRows/FillRow/CopyRowTo` do it as one `Array.Copy` (memmove) — used by ScrollRegionUp/Down, InsertLines, DeleteLines, PushHistory.

## Supporting changes
- **Frame cap (15 ms)** — floods render at ~66 fps, not per-chunk; quiet-period first frame still immediate
- **Snapshot render** — viewport copied under the session lock (sub-ms), drawn outside it; no render↔pump lock convoy
- **Sync pump thread** — plain blocking `Read` (64 KB) on a `LongRunning` thread; kills the async-over-sync layer the trace showed

## Verification
- ✅ 110/110 Core (scroll/IL/DL semantics), 38/38 Pty
- ✅ Leak harness re-run: round-2 delta ≈ 0 — pump threads exit on dispose
- ✅ Visual smoke clean

No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)