### PR TITLE
fix(defterm): attached consoles never received resizes (Far corruption)

### DIFF
--- a/src/Agwinterm.Pty/AttachedPty.cs
+++ b/src/Agwinterm.Pty/AttachedPty.cs
@@ -42,13 +42,26 @@ internal sealed class AttachedPty : IPtyConnection
     public void Resize(int cols, int rows)
     {
         // ConPTY signal-pipe resize packet: [PTY_SIGNAL_RESIZE_WINDOW=8][cols][rows] as little-endian UINT16s.
+        // NOTE: byte[] (not Span) — classic DllImport can't marshal Span without assembly-wide
+        // DisableRuntimeMarshalling; the old Span overload threw MarshalDirectiveException on every
+        // call (swallowed below), so attached consoles never saw resizes and painted at a stale width.
         if (_signal is null || _signal.IsInvalid || _signal.IsClosed) return;
-        Span<byte> pkt = stackalloc byte[6];
-        pkt[0] = 8; pkt[1] = 0;
-        pkt[2] = (byte)(cols & 0xFF); pkt[3] = (byte)((cols >> 8) & 0xFF);
-        pkt[4] = (byte)(rows & 0xFF); pkt[5] = (byte)((rows >> 8) & 0xFF);
-        try { uint written; WriteFile(_signal, pkt, (uint)pkt.Length, out written, IntPtr.Zero); } catch { }
+        byte[] pkt =
+        {
+            8, 0,
+            (byte)(cols & 0xFF), (byte)((cols >> 8) & 0xFF),
+            (byte)(rows & 0xFF), (byte)((rows >> 8) & 0xFF),
+        };
+        try
+        {
+            if (!WriteFile(_signal, pkt, (uint)pkt.Length, out _, IntPtr.Zero))
+                Log($"resize signal write failed: err={Marshal.GetLastWin32Error()}");
+        }
+        catch (Exception ex) { Log($"resize signal write threw: {ex.GetType().Name} {ex.Message}"); }
     }
+
+    private static readonly string? LogPath = Environment.GetEnvironmentVariable("AGWINTERM_PTYLOG");
+    private static void Log(string m) { if (LogPath is not null) try { File.AppendAllText(LogPath, $"[attached] {m}\n"); } catch { } }
 
     public bool WaitForExit(int milliseconds)
     {
@@ -69,7 +82,7 @@ internal sealed class AttachedPty : IPtyConnection
         if (_clientProcess != IntPtr.Zero) { CloseHandle(_clientProcess); _clientProcess = IntPtr.Zero; }
     }
 
-    [DllImport("kernel32.dll", SetLastError = true)] private static extern bool WriteFile(SafeFileHandle h, ReadOnlySpan<byte> buf, uint n, out uint written, IntPtr overlapped);
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern bool WriteFile(SafeFileHandle h, byte[] buf, uint n, out uint written, IntPtr overlapped);
     [DllImport("kernel32.dll", SetLastError = true)] private static extern uint WaitForSingleObject(IntPtr h, uint ms);
     [DllImport("kernel32.dll", SetLastError = true)] private static extern bool GetExitCodeProcess(IntPtr h, out int code);
     [DllImport("kernel32.dll", SetLastError = true)] private static extern bool TerminateProcess(IntPtr h, uint code);

--- a/src/Agwinterm.Win32/DefTerm.cs
+++ b/src/Agwinterm.Win32/DefTerm.cs
@@ -48,6 +48,24 @@ internal static partial class DefTerm
 
     internal static nint MakeComObject(object o) => ComWrappers.GetOrCreateComInterfaceForObject(o, CreateComInterfaceFlags.None);
 
+    private static readonly string? LogPath = Environment.GetEnvironmentVariable("AGWINTERM_PTYLOG");
+    internal static void Log(string m) { if (LogPath is not null) try { File.AppendAllText(LogPath, $"[defterm] {m}\n"); } catch { } }
+
+    /// <summary>Duplicate a marshalled [in] system_handle into this process. COM in-param handles are
+    /// only valid for the DURATION of the call (the stub closes them on return), so anything kept past
+    /// EstablishPtyHandoff must be duplicated synchronously inside it.</summary>
+    internal static nint DupIntoSelf(nint h)
+    {
+        if (h == 0) return 0;
+        nint self = GetCurrentProcess();
+        return DuplicateHandle(self, h, self, out nint dup, 0, false, 2 /* DUPLICATE_SAME_ACCESS */) ? dup : 0;
+    }
+
+    [LibraryImport("kernel32.dll")] private static partial nint GetCurrentProcess();
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool DuplicateHandle(nint srcProc, nint src, nint dstProc, out nint dst, uint access, [MarshalAs(UnmanagedType.Bool)] bool inherit, uint options);
+
     private const int CLSCTX_LOCAL_SERVER = 0x4;
     private const int REGCLS_MULTIPLEUSE = 0x1;
 
@@ -61,7 +79,7 @@ internal static partial class DefTerm
 /// <summary>Handles/PID delivered to the app when a console session is handed off. <c>conOut</c> is where
 /// we read the console's VT output; <c>conIn</c> is where we write user input; <c>signal</c> is the
 /// ConPTY signal pipe (resize); <c>client</c> is the console app process (for exit detection).</summary>
-internal readonly record struct HandoffArgs(nint ConOut, nint ConIn, nint Signal, nint Client, int ClientPid, nint StartupInfo);
+internal readonly record struct HandoffArgs(nint ConOut, nint ConIn, nint Signal, nint Client, int ClientPid, string? Title);
 
 /// <summary>MIDL <c>TERMINAL_STARTUP_INFO</c> — title/icon/show-window for the handed-off session.
 /// BSTR fields are just pointers here; we only peek at the title.</summary>
@@ -103,7 +121,24 @@ internal partial class TerminalHandoffImpl : ITerminalHandoff3
         @in = inRead;
         @out = outWrite;
         int pid = client != 0 ? DefTerm.GetProcessId(client) : 0;
-        DefTerm.OnHandoff?.Invoke(new HandoffArgs(outRead, inWrite, signal, client, pid, startupInfo));
+        // The stub closes every [in] handle when this call returns, and OnHandoff defers session
+        // creation to the UI thread — duplicate what we keep (signal for resize, client for exit
+        // detection) SYNCHRONOUSLY here, or they're dead by the time the session attaches.
+        nint sigDup = DefTerm.DupIntoSelf(signal);
+        nint clientDup = DefTerm.DupIntoSelf(client);
+        // The startupInfo pointer is call-lifetime too: peek the title now, pass the string.
+        string? title = null;
+        try
+        {
+            if (startupInfo != 0)
+            {
+                var si = Marshal.PtrToStructure<TerminalStartupInfo>(startupInfo);
+                if (si.pszTitle != 0) title = Marshal.PtrToStringBSTR(si.pszTitle);
+            }
+        }
+        catch { }
+        DefTerm.Log($"handoff: signal=0x{signal:X}->0x{sigDup:X} client=0x{client:X}->0x{clientDup:X} pid={pid} title='{title}'");
+        DefTerm.OnHandoff?.Invoke(new HandoffArgs(outRead, inWrite, sigDup, clientDup, pid, title));
     }
 }
 

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -292,6 +292,7 @@ internal partial class Program
         }
         int ordinal;
         lock (_workspaces) ordinal = ws.Sessions.Count + 1;
+        if (name is null && handoff is { Title.Length: > 0 } ht) name = ht.Title;   // label handoff sessions with the app's title
         var ses = new Ses { Id = id, Name = name ?? $"session {ordinal}", Ws = ws, ProfileName = profileName, Elevated = IsElevated() && !deElevate };
         ses.Panes.Add(CreatePane(id, ws, cwd, fs, command, interactive: interactive, extraEnv: extraEnv, profileName: profileName, deElevate: deElevate, handoff: handoff));   // first pane shares the session id (control-API back-compat)
         ses.Active = 0;


### PR DESCRIPTION
Fixes the live report: Far Manager (opened via the **default-terminal handoff** — which works! 🎉) ignored window resizes, and Ctrl+O showed diagonal shear corruption — conhost painting at a stale width while our grid reflowed.

## Two stacked bugs
1. **`AttachedPty.Resize` never sent a byte** — classic `DllImport` can't marshal `ReadOnlySpan<byte>` without `DisableRuntimeMarshalling`; `WriteFile` threw `MarshalDirectiveException` on every call, silently swallowed. → `byte[]` signature + failure logging (`AGWINTERM_PTYLOG`).
2. **The handles died before use** — COM `[in] system_handle` params are valid only for the duration of the call (the stub closes them on return), and `OnHandoff` defers to the UI thread via `Post()`. By attach time signal/client were dead (`WriteFile` err=6). → `EstablishPtyHandoff` now **duplicates signal + client synchronously** inside the call (exactly what Windows Terminal's `NewHandoff` does) and reads the startup-info title there too — handoff sessions are now labeled with the app's title.

## Verification (live, end-to-end)
- external `cmd` handoff → `mode con`: **32×79 → resize → 44×131** ✅
- **Far via handoff redraws cleanly at the new size — no shear** ✅ (screenshots)
- 110/110 Core, 38/38 Pty

No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)