### PR TITLE
feat(uia): settings tabs in tree, modal scoping, button tooltips

### DIFF
--- a/src/Agwinterm.Win32/Program.Chrome.cs
+++ b/src/Agwinterm.Win32/Program.Chrome.cs
@@ -1240,9 +1240,48 @@ internal partial class Program
         {
             _hotPaint = hit; _hotAlpha = 1f;   // light instantly on hover-in
             if (Uia.ClientsListening) Uia.Announce(ChromeButtonLabel(hit) + " button");   // speak the hovered button
+            _tipText = null;
+            SetTimer(_hwnd, (IntPtr)TipTimer, 550, IntPtr.Zero);    // tooltip after a short hover dwell
         }
-        else SetTimer(_hwnd, (IntPtr)HoverTimer, 15, IntPtr.Zero);  // fade out when leaving
+        else
+        {
+            KillTimer(_hwnd, (IntPtr)TipTimer);
+            _tipText = null;
+            SetTimer(_hwnd, (IntPtr)HoverTimer, 15, IntPtr.Zero);   // fade out when leaving
+        }
         RequestRedraw();
+    }
+
+    // ---- Hover tooltips for chrome buttons ----
+    private const int TipTimer = 12;      // WM_TIMER id: show the tip after a hover dwell
+    private string? _tipText;             // visible tooltip text (null = none)
+
+    /// <summary>TipTimer fired: show the tooltip for the still-hovered button.</summary>
+    private void TipTick()
+    {
+        KillTimer(_hwnd, (IntPtr)TipTimer);
+        if (_hotBtn is null) return;
+        _tipText = ChromeButtonLabel(_hotBtn);
+        RequestRedraw();
+    }
+
+    /// <summary>Draw the hover tooltip near its button (below title-bar buttons, above footer ones).</summary>
+    private void DrawButtonTip(ID2D1HwndRenderTarget rt, ID2D1SolidColorBrush brush)
+    {
+        if (_tipText is null || _hotBtn is null) return;
+        float bx0 = -1, bx1 = -1; bool footer = false;
+        foreach (var b in _titleButtons) if (b.action == _hotBtn) { bx0 = b.x0; bx1 = b.x1; }
+        if (bx0 < 0) foreach (var b in _footerButtons) if (b.action == _hotBtn) { bx0 = b.x0; bx1 = b.x1; footer = true; }
+        if (bx0 < 0) return;
+        float tw = MeasureText(_tipText, _uiSmall) + 16f, th = 22f;
+        float tx = Math.Clamp((bx0 + bx1) / 2f - tw / 2f, 4f, ClientW() - tw - 4f);
+        float ty = footer ? ClientH() - FooterH - th - 6f : TitleBarH + 6f;
+        brush.Color = Mix(PalBg, ChromeText, 0.10f);
+        rt.FillRoundedRectangle(new RoundedRectangle { Rect = new Rect(tx, ty, tw, th), RadiusX = 5f, RadiusY = 5f }, brush);
+        brush.Color = PalBorder;
+        rt.DrawRoundedRectangle(new RoundedRectangle { Rect = new Rect(tx, ty, tw, th), RadiusX = 5f, RadiusY = 5f }, brush, 1f);
+        brush.Color = ChromeText;
+        rt.DrawText(_tipText, _uiSmallCenter, new Rect(tx, ty, tw, th), brush);
     }
 
     /// <summary>Friendly spoken name for a chrome button action id (screen-reader hover announcements).</summary>

--- a/src/Agwinterm.Win32/Program.Render.cs
+++ b/src/Agwinterm.Win32/Program.Render.cs
@@ -558,6 +558,7 @@ internal partial class Program
         DrawTitleBar(rt, brush);
         DrawSearchBar(rt, brush);
         DrawToast(rt, brush);
+        DrawButtonTip(rt, brush);
         DrawLeaderHint(rt, brush);
         DrawPalette(rt, brush);
         DrawSettingsPanel(rt, brush);

--- a/src/Agwinterm.Win32/Program.WndProc.cs
+++ b/src/Agwinterm.Win32/Program.WndProc.cs
@@ -183,6 +183,7 @@ internal partial class Program
                 if ((int)wParam == 2) { _toastText = null; _toastTarget = null; KillTimer(hwnd, (IntPtr)2); InvalidateRect(hwnd, IntPtr.Zero, false); return IntPtr.Zero; }
                 if ((int)wParam == SelAutoTimer) { SelAutoscrollTick(); return IntPtr.Zero; }
                 if ((int)wParam == HoverTimer) { HoverTick(); return IntPtr.Zero; }
+                if ((int)wParam == TipTimer) { TipTick(); return IntPtr.Zero; }
                 if ((int)wParam == PromptPreviewTimer) { PromptPreviewTick(); return IntPtr.Zero; }
                 if ((int)wParam == RedrawTimer)
                 {

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -546,6 +546,46 @@ internal partial class Program : ISessionHost, IWindowHost
     {
         var nodes = new List<Uia.Node> { new() { Kind = Uia.NodeKind.Root, Name = "agwinterm" } };
 
+        // Settings is modal: while it's open, expose ONLY the dialog (tabs + the current tab's
+        // controls) so a reader can't wander into the inert main-window elements behind it.
+        if (_setOpen)
+        {
+            int grp = nodes.Count;
+            nodes.Add(new Uia.Node
+            {
+                Kind = Uia.NodeKind.SettingsGroup, Name = "Settings", Parent = 0,
+                Rect = ScreenRect(_setCard.Left, _setCard.Top, _setCard.Right - _setCard.Left, _setCard.Bottom - _setCard.Top),
+            });
+            var gkids = new List<int>();
+            for (int i = 0; i < SetTabNames.Length; i++)   // tab items (invokable; current one marked)
+            {
+                gkids.Add(nodes.Count);
+                nodes.Add(new Uia.Node
+                {
+                    Kind = Uia.NodeKind.SettingsTab, Index = i, Parent = grp,
+                    Name = SetTabNames[i] + (i == _setTab ? " tab, selected" : " tab"),
+                    Selected = i == _setTab,
+                    Rect = ScreenRect(_setCard.Left + 8f, _navHit[i * 2], SetNavW - 16f, _navHit[i * 2 + 1] - _navHit[i * 2]),
+                });
+            }
+            var srows = FocusableRows();
+            for (int i = 0; i < srows.Count; i++)
+            {
+                var r = srows[i];
+                gkids.Add(nodes.Count);
+                nodes.Add(new Uia.Node
+                {
+                    Kind = Uia.NodeKind.SettingsControl, Index = i, Parent = grp,
+                    Name = SettingsControlName(r),
+                    Focused = ReferenceEquals(r, _setFocus),
+                    Rect = r.Vis ? ScreenRect(r.Hx0, r.Hy0, Math.Max(1, r.Hx1 - r.Hx0), Math.Max(1, r.Hy1 - r.Hy0)) : default,
+                });
+            }
+            nodes[grp].Children = gkids.ToArray();
+            nodes[0].Children = new[] { grp };
+            return new Uia.TreeSnapshot { Nodes = nodes.ToArray() };
+        }
+
         int term = nodes.Count;
         float contentBottom = ClientH() - FooterH;
         nodes.Add(new Uia.Node
@@ -592,28 +632,6 @@ internal partial class Program : ISessionHost, IWindowHost
             rootKids.Add(nodes.Count);
             nodes.Add(new Uia.Node { Kind = Uia.NodeKind.ChromeButton, Index = i, Name = btns[i].label, Parent = 0, Rect = btns[i].rect });
         }
-        // Settings dialog controls (when open) under a Settings group.
-        if (_setOpen)
-        {
-            int grp = nodes.Count;
-            rootKids.Add(grp);
-            nodes.Add(new Uia.Node { Kind = Uia.NodeKind.SettingsGroup, Name = "Settings", Parent = 0 });
-            var srows = FocusableRows();
-            var gkids = new List<int>();
-            for (int i = 0; i < srows.Count; i++)
-            {
-                var r = srows[i];
-                gkids.Add(nodes.Count);
-                nodes.Add(new Uia.Node
-                {
-                    Kind = Uia.NodeKind.SettingsControl, Index = i, Parent = grp,
-                    Name = SettingsControlName(r),
-                    Focused = ReferenceEquals(r, _setFocus),
-                    Rect = r.Vis ? ScreenRect(r.Hx0, r.Hy0, Math.Max(1, r.Hx1 - r.Hx0), Math.Max(1, r.Hy1 - r.Hy0)) : default,
-                });
-            }
-            nodes[grp].Children = gkids.ToArray();
-        }
         nodes[0].Children = rootKids.ToArray();
         return new Uia.TreeSnapshot { Nodes = nodes.ToArray() };
     }
@@ -657,6 +675,13 @@ internal partial class Program : ISessionHost, IWindowHost
         {
             var rows = FocusableRows();
             if (index >= 0 && index < rows.Count) { _setFocus = rows[index]; ActivateSetFocus(); }
+        }
+        else if (kind == Uia.NodeKind.SettingsTab && _setOpen && index >= 0 && index < SetTabNames.Length)
+        {
+            _setTab = index; _setScroll = 0;
+            _setFocus = FocusableRows().FirstOrDefault();
+            Uia.Announce($"{SetTabNames[index]} tab");
+            RequestRedraw();
         }
     }
 

--- a/src/Agwinterm.Win32/Uia.Tree.cs
+++ b/src/Agwinterm.Win32/Uia.Tree.cs
@@ -38,7 +38,7 @@ internal partial interface IRawElementProviderFragmentRoot
 
 partial class Uia
 {
-    internal enum NodeKind { Root, Terminal, Sidebar, Session, ChromeButton, SettingsGroup, SettingsControl }
+    internal enum NodeKind { Root, Terminal, Sidebar, Session, ChromeButton, SettingsGroup, SettingsControl, SettingsTab }
 
     /// <summary>One node in the accessibility tree snapshot (built by Program.BuildUiaTree).</summary>
     internal sealed class Node
@@ -52,7 +52,7 @@ partial class Uia
         public int[] Children = Array.Empty<int>();
     }
 
-    private static bool IsButton(NodeKind k) => k is NodeKind.ChromeButton or NodeKind.SettingsControl;
+    private static bool IsButton(NodeKind k) => k is NodeKind.ChromeButton or NodeKind.SettingsControl or NodeKind.SettingsTab;
 
     internal sealed class TreeSnapshot { public required Node[] Nodes; }   // Nodes[0] is the root
 
@@ -105,7 +105,7 @@ partial class Uia
 
     // UIA control-type ids + common property ids (shared by all fragments).
     internal const int CT_Pane = 50033, CT_Document = 50030, CT_List = 50008, CT_ListItem = 50007,
-        CT_Button = 50000, CT_Group = 50026;
+        CT_Button = 50000, CT_Group = 50026, CT_TabItem = 50019;
     internal const int P_ControlType = 30003, P_Name = 30005, P_LocalizedControlType = 30004,
         P_IsControlElement = 30016, P_IsContentElement = 30017, P_IsKeyboardFocusable = 30009,
         P_HasKeyboardFocus = 30008;
@@ -275,7 +275,12 @@ internal partial class UiaButton : UiaNodeBase, IRawElementProviderSimple, IRawE
     public ProviderOptions GetProviderOptions() => ProviderOptions.ServerSideProvider;
     public nint GetPatternProvider(int patternId) => patternId == 10000 /* Invoke */ ? Uia.AsInterface(this, Uia.IID_IInvokeProvider) : 0;
     public nint GetHostRawElementProvider() => 0;
-    public void GetPropertyValue(int propertyId, nint pRetVal) { VariantInit(pRetVal); FillProperty(propertyId, pRetVal, Uia.CT_Button, "button", true); }
+    public void GetPropertyValue(int propertyId, nint pRetVal)
+    {
+        VariantInit(pRetVal);
+        var (ct, lct) = Kind == Uia.NodeKind.SettingsTab ? (Uia.CT_TabItem, "tab") : (Uia.CT_Button, "button");
+        FillProperty(propertyId, pRetVal, ct, lct, true);
+    }
     public void Invoke() { try { Uia.OnInvoke?.Invoke(Kind, Index); } catch { } }
     [LibraryImport("oleaut32.dll")] private static partial void VariantInit(nint pvarg);
 }


### PR DESCRIPTION
Three fixes from live Narrator iteration:

## Settings tabs are now elements
`[TabItem] "General tab, selected"`, `"Appearance tab"`, … — each **invokable**: Invoke switches the tab and the tree re-exposes that tab's controls. Verified: `Invoke("Appearance tab")` → controls became *Font, MesloLGSDZ Nerd Font | Font size, 16 | Theme, default…*

## Modal scoping
While Settings is open the UIA tree exposes **only the dialog** — Caps+arrows can't wander into the inert terminal/sidebar/buttons behind it. Escape restores the full tree (verified: root children return to Document + List + 9 Buttons).

## Hover tooltips for all buttons
After a 550 ms dwell, a themed tip ("Quick terminal", "Scratch terminal", …) appears below title-bar buttons / above footer buttons — for sighted users; screen readers already get the spoken hover announcement.

110/110 Core, 38/38 Pty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)