### PR TITLE
feat(settings): apply font changes live

### DIFF
--- a/src/Agwinterm.Win32/Program.Services.cs
+++ b/src/Agwinterm.Win32/Program.Services.cs
@@ -821,9 +821,10 @@ internal partial class Program
         ApplyWindowOpacity();
         if (key is "compact-toolbar" or "toolbar-mode")   // title-bar height changed → reflow the terminal grid
         { if (_active is not null) RegridSession(_active); if (_cover is not null) RegridCover(); }
+        if (key is "font-family" or "font-size") RebuildFont();   // apply live to the running window
         RequestRedraw();
         RefreshSettingsControls();                        // keep an open Settings window in sync
-        bool deferred = key is "font-family" or "font-size" or "scrollback-lines" or "shell-integration" or "restore-commands";
+        bool deferred = key is "scrollback-lines" or "shell-integration" or "restore-commands";
         return $"{key} = {ConfigValue(key)}" + (deferred ? "  (applies to new sessions)" : "");
     }
 

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -531,6 +531,22 @@ internal partial class Program : ISessionHost, IWindowHost
         return f;
     }
 
+    /// <summary>Apply a font-family / default-font-size change live: rebuild the base format, dispose and
+    /// clear the per-size metrics cache (each entry bakes in the family), remeasure, and reflow every
+    /// session so the change is visible immediately instead of only on new sessions.</summary>
+    private void RebuildFont()
+    {
+        var old = _format;
+        _format = CreateTextFormat(_config);
+        try { old?.Dispose(); } catch { }
+        foreach (var m in _metrics.Values) { try { m.Fmt.Dispose(); } catch { } }   // COM formats — dispose before dropping
+        _metrics.Clear();
+        MeasureCell();
+        foreach (var s in AllSessions()) RegridSession(s);
+        if (_cover is not null) RegridCover();
+        RequestRedraw();
+    }
+
     private void MeasureCell()
     {
         using var run = _dwrite.CreateTextLayout(new string('M', 10), _format, 4096f, 4096f);


### PR DESCRIPTION
Changing the font in **Appearance** was deferred ("applies to new sessions"), so you couldn't see what it looked like. Now `font-family` / `font-size` apply **immediately** to the running window.

`RebuildFont()`: rebuilds the base text format, **disposes + clears** the per-size metrics cache (each cached `IDWriteTextFormat` bakes in the family, so a family/default-size change invalidates all — and disposing avoids leaking COM formats), remeasures the cell, reflows every session.

Verified live: Consolas 14 (separate `=> <= !=`) → Cascadia Code 20 (ligated `⇒ ≤ ≠`, larger, grid reflowed). 110/110 Core, 38/38 Pty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)