### PR TITLE
ci: auto-publish to winget on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,3 +52,26 @@ jobs:
             installer/Output/agwinterm-portable-*.exe
           generate_release_notes: true
           fail_on_unmatched_files: true
+
+  # Opens the version-bump PR to microsoft/winget-pkgs for each release. Runs as a job here
+  # (not a `release:` workflow) because releases published with GITHUB_TOKEN don't trigger
+  # other workflows. Needs the WINGET_TOKEN secret — a classic PAT with the public_repo
+  # scope (used to fork winget-pkgs and open the PR); skips with a warning if unset.
+  # The scoop bucket needs no equivalent: its Excavator updates itself on a schedule.
+  winget:
+    needs: installer
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Submit manifest to winget-pkgs
+        shell: pwsh
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        run: |
+          if (-not $env:WINGET_TOKEN) { Write-Warning 'WINGET_TOKEN secret not set - skipping winget publish'; exit 0 }
+          $version = '${{ github.ref_name }}'.TrimStart('v')
+          $url = "https://github.com/${{ github.repository }}/releases/download/v$version/agwinterm-setup-$version.exe"
+          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          .\wingetcreate.exe update yeroo.agwinterm --version $version --urls $url --submit --token $env:WINGET_TOKEN


### PR DESCRIPTION
## What

Adds a `winget` job to `release.yml`: after the installer job publishes a release, it runs
`wingetcreate update yeroo.agwinterm --submit`, which opens the version-bump PR to
microsoft/winget-pkgs automatically. Microsoft''s bots auto-merge routine bumps, so future
releases publish to winget hands-free.

Implemented as a job in the same workflow (not a `release:`-triggered one) because releases
created with `GITHUB_TOKEN` do not trigger other workflows.

## Manual step required (one-time)

The job needs a **`WINGET_TOKEN`** repo secret — a **classic PAT with the `public_repo` scope**
(it forks winget-pkgs and opens the PR as you). Until the secret is added the job skips with a
warning instead of failing.

Create: GitHub -> Settings -> Developer settings -> Personal access tokens (classic) -> `public_repo` only.
Add: `gh secret set WINGET_TOKEN -R yeroo/agwinterm`

## Context

- Initial package PR (v0.10.0), submitted today: microsoft/winget-pkgs#400270
- Manifests validated locally: `winget validate` -> "Manifest validation succeeded"
- ProductCode `{A7E3F1C2-5B9D-4E6A-8C21-3F0D9B4A7E15}_is1` from the Inno AppId; per-user scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k