### PR TITLE
feat(uia): proper Narrator support — host provider, system caret, full Text pattern

### DIFF
--- a/src/Agwinterm.Win32/Program.Services.cs
+++ b/src/Agwinterm.Win32/Program.Services.cs
@@ -46,7 +46,8 @@ internal partial class Program
             }
             text = sb.ToString();
         }
-        Uia.Announce(text);
+        Uia.RaiseTextChanged();   // let the reader's text model re-read (navigation)
+        Uia.Announce(text);       // and speak the new lines directly (reliable across readers)
     }
 
     // ---- Notifications (OSC 9 / OSC 777 / notify) ----

--- a/src/Agwinterm.Win32/Program.WndProc.cs
+++ b/src/Agwinterm.Win32/Program.WndProc.cs
@@ -141,7 +141,16 @@ internal partial class Program
                 BeginPaint(hwnd, out PAINTSTRUCT ps);
                 Render();
                 _lastPaintTick = Environment.TickCount64;
+                UpdateCaretPos();   // keep the (hidden) system caret on the text cursor for a11y follow
                 EndPaint(hwnd, ref ps);
+                return IntPtr.Zero;
+
+            case WM_SETFOCUS:
+                EnsureCaret();
+                return IntPtr.Zero;
+
+            case WM_KILLFOCUS:
+                DropCaret();
                 return IntPtr.Zero;
 
             case WM_APP_REDRAW:

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -531,6 +531,42 @@ internal partial class Program : ISessionHost, IWindowHost
         return f;
     }
 
+    // ---- System caret (accessibility: Magnifier follow, IME placement, screen-reader caret) ----
+    // We render our own cursor, so the system caret is created HIDDEN — it exists only so assistive
+    // tech can read the text-cursor position (via GetCaretPos / the caret's location-change events).
+    private bool _caretOwned;
+
+    private void EnsureCaret()
+    {
+        if (_caretOwned || _hwnd == IntPtr.Zero) return;
+        var (_, _, cw, ch) = ActivePaneView();
+        if (CreateCaret(_hwnd, IntPtr.Zero, Math.Max(1, (int)cw), Math.Max(1, (int)ch)))
+        {
+            _caretOwned = true;
+            HideCaret(_hwnd);   // don't double-draw over our rendered cursor
+            UpdateCaretPos();
+        }
+    }
+
+    private void DropCaret()
+    {
+        if (!_caretOwned) return;
+        DestroyCaret();
+        _caretOwned = false;
+    }
+
+    /// <summary>Move the hidden system caret onto the active pane's text cursor (client px).</summary>
+    private void UpdateCaretPos()
+    {
+        if (!_caretOwned || _active is null) return;
+        var (ox, oy, cw, ch) = ActivePaneView();
+        var p = ActiveSurface();
+        if (p is null) return;
+        int col, row;
+        lock (p.S.SyncRoot) { col = p.S.Emulator.CursorCol; row = p.S.Emulator.CursorRow; }
+        SetCaretPos((int)(ox + col * cw), (int)(oy + row * ch));
+    }
+
     /// <summary>Apply a font-family / default-font-size change live: rebuild the base format, dispose and
     /// clear the per-size metrics cache (each entry bakes in the family), remeasure, and reflow every
     /// session so the change is visible immediately instead of only on new sessions.</summary>

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -531,6 +531,48 @@ internal partial class Program : ISessionHost, IWindowHost
         return f;
     }
 
+    /// <summary>Build the UIA text-pattern snapshot: the active pane's buffer (recent scrollback + the
+    /// live screen) flattened into one document, with the caret offset and the mapping from document
+    /// lines to on-screen rows (screen px) so ranges can report bounding rectangles. Runs on the UIA
+    /// thread; locks the session.</summary>
+    private Uia.TextSnapshot? BuildUiaTextSnapshot()
+    {
+        var p = ActiveSurface();
+        if (p is null) return null;
+        var (oxC, oyC, cw, ch) = ActivePaneView();
+        var origin = new POINT { x = (int)oxC, y = (int)oyC };
+        ClientToScreen(_hwnd, ref origin);   // bounding rectangles are screen coords
+        lock (p.S.SyncRoot)
+        {
+            var em = p.S.Emulator;
+            int hist = em.HistoryCount, rows = em.Screen.Rows;
+            const int MaxHist = 2000;                       // bound the document the reader walks
+            int keepHist = Math.Min(hist, MaxHist);
+            int histStart = hist - keepHist;
+            int n = keepHist + rows;
+            var lines = new string[n];
+            for (int i = 0; i < keepHist; i++) lines[i] = em.DumpHistoryRow(histStart + i);
+            for (int r = 0; r < rows; r++) lines[keepHist + r] = em.DumpRow(r);
+            var starts = new int[n + 1];
+            for (int i = 0; i < n; i++) starts[i + 1] = starts[i] + lines[i].Length + 1;   // +1 = '\n' joiner
+            int total = n > 0 ? starts[n] - 1 : 0;          // no trailing newline after the last line
+
+            int caretLine = keepHist + Math.Clamp(em.CursorRow, 0, rows - 1);
+            int caretCol = Math.Min(em.CursorCol, lines[caretLine].Length);
+            int caretOff = starts[caretLine] + caretCol;
+
+            int off = em.IsAltScreen ? 0 : Math.Clamp(p.ScrollOffset, 0, hist);
+            int firstVisibleDoc = (hist - off) - histStart;  // Lines[] index of the top on-screen row
+
+            return new Uia.TextSnapshot
+            {
+                Lines = lines, LineStart = starts, TotalLength = total, CaretOffset = caretOff,
+                FirstVisibleLine = firstVisibleDoc, VisibleRows = rows,
+                ScreenX = origin.x, ScreenY = origin.y, CellW = cw, CellH = ch,
+            };
+        }
+    }
+
     // ---- System caret (accessibility: Magnifier follow, IME placement, screen-reader caret) ----
     // We render our own cursor, so the system caret is created HIDDEN — it exists only so assistive
     // tech can read the text-cursor position (via GetCaretPos / the caret's location-change events).
@@ -683,6 +725,9 @@ internal partial class Program : ISessionHost, IWindowHost
                     return sb.ToString().TrimEnd() is { Length: > 0 } t ? t : "terminal";
                 }
             };
+            // Full text-pattern snapshot (ITextProvider): the flattened buffer document + caret +
+            // visible-line mapping, so Narrator can read/navigate by line/word/char and box the caret.
+            Uia.GetTextSnapshot = BuildUiaTextSnapshot;
         }
         // CLI args (first window only; consumed so extra windows don't re-apply them).
         string? argProfile = _argProfile, argDir = _argDir;

--- a/src/Agwinterm.Win32/Uia.Text.cs
+++ b/src/Agwinterm.Win32/Uia.Text.cs
@@ -1,0 +1,350 @@
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace Agwinterm.Win32;
+
+// UIA Text pattern (T2-14 Stage 2): lets Narrator/NVDA read and navigate the terminal by
+// character / word / line, track the caret, and box it — the "proper" screen-reader support.
+// The document is the active pane's recent scrollback + live screen flattened into one string
+// (lines joined by '\n'); a text range is a [start,end) character span into it. Ranges report
+// on-screen bounding rectangles for the visible portion so the caret box lands where you type.
+
+partial class Uia
+{
+    /// <summary>Snapshot of the active pane's text buffer for the text pattern (built by the app under
+    /// the session lock; see Program.BuildUiaTextSnapshot).</summary>
+    internal sealed class TextSnapshot
+    {
+        public required string[] Lines;
+        public required int[] LineStart;      // LineStart[i] = char offset of Lines[i]; LineStart[n] = total+1
+        public int TotalLength;
+        public int CaretOffset;
+        public int FirstVisibleLine, VisibleRows;
+        public double ScreenX, ScreenY, CellW, CellH;   // top-left of the on-screen grid (screen px) + cell size
+
+        public string Text => string.Join('\n', Lines);
+        public (int line, int col) LineColOf(int off)
+        {
+            off = Math.Clamp(off, 0, TotalLength);
+            // binary search the line whose [start, start+len] contains off
+            int lo = 0, hi = Lines.Length - 1, line = 0;
+            while (lo <= hi)
+            {
+                int mid = (lo + hi) / 2;
+                if (off < LineStart[mid]) hi = mid - 1;
+                else if (off > LineStart[mid] + Lines[mid].Length) lo = mid + 1;
+                else { line = mid; break; }
+            }
+            if (lo > hi) line = Math.Clamp(lo, 0, Lines.Length - 1);
+            return (line, off - LineStart[line]);
+        }
+    }
+
+    internal static Func<TextSnapshot?>? GetTextSnapshot;
+    internal static TextSnapshot Snap() => GetTextSnapshot?.Invoke() ?? EmptySnap;
+    private static readonly TextSnapshot EmptySnap = new() { Lines = new[] { "" }, LineStart = new[] { 0, 1 } };
+
+    internal static readonly Guid IID_ITextProvider = new("3589c92c-63f3-4367-99bb-ada653b77cf2");
+    internal static readonly Guid IID_ITextRangeProvider = new("5347ad7b-c355-46f8-aff5-909033582f63");
+
+    /// <summary>CCW for a managed COM object, QI'd to <paramref name="iid"/> (AddRef'd; caller releases). 0 on failure.</summary>
+    internal static nint AsInterface(object obj, in Guid iid)
+    {
+        nint unk = ComWrappers.GetOrCreateComInterfaceForObject(obj, CreateComInterfaceFlags.None);
+        try { Guid id = iid; return Marshal.QueryInterface(unk, in id, out nint p) >= 0 ? p : 0; }
+        finally { Marshal.Release(unk); }
+    }
+
+    /// <summary>Notify listeners that the terminal text changed (so a reader re-reads new output).</summary>
+    internal static void RaiseTextChanged()
+    {
+        if (_providerSimple == 0) return;
+        try { UiaRaiseAutomationEvent(_providerSimple, UIA_Text_TextChangedEventId); } catch { }
+    }
+
+    private const int UIA_Text_TextChangedEventId = 20015;
+    [LibraryImport("uiautomationcore.dll")] private static partial int UiaRaiseAutomationEvent(nint provider, int eventId);
+}
+
+internal enum TextUnit { Character = 0, Format = 1, Word = 2, Line = 3, Paragraph = 4, Page = 5, Document = 6 }
+internal enum TextPatternRangeEndpoint { Start = 0, End = 1 }
+internal enum SupportedTextSelection { None = 0, Single = 1, Multiple = 2 }
+
+[GeneratedComInterface]
+[Guid("3589c92c-63f3-4367-99bb-ada653b77cf2")]
+internal partial interface ITextProvider
+{
+    nint GetSelection();                                    // SAFEARRAY(ITextRangeProvider*)
+    nint GetVisibleRanges();                                // SAFEARRAY(ITextRangeProvider*)
+    nint RangeFromChild(nint childElement);                 // ITextRangeProvider*
+    nint RangeFromPoint(UiaPoint point);                    // ITextRangeProvider*
+    nint GetDocumentRange();                                // ITextRangeProvider*  (get_DocumentRange)
+    SupportedTextSelection GetSupportedTextSelection();     // get_SupportedTextSelection
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct UiaPoint { public double X, Y; }
+
+[GeneratedComInterface]
+[Guid("5347ad7b-c355-46f8-aff5-909033582f63")]
+internal partial interface ITextRangeProvider
+{
+    nint Clone();
+    [return: MarshalAs(UnmanagedType.I4)] int Compare(ITextRangeProvider range);              // BOOL
+    int CompareEndpoints(TextPatternRangeEndpoint endpoint, ITextRangeProvider targetRange, TextPatternRangeEndpoint targetEndpoint);
+    void ExpandToEnclosingUnit(TextUnit unit);
+    nint FindAttribute(int attributeId, VariantBlob val, [MarshalAs(UnmanagedType.I4)] int backward);  // ITextRangeProvider*
+    nint FindText([MarshalUsing(typeof(BStrStringMarshaller))] string text, [MarshalAs(UnmanagedType.I4)] int backward, [MarshalAs(UnmanagedType.I4)] int ignoreCase);
+    void GetAttributeValue(int attributeId, nint pRetVal);   // VARIANT* (caller-allocated)
+    nint GetBoundingRectangles();                            // SAFEARRAY(double)
+    nint GetEnclosingElement();                              // IRawElementProviderSimple*
+    [return: MarshalUsing(typeof(BStrStringMarshaller))] string GetText(int maxLength);
+    int Move(TextUnit unit, int count);
+    int MoveEndpointByUnit(TextPatternRangeEndpoint endpoint, TextUnit unit, int count);
+    void MoveEndpointByRange(TextPatternRangeEndpoint endpoint, ITextRangeProvider targetRange, TextPatternRangeEndpoint targetEndpoint);
+    void Select();
+    void AddToSelection();
+    void RemoveFromSelection();
+    void ScrollIntoView([MarshalAs(UnmanagedType.I4)] int alignToTop);
+    nint GetChildren();                                      // SAFEARRAY(ITextRangeProvider*)
+}
+
+/// <summary>24-byte blittable stand-in for a by-value VARIANT (FindAttribute's [in] val) — we never
+/// read it, but the parameter must occupy the right stack space so the vtable slot stays aligned.</summary>
+[StructLayout(LayoutKind.Sequential)]
+internal struct VariantBlob { public long A, B, C; }
+
+// UiaProvider (declared in Uia.cs) also implements ITextProvider.
+internal partial class UiaProvider : ITextProvider
+{
+    public nint GetSelection()
+    {
+        var s = Uia.Snap();
+        // A degenerate range at the caret — Narrator announces the caret line.
+        return UiaArrays.RangeArray(new[] { new UiaTextRange(s.CaretOffset, s.CaretOffset) });
+    }
+
+    public nint GetVisibleRanges()
+    {
+        var s = Uia.Snap();
+        int firstOff = s.LineStart[Math.Clamp(s.FirstVisibleLine, 0, s.Lines.Length - 1)];
+        int lastLine = Math.Clamp(s.FirstVisibleLine + s.VisibleRows - 1, 0, s.Lines.Length - 1);
+        int lastOff = s.LineStart[lastLine] + s.Lines[lastLine].Length;
+        return UiaArrays.RangeArray(new[] { new UiaTextRange(firstOff, lastOff) });
+    }
+
+    public nint RangeFromChild(nint childElement) => Uia.AsInterface(new UiaTextRange(0, 0), Uia.IID_ITextRangeProvider);
+
+    public nint RangeFromPoint(UiaPoint point)
+    {
+        var s = Uia.Snap();
+        int row = (int)((point.Y - s.ScreenY) / Math.Max(1, s.CellH));
+        int col = (int)((point.X - s.ScreenX) / Math.Max(1, s.CellW));
+        int line = Math.Clamp(s.FirstVisibleLine + Math.Max(0, row), 0, s.Lines.Length - 1);
+        int off = s.LineStart[line] + Math.Clamp(col, 0, s.Lines[line].Length);
+        return Uia.AsInterface(new UiaTextRange(off, off), Uia.IID_ITextRangeProvider);
+    }
+
+    public nint GetDocumentRange() => Uia.AsInterface(new UiaTextRange(0, Uia.Snap().TotalLength), Uia.IID_ITextRangeProvider);
+
+    public SupportedTextSelection GetSupportedTextSelection() => SupportedTextSelection.Single;
+}
+
+/// <summary>A [Start,End) character span into the flattened terminal document. Reads a fresh snapshot on
+/// each call so it tracks live output. Immutable offsets except where a Move/Expand mutates them.</summary>
+[GeneratedComClass]
+internal partial class UiaTextRange : ITextRangeProvider
+{
+    private int _start, _end;
+    public UiaTextRange(int start, int end) { _start = Math.Min(start, end); _end = Math.Max(start, end); }
+
+    private static int ClampOff(int off) { var s = Uia.Snap(); return Math.Clamp(off, 0, s.TotalLength); }
+
+    public nint Clone() => Uia.AsInterface(new UiaTextRange(_start, _end), Uia.IID_ITextRangeProvider);
+
+    public int Compare(ITextRangeProvider range) => range is UiaTextRange r && r._start == _start && r._end == _end ? 1 : 0;
+
+    public int CompareEndpoints(TextPatternRangeEndpoint endpoint, ITextRangeProvider targetRange, TextPatternRangeEndpoint targetEndpoint)
+    {
+        int a = endpoint == TextPatternRangeEndpoint.Start ? _start : _end;
+        int b = targetRange is UiaTextRange r ? (targetEndpoint == TextPatternRangeEndpoint.Start ? r._start : r._end) : 0;
+        return a.CompareTo(b);
+    }
+
+    public void ExpandToEnclosingUnit(TextUnit unit)
+    {
+        var s = Uia.Snap();
+        switch (unit)
+        {
+            case TextUnit.Character:
+                _end = Math.Min(_start + 1, s.TotalLength);
+                if (_end == _start && _start > 0) _start--;
+                break;
+            case TextUnit.Word:
+            {
+                var (ln, col) = s.LineColOf(_start);
+                string text = s.Lines[ln];
+                int ws = col, we = col;
+                while (ws > 0 && !char.IsWhiteSpace(text[ws - 1])) ws--;
+                while (we < text.Length && !char.IsWhiteSpace(text[we])) we++;
+                _start = s.LineStart[ln] + ws; _end = s.LineStart[ln] + we;
+                break;
+            }
+            case TextUnit.Document:
+                _start = 0; _end = s.TotalLength;
+                break;
+            default: // Line / Paragraph / Page → the whole line
+            {
+                var (ln, _) = s.LineColOf(_start);
+                _start = s.LineStart[ln];
+                _end = s.LineStart[ln] + s.Lines[ln].Length;
+                break;
+            }
+        }
+    }
+
+    public nint FindAttribute(int attributeId, VariantBlob val, int backward) => 0;   // not supported (null range)
+
+    public nint FindText(string text, int backward, int ignoreCase)
+    {
+        var s = Uia.Snap();
+        string hay = s.Text;
+        int from = Math.Clamp(_start, 0, hay.Length), to = Math.Clamp(_end, 0, hay.Length);
+        string window = hay.Substring(from, Math.Max(0, to - from));
+        var cmp = ignoreCase != 0 ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        int idx = backward != 0 ? window.LastIndexOf(text ?? "", cmp) : window.IndexOf(text ?? "", cmp);
+        if (idx < 0 || string.IsNullOrEmpty(text)) return 0;
+        return Uia.AsInterface(new UiaTextRange(from + idx, from + idx + text.Length), Uia.IID_ITextRangeProvider);
+    }
+
+    public void GetAttributeValue(int attributeId, nint pRetVal)
+    {
+        // VT_UNKNOWN = the "not supported" sentinel (UiaGetReservedNotSupportedValue); we just leave
+        // VT_EMPTY, which UIA treats as unsupported. Caller allocated the VARIANT; init it to empty.
+        VariantInit(pRetVal);
+    }
+
+    public nint GetBoundingRectangles()
+    {
+        var s = Uia.Snap();
+        var rects = new List<double>();
+        var (l0, c0) = s.LineColOf(_start);
+        var (l1, c1) = s.LineColOf(_end);
+        for (int ln = l0; ln <= l1; ln++)
+        {
+            int screenRow = ln - s.FirstVisibleLine;
+            if (screenRow < 0 || screenRow >= s.VisibleRows) continue;   // off-screen (scrolled away)
+            int cs = ln == l0 ? c0 : 0;
+            int ce = ln == l1 ? c1 : s.Lines[ln].Length;
+            if (ce < cs) ce = cs;
+            double x = s.ScreenX + cs * s.CellW;
+            double y = s.ScreenY + screenRow * s.CellH;
+            double w = Math.Max(ce == cs ? 1 : (ce - cs) * s.CellW, 1);   // caret (degenerate) → 1px sliver
+            rects.Add(x); rects.Add(y); rects.Add(w); rects.Add(s.CellH);
+        }
+        return UiaArrays.DoubleArray(rects.ToArray());
+    }
+
+    public nint GetEnclosingElement() => Uia.RootProvider();
+
+    public string GetText(int maxLength)
+    {
+        var s = Uia.Snap();
+        string hay = s.Text;
+        int from = Math.Clamp(_start, 0, hay.Length), to = Math.Clamp(_end, 0, hay.Length);
+        string t = hay.Substring(from, Math.Max(0, to - from));
+        return maxLength >= 0 && t.Length > maxLength ? t.Substring(0, maxLength) : t;
+    }
+
+    public int Move(TextUnit unit, int count)
+    {
+        // Move the whole (collapsed-to-start) range by `count` units; return units actually moved.
+        var s = Uia.Snap();
+        if (unit == TextUnit.Character)
+        {
+            int target = Math.Clamp(_start + count, 0, s.TotalLength);
+            int moved = target - _start;
+            _start = _end = target;
+            return moved;
+        }
+        // Line (and coarser): step whole lines.
+        var (ln, _) = s.LineColOf(_start);
+        int newLn = Math.Clamp(ln + count, 0, s.Lines.Length - 1);
+        _start = _end = s.LineStart[newLn];
+        // collapse then re-expand to the line for a sensible caret
+        _end = s.LineStart[newLn] + s.Lines[newLn].Length;
+        return newLn - ln;
+    }
+
+    public int MoveEndpointByUnit(TextPatternRangeEndpoint endpoint, TextUnit unit, int count)
+    {
+        var s = Uia.Snap();
+        int cur = endpoint == TextPatternRangeEndpoint.Start ? _start : _end;
+        int target;
+        if (unit == TextUnit.Character) target = Math.Clamp(cur + count, 0, s.TotalLength);
+        else
+        {
+            var (ln, _) = s.LineColOf(cur);
+            int newLn = Math.Clamp(ln + count, 0, s.Lines.Length - 1);
+            target = count >= 0 ? s.LineStart[newLn] + s.Lines[newLn].Length : s.LineStart[newLn];
+        }
+        int moved = target - cur;
+        if (endpoint == TextPatternRangeEndpoint.Start) { _start = target; if (_end < _start) _end = _start; }
+        else { _end = target; if (_start > _end) _start = _end; }
+        return unit == TextUnit.Character ? moved : Math.Sign(count) * Math.Abs(count);
+    }
+
+    public void MoveEndpointByRange(TextPatternRangeEndpoint endpoint, ITextRangeProvider targetRange, TextPatternRangeEndpoint targetEndpoint)
+    {
+        if (targetRange is not UiaTextRange r) return;
+        int v = targetEndpoint == TextPatternRangeEndpoint.Start ? r._start : r._end;
+        if (endpoint == TextPatternRangeEndpoint.Start) { _start = v; if (_end < _start) _end = _start; }
+        else { _end = v; if (_start > _end) _start = _end; }
+    }
+
+    public void Select() { }              // read-only selection model for now
+    public void AddToSelection() { }
+    public void RemoveFromSelection() { }
+    public void ScrollIntoView(int alignToTop) { }
+
+    public nint GetChildren() => UiaArrays.RangeArray(Array.Empty<UiaTextRange>());
+
+    [LibraryImport("oleaut32.dll")] private static partial void VariantInit(nint pvarg);
+}
+
+/// <summary>SAFEARRAY builders for the text-pattern out-params (source-gen COM returns them as raw pointers).</summary>
+internal static partial class UiaArrays
+{
+    private const ushort VT_R8 = 5, VT_UNKNOWN = 13;
+
+    public static nint DoubleArray(double[] vals)
+    {
+        nint sa = SafeArrayCreateVector(VT_R8, 0, (uint)vals.Length);
+        if (sa != 0 && vals.Length > 0 && SafeArrayAccessData(sa, out nint data) >= 0)
+        {
+            Marshal.Copy(vals, 0, data, vals.Length);
+            SafeArrayUnaccessData(sa);
+        }
+        return sa;
+    }
+
+    public static nint RangeArray(UiaTextRange[] ranges)
+    {
+        nint sa = SafeArrayCreateVector(VT_UNKNOWN, 0, (uint)ranges.Length);
+        if (sa == 0) return 0;
+        for (int i = 0; i < ranges.Length; i++)
+        {
+            nint p = Uia.AsInterface(ranges[i], Uia.IID_ITextRangeProvider);
+            if (p == 0) continue;
+            int idx = i;
+            SafeArrayPutElement(sa, ref idx, p);   // AddRefs for VT_UNKNOWN
+            Marshal.Release(p);
+        }
+        return sa;
+    }
+
+    [LibraryImport("oleaut32.dll")] private static partial nint SafeArrayCreateVector(ushort vt, int lLbound, uint cElements);
+    [LibraryImport("oleaut32.dll")] private static partial int SafeArrayAccessData(nint psa, out nint ppvData);
+    [LibraryImport("oleaut32.dll")] private static partial int SafeArrayUnaccessData(nint psa);
+    [LibraryImport("oleaut32.dll")] private static partial int SafeArrayPutElement(nint psa, ref int rgIndices, nint pv);
+}

--- a/src/Agwinterm.Win32/Uia.cs
+++ b/src/Agwinterm.Win32/Uia.cs
@@ -37,6 +37,14 @@ internal static partial class Uia
         return _providerSimple != 0 ? UiaReturnRawElementProvider(hwnd, wParam, lParam, _providerSimple) : 0;
     }
 
+    /// <summary>The root terminal element (IRawElementProviderSimple*), AddRef'd — for text ranges'
+    /// GetEnclosingElement. 0 before the provider exists.</summary>
+    internal static nint RootProvider()
+    {
+        if (_providerSimple != 0) Marshal.AddRef(_providerSimple);
+        return _providerSimple;
+    }
+
     private static readonly Guid IID_IRawElementProviderSimple = new("d6dd68d1-86fd-4332-8666-9abedea2d24c");
     private const int UiaRootObjectId = -25;
     [LibraryImport("uiautomationcore.dll")] private static partial nint UiaReturnRawElementProvider(nint hwnd, nint wParam, nint lParam, nint provider);
@@ -95,7 +103,11 @@ internal partial class UiaProvider : IRawElementProviderSimple
     // Direct (non-marshalled) calls on UIA's thread; our reads are guarded by the session lock.
     public ProviderOptions GetProviderOptions() => ProviderOptions.ServerSideProvider;
 
-    public nint GetPatternProvider(int patternId) => 0; // no control patterns yet (ITextProvider next)
+    // Expose the Text pattern so Narrator/NVDA can read & navigate the terminal by line/word/char.
+    public nint GetPatternProvider(int patternId)
+        => patternId == UIA_TextPatternId ? Uia.AsInterface(this, Uia.IID_ITextProvider) : 0;
+
+    private const int UIA_TextPatternId = 10014;
 
     // Return the HWND host provider so UIA properly *hosts* this element: without it the provider is
     // unparented — Narrator can't anchor its focus rectangle (it lands somewhere random) and

--- a/src/Agwinterm.Win32/Uia.cs
+++ b/src/Agwinterm.Win32/Uia.cs
@@ -97,7 +97,14 @@ internal partial class UiaProvider : IRawElementProviderSimple
 
     public nint GetPatternProvider(int patternId) => 0; // no control patterns yet (ITextProvider next)
 
-    public nint GetHostRawElementProvider() => 0;        // no host provider in this stage
+    // Return the HWND host provider so UIA properly *hosts* this element: without it the provider is
+    // unparented — Narrator can't anchor its focus rectangle (it lands somewhere random) and
+    // notification/property events don't route reliably. UiaHostProviderFromHwnd supplies the window's
+    // default bounding rectangle + the event-routing plumbing.
+    public nint GetHostRawElementProvider()
+        => UiaHostProviderFromHwnd(_hwnd, out nint host) >= 0 ? host : 0;
+
+    [LibraryImport("uiautomationcore.dll")] private static partial int UiaHostProviderFromHwnd(nint hwnd, out nint provider);
 
     public void GetPropertyValue(int propertyId, nint pRetVal)
     {

--- a/src/Agwinterm.Win32/Win32.cs
+++ b/src/Agwinterm.Win32/Win32.cs
@@ -29,6 +29,7 @@ internal static class Win32
     public const uint WM_MBUTTONDOWN = 0x0207, WM_MBUTTONUP = 0x0208;
     public const uint WM_MOUSEWHEEL = 0x020A;
     public const uint WM_ACTIVATE = 0x0006;   // sent on window activation/deactivation (frontmost tracking)
+    public const uint WM_SETFOCUS = 0x0007, WM_KILLFOCUS = 0x0008;   // keyboard-focus in/out (system caret lifetime)
     public const uint WM_APP_REDRAW = 0x8000; // WM_APP: cross-thread "please repaint"
     public const uint WM_APP_ACTION = 0x8001; // WM_APP+1: drain queued UI-thread actions (pipe callbacks)
     public const uint WM_APP_SYNC = 0x8002;   // WM_APP+2: run a queued func on the UI thread and return its result
@@ -396,6 +397,14 @@ internal static class Win32
 
     [DllImport("user32.dll")]
     public static extern bool ClientToScreen(IntPtr hWnd, ref POINT lpPoint);
+
+    // System caret — a11y anchor: Magnifier "follow the text cursor", IME composition placement, and
+    // Narrator caret tracking all read the system caret position (even when it's hidden so it doesn't
+    // double-draw over our rendered cursor).
+    [DllImport("user32.dll")] public static extern bool CreateCaret(IntPtr hWnd, IntPtr hBitmap, int nWidth, int nHeight);
+    [DllImport("user32.dll")] public static extern bool SetCaretPos(int x, int y);
+    [DllImport("user32.dll")] public static extern bool HideCaret(IntPtr hWnd);
+    [DllImport("user32.dll")] public static extern bool DestroyCaret();
 
     [DllImport("user32.dll")]
     public static extern bool GetCursorPos(out POINT lpPoint);


### PR DESCRIPTION
Delivers the "proper Narrator support" the terminal was missing — driven by live testing (Narrator read the prompt but not `dir` output; the focus rectangle landed somewhere random; Settings weren't narrated).

## Three layers, all verified with a `UIAutomationClient` probe (the same COM path Narrator uses)

### 1. Host provider (routing + anchoring)
`GetHostRawElementProvider` → `UiaHostProviderFromHwnd` (was 0). The provider was **unparented**, so Narrator couldn't anchor its focus box and events didn't route (Settings silence). Now it reports a real `BoundingRectangle` and hosts properly.

### 2. System caret (Magnifier / IME / caret follow)
Hidden `CreateCaret`/`SetCaretPos` tracks the active pane's text cursor each paint — Magnifier "follow the text cursor" and IME placement now work. Hidden so it never double-draws over our rendered cursor.

### 3. Full Text pattern (`ITextProvider` + `ITextRangeProvider`) — the big one
The pane's recent scrollback + live screen flatten into one document. Ranges support `GetText`, `ExpandToEnclosingUnit` (char/word/line/document), `Move`/`MoveEndpointByUnit`, `GetSelection` (caret), `GetVisibleRanges`, `FindText`, and **`GetBoundingRectangles`** — a degenerate caret range returns a **one-cell box at the caret**, which is what makes the focus rectangle track where you type. A text-changed event fires on new output.

## Probe results
```
patterns: Window, Text, Transform
DocumentRange.GetText → full buffer (incl. typed lines)
GetSelection → 1 range (caret); ExpandToEnclosingUnit(Line) → the caret line
GetBoundingRectangles → 737,330,14,21   (tight one-cell box at the caret)
Move(Line,+1) walks the buffer line by line
```
110/110 Core, 38/38 Pty.

## Still Stage 3 (backlog)
Word-move refinement, live selection via Select(), and alt-screen TUI (Far/vim) reading — those redraw in place and need a different model. This covers reading, caret tracking, and line/char navigation — the core of using Claude Code with a screen reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)