### PR TITLE
feat(a11y): F6 focus zones + spoken hover for chrome buttons

### DIFF
--- a/src/Agwinterm.Win32/Program.Chrome.cs
+++ b/src/Agwinterm.Win32/Program.Chrome.cs
@@ -143,6 +143,12 @@ internal partial class Program
             brush.Color = SbHighlight;
             rt.FillRectangle(new Rect(0, y, _sidebarW, rowH), brush);
         }
+        // F6 focus ring: the sidebar zone's focused row (keyboard navigation, without the mouse).
+        if (_chromeFocus && ReferenceEquals(_focusRow, s))
+        {
+            brush.Color = ChromeAccent;
+            rt.DrawRectangle(new Rect(1.5f, y + 1.5f, _sidebarW - 3f, rowH - 3f), brush, 2f);
+        }
         // Flag marker in the left gutter (before the name, which starts at x=26).
         if (s.Flagged)
         {
@@ -1230,10 +1236,30 @@ internal partial class Program
         else if (mx < (int)_sidebarW && my >= ClientH() - (int)FooterH) hit = ChromeHit(_footerButtons, mx);
         if (hit == _hotBtn) return;
         _hotBtn = hit;
-        if (hit is not null) { _hotPaint = hit; _hotAlpha = 1f; }   // light instantly on hover-in
+        if (hit is not null)
+        {
+            _hotPaint = hit; _hotAlpha = 1f;   // light instantly on hover-in
+            if (Uia.ClientsListening) Uia.Announce(ChromeButtonLabel(hit) + " button");   // speak the hovered button
+        }
         else SetTimer(_hwnd, (IntPtr)HoverTimer, 15, IntPtr.Zero);  // fade out when leaving
         RequestRedraw();
     }
+
+    /// <summary>Friendly spoken name for a chrome button action id (screen-reader hover announcements).</summary>
+    private static string ChromeButtonLabel(string a) => a switch
+    {
+        "toggle" => "Toggle sidebar",
+        "add-session" => "New session",
+        "new-workspace" => "New workspace",
+        "attention" => "Next attention",
+        "scratch" => "Scratch terminal",
+        "split" => "Split pane",
+        "quick terminal" => "Quick terminal",
+        "flag" => "Flagged view",
+        "unfocus" => "Unfocus workspace",
+        "settings" => "Settings",
+        _ => a,
+    };
 
     /// <summary>Ease the hover-fill alpha toward the target; stop the timer once settled.</summary>
     private void HoverTick()

--- a/src/Agwinterm.Win32/Program.Input.cs
+++ b/src/Agwinterm.Win32/Program.Input.cs
@@ -903,6 +903,11 @@ internal partial class Program
         // While the find bar is open it owns the keyboard (Enter/F3 nav, Esc close, Backspace edit).
         if (_searchActive) return SearchKeyDown(vk);
 
+        // Focus zones (F6): the sidebar zone owns the keyboard while active; plain F6 from the terminal
+        // lifts focus out to the sidebar (the accessible "leave the terminal" gesture).
+        if (_chromeFocus) return SidebarZoneKey(vk);
+        if (vk == 0x75 /* F6 */ && !ctrl && !alt && !shift) { EnterChromeFocus(); return true; }
+
         // Leader/prefix sequence (tmux-style). When pending, the next chord resolves against the leader
         // bindings; Esc / timeout cancels; modifier-only keydowns stay pending. Checked before the normal
         // chord/clipboard/terminal paths so the leader chord and its follow-up key are captured.

--- a/src/Agwinterm.Win32/Program.WndProc.cs
+++ b/src/Agwinterm.Win32/Program.WndProc.cs
@@ -269,6 +269,7 @@ internal partial class Program
             case WM_LBUTTONDOWN:
                 {
                     int mx = LoWord(lParam), my = HiWord(lParam);
+                    if (_chromeFocus) ExitChromeFocus(announce: false);   // a click leaves the F6 sidebar zone
                     if (_setOpen) { SettingsClick(mx, my); return IntPtr.Zero; }
                     if (_palette != PaletteKind.None) { PaletteClick(mx, my); return IntPtr.Zero; }
                     // Notification banner: clicking it jumps to the raising session and dismisses.

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -573,6 +573,63 @@ internal partial class Program : ISessionHost, IWindowHost
         }
     }
 
+    // ---- Focus zones (F6): move keyboard focus between the terminal and the sidebar ----
+    // The terminal owns the keyboard by default (everything goes to the shell). F6 lifts focus OUT
+    // to the sidebar so it can be walked without the mouse — the accessible way to leave the terminal.
+    private bool _chromeFocus;    // keyboard focus is in the sidebar zone (not the terminal)
+    private Ses? _focusRow;       // the focused sidebar session while _chromeFocus
+
+    private void EnterChromeFocus()
+    {
+        if (_sidebarW <= 0) ToggleSidebar();   // reveal the sidebar so the focus ring is visible
+        _chromeFocus = true;
+        _focusRow = _active ?? AllSessions().FirstOrDefault();
+        Uia.Announce("Sidebar");
+        AnnounceFocusRow();
+        RequestRedraw();
+    }
+
+    private void ExitChromeFocus(bool announce = true)
+    {
+        if (!_chromeFocus) return;
+        _chromeFocus = false;
+        if (announce) Uia.Announce("Terminal");
+        RequestRedraw();
+    }
+
+    private void AnnounceFocusRow()
+    {
+        if (_focusRow is null) return;
+        ShowToast(_focusRow.Name);   // a visible hint alongside the spoken one
+        bool current = ReferenceEquals(_focusRow, _active);
+        int unread = UnreadOf(_focusRow);
+        string extra = (current ? ", current" : "") + (unread > 0 ? $", {unread} unread" : "");
+        Uia.Announce($"{_focusRow.Name}, session{extra}");
+    }
+
+    /// <summary>Keyboard handling while the sidebar zone has focus (F6). Up/Down walk sessions, Enter/Space
+    /// opens one, Escape/F6 returns to the terminal. Swallows everything else so it can't reach the shell.</summary>
+    private bool SidebarZoneKey(int vk)
+    {
+        var list = AllSessions();
+        if (list.Count == 0) { ExitChromeFocus(); return true; }
+        int idx = _focusRow is not null ? list.IndexOf(_focusRow) : 0;
+        if (idx < 0) idx = 0;
+        switch (vk)
+        {
+            case VK_DOWN: _focusRow = list[Math.Min(idx + 1, list.Count - 1)]; AnnounceFocusRow(); RequestRedraw(); return true;
+            case VK_UP: _focusRow = list[Math.Max(idx - 1, 0)]; AnnounceFocusRow(); RequestRedraw(); return true;
+            case VK_HOME: _focusRow = list[0]; AnnounceFocusRow(); RequestRedraw(); return true;
+            case VK_END: _focusRow = list[^1]; AnnounceFocusRow(); RequestRedraw(); return true;
+            case VK_RETURN: case VK_SPACE:
+                if (_focusRow is not null) SetActive(_focusRow);
+                ExitChromeFocus();
+                return true;
+            case VK_ESCAPE: case 0x75 /* F6 */: ExitChromeFocus(); return true;
+        }
+        return true;
+    }
+
     // ---- System caret (accessibility: Magnifier follow, IME placement, screen-reader caret) ----
     // We render our own cursor, so the system caret is created HIDDEN — it exists only so assistive
     // tech can read the text-cursor position (via GetCaretPos / the caret's location-change events).


### PR DESCRIPTION
From live Narrator use: no way to move keyboard focus **out** of the terminal, and hovering chrome buttons was silent.

## F6 — leave the terminal
`F6` lifts keyboard focus from the terminal to the **sidebar zone** (revealing it if hidden). There:
- **Up/Down/Home/End** walk sessions — a visible **focus ring** + spoken *"‹name›, session, current, N unread"*
- **Enter/Space** opens the focused session
- **Escape/F6** (or a click in the terminal) returns to the terminal

F6 is the Windows convention for cycling a window's panes, so it's the natural "how do I get out of the terminal" gesture — useful for every keyboard user, not just Narrator.

## Spoken hover for chrome buttons
Hovering **Quick terminal, Scratch terminal, Split pane, Settings, New session/workspace, Toggle sidebar, …** now speaks the button name (UIA notification event, gated on a reader actually listening).

## Verified
Live: F6 → sidebar, arrows move the focus ring across alpha/beta/gamma with the name announced (screenshot). 110/110 Core, 38/38 Pty.

## Note on "vertical split" on activation
Not in our UIA tree (it's flat: one Document). It's the **Windows 11 snap-layout hint** synthesized on the maximize caption button — separate from agwinterm. Can suppress snap layouts for the window if it's bothersome.

## Scope
This gives keyboard navigation + spoken feedback now. A **formal fragment tree** (so Narrator's own Tab/scan walks each control as a first-class element) is the deeper follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)