### PR TITLE
ci: winget/chocolatey publish jobs are best-effort (continue-on-error)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,9 @@ jobs:
     needs: installer
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: windows-latest
+    # Best-effort: a brand-new package can't be updated until its first version clears winget-pkgs
+    # moderation, so this can legitimately fail early on — don't fail the whole release for it.
+    continue-on-error: true
     permissions:
       contents: read
     steps:
@@ -85,6 +88,9 @@ jobs:
     needs: installer
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: windows-latest
+    # Best-effort: Chocolatey rejects new versions of a package whose first version is still in
+    # moderation (403), so this can legitimately fail early on — don't fail the whole release for it.
+    continue-on-error: true
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
The v0.10.1 release run was marked failed only because the winget and Chocolatey auto-publish jobs failed — both because agwinterm''s **first** version (0.10.0) is still in each channel''s moderation queue, so a second version can''t publish yet (winget `update` has no base manifest; `choco push` returns 403).

The core release (installer + portable + Sigstore attestation + GitHub Release) succeeded and is the real deliverable. This marks both publish jobs `continue-on-error: true` so a moderation-gated channel can''t turn the whole release red. They''ll succeed on their own once 0.10.0 is approved on each channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k