### PR TITLE
feat(sidebar): configurable sidebar font size (agterm #187)

### DIFF
--- a/src/Agwinterm.Core/TerminalConfig.cs
+++ b/src/Agwinterm.Core/TerminalConfig.cs
@@ -84,6 +84,9 @@ public sealed class TerminalConfig
     /// <summary>Shifts the themed sidebar shade relative to the theme base: -100 (darker) … +100 (lighter). Default 0.</summary>
     public int SidebarTint { get; set; } = 0;
 
+    /// <summary>Font size (pt) of the workspace/session names in the sidebar. Default 13.</summary>
+    public int SidebarFontSize { get; set; } = 13;
+
     /// <summary>Default working directory for newly created sessions (empty = inherit current behavior).</summary>
     public string NewSessionDir { get; set; } = "";
 
@@ -211,6 +214,9 @@ public sealed class TerminalConfig
         # Sidebar tint relative to the theme: -100 (darker) .. +100 (lighter).
         sidebar-tint = 0
 
+        # Sidebar font size (pt) for workspace/session names (9..20).
+        sidebar-font-size = 13
+
         # Default directory for new sessions (empty = current behavior).
         new-session-dir =
 
@@ -291,6 +297,7 @@ public sealed class TerminalConfig
                 case "ligatures": cfg.Ligatures = ParseBool(val, cfg.Ligatures); break;
                 case "window-opacity": if (int.TryParse(val, out var wo)) cfg.WindowOpacity = System.Math.Clamp(wo, 30, 100); break;
                 case "sidebar-tint": if (int.TryParse(val, out var st)) cfg.SidebarTint = System.Math.Clamp(st, -100, 100); break;
+                case "sidebar-font-size": if (int.TryParse(val, out var sfs)) cfg.SidebarFontSize = System.Math.Clamp(sfs, 9, 20); break;
                 case "new-session-dir": cfg.NewSessionDir = val; break;
                 case "scroll-speed": if (int.TryParse(val, out var ss)) cfg.ScrollSpeed = System.Math.Clamp(ss, 1, 10); break;
                 case "omp-theme": cfg.OmpTheme = val; break;

--- a/src/Agwinterm.Win32/Program.Chrome.cs
+++ b/src/Agwinterm.Win32/Program.Chrome.cs
@@ -96,8 +96,8 @@ internal partial class Program
             brush.Color = SbHeaderText;
             rt.DrawText(expanded ? "▾" : "▸", _format, TextRect(6f, y, 18f, rowH), brush); // chevron (mono, top-aligned)
             if (!ReferenceEquals(_editing, ws)) // the rename box covers the name while editing
-                rt.DrawText(ws.Name, _uiFont, new Rect(24f, y, _sidebarW - 48f, rowH), brush);
-            rt.DrawText(sessions.Count.ToString(), _uiSmall, new Rect(_sidebarW - 28f, y, 22f, rowH), brush);
+                rt.DrawText(ws.Name, _sidebarFont, new Rect(24f, y, _sidebarW - 48f, rowH), brush);
+            rt.DrawText(sessions.Count.ToString(), _sidebarSmall, new Rect(_sidebarW - 28f, y, 22f, rowH), brush);
             _sidebarRows.Add((y, y + rowH, true, ws));
             y += rowH;
 
@@ -166,7 +166,7 @@ internal partial class Program
         bool isDrag = _dragging && ReferenceEquals(s, _dragItem);
         brush.Color = isDrag ? new Color4(0.5f, 0.53f, 0.57f, 0.45f) : (active ? SbActiveText : SbDimText);
         if (!ReferenceEquals(_editing, s)) // the rename box covers the name while editing
-            rt.DrawText(s.Name, _uiFont, new Rect(nameX, y, _sidebarW - nameX - 22f, rowH), brush);
+            rt.DrawText(s.Name, _sidebarFont, new Rect(nameX, y, _sidebarW - nameX - 22f, rowH), brush);
         // Unread-notification count badge, just left of the status circle (can be hidden; the count still tracks).
         int unread = UnreadOf(s);
         if (unread > 0 && _config.NotificationBadges)
@@ -494,7 +494,7 @@ internal partial class Program
         if (label.Length > 0)
         {
             brush.Color = new Color4(1f, 1f, 1f, 0.92f);
-            rt.DrawText(label, _uiFont, new Rect(24f, _dragY - 9f, _sidebarW - 8f, _dragY + 11f), brush);
+            rt.DrawText(label, _sidebarFont, new Rect(24f, _dragY - 9f, _sidebarW - 8f, _dragY + 11f), brush);
         }
     }
 

--- a/src/Agwinterm.Win32/Program.Services.cs
+++ b/src/Agwinterm.Win32/Program.Services.cs
@@ -766,7 +766,7 @@ internal partial class Program
     {
         "font-family", "font-size", "cursor-style", "cursor-blink", "cursor-blink-ms", "theme",
         "theme-follow-system", "theme-dark", "theme-light",
-        "scrollback-lines", "inactive-pane-dim", "unfocused-dim", "builtin-glyphs", "ligatures", "window-opacity", "sidebar-tint", "scroll-speed",
+        "scrollback-lines", "inactive-pane-dim", "unfocused-dim", "builtin-glyphs", "ligatures", "window-opacity", "sidebar-tint", "sidebar-font-size", "scroll-speed",
         "new-session-dir", "right-click-paste", "copy-on-select", "word-delimiters", "desktop-notifications", "shell-integration",
         "restore-commands", "restore-buffer", "blocked-sound", "omp-theme", "omp-integration", "prompt-engine", "starship-theme",
         "new-session-dir-mode", "confirm-close-session", "compact-toolbar", "toolbar-mode", "notification-badges",
@@ -810,6 +810,7 @@ internal partial class Program
         "ligatures" => _config.Ligatures ? "true" : "false",
         "window-opacity" => _config.WindowOpacity.ToString(),
         "sidebar-tint" => _config.SidebarTint.ToString(),
+        "sidebar-font-size" => _config.SidebarFontSize.ToString(),
         "scroll-speed" => _config.ScrollSpeed.ToString(),
         "new-session-dir" => _config.NewSessionDir,
         "right-click-paste" => _config.RightClickPaste ? "true" : "false",
@@ -851,6 +852,7 @@ internal partial class Program
         if (key is "compact-toolbar" or "toolbar-mode")   // title-bar height changed → reflow the terminal grid
         { if (_active is not null) RegridSession(_active); if (_cover is not null) RegridCover(); }
         if (key is "font-family" or "font-size") RebuildFont();   // apply live to the running window
+        if (key == "sidebar-font-size") RebuildSidebarFonts();    // apply the new sidebar name size live
         RequestRedraw();
         RefreshSettingsControls();                        // keep an open Settings window in sync
         bool deferred = key is "scrollback-lines" or "shell-integration" or "restore-commands";

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -230,6 +230,8 @@ internal partial class Program : ISessionHost, IWindowHost
     // Chrome fonts (native Segoe UI for text, icon font for glyphs).
     private static IDWriteTextFormat _uiFont = null!;
     private static IDWriteTextFormat _uiSmall = null!;
+    private static IDWriteTextFormat _sidebarFont = null!;     // sidebar names (size = config sidebar-font-size)
+    private static IDWriteTextFormat _sidebarSmall = null!;    // sidebar counts/badges (sidebar-font-size − 1.5)
     private static IDWriteTextFormat _uiSmallCenter = null!;   // horizontally centered (panel buttons)
     private static IDWriteTextFormat _uiTitle = null!;      // single centered title-bar line (vertically centered + ellipsized)
     private static IDWriteInlineObject _ellipsis = null!;   // "…" trimming sign for the title (kept alive)
@@ -378,6 +380,7 @@ internal partial class Program : ISessionHost, IWindowHost
         _format = CreateTextFormat(_config);
         _uiFont = NewChromeFormat("Segoe UI", 13f, center: false);
         _uiSmall = NewChromeFormat("Segoe UI", 11.5f, center: false);
+        RebuildSidebarFonts();
         _uiSmallCenter = NewChromeFormat("Segoe UI", 11.5f, center: true);
         _uiTitle = NewChromeFormat("Segoe UI", 13f, center: true); // vertically centered single line
         _ellipsis = _dwrite.CreateEllipsisTrimmingSign(_uiTitle);
@@ -538,6 +541,16 @@ internal partial class Program : ISessionHost, IWindowHost
         using var layout = _dwrite.CreateTextLayout(text, fmt, w, h);
         layout.SetTypography(NoLigTypography(), new TextRange(0, (uint)text.Length));
         rt.DrawTextLayout(new System.Numerics.Vector2(rx, y), layout, brush);
+    }
+
+    /// <summary>(Re)create the sidebar name/badge fonts from the configured sidebar-font-size. Shared across
+    /// windows; called at startup and when the setting changes so it applies live.</summary>
+    private static void RebuildSidebarFonts()
+    {
+        float px = System.Math.Clamp(_config.SidebarFontSize, 9, 20);
+        _sidebarFont?.Dispose(); _sidebarSmall?.Dispose();
+        _sidebarFont = NewChromeFormat("Segoe UI", px, center: false);
+        _sidebarSmall = NewChromeFormat("Segoe UI", System.Math.Max(9f, px - 1.5f), center: false);
     }
 
     private static IDWriteTextFormat NewChromeFormat(string family, float px, bool center)

--- a/src/Agwinterm.Win32/Settings.cs
+++ b/src/Agwinterm.Win32/Settings.cs
@@ -138,6 +138,7 @@ internal partial class Program
         Tog(1, "compact-toolbar", "Compact toolbar");
         Sld(1, "window-opacity", "Window opacity", 30, 100);
         Sld(1, "sidebar-tint", "Sidebar tint", -100, 100);
+        Sld(1, "sidebar-font-size", "Sidebar font size", 9, 20);
         Sec(1, "Panes");
         Sld(1, "inactive-pane-dim", "Inactive pane mute", 0, 100);
 


### PR DESCRIPTION
First item from the fresh agterm gap analysis (agterm is now at **v0.11.0**).

## What
New **`sidebar-font-size`** config key (9–20, default 13) with an **Appearance → Window** slider. Scales the workspace/session names, the per-workspace session count, and the drag label, applied **live** via dedicated sidebar font formats. Row height stays terminal-aligned (agterm #175), so only the text scales — no layout disruption.

## Evidence (screenshots attached in chat)
Same sidebar at `sidebar-font-size = 13` vs `19` — names visibly larger, rows unchanged. Set live over the control API.

## Tests
- `dotnet test Agwinterm.slnx` → **148 passed / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k