### PR TITLE
docs: Scoop install (yeroo/scoop-bucket)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ Grab either from the [**Releases**](https://github.com/yeroo/agwinterm/releases)
 
 Both are **self-contained** (no .NET runtime needed) and need **no admin rights**.
 
+Or install with [**Scoop**](https://scoop.sh) (uses the portable build; `scoop update` picks up new
+releases automatically):
+
+```powershell
+scoop bucket add agwinterm https://github.com/yeroo/scoop-bucket
+scoop install agwinterm
+```
+
 - Binaries are currently **unsigned**, so SmartScreen will warn on first run → *More info → Run
   anyway*. Release artifacts carry **Sigstore build-provenance attestations** — verify with
   `gh attestation verify <file> --repo yeroo/agwinterm`.


### PR DESCRIPTION
## What

Adds a Scoop install option to the README, backed by the new bucket **[yeroo/scoop-bucket](https://github.com/yeroo/scoop-bucket)** (created from the official `ScoopInstaller/BucketTemplate`).

```powershell
scoop bucket add agwinterm https://github.com/yeroo/scoop-bucket
scoop install agwinterm
```

## Bucket details

- Manifest packages the **portable single-file build** (`#/agwinterm.exe` rename), SHA256 pinned: `2c6f5791b544…`
- `checkver: github` + **Excavator autoupdate** — every future `v*` tag bumps the manifest automatically, no manual steps
- Start-menu shortcut + `agwinterm` on the Scoop shims PATH; settings stay in `%LOCALAPPDATA%\agwinterm`
- Repo topics set (`scoop-bucket`) so it gets indexed on scoop.sh

## Evidence

- Bucket CI (Pester manifest tests, pwsh + powershell): **green** — https://github.com/yeroo/scoop-bucket/actions/runs/29034174005
- Manifest: https://github.com/yeroo/scoop-bucket/blob/main/bucket/agwinterm.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k