### PR TITLE
feat(uia): announce terminal output + settings interactions to screen readers

### DIFF
--- a/src/Agwinterm.Core/TerminalEmulator.cs
+++ b/src/Agwinterm.Core/TerminalEmulator.cs
@@ -743,6 +743,20 @@ public sealed class TerminalEmulator : IParserPerformer
         return sb.ToString().TrimEnd();
     }
 
+    /// <summary>Plain text of one scrollback row (same conventions as <see cref="DumpRow"/>).</summary>
+    public string DumpHistoryRow(int index)
+    {
+        var sb = new System.Text.StringBuilder();
+        for (int c = 0; c < Screen.Cols; c++)
+        {
+            Cell cell = GetHistoryCell(index, c);
+            if (cell.Width == 0) continue;
+            if (cell.Rune > 0xFFFF) sb.Append(char.ConvertFromUtf32(cell.Rune));
+            else sb.Append((char)cell.Rune);
+        }
+        return sb.ToString().TrimEnd();
+    }
+
     /// <summary>The whole buffer as plain-text lines (history + visible), trailing blank rows dropped —
     /// for buffer-content persistence.</summary>
     public IReadOnlyList<string> DumpBuffer()

--- a/src/Agwinterm.Win32/Program.Services.cs
+++ b/src/Agwinterm.Win32/Program.Services.cs
@@ -17,6 +17,38 @@ namespace Agwinterm.Win32;
 /// <summary>Services: notifications, taskbar progress, config, theming, omp, persistence, fullscreen.</summary>
 internal partial class Program
 {
+    // ---- Screen-reader output announcements (UIA notification events; T2-14 Stage 1.5) ----
+
+    /// <summary>Speak the active pane's NEW output since the last announcement (debounced via
+    /// UiaAnnounceTimer; only runs while a UIA client listens). Tracks an absolute buffer line
+    /// (history + cursor row) per pane; the delta rows are read as plain text. Alt-screen apps
+    /// (full-screen TUIs redrawing in place) are skipped — line diffs there are meaningless.</summary>
+    private void AnnounceNewOutput()
+    {
+        if (!Uia.ClientsListening) return;
+        var p = ActiveSurface();
+        if (p is null) return;
+        string text;
+        lock (p.S.SyncRoot)
+        {
+            var em = p.S.Emulator;
+            if (em.IsAltScreen) { p.UiaAnnouncedAbs = -1; return; }
+            int curAbs = em.HistoryCount + em.CursorRow;
+            int prev = p.UiaAnnouncedAbs;
+            p.UiaAnnouncedAbs = curAbs;
+            if (prev < 0 || prev >= curAbs) return;             // first sight / scroll trim — set baseline only
+            int lines = Math.Min(curAbs - prev, 40);            // cap floods; the reader can't keep up anyway
+            var sb = new StringBuilder();
+            for (int abs = curAbs - lines; abs < curAbs; abs++)
+            {
+                string row = abs < em.HistoryCount ? em.DumpHistoryRow(abs) : em.DumpRow(abs - em.HistoryCount);
+                if (row.Length > 0) sb.Append(row).Append('\n');
+            }
+            text = sb.ToString();
+        }
+        Uia.Announce(text);
+    }
+
     // ---- Notifications (OSC 9 / OSC 777 / notify) ----
 
     /// <summary>Find the session that owns a pane (any pane, its scratch, or its overlay; or the quick cover).</summary>

--- a/src/Agwinterm.Win32/Program.WndProc.cs
+++ b/src/Agwinterm.Win32/Program.WndProc.cs
@@ -156,6 +156,8 @@ internal partial class Program
                     _redrawTimerArmed = true;
                     SetTimer(hwnd, (IntPtr)RedrawTimer, (uint)Math.Max(1, RedrawMinIntervalMs - (int)since), IntPtr.Zero);
                 }
+                // Screen reader active: (re)arm the announce debounce — speaks once output settles.
+                if (Uia.ClientsListening) SetTimer(hwnd, (IntPtr)UiaAnnounceTimer, UiaAnnounceQuietMs, IntPtr.Zero);
                 return IntPtr.Zero;
             }
 
@@ -177,6 +179,12 @@ internal partial class Program
                 {
                     KillTimer(hwnd, (IntPtr)RedrawTimer); _redrawTimerArmed = false;
                     InvalidateRect(hwnd, IntPtr.Zero, false);
+                    return IntPtr.Zero;
+                }
+                if ((int)wParam == UiaAnnounceTimer)
+                {
+                    KillTimer(hwnd, (IntPtr)UiaAnnounceTimer);
+                    AnnounceNewOutput();
                     return IntPtr.Zero;
                 }
                 _cursorOn = !_cursorOn;

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -252,6 +252,7 @@ internal partial class Program : ISessionHost, IWindowHost
         public int SelAncLine, SelAncCol, SelFocLine, SelFocCol;
         public bool BlockSel;   // rectangular (Alt+drag) selection: clip each row to [minCol,maxCol]
         public void ClearSel() => HasSel = false;
+        public int UiaAnnouncedAbs = -1;   // absolute buffer line (history + cursor row) last spoken to a screen reader
     }
 
     private sealed class Ses
@@ -299,6 +300,8 @@ internal partial class Program : ISessionHost, IWindowHost
     // The first frame after a quiet period still paints immediately — no interactive latency cost.
     private const int RedrawTimer = 10;               // WM_TIMER id for the deferred frame
     private const int RedrawMinIntervalMs = 15;
+    private const int UiaAnnounceTimer = 11;          // debounce: announce new output to a screen reader
+    private const int UiaAnnounceQuietMs = 350;       // speak once output has settled this long
     private long _lastPaintTick;                      // Environment.TickCount64 of the last WM_PAINT render
     private bool _redrawTimerArmed;
 

--- a/src/Agwinterm.Win32/Settings.cs
+++ b/src/Agwinterm.Win32/Settings.cs
@@ -62,12 +62,14 @@ internal partial class Program
         if (_palette != PaletteKind.None) ClosePalette();
         BuildSettingsRows();
         _setOpen = true; _setTab = 0; _setScroll = 0; _ddRow = null; _setDragRow = null;
+        Uia.Announce("Settings, General tab");
         RequestRedraw();
     }
 
     private void CloseSettings()
     {
         _setOpen = false; _ddRow = null; _setDragRow = null;
+        Uia.Announce("Settings closed");
         RequestRedraw();
     }
 
@@ -512,6 +514,7 @@ internal partial class Program
             else { ConfigSetInternal("blocked-sound", val == "None" ? "" : val); if (val != "None") PlayStatusSound(val); }
         }
         else ConfigSetInternal(r.Key, val);
+        Uia.Announce($"{r.Label}, {r.Opts[_ddFiltered[filteredIdx]]}");
         RequestRedraw();
     }
 
@@ -532,7 +535,7 @@ internal partial class Program
         // nav
         if (mx >= _setCard.Left + 8f && mx <= _setCard.Left + SetNavW - 8f)
             for (int i = 0; i < SetTabNames.Length; i++)
-                if (my >= _navHit[i * 2] && my < _navHit[i * 2 + 1]) { _setTab = i; _setScroll = 0; RequestRedraw(); return; }
+                if (my >= _navHit[i * 2] && my < _navHit[i * 2 + 1]) { _setTab = i; _setScroll = 0; Uia.Announce(SetTabNames[i] + " tab"); RequestRedraw(); return; }
         // outside the card → dismiss
         if (mx < _setCard.Left || mx > _setCard.Right || my < _setCard.Top || my > _setCard.Bottom) { CloseSettings(); return; }
         // widgets (only within the visible pane)
@@ -545,12 +548,18 @@ internal partial class Program
             if (!r.Vis || !Hit(r.Hx0, r.Hy0, r.Hx1, r.Hy1, mx, my)) continue;
             switch (r.Kind)
             {
-                case SW.Toggle: ConfigSetInternal(r.Key, IsOn(ConfigValue(r.Key)) ? "false" : "true"); return;
+                case SW.Toggle:
+                {
+                    bool on = !IsOn(ConfigValue(r.Key));
+                    ConfigSetInternal(r.Key, on ? "true" : "false");
+                    Uia.Announce($"{r.Label}, {(on ? "on" : "off")}");
+                    return;
+                }
                 case SW.Slider: _setDragRow = r; SetCapture(_hwnd); SliderTo(r, mx); return;
                 case SW.Dropdown: case SW.Sound: OpenDropdown(r); return;
                 case SW.Color: PickColorKey(r.Key); return;
-                case SW.Profile: SetProfileDefault(r.Key); return;
-                case SW.Button: r.OnClick?.Invoke(); return;
+                case SW.Profile: SetProfileDefault(r.Key); Uia.Announce($"{r.Key} is now the default profile"); return;
+                case SW.Button: Uia.Announce(r.Label); r.OnClick?.Invoke(); return;
             }
         }
     }
@@ -570,7 +579,11 @@ internal partial class Program
 
     private void SettingsMouseUp()
     {
-        if (_setDragRow is not null) { _setDragRow = null; ReleaseCapture(); RequestRedraw(); }
+        if (_setDragRow is not null)
+        {
+            Uia.Announce($"{_setDragRow.Label}, {ConfigValue(_setDragRow.Key)}");
+            _setDragRow = null; ReleaseCapture(); RequestRedraw();
+        }
     }
 
     private void SettingsWheel(int dir)

--- a/src/Agwinterm.Win32/Uia.cs
+++ b/src/Agwinterm.Win32/Uia.cs
@@ -40,6 +40,35 @@ internal static partial class Uia
     private static readonly Guid IID_IRawElementProviderSimple = new("d6dd68d1-86fd-4332-8666-9abedea2d24c");
     private const int UiaRootObjectId = -25;
     [LibraryImport("uiautomationcore.dll")] private static partial nint UiaReturnRawElementProvider(nint hwnd, nint wParam, nint lParam, nint provider);
+
+    /// <summary>True while a UIA client (Narrator, NVDA, …) is subscribed — gates all announcement work.</summary>
+    internal static bool ClientsListening
+    {
+        get { try { return UiaClientsAreListening(); } catch { return false; } }
+    }
+
+    /// <summary>Push text to the active screen reader via a UIA notification event (new terminal output,
+    /// settings interactions). Cheap alternative to a full ITextProvider: the reader simply speaks the
+    /// string. No-op until the provider exists (first WM_GETOBJECT) or when nothing is listening.</summary>
+    internal static void Announce(string text)
+    {
+        if (_providerSimple == 0 || string.IsNullOrWhiteSpace(text)) return;
+        try
+        {
+            // NotificationKind_Other = 4, NotificationProcessing_All = 2 (queue, don't drop).
+            UiaRaiseNotificationEvent(_providerSimple, 4, 2, text, "agwinterm-announce");
+        }
+        catch { }
+    }
+
+    [LibraryImport("uiautomationcore.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool UiaClientsAreListening();
+
+    [LibraryImport("uiautomationcore.dll")]
+    private static partial int UiaRaiseNotificationEvent(nint provider, int kind, int processing,
+        [MarshalUsing(typeof(BStrStringMarshaller))] string displayString,
+        [MarshalUsing(typeof(BStrStringMarshaller))] string activityId);
 }
 
 [Flags]


### PR DESCRIPTION
Driven by live Narrator testing: typed keys were echoed (the reader's own echo) but **command output was silent** — Stage 1 raised no events. This ships the highest-value piece via `UiaRaiseNotificationEvent` (reader speaks pushed text), well short of the full ITextProvider project.

## What gets spoken now
- **New terminal output**: 350 ms after output settles, the active pane's new lines are announced (per-pane absolute-line tracking, 40-line cap, alt-screen TUIs skipped)
- **Settings**: open/close, tab switches, toggles ("…, on"), slider releases ("Font size, 14"), dropdown commits ("Theme, Dracula"), profile default changes, button presses

## Design notes
- Zero overhead without a reader — all gated on `UiaClientsAreListening()`, and the provider only exists after a `WM_GETOBJECT`
- `TerminalEmulator.DumpHistoryRow` added (plain-text scrollback row)

## Verification
- ✅ 110/110 Core, 38/38 Pty; no-reader smoke clean (output + settings, no crash, nothing spoken)
- 🔊 **Audible check is the user's follow-up**: Narrator on → `dir` → output should be read after it settles

No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)