### PR TITLE
fix(settings): taller panel so General fits the Default Terminal section

### DIFF
--- a/src/Agwinterm.Win32/Settings.cs
+++ b/src/Agwinterm.Win32/Settings.cs
@@ -202,7 +202,7 @@ internal partial class Program
         rt.FillRectangle(new Rect(0, 0, cw, ch), brush);
 
         float cardW = MathF.Min(680f, cw - 60f);
-        float cardH = MathF.Min(600f, ch - 80f);
+        float cardH = MathF.Min(700f, ch - 80f);   // tall enough for General incl. the Default Terminal section
         float cardX = (cw - cardW) / 2f;
         float cardY = MathF.Max(TitleBarH + 16f, (ch - cardH) / 2f);
         _setCard = new Rect(cardX, cardY, cardW, cardH);


### PR DESCRIPTION
Raises the Settings card height cap 600 → 700 px (still clamped to `clientHeight − 80` on small screens), so the General tab shows the whole Default Terminal section — info line + register/restore button — without scrolling. Verified with a screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)