### PR TITLE
feat(sidebar): multi-session selection + batch actions (agterm #179)

### DIFF
--- a/src/Agwinterm.Win32/Program.Chrome.cs
+++ b/src/Agwinterm.Win32/Program.Chrome.cs
@@ -138,10 +138,21 @@ internal partial class Program
     private void DrawSessionRow(ID2D1HwndRenderTarget rt, ID2D1SolidColorBrush brush, Ses s, float y, float rowH)
     {
         bool active = ReferenceEquals(_active, s);
+        bool selected = _selectedIds.Count > 0 && _selectedIds.Contains(s.Id);
         if (active)
         {
             brush.Color = SbHighlight;
             rt.FillRectangle(new Rect(0, y, _sidebarW, rowH), brush);
+        }
+        else if (selected)   // multi-selected (not the active one): accent-tinted fill
+        {
+            brush.Color = Mix(SbBg, ChromeAccent, 0.20f);
+            rt.FillRectangle(new Rect(0, y, _sidebarW, rowH), brush);
+        }
+        if (selected)        // accent bar marks membership in the multi-selection (incl. the active row)
+        {
+            brush.Color = ChromeAccent;
+            rt.FillRectangle(new Rect(0, y, 3f, rowH), brush);
         }
         // F6 focus ring: the sidebar zone's focused row (keyboard navigation, without the mouse).
         if (_chromeFocus && ReferenceEquals(_focusRow, s))
@@ -248,9 +259,39 @@ internal partial class Program
             if (my < y0 || my >= y1) continue;
             if (ReferenceEquals(item, _showAllMarker)) { _focusedWorkspaceId = null; RequestRedraw(); SaveState(); }
             else if (isWs && item is Workspace ws) { lock (_workspaces) ws.Expanded = !ws.Expanded; RequestRedraw(); SaveState(); }
-            else if (!isWs && item is Ses s) SetActive(s);
+            else if (!isWs && item is Ses s) SidebarSelectClick(s, KeyDown(VK_CONTROL), KeyDown(VK_SHIFT));
             return;
         }
+    }
+
+    /// <summary>Live sessions currently in the multi-selection (Ctrl/Shift+click).</summary>
+    private List<Ses> SelectedSessions()
+    { lock (_workspaces) return _workspaces.SelectMany(w => w.Sessions).Where(x => _selectedIds.Contains(x.Id)).ToList(); }
+
+    private void ClearSelection() { _selectedIds.Clear(); RequestRedraw(); }
+
+    /// <summary>Sidebar session click with modifiers: plain = single-select, Ctrl = toggle one, Shift = range.</summary>
+    private void SidebarSelectClick(Ses s, bool ctrl, bool shift)
+    {
+        var order = _sidebarRows.Where(r => !r.isWs && r.item is Ses).Select(r => (Ses)r.item).ToList();
+        if (shift && _selAnchorId is not null &&
+            order.FindIndex(x => x.Id == _selAnchorId) is var ai and >= 0 &&
+            order.FindIndex(x => x.Id == s.Id) is var ci and >= 0)
+        {
+            _selectedIds.Clear();
+            for (int i = Math.Min(ai, ci); i <= Math.Max(ai, ci); i++) _selectedIds.Add(order[i].Id);
+            SetActive(s);
+        }
+        else if (ctrl)
+        {
+            if (_selectedIds.Count == 0 && _active is not null) _selectedIds.Add(_active.Id);
+            if (!_selectedIds.Add(s.Id)) _selectedIds.Remove(s.Id);   // toggle
+            _selAnchorId = s.Id;
+            SetActive(_selectedIds.Contains(s.Id) ? s : (SelectedSessions().FirstOrDefault() ?? s));
+        }
+        else { _selectedIds.Clear(); _selAnchorId = s.Id; SetActive(s); }
+        if (_selectedIds.Count <= 1) _selectedIds.Clear();   // a lone item is not a multi-selection
+        RequestRedraw();
     }
 
     private object? RowAt(int my)
@@ -353,6 +394,22 @@ internal partial class Program
     {
         var list = new List<PalItem>();
         void A(string label, string hint, Action run) => list.Add(new PalItem { Label = label, Hint = hint, Search = label, Run = run });
+        // Batch menu: right-clicking a session that's part of a multi-selection acts on the whole set.
+        if (item is Ses bs && _selectedIds.Count > 1 && _selectedIds.Contains(bs.Id))
+        {
+            var sel = SelectedSessions();
+            int n = sel.Count;
+            bool allFlagged = sel.All(x => x.Flagged);
+            A(allFlagged ? $"Unflag {n} Sessions" : $"Flag {n} Sessions", "", () => { foreach (var x in sel) FlagOp(x, allFlagged ? "off" : "on"); });
+            List<Workspace> mt; lock (_workspaces) mt = _workspaces.ToList();
+            foreach (var t in mt)
+                A($"Move {n} to — {t.Name}", "", () => { foreach (var x in sel.Where(x => !ReferenceEquals(x.Ws, t))) MoveSession(x, t); ClearSelection(); });
+            if (sel.Any(x => AggStatus(x) != AgentStatus.Idle))
+                A($"Clear Status of {n}", "", () => { foreach (var x in sel) foreach (var p in x.Panes) p.S.SetStatus(AgentStatus.Idle); RequestRedraw(); });
+            list.Add(MenuSeparator());
+            A($"Close {n} Sessions", "", () => { if (ConfirmCloseOk()) { foreach (var x in sel) CloseSessionInternal(x); ClearSelection(); } });
+            return list;
+        }
         if (item is Ses ses)
         {
             if (_profileCfg.Profiles.Count > 1)

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -358,6 +358,8 @@ internal partial class Program
 
     private void SetActive(Ses ses)
     {
+        // Navigating to a session outside the multi-selection drops the selection (single-select again).
+        if (!_selectedIds.Contains(ses.Id)) _selectedIds.Clear();
         _active = ses;
         ClearUnread(ses);   // visiting a session clears its notification badge (agterm's "cleared when seen")
         // Auto-reset-on-select: a status marked auto-reset clears to idle once the user looks at the session.

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -123,6 +123,8 @@ internal partial class Program : ISessionHost, IWindowHost
 
     // Row hit-boxes rebuilt each paint: (top, bottom, isWorkspace, item(Workspace|Ses)).
     private readonly List<(float y0, float y1, bool isWs, object item)> _sidebarRows = new();
+    private readonly HashSet<string> _selectedIds = new();   // multi-selected session ids (Ctrl/Shift+click); >1 = batch mode
+    private string? _selAnchorId;                             // anchor session for Shift+range selection
     // Chrome button hit-boxes rebuilt each paint: (x0, x1, action).
     private readonly List<(float x0, float x1, string action)> _titleButtons = new();
     private readonly List<(float x0, float x1, string action)> _footerButtons = new();


### PR DESCRIPTION
The meaty item from the agterm v0.11.0 gap analysis. Interaction + actions per your choices.

## What
- **Ctrl+click** toggles a session into the selection; **Shift+click** selects a contiguous range. Plain click (or navigating away by keyboard) clears back to single-select.
- Selected rows get an **accent tint + a left accent bar**; the active row keeps its stronger highlight.
- **Right-clicking a selected session** shows batch actions over the whole set:
  - **Flag / Unflag N Sessions**
  - **Move N to — <workspace>** (each other workspace)
  - **Clear Status of N** (when any have a status glyph)
  - **Close N Sessions** (honors confirm-before-close)

## Evidence (screenshot attached in chat)
Clean 4-session window; Ctrl+clicking `alpha` and `beta` (with `gamma` already active) selects all three — accent bars on each, active row distinct. Verified by posting `WM_LBUTTONDOWN` at the row coords while holding Ctrl (mouse injection is DPI-unreliable here). Batch actions reuse already-verified operations (close/flag/move/set-status).

## Tests
- `dotnet test Agwinterm.slnx` → **148 passed / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k