### PR TITLE
release: v0.10.1

### DIFF
--- a/installer/agwinterm.iss
+++ b/installer/agwinterm.iss
@@ -2,7 +2,7 @@
 ; Build via installer\build.ps1 (publishes to stage\ then runs ISCC on this file).
 
 #define AppName    "agwinterm"
-#define AppVersion "0.10.0"
+#define AppVersion "0.10.1"
 #define AppExe     "Agwinterm.Win32.exe"
 #define AppPublisher "Boris Kudriashov"
 


### PR DESCRIPTION
Version bump 0.10.0 → 0.10.1 (single source: `installer/agwinterm.iss`).

Tagging `v0.10.1` after merge triggers `release.yml`: installer + portable + Sigstore attestation + GitHub Release, plus the new winget & Chocolatey auto-publish jobs and Scoop Excavator pickup.

**Since v0.10.0:**
- Stable session/workspace ids across reopen + on-screen window-restore clamp (#60)
- Follow Windows light/dark, two configurable themes (#61)
- Keyboard-only Settings focus rectangle + Tab-navigable tab headers (#62)
- Scoop / winget / Chocolatey packaging + CI auto-publish (#57–#59)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k