### PR TITLE
feat(appearance): follow Windows light/dark theme (agterm #74)

### DIFF
--- a/src/Agwinterm.Core/TerminalConfig.cs
+++ b/src/Agwinterm.Core/TerminalConfig.cs
@@ -21,6 +21,14 @@ public sealed class TerminalConfig
     public int CursorBlinkMs { get; set; } = 530;
     public string Theme { get; set; } = "default";
 
+    /// <summary>Follow the Windows light/dark app setting, swapping between <see cref="ThemeLight"/> and
+    /// <see cref="ThemeDark"/> as it changes. Off = the single <see cref="Theme"/> is used.</summary>
+    public bool ThemeFollowSystem { get; set; }
+    /// <summary>Theme applied when Windows is in dark mode (used only when <see cref="ThemeFollowSystem"/>).</summary>
+    public string ThemeDark { get; set; } = "";
+    /// <summary>Theme applied when Windows is in light mode (used only when <see cref="ThemeFollowSystem"/>).</summary>
+    public string ThemeLight { get; set; } = "";
+
     /// <summary>Rows of scrollback history kept per pane (0 disables). Scroll up with the wheel / Shift+PgUp.</summary>
     public int Scrollback { get; set; } = 5000;
 
@@ -145,6 +153,12 @@ public sealed class TerminalConfig
         # Color theme (pick live from the action palette; Ctrl+Shift+P -> Select Theme)
         theme = default
 
+        # Follow the Windows light/dark app setting, swapping between theme-dark and theme-light
+        # as it changes (Settings -> Appearance). false = use the single `theme` above.
+        theme-follow-system = false
+        theme-dark =
+        theme-light =
+
         # Scrollback: rows of history to keep per pane (0 disables). Scroll with the wheel or Shift+PgUp/PgDn.
         scrollback-lines = 5000
 
@@ -260,6 +274,9 @@ public sealed class TerminalConfig
                 case "cursor-blink": cfg.CursorBlink = ParseBool(val, cfg.CursorBlink); break;
                 case "cursor-blink-ms": if (int.TryParse(val, out var ms) && ms > 0) cfg.CursorBlinkMs = ms; break;
                 case "theme": if (val.Length > 0) cfg.Theme = val; break;
+                case "theme-follow-system": cfg.ThemeFollowSystem = ParseBool(val, cfg.ThemeFollowSystem); break;
+                case "theme-dark": cfg.ThemeDark = val; break;
+                case "theme-light": cfg.ThemeLight = val; break;
                 case "shell-integration": cfg.ShellIntegration = ParseBool(val, cfg.ShellIntegration); break;
                 case "restore-commands": cfg.RestoreCommands = ParseBool(val, cfg.RestoreCommands); break;
                 case "restore-buffer": cfg.RestoreBuffer = ParseBool(val, cfg.RestoreBuffer); break;

--- a/src/Agwinterm.Win32/Program.Services.cs
+++ b/src/Agwinterm.Win32/Program.Services.cs
@@ -467,6 +467,29 @@ internal partial class Program
 
     private void ApplyTheme(Theme t) { _theme = t; RecomputeChrome(); RequestRedraw(); }
 
+    /// <summary>Resolve the effective theme when "follow Windows light/dark" is on: pick theme-light or
+    /// theme-dark per the current OS setting; when off, fall back to the single manual <c>theme</c>.
+    /// Called at startup, on WM_SETTINGCHANGE (ImmersiveColorSet), and when any theme key changes.</summary>
+    private void ApplySystemTheme()
+    {
+        if (!_config.ThemeFollowSystem) { ApplyTheme(FindTheme(_config.Theme)); return; }
+        string want = WindowsPrefersLightTheme() ? _config.ThemeLight : _config.ThemeDark;
+        if (!string.IsNullOrWhiteSpace(want)) ApplyTheme(FindTheme(want));  // unset side → leave current
+    }
+
+    /// <summary>True when Windows apps are set to light mode (HKCU …Personalize\AppsUseLightTheme=1).
+    /// Missing value or any error → treated as dark, the Windows default.</summary>
+    private static bool WindowsPrefersLightTheme()
+    {
+        try
+        {
+            using var k = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(
+                @"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize");
+            return k?.GetValue("AppsUseLightTheme") is int v && v != 0;
+        }
+        catch { return false; }
+    }
+
     /// <summary>Apply the window-opacity config via a layered window (LWA_ALPHA). 100% removes the layered style.</summary>
     private void ApplyWindowOpacity()
     {
@@ -742,6 +765,7 @@ internal partial class Program
     private static readonly string[] ConfigKeys =
     {
         "font-family", "font-size", "cursor-style", "cursor-blink", "cursor-blink-ms", "theme",
+        "theme-follow-system", "theme-dark", "theme-light",
         "scrollback-lines", "inactive-pane-dim", "unfocused-dim", "builtin-glyphs", "ligatures", "window-opacity", "sidebar-tint", "scroll-speed",
         "new-session-dir", "right-click-paste", "copy-on-select", "word-delimiters", "desktop-notifications", "shell-integration",
         "restore-commands", "restore-buffer", "blocked-sound", "omp-theme", "omp-integration", "prompt-engine", "starship-theme",
@@ -776,6 +800,9 @@ internal partial class Program
         "cursor-blink" => _config.CursorBlink ? "true" : "false",
         "cursor-blink-ms" => _config.CursorBlinkMs.ToString(),
         "theme" => _config.Theme,
+        "theme-follow-system" => _config.ThemeFollowSystem ? "true" : "false",
+        "theme-dark" => _config.ThemeDark,
+        "theme-light" => _config.ThemeLight,
         "scrollback-lines" => _config.Scrollback.ToString(),
         "inactive-pane-dim" => _config.InactivePaneDim.ToString(),
         "unfocused-dim" => _config.UnfocusedDim.ToString(),
@@ -817,6 +844,7 @@ internal partial class Program
         WriteConfigKey(key, value.Trim());
         _config = TerminalConfig.Load(ConfigPath);       // reparse so clamping/validation is centralized
         if (key == "theme") _theme = FindTheme(_config.Theme);
+        if (key is "theme" or "theme-follow-system" or "theme-dark" or "theme-light") ApplySystemTheme();
         if (key == "cursor-blink-ms" && _hwnd != IntPtr.Zero) SetTimer(_hwnd, (IntPtr)1, (uint)_config.CursorBlinkMs, IntPtr.Zero);
         RecomputeChrome();
         ApplyWindowOpacity();

--- a/src/Agwinterm.Win32/Program.WndProc.cs
+++ b/src/Agwinterm.Win32/Program.WndProc.cs
@@ -499,6 +499,13 @@ internal partial class Program
                     return IntPtr.Zero;
                 }
 
+            case WM_SETTINGCHANGE:
+                // The system light/dark switch broadcasts this with lParam = "ImmersiveColorSet".
+                if (lParam != IntPtr.Zero &&
+                    System.Runtime.InteropServices.Marshal.PtrToStringUni(lParam) == "ImmersiveColorSet")
+                    ApplySystemTheme();
+                return DefWindowProcW(hwnd, msg, wParam, lParam);
+
             case WM_ACTIVATE:
                 _windowActive = LoWord(wParam) != 0;   // WA_ACTIVE/WA_CLICKACTIVE vs WA_INACTIVE (drives unfocused dim)
                 if (_config.UnfocusedDim > 0) RequestRedraw();

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -480,6 +480,8 @@ internal partial class Program : ISessionHost, IWindowHost
         CreateRenderTarget();
         StartSession();
 
+        ApplySystemTheme();   // if "follow Windows light/dark" is on, pick light/dark before the first paint
+
         // Apply the custom frame (WM_NCCALCSIZE strips the OS title bar) before showing.
         SetWindowPos(_hwnd, IntPtr.Zero, 0, 0, 0, 0, SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
 

--- a/src/Agwinterm.Win32/Settings.cs
+++ b/src/Agwinterm.Win32/Settings.cs
@@ -125,6 +125,9 @@ internal partial class Program
         Drop(1, "font-family", "Font", fonts);
         Sld(1, "font-size", "Font size", 8, 32);
         Drop(1, "theme", "Theme", _allThemes.Select(t => t.Name).ToArray());
+        Tog(1, "theme-follow-system", "Follow Windows light/dark");
+        Drop(1, "theme-dark", "Dark theme", _allThemes.Select(t => t.Name).ToArray());
+        Drop(1, "theme-light", "Light theme", _allThemes.Select(t => t.Name).ToArray());
         Drop(1, "cursor-style", "Cursor style", new[] { "bar", "block", "underline" });
         Tog(1, "cursor-blink", "Blink cursor");
         Sec(1, "Window");

--- a/src/Agwinterm.Win32/Win32.cs
+++ b/src/Agwinterm.Win32/Win32.cs
@@ -30,6 +30,7 @@ internal static class Win32
     public const uint WM_MOUSEWHEEL = 0x020A;
     public const uint WM_ACTIVATE = 0x0006;   // sent on window activation/deactivation (frontmost tracking)
     public const uint WM_SETFOCUS = 0x0007, WM_KILLFOCUS = 0x0008;   // keyboard-focus in/out (system caret lifetime)
+    public const uint WM_SETTINGCHANGE = 0x001A;   // system setting changed; lParam "ImmersiveColorSet" = light/dark toggle
     public const uint WM_APP_REDRAW = 0x8000; // WM_APP: cross-thread "please repaint"
     public const uint WM_APP_ACTION = 0x8001; // WM_APP+1: drain queued UI-thread actions (pipe callbacks)
     public const uint WM_APP_SYNC = 0x8002;   // WM_APP+2: run a queued func on the UI thread and return its result


### PR DESCRIPTION
Closes the one remaining **feature** gap from the agterm v0.10.2 analysis: following the OS light/dark appearance.

## What
A **Settings → Appearance** toggle **"Follow Windows light/dark"** plus two theme pickers (**Dark theme** / **Light theme**). When enabled, agwinterm applies `theme-dark` or `theme-light` based on the Windows `AppsUseLightTheme` setting, and re-applies **live** when you flip the OS setting (via `WM_SETTINGCHANGE` / `ImmersiveColorSet`) and at startup. When off, the single `theme` is used exactly as before (fully backward-compatible).

New config keys: `theme-follow-system`, `theme-dark`, `theme-light`.

## Evidence — live E2E against the built binary
Configured dark=Tokyo Night, light=Catppuccin Latte, drove the OS signal (targeted to agwinterm only), sampled the terminal background, and **restored the real OS setting afterward**:
```
DARK  mode -> terminal avg RGB = 26,27,38    (#1a1b26 = Tokyo Night)
LIGHT mode -> terminal avg RGB = 239,241,245 (#eff1f5 = Catppuccin Latte)
luminance: dark=28  light=241
RESULT: PASS - window followed Windows light/dark
restored AppsUseLightTheme = 0
```
Screenshots confirm the **whole window** (sidebar + title bar + terminal) retints, not just the terminal body. (Attached in chat.)

## Tests
- `dotnet test Agwinterm.slnx` → **148 passed / 0 failed**.
- Win32 build clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k