### PR TITLE
feat(uia): formal fragment tree — Narrator scans/Tabs controls as real elements

### DIFF
--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -531,6 +531,87 @@ internal partial class Program : ISessionHost, IWindowHost
         return f;
     }
 
+    // ---- UIA control tree (fragment tree the reader scans/Tabs through) ----
+
+    private UiaRect ScreenRect(float x, float y, float w, float h)
+    {
+        var p = new POINT { x = (int)x, y = (int)y };
+        ClientToScreen(_hwnd, ref p);
+        return new UiaRect { Left = p.x, Top = p.y, Width = Math.Max(0, w), Height = Math.Max(0, h) };
+    }
+
+    /// <summary>Build the accessibility tree snapshot: root → [terminal, sidebar → session items], with
+    /// names, focus, and on-screen bounding rectangles. Runs on the UIA thread.</summary>
+    private Uia.TreeSnapshot BuildUiaTree()
+    {
+        var nodes = new List<Uia.Node> { new() { Kind = Uia.NodeKind.Root, Name = "agwinterm" } };
+
+        int term = nodes.Count;
+        float contentBottom = ClientH() - FooterH;
+        nodes.Add(new Uia.Node
+        {
+            Kind = Uia.NodeKind.Terminal, Name = "terminal", Parent = 0,
+            Focused = !_chromeFocus && !_setOpen,
+            Rect = ScreenRect(_sidebarW, TitleBarH, ClientW() - _sidebarW, contentBottom - TitleBarH),
+        });
+
+        int list = nodes.Count;
+        bool sidebarShown = _sidebarW > 0;
+        nodes.Add(new Uia.Node
+        {
+            Kind = Uia.NodeKind.Sidebar, Name = "Sessions", Parent = 0,
+            Rect = sidebarShown ? ScreenRect(0, TitleBarH, _sidebarW, contentBottom - TitleBarH) : default,
+        });
+
+        // Map each session to its sidebar row rect (from the last render), for bounding rectangles.
+        var rowRect = new Dictionary<Ses, UiaRect>();
+        foreach (var (y0, y1, isWs, item) in _sidebarRows)
+            if (!isWs && item is Ses s && sidebarShown) rowRect[s] = ScreenRect(0, y0, _sidebarW, y1 - y0);
+
+        var sessions = AllSessions();
+        var kids = new List<int>();
+        for (int i = 0; i < sessions.Count; i++)
+        {
+            var s = sessions[i];
+            kids.Add(nodes.Count);
+            nodes.Add(new Uia.Node
+            {
+                Kind = Uia.NodeKind.Session, Index = i, Name = s.Name, Parent = list,
+                Focused = _chromeFocus && ReferenceEquals(_focusRow, s),
+                Selected = ReferenceEquals(_active, s),
+                Rect = rowRect.TryGetValue(s, out var r) ? r : default,
+            });
+        }
+        nodes[list].Children = kids.ToArray();
+        nodes[0].Children = new[] { term, list };
+        return new Uia.TreeSnapshot { Nodes = nodes.ToArray() };
+    }
+
+    /// <summary>A UIA client (or Narrator) called SetFocus on a tree element — move our internal focus.</summary>
+    private void HandleUiaSetFocus(Uia.NodeKind kind, int index)
+    {
+        switch (kind)
+        {
+            case Uia.NodeKind.Terminal: ExitChromeFocus(announce: false); break;
+            case Uia.NodeKind.Sidebar: EnterChromeFocus(); break;
+            case Uia.NodeKind.Session:
+                var list = AllSessions();
+                if (index >= 0 && index < list.Count)
+                {
+                    if (_sidebarW <= 0) ToggleSidebar();
+                    _chromeFocus = true; _focusRow = list[index]; RequestRedraw();
+                }
+                break;
+        }
+    }
+
+    private void RaiseUiaFocusForRow()
+    {
+        if (_focusRow is null) return;
+        int idx = AllSessions().IndexOf(_focusRow);
+        if (idx >= 0) Uia.RaiseFocus(Uia.NodeKind.Session, idx);
+    }
+
     /// <summary>Build the UIA text-pattern snapshot: the active pane's buffer (recent scrollback + the
     /// live screen) flattened into one document, with the caret offset and the mapping from document
     /// lines to on-screen rows (screen px) so ranges can report bounding rectangles. Runs on the UIA
@@ -593,7 +674,7 @@ internal partial class Program : ISessionHost, IWindowHost
     {
         if (!_chromeFocus) return;
         _chromeFocus = false;
-        if (announce) Uia.Announce("Terminal");
+        if (announce) { Uia.Announce("Terminal"); Uia.RaiseFocus(Uia.NodeKind.Terminal, 0); }
         RequestRedraw();
     }
 
@@ -601,6 +682,7 @@ internal partial class Program : ISessionHost, IWindowHost
     {
         if (_focusRow is null) return;
         ShowToast(_focusRow.Name);   // a visible hint alongside the spoken one
+        RaiseUiaFocusForRow();       // move UIA focus to this element (Narrator announces it)
         bool current = ReferenceEquals(_focusRow, _active);
         int unread = UnreadOf(_focusRow);
         string extra = (current ? ", current" : "") + (unread > 0 ? $", {unread} unread" : "");
@@ -785,6 +867,9 @@ internal partial class Program : ISessionHost, IWindowHost
             // Full text-pattern snapshot (ITextProvider): the flattened buffer document + caret +
             // visible-line mapping, so Narrator can read/navigate by line/word/char and box the caret.
             Uia.GetTextSnapshot = BuildUiaTextSnapshot;
+            // Fragment tree (root → terminal + sidebar/sessions) so the reader scans/Tabs the controls.
+            Uia.GetTree = BuildUiaTree;
+            Uia.OnSetFocus = (kind, index) => Post(() => HandleUiaSetFocus(kind, index));
         }
         // CLI args (first window only; consumed so extra windows don't re-apply them).
         string? argProfile = _argProfile, argDir = _argDir;

--- a/src/Agwinterm.Win32/Uia.Text.cs
+++ b/src/Agwinterm.Win32/Uia.Text.cs
@@ -114,8 +114,8 @@ internal partial interface ITextRangeProvider
 [StructLayout(LayoutKind.Sequential)]
 internal struct VariantBlob { public long A, B, C; }
 
-// UiaProvider (declared in Uia.cs) also implements ITextProvider.
-internal partial class UiaProvider : ITextProvider
+// UiaTerminal (declared in Uia.Tree.cs) also implements ITextProvider — the terminal Document element.
+internal partial class UiaTerminal : ITextProvider
 {
     public nint GetSelection()
     {

--- a/src/Agwinterm.Win32/Uia.Tree.cs
+++ b/src/Agwinterm.Win32/Uia.Tree.cs
@@ -1,0 +1,268 @@
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace Agwinterm.Win32;
+
+// UIA fragment tree (T2-14 Stage 3): exposes agwinterm's controls as a navigable, focusable element
+// tree so Narrator/NVDA can scan/Tab through them as first-class elements —
+//   Root (window) ─┬─ Terminal (Document + Text pattern)
+//                  └─ Sidebar (List) ── Session (ListItem) × N
+// Fragments are lightweight: each holds its (kind,index) identity and re-reads a fresh snapshot
+// (Uia.Tree(), built by the app on the UIA thread) to answer navigation/properties/bounds. Stable
+// RuntimeIds let UIA correlate the freshly-built fragments across calls.
+
+internal enum NavigateDirection { Parent = 0, NextSibling = 1, PreviousSibling = 2, FirstChild = 3, LastChild = 4 }
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct UiaRect { public double Left, Top, Width, Height; }
+
+[GeneratedComInterface]
+[Guid("f7063da8-8359-439c-9297-bbc5299a7d87")]
+internal partial interface IRawElementProviderFragment
+{
+    nint Navigate(NavigateDirection direction);   // IRawElementProviderFragment*
+    nint GetRuntimeId();                            // SAFEARRAY(int)
+    UiaRect GetBoundingRectangle();
+    nint GetEmbeddedFragmentRoots();                // SAFEARRAY
+    void SetFocus();
+    nint GetFragmentRoot();                          // IRawElementProviderFragmentRoot*
+}
+
+[GeneratedComInterface]
+[Guid("620ce2a5-ab8f-40a9-86cb-de3c75599b58")]
+internal partial interface IRawElementProviderFragmentRoot
+{
+    nint ElementProviderFromPoint(double x, double y);   // IRawElementProviderFragment*
+    nint GetFocus();                                       // IRawElementProviderFragment*
+}
+
+partial class Uia
+{
+    internal enum NodeKind { Root, Terminal, Sidebar, Session }
+
+    /// <summary>One node in the accessibility tree snapshot (built by Program.BuildUiaTree).</summary>
+    internal sealed class Node
+    {
+        public NodeKind Kind;
+        public int Index;                 // session index (Session nodes)
+        public string Name = "";
+        public bool Focused, Selected;
+        public UiaRect Rect;              // screen px (all zero → fall back to the host/window rect)
+        public int Parent = -1;          // index into TreeSnapshot.Nodes
+        public int[] Children = Array.Empty<int>();
+    }
+
+    internal sealed class TreeSnapshot { public required Node[] Nodes; }   // Nodes[0] is the root
+
+    internal static Func<TreeSnapshot>? GetTree;
+    internal static Action<NodeKind, int>? OnSetFocus;   // app moves internal focus when UIA calls SetFocus
+    private static readonly TreeSnapshot EmptyTree = new()
+    { Nodes = new[] { new Node { Kind = NodeKind.Root, Name = "agwinterm" } } };
+    internal static TreeSnapshot Tree() { try { return GetTree?.Invoke() ?? EmptyTree; } catch { return EmptyTree; } }
+
+    /// <summary>Find a node by identity (kind + index) in a snapshot; null if it's gone (e.g. closed session).</summary>
+    internal static Node? Find(TreeSnapshot t, NodeKind kind, int index)
+    {
+        foreach (var n in t.Nodes) if (n.Kind == kind && n.Index == index) return n;
+        return null;
+    }
+    internal static int IndexOf(TreeSnapshot t, Node n) => Array.IndexOf(t.Nodes, n);
+
+    /// <summary>A COM fragment pointer (IRawElementProviderFragment*, AddRef'd) for a node, or 0.</summary>
+    internal static nint FragmentPtr(NodeKind kind, int index)
+    {
+        object obj = kind switch
+        {
+            NodeKind.Root => new UiaRoot(_treeHwnd),
+            NodeKind.Terminal => new UiaTerminal(_treeHwnd),
+            _ => new UiaFragment(kind, index),
+        };
+        return AsInterface(obj, IID_IRawElementProviderFragment);
+    }
+
+    internal static readonly Guid IID_IRawElementProviderFragment = new("f7063da8-8359-439c-9297-bbc5299a7d87");
+    internal static readonly Guid IID_IRawElementProviderFragmentRoot = new("620ce2a5-ab8f-40a9-86cb-de3c75599b58");
+    internal static nint _treeHwnd;   // set in OnGetObject
+
+    /// <summary>Raise a UIA focus-changed event on a tree node (so the reader announces it) — used when
+    /// F6 / arrow keys move the internal focus.</summary>
+    internal static void RaiseFocus(NodeKind kind, int index)
+    {
+        if (_providerSimple == 0 || !ClientsListening) return;
+        nint frag = 0;
+        try { frag = FragmentPtr(kind, index); if (frag != 0) UiaRaiseAutomationEvent(frag, UIA_AutomationFocusChangedEventId); }
+        catch { }
+        finally { if (frag != 0) Marshal.Release(frag); }
+    }
+
+    private const int UIA_AutomationFocusChangedEventId = 20005;
+
+    // UIA control-type ids + common property ids (shared by all fragments).
+    internal const int CT_Pane = 50033, CT_Document = 50030, CT_List = 50008, CT_ListItem = 50007;
+    internal const int P_ControlType = 30003, P_Name = 30005, P_LocalizedControlType = 30004,
+        P_IsControlElement = 30016, P_IsContentElement = 30017, P_IsKeyboardFocusable = 30009,
+        P_HasKeyboardFocus = 30008;
+}
+
+// ---- Fragment implementations ----
+
+/// <summary>Shared property/navigation logic over a tree node identified by (kind,index).</summary>
+internal abstract class UiaNodeBase
+{
+    protected readonly Uia.NodeKind Kind;
+    protected readonly int Index;
+    protected UiaNodeBase(Uia.NodeKind kind, int index) { Kind = kind; Index = index; }
+
+    protected Uia.Node? Self(Uia.TreeSnapshot t) => Uia.Find(t, Kind, Index);
+
+    public nint Navigate(NavigateDirection direction)
+    {
+        var t = Uia.Tree();
+        var me = Self(t);
+        if (me is null) return 0;
+        int myIdx = Uia.IndexOf(t, me);
+        switch (direction)
+        {
+            case NavigateDirection.Parent:
+                return me.Parent >= 0 ? Uia.FragmentPtr(t.Nodes[me.Parent].Kind, t.Nodes[me.Parent].Index) : 0;
+            case NavigateDirection.FirstChild:
+                return me.Children.Length > 0 ? NodePtr(t, me.Children[0]) : 0;
+            case NavigateDirection.LastChild:
+                return me.Children.Length > 0 ? NodePtr(t, me.Children[^1]) : 0;
+            case NavigateDirection.NextSibling:
+            case NavigateDirection.PreviousSibling:
+            {
+                if (me.Parent < 0) return 0;
+                var sib = t.Nodes[me.Parent].Children;
+                int at = Array.IndexOf(sib, myIdx);
+                int to = direction == NavigateDirection.NextSibling ? at + 1 : at - 1;
+                return at >= 0 && to >= 0 && to < sib.Length ? NodePtr(t, sib[to]) : 0;
+            }
+        }
+        return 0;
+    }
+
+    private static nint NodePtr(Uia.TreeSnapshot t, int nodeIdx) => Uia.FragmentPtr(t.Nodes[nodeIdx].Kind, t.Nodes[nodeIdx].Index);
+
+    public nint GetRuntimeId() => UiaArrays.IntArray(new[] { 42, (int)Kind, Index });   // stable identity
+
+    public UiaRect GetBoundingRectangle() { var n = Self(Uia.Tree()); return n?.Rect ?? default; }
+
+    public nint GetEmbeddedFragmentRoots() => 0;
+
+    public void SetFocus() { try { Uia.OnSetFocus?.Invoke(Kind, Index); } catch { } }
+
+    public nint GetFragmentRoot() => Uia.FragmentRootPtr();
+
+    protected void FillProperty(int propertyId, nint pRetVal, int controlType, string localized, bool content)
+    {
+        var n = Self(Uia.Tree());
+        object? val = propertyId switch
+        {
+            Uia.P_ControlType => controlType,
+            Uia.P_Name => n?.Name is { Length: > 0 } nm ? nm : localized,
+            Uia.P_LocalizedControlType => localized,
+            Uia.P_IsControlElement or Uia.P_IsKeyboardFocusable => true,
+            Uia.P_IsContentElement => content,
+            Uia.P_HasKeyboardFocus => n?.Focused == true,
+            _ => null,
+        };
+        if (val is not null) Marshal.GetNativeVariantForObject(val, pRetVal);
+    }
+}
+
+[GeneratedComClass]
+internal partial class UiaRoot : UiaNodeBase, IRawElementProviderSimple, IRawElementProviderFragment, IRawElementProviderFragmentRoot
+{
+    private readonly nint _hwnd;
+    public UiaRoot(nint hwnd) : base(Uia.NodeKind.Root, 0) => _hwnd = hwnd;
+
+    public ProviderOptions GetProviderOptions() => ProviderOptions.ServerSideProvider;
+    public nint GetPatternProvider(int patternId) => 0;
+    public nint GetHostRawElementProvider() => UiaHostProviderFromHwnd(_hwnd, out nint host) >= 0 ? host : 0;
+    public void GetPropertyValue(int propertyId, nint pRetVal) { VariantInit(pRetVal); FillProperty(propertyId, pRetVal, Uia.CT_Pane, "terminal window", true); }
+
+    // FragmentRoot
+    public nint ElementProviderFromPoint(double x, double y)
+    {
+        var t = Uia.Tree();
+        // deepest node whose rect contains the point (sessions/terminal before the containers)
+        for (int i = t.Nodes.Length - 1; i >= 1; i--)
+        {
+            var r = t.Nodes[i].Rect;
+            if (r.Width > 0 && x >= r.Left && x < r.Left + r.Width && y >= r.Top && y < r.Top + r.Height)
+                return Uia.FragmentPtr(t.Nodes[i].Kind, t.Nodes[i].Index);
+        }
+        return 0;
+    }
+    public nint GetFocus()
+    {
+        var t = Uia.Tree();
+        foreach (var n in t.Nodes) if (n.Focused) return Uia.FragmentPtr(n.Kind, n.Index);
+        return 0;
+    }
+
+    [LibraryImport("uiautomationcore.dll")] private static partial int UiaHostProviderFromHwnd(nint hwnd, out nint provider);
+    [LibraryImport("oleaut32.dll")] private static partial void VariantInit(nint pvarg);
+}
+
+[GeneratedComClass]
+internal partial class UiaTerminal : UiaNodeBase, IRawElementProviderSimple, IRawElementProviderFragment
+{
+    private readonly nint _hwnd;
+    public UiaTerminal(nint hwnd) : base(Uia.NodeKind.Terminal, 0) => _hwnd = hwnd;
+
+    public ProviderOptions GetProviderOptions() => ProviderOptions.ServerSideProvider;
+    public nint GetPatternProvider(int patternId) => patternId == 10014 /* Text */ ? Uia.AsInterface(this, Uia.IID_ITextProvider) : 0;
+    public nint GetHostRawElementProvider() => 0;   // hosted via the root
+    public void GetPropertyValue(int propertyId, nint pRetVal)
+    {
+        VariantInit(pRetVal);
+        // Name = live screen text (so a plain read still speaks the terminal); rest via FillProperty.
+        if (propertyId == Uia.P_Name)
+        {
+            string t = Uia.GetVisibleText?.Invoke() is { Length: > 0 } v ? v : "terminal";
+            Marshal.GetNativeVariantForObject(t, pRetVal);
+            return;
+        }
+        FillProperty(propertyId, pRetVal, Uia.CT_Document, "terminal", true);
+    }
+    [LibraryImport("oleaut32.dll")] private static partial void VariantInit(nint pvarg);
+}
+
+[GeneratedComClass]
+internal partial class UiaFragment : UiaNodeBase, IRawElementProviderSimple, IRawElementProviderFragment
+{
+    public UiaFragment(Uia.NodeKind kind, int index) : base(kind, index) { }
+
+    public ProviderOptions GetProviderOptions() => ProviderOptions.ServerSideProvider;
+    public nint GetPatternProvider(int patternId) => 0;
+    public nint GetHostRawElementProvider() => 0;
+    public void GetPropertyValue(int propertyId, nint pRetVal)
+    {
+        VariantInit(pRetVal);
+        var (ct, lct, content) = Kind switch
+        {
+            Uia.NodeKind.Sidebar => (Uia.CT_List, "session list", false),
+            Uia.NodeKind.Session => (Uia.CT_ListItem, "session", true),
+            _ => (Uia.CT_Pane, "group", false),
+        };
+        FillProperty(propertyId, pRetVal, ct, lct, content);
+    }
+    [LibraryImport("oleaut32.dll")] private static partial void VariantInit(nint pvarg);
+}
+
+internal static partial class UiaArrays
+{
+    private const ushort VT_I4 = 3;
+    public static nint IntArray(int[] vals)
+    {
+        nint sa = SafeArrayCreateVector(VT_I4, 0, (uint)vals.Length);
+        if (sa != 0 && vals.Length > 0 && SafeArrayAccessData(sa, out nint data) >= 0)
+        {
+            Marshal.Copy(vals, 0, data, vals.Length);
+            SafeArrayUnaccessData(sa);
+        }
+        return sa;
+    }
+}

--- a/src/Agwinterm.Win32/Uia.cs
+++ b/src/Agwinterm.Win32/Uia.cs
@@ -12,38 +12,44 @@ namespace Agwinterm.Win32;
 internal static partial class Uia
 {
     private static readonly StrategyBasedComWrappers ComWrappers = new();
-    private static UiaProvider? _provider;   // keep a managed ref alive
-    private static nint _providerSimple;     // QI'd IRawElementProviderSimple* handed to UIA
+    private static UiaRoot? _root;           // keep the singleton root alive
+    private static nint _providerSimple;     // QI'd IRawElementProviderSimple* of the root (handed to UIA)
+    private static nint _fragmentRoot;       // QI'd IRawElementProviderFragmentRoot* of the root
 
-    /// <summary>Supplies the current visible terminal text (set by the app) for the provider's Name.</summary>
+    /// <summary>Supplies the current visible terminal text (set by the app) for the terminal element's Name.</summary>
     internal static Func<string>? GetVisibleText;
 
-    /// <summary>Handle WM_GETOBJECT: return our root UIA provider when UIA asks for it.</summary>
+    /// <summary>Handle WM_GETOBJECT: return our root UIA fragment when UIA asks for it.</summary>
     internal static nint OnGetObject(nint hwnd, nint wParam, nint lParam)
     {
         if ((int)lParam != UiaRootObjectId) return 0;
         if (_providerSimple == 0)
         {
-            _provider = new UiaProvider(hwnd);
-            nint unk = ComWrappers.GetOrCreateComInterfaceForObject(_provider, CreateComInterfaceFlags.None);
+            _treeHwnd = hwnd;
+            _root = new UiaRoot(hwnd);
+            nint unk = ComWrappers.GetOrCreateComInterfaceForObject(_root, CreateComInterfaceFlags.None);
             try
             {
                 // Hand UIA a real IRawElementProviderSimple* (not the raw IUnknown* — vtables differ).
                 Guid iid = IID_IRawElementProviderSimple;
                 if (Marshal.QueryInterface(unk, in iid, out _providerSimple) < 0) _providerSimple = 0;
+                Guid fr = IID_IRawElementProviderFragmentRoot;
+                if (Marshal.QueryInterface(unk, in fr, out _fragmentRoot) < 0) _fragmentRoot = 0;
             }
             finally { Marshal.Release(unk); }
         }
         return _providerSimple != 0 ? UiaReturnRawElementProvider(hwnd, wParam, lParam, _providerSimple) : 0;
     }
 
-    /// <summary>The root terminal element (IRawElementProviderSimple*), AddRef'd — for text ranges'
-    /// GetEnclosingElement. 0 before the provider exists.</summary>
-    internal static nint RootProvider()
+    /// <summary>The fragment root (IRawElementProviderFragmentRoot*), AddRef'd — each fragment's FragmentRoot.</summary>
+    internal static nint FragmentRootPtr()
     {
-        if (_providerSimple != 0) Marshal.AddRef(_providerSimple);
-        return _providerSimple;
+        if (_fragmentRoot != 0) Marshal.AddRef(_fragmentRoot);
+        return _fragmentRoot;
     }
+
+    /// <summary>The terminal element (IRawElementProviderSimple*), AddRef'd — text ranges' GetEnclosingElement.</summary>
+    internal static nint RootProvider() => AsInterface(new UiaTerminal(_treeHwnd), IID_IRawElementProviderSimple);
 
     private static readonly Guid IID_IRawElementProviderSimple = new("d6dd68d1-86fd-4332-8666-9abedea2d24c");
     private const int UiaRootObjectId = -25;
@@ -82,8 +88,8 @@ internal static partial class Uia
 [Flags]
 internal enum ProviderOptions { ClientSideProvider = 0x1, ServerSideProvider = 0x2, NonClientAreaProvider = 0x4, OverrideProvider = 0x8, ProviderOwnsSetFocus = 0x10, UseComThreading = 0x20 }
 
-/// <summary>Minimal server-side UIA element: IRawElementProviderSimple only (control type + name). The
-/// GUID is the standard IRawElementProviderSimple IID; method order matches its COM vtable exactly.</summary>
+/// <summary>Server-side UIA element base (control type + name + patterns). GUID is the standard
+/// IRawElementProviderSimple IID; method order matches its COM vtable exactly.</summary>
 [GeneratedComInterface]
 [Guid("d6dd68d1-86fd-4332-8666-9abedea2d24c")]
 internal partial interface IRawElementProviderSimple
@@ -92,52 +98,4 @@ internal partial interface IRawElementProviderSimple
     nint GetPatternProvider(int patternId);
     void GetPropertyValue(int propertyId, nint pRetVal);   // pRetVal is a caller-allocated VARIANT*
     nint GetHostRawElementProvider();                       // IRawElementProviderSimple** (null = none)
-}
-
-[GeneratedComClass]
-internal partial class UiaProvider : IRawElementProviderSimple
-{
-    private readonly nint _hwnd;
-    public UiaProvider(nint hwnd) => _hwnd = hwnd;
-
-    // Direct (non-marshalled) calls on UIA's thread; our reads are guarded by the session lock.
-    public ProviderOptions GetProviderOptions() => ProviderOptions.ServerSideProvider;
-
-    // Expose the Text pattern so Narrator/NVDA can read & navigate the terminal by line/word/char.
-    public nint GetPatternProvider(int patternId)
-        => patternId == UIA_TextPatternId ? Uia.AsInterface(this, Uia.IID_ITextProvider) : 0;
-
-    private const int UIA_TextPatternId = 10014;
-
-    // Return the HWND host provider so UIA properly *hosts* this element: without it the provider is
-    // unparented — Narrator can't anchor its focus rectangle (it lands somewhere random) and
-    // notification/property events don't route reliably. UiaHostProviderFromHwnd supplies the window's
-    // default bounding rectangle + the event-routing plumbing.
-    public nint GetHostRawElementProvider()
-        => UiaHostProviderFromHwnd(_hwnd, out nint host) >= 0 ? host : 0;
-
-    [LibraryImport("uiautomationcore.dll")] private static partial int UiaHostProviderFromHwnd(nint hwnd, out nint provider);
-
-    public void GetPropertyValue(int propertyId, nint pRetVal)
-    {
-        VariantInit(pRetVal);   // default VT_EMPTY (= "not supported", UIA falls back)
-        object? val = propertyId switch
-        {
-            UIA_ControlTypePropertyId => UIA_DocumentControlTypeId,
-            UIA_NamePropertyId => SafeText(),
-            UIA_IsContentElementPropertyId or UIA_IsControlElementPropertyId or UIA_IsKeyboardFocusablePropertyId => true,
-            UIA_LocalizedControlTypePropertyId => "terminal",
-            _ => null,
-        };
-        if (val is not null) Marshal.GetNativeVariantForObject(val, pRetVal);
-    }
-
-    private static string SafeText() { try { return Uia.GetVisibleText?.Invoke() ?? "terminal"; } catch { return "terminal"; } }
-
-    [LibraryImport("oleaut32.dll")] private static partial void VariantInit(nint pvarg);
-
-    private const int UIA_ControlTypePropertyId = 30003, UIA_NamePropertyId = 30005,
-        UIA_IsControlElementPropertyId = 30016, UIA_IsContentElementPropertyId = 30017,
-        UIA_IsKeyboardFocusablePropertyId = 30009, UIA_LocalizedControlTypePropertyId = 30004;
-    private const int UIA_DocumentControlTypeId = 50030;
 }


### PR DESCRIPTION
The deep accessibility work: agwinterm's controls are now a **navigable, focusable UIA element tree**, not one flat Document. Narrator's own scan/Tab walks each control as a first-class element.

```
[Pane] agwinterm
 ├─ [Document] terminal        ← full Text pattern (line/caret navigation)
 └─ [List] Sessions
      ├─ [ListItem] session 1
      ├─ [ListItem] alpha
      └─ [ListItem] beta
```

## How
- **`Uia.Tree.cs`**: `IRawElementProviderFragment` + `IRawElementProviderFragmentRoot`, a snapshot-driven node model, and per-kind fragment classes. Fragments are lightweight — each holds its `(kind,index)` identity and re-reads a fresh `BuildUiaTree` snapshot to answer Navigate / properties / bounding rectangles. Stable RuntimeIds correlate them across calls.
- The old single provider is gone; the terminal Document (with the **whole Text pattern**) is now a child of the Pane root; the root carries the HWND host provider.
- **Two-way focus**: UIA `SetFocus` on a session moves agwinterm's internal focus (the F6 sidebar zone + focus ring); F6/arrow raises UIA focus-changed events so the reader announces the focused element.

## Verified (UIAutomationClient probe — Narrator's exact path)
- Tree walks root → terminal + Sessions list → session items, each a focusable **ListItem** with its name + a real bounding rect
- Terminal still exposes the **Text pattern** (`DocumentRange.GetText` returns the buffer)
- **`SetFocus("beta")`** → `FocusedElement` = that ListItem, and the focus ring appears on-screen (screenshot)

110/110 Core, 38/38 Pty.

## Backlog (Stage 5)
Workspace group nodes, settings controls as elements, `SelectionItem` pattern ("selected"), and richer roles. Foundation's all here now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)