### PR TITLE
feat(settings): defterm register/unregister + panel-button text centering

### DIFF
--- a/src/Agwinterm.Win32/DefTerm.cs
+++ b/src/Agwinterm.Win32/DefTerm.cs
@@ -51,6 +51,77 @@ internal static partial class DefTerm
     private static readonly string? LogPath = Environment.GetEnvironmentVariable("AGWINTERM_PTYLOG");
     internal static void Log(string m) { if (LogPath is not null) try { File.AppendAllText(LogPath, $"[defterm] {m}\n"); } catch { } }
 
+    // ---- Default-terminal registration (Settings UI; mirrors tools/defterm-register.ps1) ----
+
+    private const string ClsidOpenConsole = "{2EACA947-7F5F-4CFA-BA87-8F7FBEEFBE69}";  // DelegationConsole
+    private const string ClsidProxy = "{3171DE52-6EFA-4AEF-8A9F-D02BD67E7A4F}";        // OpenConsoleHandoffProxy
+    private const string ZeroGuid = "{00000000-0000-0000-0000-000000000000}";          // "Let Windows decide"
+    private static readonly string[] HandoffIids =                                     // interfaces the proxy marshals
+    {
+        "{E686C757-9A35-4A1C-B3CE-0BCC8B5C69F4}",
+        "{6F23DA90-15C5-4203-9DB0-64E73F1B1B00}",   // ITerminalHandoff3
+        "{746E6BC0-AB05-4E38-AB14-71E86763141F}",
+    };
+
+    /// <summary>Is agwinterm currently the OS default terminal (HKCU delegation points at our CLSID)?</summary>
+    internal static bool IsRegisteredDefault()
+    {
+        try
+        {
+            using var k = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(@"Console\%%Startup");
+            return string.Equals(k?.GetValue("DelegationTerminal") as string, Clsid.ToString("B"), StringComparison.OrdinalIgnoreCase);
+        }
+        catch { return false; }
+    }
+
+    /// <summary>Register agwinterm as the Windows default terminal (per-user, no admin): our exe as the
+    /// handoff COM server, OpenConsole as the delegation console, OpenConsoleProxy as the handle-marshalling
+    /// proxy/stub, then point HKCU\Console\%%Startup at them. Returns a status string for the UI.</summary>
+    internal static string RegisterAsDefault()
+    {
+        try
+        {
+            string dir = AppContext.BaseDirectory;
+            string agw = Path.Combine(dir, "Agwinterm.Win32.exe");
+            string oc = Path.Combine(dir, "OpenConsole.exe");
+            string proxy = Path.Combine(dir, "OpenConsoleProxy.dll");
+            if (!File.Exists(oc) || !File.Exists(proxy))
+                return "OpenConsole.exe / OpenConsoleProxy.dll not found next to agwinterm — run tools/defterm-fetch-openconsole.ps1";
+
+            using var classes = Microsoft.Win32.Registry.CurrentUser.CreateSubKey(@"Software\Classes");
+            string us = Clsid.ToString("B").ToUpperInvariant();
+            using (var k = classes.CreateSubKey($@"CLSID\{us}")) k.SetValue(null, "agwinterm default-terminal handoff");
+            using (var k = classes.CreateSubKey($@"CLSID\{us}\LocalServer32")) k.SetValue(null, $"\"{agw}\"");
+            using (var k = classes.CreateSubKey($@"CLSID\{ClsidOpenConsole}")) k.SetValue(null, "OpenConsole");
+            using (var k = classes.CreateSubKey($@"CLSID\{ClsidOpenConsole}\LocalServer32")) k.SetValue(null, $"\"{oc}\"");
+            using (var k = classes.CreateSubKey($@"CLSID\{ClsidProxy}")) k.SetValue(null, "OpenConsoleHandoffProxy");
+            using (var k = classes.CreateSubKey($@"CLSID\{ClsidProxy}\InprocServer32"))
+            { k.SetValue(null, proxy); k.SetValue("ThreadingModel", "Both"); }
+            foreach (var iid in HandoffIids)
+                using (var k = classes.CreateSubKey($@"Interface\{iid}\ProxyStubClsid32")) k.SetValue(null, ClsidProxy);
+
+            using var startup = Microsoft.Win32.Registry.CurrentUser.CreateSubKey(@"Console\%%Startup");
+            startup.SetValue("DelegationConsole", ClsidOpenConsole);
+            startup.SetValue("DelegationTerminal", us);
+            return "agwinterm is now the default terminal";
+        }
+        catch (Exception ex) { return "register failed: " + ex.Message; }
+    }
+
+    /// <summary>Restore the Windows default ("Let Windows decide" = conhost). Mirrors
+    /// tools/defterm-restore-conhost.ps1 — the safety net.</summary>
+    internal static string RestoreWindowsDefault()
+    {
+        try
+        {
+            using var startup = Microsoft.Win32.Registry.CurrentUser.CreateSubKey(@"Console\%%Startup");
+            startup.SetValue("DelegationConsole", ZeroGuid);
+            startup.SetValue("DelegationTerminal", ZeroGuid);
+            return "default terminal restored to Windows (conhost)";
+        }
+        catch (Exception ex) { return "restore failed: " + ex.Message; }
+    }
+
     /// <summary>Duplicate a marshalled [in] system_handle into this process. COM in-param handles are
     /// only valid for the DURATION of the call (the stub closes them on return), so anything kept past
     /// EstablishPtyHandoff must be duplicated synchronously inside it.</summary>

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -230,6 +230,7 @@ internal partial class Program : ISessionHost, IWindowHost
     // Chrome fonts (native Segoe UI for text, icon font for glyphs).
     private static IDWriteTextFormat _uiFont = null!;
     private static IDWriteTextFormat _uiSmall = null!;
+    private static IDWriteTextFormat _uiSmallCenter = null!;   // horizontally centered (panel buttons)
     private static IDWriteTextFormat _uiTitle = null!;      // single centered title-bar line (vertically centered + ellipsized)
     private static IDWriteInlineObject _ellipsis = null!;   // "…" trimming sign for the title (kept alive)
     private static IDWriteTextFormat _iconFont = null!;
@@ -374,6 +375,7 @@ internal partial class Program : ISessionHost, IWindowHost
         _format = CreateTextFormat(_config);
         _uiFont = NewChromeFormat("Segoe UI", 13f, center: false);
         _uiSmall = NewChromeFormat("Segoe UI", 11.5f, center: false);
+        _uiSmallCenter = NewChromeFormat("Segoe UI", 11.5f, center: true);
         _uiTitle = NewChromeFormat("Segoe UI", 13f, center: true); // vertically centered single line
         _ellipsis = _dwrite.CreateEllipsisTrimmingSign(_uiTitle);
         _uiTitle.SetTrimming(new Trimming { Granularity = TrimmingGranularity.Character }, _ellipsis);

--- a/src/Agwinterm.Win32/Settings.cs
+++ b/src/Agwinterm.Win32/Settings.cs
@@ -98,6 +98,18 @@ internal partial class Program
         Sec(0, "Shell");
         Tog(0, "shell-integration", "Shell integration (live cwd)");
         Tog(0, "omp-integration", "oh-my-posh integration");
+        Sec(0, "Default Terminal");
+        _setRows.Add(new SetRow
+        {
+            Kind = SW.Info, Tab = 0,
+            Label = DefTerm.IsRegisteredDefault()
+                ? "Console apps currently open in agwinterm."
+                : "Console apps currently open in the Windows default (conhost / Windows Terminal).",
+        });
+        if (DefTerm.IsRegisteredDefault())
+            Btn(0, "Restore Windows default", () => { ShowToast(DefTerm.RestoreWindowsDefault()); BuildSettingsRows(); RequestRedraw(); });
+        else
+            Btn(0, "Make agwinterm the default terminal", () => { ShowToast(DefTerm.RegisterAsDefault()); BuildSettingsRows(); RequestRedraw(); });
 
         // Appearance
         Sec(1, "Terminal");
@@ -389,7 +401,9 @@ internal partial class Program
         brush.Color = PalBorder;
         rt.DrawRoundedRectangle(new RoundedRectangle { Rect = new Rect(x, y, w, h), RadiusX = 6f, RadiusY = 6f }, brush, 1f);
         brush.Color = ChromeText;
-        rt.DrawText(label, _uiSmall, new Rect(x, y, w, h), brush);
+        // Centered format: the leading-aligned _uiSmall put the label flush against the button's left
+        // edge (the width budget's padding all landed on the right).
+        rt.DrawText(label, _uiSmallCenter, new Rect(x, y, w, h), brush);
     }
 
     private string CurrentDropdownText(SetRow r)


### PR DESCRIPTION
Two items from live use:

## Default Terminal in Settings
**Settings → General → Default Terminal**: shows whether console apps currently open in agwinterm or the Windows default, with a one-click **Make agwinterm the default terminal** / **Restore Windows default** button (label flips with state).
- `DefTerm.RegisterAsDefault()` mirrors `tools/defterm-register.ps1` in-process: CLSID `LocalServer32` for agwinterm + OpenConsole, `OpenConsoleProxy` proxy/stub for the handoff IIDs, `HKCU\Console\%%Startup` delegation. Clear error if `OpenConsole.exe`/`OpenConsoleProxy.dll` aren't next to the exe.
- `RestoreWindowsDefault()` mirrors the restore script (zero-GUID = "Let Windows decide" = conhost). All per-user HKCU, no admin.

## Button text centering
Panel buttons (**Edit profiles.json…, Reload, Open Folder, Reload keymap, Reset to defaults, Choose…**) drew their label flush against the left edge — `DrawPanelButton` used the leading-aligned `_uiSmall`, so the 32 px width budget all landed to the right of the text. New `_uiSmallCenter` format centers labels in all panel buttons.

## Verification
- ✅ General tab renders the new section with correct registered-state detection (screenshot)
- ✅ Button labels centered (Choose… visible in screenshot; same code path for all)
- ✅ 110/110 Core, 38/38 Pty

No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)