### PR TITLE
feat(status): clear active agent-status on Ctrl+C / Escape (agterm #185)

### DIFF
--- a/src/Agwinterm.Win32/Program.Input.cs
+++ b/src/Agwinterm.Win32/Program.Input.cs
@@ -997,6 +997,13 @@ internal partial class Program
 
         if (_session is null) return false;
 
+        // User interrupt: Ctrl+C or Escape to the shell clears an "active" agent-status glyph — the
+        // user has taken over the running agent (agterm #185). Falls through so the key still reaches
+        // the terminal. Blocked/Completed keep clearing on select instead.
+        if (_cover is null && (vk == VK_ESCAPE || (ctrl && !alt && vk == 0x43 /* C */))
+            && _active?.ActivePane?.S is { Status: AgentStatus.Active } asf)
+        { asf.SetStatus(AgentStatus.Idle); RequestRedraw(); }
+
         // Kitty keyboard protocol: when an app has enabled it, encode keys in CSI-u form.
         if ((ActiveSurface()?.S.Emulator.KeyboardFlags ?? 0) != 0 && KittyKeyEncode(vk, ctrl, alt, shift) is { } ku)
         { Send(ku); _kittyAteChar = true; return true; }


### PR DESCRIPTION
Second item from the agterm v0.11.0 gap analysis.

## What
When the user interrupts a running agent with **Ctrl+C** or **Escape**, the session''s **active** status glyph resets to idle — they''ve taken over. Scoped to the `Active` state only (Blocked/Completed still clear on select, as before). The keystroke still falls through to the shell.

## Evidence — live E2E
```
1) set active session status -> active
2) after Ctrl+C -> idle
RESULT: PASS - Ctrl+C cleared the active status glyph
```

## Tests
- `dotnet test Agwinterm.slnx` → **148 passed / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k