### PR TITLE
feat(uia): all chrome buttons + settings controls in the tree (invokable)

### DIFF
--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -583,8 +583,81 @@ internal partial class Program : ISessionHost, IWindowHost
             });
         }
         nodes[list].Children = kids.ToArray();
-        nodes[0].Children = new[] { term, list };
+
+        var rootKids = new List<int> { term, list };
+        // Chrome buttons (title bar + footer) as invokable Button elements.
+        var btns = ChromeButtonsForUia();
+        for (int i = 0; i < btns.Count; i++)
+        {
+            rootKids.Add(nodes.Count);
+            nodes.Add(new Uia.Node { Kind = Uia.NodeKind.ChromeButton, Index = i, Name = btns[i].label, Parent = 0, Rect = btns[i].rect });
+        }
+        // Settings dialog controls (when open) under a Settings group.
+        if (_setOpen)
+        {
+            int grp = nodes.Count;
+            rootKids.Add(grp);
+            nodes.Add(new Uia.Node { Kind = Uia.NodeKind.SettingsGroup, Name = "Settings", Parent = 0 });
+            var srows = FocusableRows();
+            var gkids = new List<int>();
+            for (int i = 0; i < srows.Count; i++)
+            {
+                var r = srows[i];
+                gkids.Add(nodes.Count);
+                nodes.Add(new Uia.Node
+                {
+                    Kind = Uia.NodeKind.SettingsControl, Index = i, Parent = grp,
+                    Name = SettingsControlName(r),
+                    Focused = ReferenceEquals(r, _setFocus),
+                    Rect = r.Vis ? ScreenRect(r.Hx0, r.Hy0, Math.Max(1, r.Hx1 - r.Hx0), Math.Max(1, r.Hy1 - r.Hy0)) : default,
+                });
+            }
+            nodes[grp].Children = gkids.ToArray();
+        }
+        nodes[0].Children = rootKids.ToArray();
         return new Uia.TreeSnapshot { Nodes = nodes.ToArray() };
+    }
+
+    /// <summary>Title-bar + footer chrome buttons as (action, spoken label, screen rect) for the UIA tree.</summary>
+    private List<(string action, string label, UiaRect rect)> ChromeButtonsForUia()
+    {
+        var list = new List<(string, string, UiaRect)>();
+        foreach (var (x0, x1, action) in _titleButtons)
+            list.Add((action, ChromeButtonLabel(action), ScreenRect(x0, 0, x1 - x0, TitleBarH)));
+        float fy = ClientH() - FooterH;
+        foreach (var (x0, x1, action) in _footerButtons)
+            list.Add((action, ChromeButtonLabel(action), ScreenRect(x0, fy, x1 - x0, FooterH)));
+        return list;
+    }
+
+    private string SettingsControlName(SetRow r)
+    {
+        if (r.Kind == SW.Button) return r.Label;
+        string val = r.Kind switch
+        {
+            SW.Toggle => IsOn(ConfigValue(r.Key)) ? "on" : "off",
+            SW.Slider => ConfigValue(r.Key),
+            SW.Dropdown or SW.Sound => CurrentDropdownText(r),
+            SW.Path => ConfigValue(r.Key) is { Length: > 0 } p ? p : "not set",
+            SW.Profile => string.Equals(r.Key, _profileCfg.Default, StringComparison.OrdinalIgnoreCase) ? "default" : "not default",
+            _ => "",
+        };
+        return val.Length > 0 ? $"{r.Label}, {val}" : r.Label;
+    }
+
+    /// <summary>UIA Invoke on a button/control — run the same action a click/keypress would.</summary>
+    private void HandleUiaInvoke(Uia.NodeKind kind, int index)
+    {
+        if (kind == Uia.NodeKind.ChromeButton)
+        {
+            var b = ChromeButtonsForUia();
+            if (index >= 0 && index < b.Count) ChromeAction(b[index].action);
+        }
+        else if (kind == Uia.NodeKind.SettingsControl && _setOpen)
+        {
+            var rows = FocusableRows();
+            if (index >= 0 && index < rows.Count) { _setFocus = rows[index]; ActivateSetFocus(); }
+        }
     }
 
     /// <summary>A UIA client (or Narrator) called SetFocus on a tree element — move our internal focus.</summary>
@@ -870,6 +943,7 @@ internal partial class Program : ISessionHost, IWindowHost
             // Fragment tree (root → terminal + sidebar/sessions) so the reader scans/Tabs the controls.
             Uia.GetTree = BuildUiaTree;
             Uia.OnSetFocus = (kind, index) => Post(() => HandleUiaSetFocus(kind, index));
+            Uia.OnInvoke = (kind, index) => Post(() => HandleUiaInvoke(kind, index));
         }
         // CLI args (first window only; consumed so extra windows don't re-apply them).
         string? argProfile = _argProfile, argDir = _argDir;

--- a/src/Agwinterm.Win32/Uia.Tree.cs
+++ b/src/Agwinterm.Win32/Uia.Tree.cs
@@ -38,19 +38,21 @@ internal partial interface IRawElementProviderFragmentRoot
 
 partial class Uia
 {
-    internal enum NodeKind { Root, Terminal, Sidebar, Session }
+    internal enum NodeKind { Root, Terminal, Sidebar, Session, ChromeButton, SettingsGroup, SettingsControl }
 
     /// <summary>One node in the accessibility tree snapshot (built by Program.BuildUiaTree).</summary>
     internal sealed class Node
     {
         public NodeKind Kind;
-        public int Index;                 // session index (Session nodes)
+        public int Index;                 // per-kind ordinal (session / button / settings-row index)
         public string Name = "";
         public bool Focused, Selected;
         public UiaRect Rect;              // screen px (all zero → fall back to the host/window rect)
         public int Parent = -1;          // index into TreeSnapshot.Nodes
         public int[] Children = Array.Empty<int>();
     }
+
+    private static bool IsButton(NodeKind k) => k is NodeKind.ChromeButton or NodeKind.SettingsControl;
 
     internal sealed class TreeSnapshot { public required Node[] Nodes; }   // Nodes[0] is the root
 
@@ -75,10 +77,14 @@ partial class Uia
         {
             NodeKind.Root => new UiaRoot(_treeHwnd),
             NodeKind.Terminal => new UiaTerminal(_treeHwnd),
+            _ when IsButton(kind) => new UiaButton(kind, index),
             _ => new UiaFragment(kind, index),
         };
         return AsInterface(obj, IID_IRawElementProviderFragment);
     }
+
+    internal static Action<NodeKind, int>? OnInvoke;   // app activates a button/control when UIA invokes it
+    internal static readonly Guid IID_IInvokeProvider = new("54fcb24b-e18e-47a2-b4d3-eccbe77599a2");
 
     internal static readonly Guid IID_IRawElementProviderFragment = new("f7063da8-8359-439c-9297-bbc5299a7d87");
     internal static readonly Guid IID_IRawElementProviderFragmentRoot = new("620ce2a5-ab8f-40a9-86cb-de3c75599b58");
@@ -98,7 +104,8 @@ partial class Uia
     private const int UIA_AutomationFocusChangedEventId = 20005;
 
     // UIA control-type ids + common property ids (shared by all fragments).
-    internal const int CT_Pane = 50033, CT_Document = 50030, CT_List = 50008, CT_ListItem = 50007;
+    internal const int CT_Pane = 50033, CT_Document = 50030, CT_List = 50008, CT_ListItem = 50007,
+        CT_Button = 50000, CT_Group = 50026;
     internal const int P_ControlType = 30003, P_Name = 30005, P_LocalizedControlType = 30004,
         P_IsControlElement = 30016, P_IsContentElement = 30017, P_IsKeyboardFocusable = 30009,
         P_HasKeyboardFocus = 30008;
@@ -245,10 +252,31 @@ internal partial class UiaFragment : UiaNodeBase, IRawElementProviderSimple, IRa
         {
             Uia.NodeKind.Sidebar => (Uia.CT_List, "session list", false),
             Uia.NodeKind.Session => (Uia.CT_ListItem, "session", true),
+            Uia.NodeKind.SettingsGroup => (Uia.CT_Group, "settings", false),
             _ => (Uia.CT_Pane, "group", false),
         };
         FillProperty(propertyId, pRetVal, ct, lct, content);
     }
+    [LibraryImport("oleaut32.dll")] private static partial void VariantInit(nint pvarg);
+}
+
+/// <summary>UIA Invoke pattern — lets a screen reader activate a button/control.</summary>
+[GeneratedComInterface]
+[Guid("54fcb24b-e18e-47a2-b4d3-eccbe77599a2")]
+internal partial interface IInvokeProvider { void Invoke(); }
+
+/// <summary>A focusable, invokable Button element — chrome buttons (Quick/Scratch terminal, Split,
+/// Settings, …) and the settings-dialog controls. Invoke runs the same action a click would.</summary>
+[GeneratedComClass]
+internal partial class UiaButton : UiaNodeBase, IRawElementProviderSimple, IRawElementProviderFragment, IInvokeProvider
+{
+    public UiaButton(Uia.NodeKind kind, int index) : base(kind, index) { }
+
+    public ProviderOptions GetProviderOptions() => ProviderOptions.ServerSideProvider;
+    public nint GetPatternProvider(int patternId) => patternId == 10000 /* Invoke */ ? Uia.AsInterface(this, Uia.IID_IInvokeProvider) : 0;
+    public nint GetHostRawElementProvider() => 0;
+    public void GetPropertyValue(int propertyId, nint pRetVal) { VariantInit(pRetVal); FillProperty(propertyId, pRetVal, Uia.CT_Button, "button", true); }
+    public void Invoke() { try { Uia.OnInvoke?.Invoke(Kind, Index); } catch { } }
     [LibraryImport("oleaut32.dll")] private static partial void VariantInit(nint pvarg);
 }
 


### PR DESCRIPTION
Completes "why can't I iterate all my controls / buttons with Caps+arrows" — the UIA tree now includes **every chrome button** and, when open, **every settings control**, each a focusable, invokable Button.

## What's in the tree now
```
[Pane] agwinterm
 ├─ [Document] terminal
 ├─ [List] Sessions → items
 ├─ [Button] Toggle sidebar / Next attention / Scratch terminal / Split pane /
 │           Quick terminal / Settings / New workspace / New session / Flagged view
 └─ [Group] Settings   (while open)
      ├─ [Button] Scroll speed, 3
      ├─ [Button] Right-click pastes clipboard, on
      └─ … every control, named with its value
```

- New `UiaButton` element implements the **Invoke pattern** — UIA Invoke runs the same action a click/keypress would (`ChromeAction` / the settings activation)
- Settings controls named with their current value so a reader announces state

## Verified (UIAutomationClient)
- Tree lists all 9 chrome buttons
- `InvokePattern.Invoke()` on the **Settings** button opens the dialog
- The Settings group then exposes every control with its value

110/110 Core, 38/38 Pty. Pairs with #51 (keyboard focus/Tab inside the dialog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)