### PR TITLE
fix: stable ids across reopen/restore + on-screen window clamp (agterm parity)

### DIFF
--- a/src/Agwinterm.Win32/Program.Services.cs
+++ b/src/Agwinterm.Win32/Program.Services.cs
@@ -1305,7 +1305,8 @@ internal partial class Program
             foreach (var w in st.Workspaces)
             {
                 // Recreate every saved workspace, including empty ones (agterm keeps empty workspaces).
-                var ws = CreateWorkspace(string.IsNullOrEmpty(w.Id) ? Guid.NewGuid().ToString() : w.Id, w.Name);
+                // StableWorkspaceId folds any duplicate id already restored this pass onto a fresh one.
+                var ws = CreateWorkspace(StableWorkspaceId(w.Id), w.Name);
                 foreach (var s in w.Sessions ?? new List<SessionState>())
                 {
                     // Back-compat: a pre-splits session has no Panes — synthesize one from its Cwd/FontSize.
@@ -1314,7 +1315,7 @@ internal partial class Program
                         : new List<PaneState> { new() { Id = s.Id, Cwd = s.Cwd, FontSize = s.FontSize, Ratio = 1f } };
                     var first = pl[0];
                     var ses = CreateSession(
-                        string.IsNullOrEmpty(s.Id) ? Guid.NewGuid().ToString() : s.Id,
+                        StableSessionId(s.Id),
                         string.IsNullOrWhiteSpace(s.Name) ? null : s.Name,
                         string.IsNullOrWhiteSpace(first.Cwd) ? null : first.Cwd,
                         ws, makeActive: s.Id == st.ActiveId,

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -685,11 +685,14 @@ internal partial class Program
         SaveState();
     }
 
-    /// <summary>A recently-closed session's restorable identity (IDE "reopen closed" / browser Ctrl+Shift+T).</summary>
+    /// <summary>A recently-closed session's restorable identity (IDE "reopen closed" / browser Ctrl+Shift+T).
+    /// SessionId is the original id, reused on reopen so control-API/agent references stay stable.</summary>
     private sealed record ClosedSession(string? CustomName, string? ProfileName, string Cwd,
-        string WorkspaceId, string WorkspaceName, bool Flagged, string Display, string Name, long Seq = 0);
-    /// <summary>A recently-closed workspace (its name + all its sessions), so it can be reopened whole.</summary>
-    private sealed record ClosedWorkspace(string Name, IReadOnlyList<ClosedSession> Sessions, long Seq);
+        string WorkspaceId, string WorkspaceName, bool Flagged, string Display, string Name,
+        string SessionId = "", long Seq = 0);
+    /// <summary>A recently-closed workspace (its name + all its sessions), so it can be reopened whole.
+    /// WorkspaceId is the original id, reused on reopen to keep it stable across close→reopen.</summary>
+    private sealed record ClosedWorkspace(string Name, IReadOnlyList<ClosedSession> Sessions, long Seq, string WorkspaceId = "");
     private readonly List<ClosedSession> _closedSessions = new();
     private readonly List<ClosedWorkspace> _closedWorkspaces = new();
     private const int MaxClosedSessions = 25;
@@ -704,7 +707,7 @@ internal partial class Program
         string display = !string.IsNullOrEmpty(ses.CustomName) ? ses.CustomName!
             : (!string.IsNullOrEmpty(cwd) ? Path.GetFileName(cwd.TrimEnd('\\', '/')) : ses.Name);
         if (string.IsNullOrEmpty(display)) display = ses.Name;
-        return new ClosedSession(ses.CustomName, ses.ProfileName, cwd, ses.Ws.Id, ses.Ws.Name, ses.Flagged, display, ses.Name, ++_closeSeq);
+        return new ClosedSession(ses.CustomName, ses.ProfileName, cwd, ses.Ws.Id, ses.Ws.Name, ses.Flagged, display, ses.Name, ses.Id, ++_closeSeq);
     }
 
     /// <summary>Remember a session's identity so it can be reopened after it's closed.</summary>
@@ -721,11 +724,22 @@ internal partial class Program
         {
             if (sessions.Count == 0) return;
             var items = sessions.Select(CaptureClosedSessionData).ToList();
-            _closedWorkspaces.Add(new ClosedWorkspace(ws.Name, items, ++_closeSeq));
+            _closedWorkspaces.Add(new ClosedWorkspace(ws.Name, items, ++_closeSeq, ws.Id));
             if (_closedWorkspaces.Count > MaxClosedSessions) _closedWorkspaces.RemoveAt(0);
         }
         catch { }
     }
+
+    /// <summary>True if any live workspace currently uses this id.</summary>
+    private bool WorkspaceIdInUse(string id) { lock (_workspaces) return _workspaces.Any(w => w.Id == id); }
+    /// <summary>True if any live session (in any workspace) currently uses this id.</summary>
+    private bool SessionIdInUse(string id) { lock (_workspaces) return _workspaces.Any(w => w.Sessions.Any(s => s.Id == id)); }
+    /// <summary>Reuse the preferred id when it's non-empty and free — so ids stay stable across close→reopen
+    /// and restore (agent / control-API references survive); otherwise mint a fresh id to fold the collision.</summary>
+    private string StableWorkspaceId(string? preferred)
+        => !string.IsNullOrEmpty(preferred) && !WorkspaceIdInUse(preferred!) ? preferred! : Guid.NewGuid().ToString();
+    private string StableSessionId(string? preferred)
+        => !string.IsNullOrEmpty(preferred) && !SessionIdInUse(preferred!) ? preferred! : Guid.NewGuid().ToString();
 
     /// <summary>Reopen the most recently closed item — a session or a whole workspace, whichever was closed last.</summary>
     private void ReopenMostRecent()
@@ -752,7 +766,7 @@ internal partial class Program
                  ?? _workspaces.FirstOrDefault(w => string.Equals(w.Name, c.WorkspaceName, StringComparison.OrdinalIgnoreCase))
                  ?? ActiveWorkspace();
         string? cwd = !string.IsNullOrEmpty(c.Cwd) && Directory.Exists(c.Cwd) ? c.Cwd : null;
-        var ses = CreateSession(Guid.NewGuid().ToString(), null, cwd, ws, makeActive: true, profileName: c.ProfileName);
+        var ses = CreateSession(StableSessionId(c.SessionId), null, cwd, ws, makeActive: true, profileName: c.ProfileName);
         if (!string.IsNullOrEmpty(c.CustomName)) { ses.CustomName = c.CustomName; ses.Name = c.CustomName!; } // mirror rename
         else if (!string.IsNullOrEmpty(c.Name)) ses.Name = c.Name;   // restore the original label
         if (c.Flagged) ses.Flagged = true;
@@ -764,12 +778,12 @@ internal partial class Program
     private void ReopenClosedWorkspace(ClosedWorkspace c)
     {
         _closedWorkspaces.Remove(c);
-        var ws = CreateWorkspace(Guid.NewGuid().ToString(), c.Name);
+        var ws = CreateWorkspace(StableWorkspaceId(c.WorkspaceId), c.Name);
         Ses? first = null;
         foreach (var cs in c.Sessions)
         {
             string? cwd = !string.IsNullOrEmpty(cs.Cwd) && Directory.Exists(cs.Cwd) ? cs.Cwd : null;
-            var ses = CreateSession(Guid.NewGuid().ToString(), null, cwd, ws, makeActive: false, profileName: cs.ProfileName);
+            var ses = CreateSession(StableSessionId(cs.SessionId), null, cwd, ws, makeActive: false, profileName: cs.ProfileName);
             if (!string.IsNullOrEmpty(cs.CustomName)) { ses.CustomName = cs.CustomName; ses.Name = cs.CustomName!; }
             else if (!string.IsNullOrEmpty(cs.Name)) ses.Name = cs.Name;
             if (cs.Flagged) ses.Flagged = true;

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -413,6 +413,21 @@ internal partial class Program : ISessionHost, IWindowHost
         }
     }
 
+    /// <summary>Clamp a restored window frame onto the nearest visible monitor work area, so a frame
+    /// saved on a display that's since been unplugged or rearranged can't restore off-screen.</summary>
+    private static void ClampGeoToVisibleScreen(ref int x, ref int y, ref int w, ref int h)
+    {
+        var rc = new RECT { left = x, top = y, right = x + w, bottom = y + h };
+        IntPtr mon = MonitorFromRect(ref rc, MONITOR_DEFAULTTONEAREST);
+        var mi = new MONITORINFO { cbSize = System.Runtime.InteropServices.Marshal.SizeOf<MONITORINFO>() };
+        if (mon == IntPtr.Zero || !GetMonitorInfoW(mon, ref mi)) return;
+        var wa = mi.rcWork;
+        w = Math.Min(w, wa.right - wa.left);
+        h = Math.Min(h, wa.bottom - wa.top);
+        x = Math.Clamp(x, wa.left, wa.right - w);
+        y = Math.Clamp(y, wa.top, wa.bottom - h);
+    }
+
     /// <summary>Per-window bootstrap: create the HWND, its render target, and the initial session.</summary>
     private void Boot(IntPtr hInstance)
     {
@@ -422,6 +437,9 @@ internal partial class Program : ISessionHost, IWindowHost
         // Window size/position comes from the WindowLibrary entry (set by CreateWindowInstance);
         // _geoValid/_geo* are already populated for a restored/positioned window.
         // Created hidden (no WS_VISIBLE) so we can position it before the first paint; shown at the end.
+        // A restored frame can land off every monitor (a display was unplugged / rearranged since save),
+        // leaving the window invisible and unreachable — clamp it onto the nearest visible work area first.
+        if (_geoValid) ClampGeoToVisibleScreen(ref _geoX, ref _geoY, ref _geoW, ref _geoH);
         _creating = this;                    // so the WindowProc trampoline can resolve us during CreateWindowExW
         _hwnd = _geoValid
             ? CreateWindowExW(0, ClassName, "agwinterm", WS_OVERLAPPEDWINDOW,

--- a/src/Agwinterm.Win32/Win32.cs
+++ b/src/Agwinterm.Win32/Win32.cs
@@ -265,6 +265,7 @@ internal static class Win32
 
     [DllImport("user32.dll")] public static extern IntPtr MonitorFromPoint(POINT pt, uint dwFlags);
     [DllImport("user32.dll")] public static extern IntPtr MonitorFromWindow(IntPtr hwnd, uint dwFlags);
+    [DllImport("user32.dll")] public static extern IntPtr MonitorFromRect(ref RECT lprc, uint dwFlags);
     [DllImport("user32.dll")] public static extern bool GetMonitorInfoW(IntPtr hMonitor, ref MONITORINFO lpmi);
     [DllImport("user32.dll")] public static extern bool SetWindowPlacement(IntPtr hWnd, ref WINDOWPLACEMENT lpwndpl);
 


### PR DESCRIPTION
Closes two correctness gaps vs **agterm v0.10.2** found in the gap analysis.

## 1. Stable session/workspace ids across reopen (the big one)

Previously `ReopenClosedSession`/`ReopenClosedWorkspace` minted a **fresh GUID** on reopen, so any agent or `agwintermctl` reference to a session id broke the moment it was closed and reopened. agterm preserves ids here (and just fixed the resulting dup-id class in d71a408/77b99dd).

Now agwinterm:
- Captures the original `SessionId`/`WorkspaceId` in the closed-item records and **reuses them on reopen**.
- Guards against collisions with `StableSessionId`/`StableWorkspaceId` (reuse the id if free, else fold onto a fresh GUID).
- Applies the same guard in `TryRestoreState`, so a persisted snapshot with duplicate ids is de-duped on load (agterm''s "fold duplicate ids when restoring a snapshot").

### Evidence — live E2E against the built binary
Create a session, read its id, close it, reopen with Ctrl+Shift+R, re-read:
```
1) created session, id = 98648147-2e2b-42bb-b27d-9eb0c32377b4
   present in tree?          True
2) after close, id present?  False   (expect False)
3) after reopen, id present? True   (expect True = SAME id restored)

RESULT: PASS - session id 98648147-2e2b-42bb-b27d-9eb0c32377b4 survived close -> reopen
```
(Before this change step 3 would be False — the reopened session carried a new GUID.)

## 2. Clamp restored window to a visible screen (agterm #178)

`Boot` restored the window at the raw saved `_geoX/_geoY/_geoW/_geoH` with no bounds check, so a frame saved on an external monitor that was later unplugged restored **off-screen and unreachable**. Added `ClampGeoToVisibleScreen` (via `MonitorFromRect(..., MONITOR_DEFAULTTONEAREST)` + work-area clamp) before window creation.

## Also confirmed during analysis
- **Hidden toolbar mode already exists** (`toolbar-mode = hidden`, full-bleed) — no change needed.

## Tests
- `dotnet test Agwinterm.slnx` → **148 passed / 0 failed** (Core 110, Pty 38).
- Win32 build clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k