### PR TITLE
feat(control): font can target a specific split/scratch/quick pane (agterm #188)

### DIFF
--- a/src/Agwinterm.Pty/AgentSkill.cs
+++ b/src/Agwinterm.Pty/AgentSkill.cs
@@ -150,7 +150,7 @@ public static class AgentSkill
 
         ## Splits, font, sidebar, theme
         - `agwintermctl session split on|off|toggle` · `session focus left|right|other` · `session resize --split-ratio 0.7` (or `--grow-left/--grow-right N`)
-        - `agwintermctl font inc|dec|reset [--target <id>]`      — per-session font zoom
+        - `agwintermctl font inc|dec|reset [--target <id>]`      — font zoom; target a session (active pane) or a specific split/scratch/quick pane by its id (see `tree` paneIds)
         - `agwintermctl sidebar show|hide|toggle|expand|collapse`
         - `agwintermctl session background set <image> [--opacity 0..100] [--mode fit|fill|center|tile]` — a faint per-session
           watermark drawn behind the terminal (the image is copied into app data); `session background clear` removes it.

--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -283,6 +283,13 @@ public sealed class ControlServer : IDisposable
                         { if (r > 0) sb.Append(','); sb.Append(n.SplitRatios[r].ToString("0.###", System.Globalization.CultureInfo.InvariantCulture)); }
                         sb.Append(']');
                     }
+                    if (n.PaneIds is { Count: > 0 })
+                    {
+                        sb.Append(",\"paneIds\":[");
+                        for (int r = 0; r < n.PaneIds.Count; r++)
+                        { if (r > 0) sb.Append(','); sb.Append(JsonSerializer.Serialize(n.PaneIds[r])); }
+                        sb.Append(']');
+                    }
                 }
                 sb.Append('}');
             }

--- a/src/Agwinterm.Pty/ISessionHost.cs
+++ b/src/Agwinterm.Pty/ISessionHost.cs
@@ -8,7 +8,7 @@ namespace Agwinterm.Pty;
 public sealed record SessionSnapshot(string Id, string Name, bool Active, AgentStatus Status,
     bool Overlay = false, int Notifications = 0, bool Flagged = false, bool Background = false,
     int FocusedPane = 0, int PaneCount = 1, bool StatusBlink = false, int OverlaySize = 0,
-    IReadOnlyList<double>? SplitRatios = null);
+    IReadOnlyList<double>? SplitRatios = null, IReadOnlyList<string>? PaneIds = null);
 
 /// <summary>A workspace (with its sessions) for the control-API tree.</summary>
 public sealed record WorkspaceSnapshot(string Id, string Name, bool Active, IReadOnlyList<SessionSnapshot> Sessions);

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -180,7 +180,8 @@ internal partial class Program
                         s.Overlay is not null, UnreadOf(s), s.Flagged, s.BgPath is not null,
                         FocusedPane: Math.Clamp(s.Active, 0, Math.Max(0, s.Panes.Count - 1)), PaneCount: s.Panes.Count,
                         StatusBlink: AggBlink(s), OverlaySize: s.OverlaySizePercent,
-                        SplitRatios: s.Panes.Select(p => (double)p.Ratio).ToList())).ToList()
+                        SplitRatios: s.Panes.Select(p => (double)p.Ratio).ToList(),
+                        PaneIds: s.Panes.Select(p => p.Id).ToList())).ToList()
                 )).ToList();
         }
 
@@ -242,9 +243,13 @@ internal partial class Program
 
         public bool SetFontSize(string? target, string op)
         {
+            int delta = op switch { "inc" => 1, "dec" => -1, _ => 0 }; // reset otherwise
+            // A specific pane id (split / scratch / overlay / quick terminal) zooms just that pane;
+            // a session id (or null = active) zooms the session's active pane, as before.
+            if (!string.IsNullOrEmpty(target) && FindPaneById(target!) is { } hit)
+            { Post(() => ZoomPane(hit, delta)); return true; }
             var ses = Find(target);
             if (ses is null) return false;
-            int delta = op switch { "inc" => 1, "dec" => -1, _ => 0 }; // reset otherwise
             Post(() => ChangeFontSizeOf(ses, delta));
             return true;
         }

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -614,6 +614,32 @@ internal partial class Program
     private void ChangeFontSizeOfPane(Pane p, int delta)
         => p.FontSize = delta == 0 ? (float)_config.FontSize : Math.Clamp(p.FontSize + delta, 6f, 48f);
 
+    /// <summary>Resolve a pane by id across split panes, per-session scratch/overlay, and the quick terminal
+    /// (so <c>agwintermctl font --target &lt;paneId&gt;</c> can zoom a specific pane). Null if no pane matches.</summary>
+    private (Pane pane, Ses? ses, bool cover)? FindPaneById(string id)
+    {
+        lock (_workspaces)
+            foreach (var w in _workspaces)
+                foreach (var s in w.Sessions)
+                {
+                    foreach (var p in s.Panes) if (p.Id == id) return (p, s, false);
+                    if (s.Scratch is { } sc && sc.Id == id) return (sc, s, true);
+                    if (s.Overlay is { } ov && ov.Id == id) return (ov, s, true);
+                }
+        if (_quick is { } q && q.Id == id) return (q, null, true);
+        return null;
+    }
+
+    /// <summary>Zoom one specific pane's font (delta 0 = reset) and reflow the surface it belongs to.</summary>
+    private void ZoomPane((Pane pane, Ses? ses, bool cover) hit, int delta)
+    {
+        ChangeFontSizeOfPane(hit.pane, delta);
+        if (hit.cover) { if (ReferenceEquals(_cover, hit.pane)) RegridCover(); }   // inactive covers regrid on show
+        else if (hit.ses is not null) RegridSession(hit.ses);
+        RequestRedraw();
+        SaveState();
+    }
+
     /// <summary>Change the active pane's font zoom (delta 0 = reset to config default), reflow + repaint.</summary>
     private void ChangeFontSizeOf(Ses ses, int delta)
     {


### PR DESCRIPTION
The last remaining item from the agterm v0.11.0 gap analysis — you asked for it.

## What
- `agwintermctl font inc|dec|reset --target <id>` now zooms a **specific pane** when the target is a pane id — a split pane, a per-session scratch/overlay, or the quick terminal — instead of always the session''s active pane. A session id (or no target) still zooms the active pane, as before.
- `tree` gains a **`paneIds`** array per multi-pane session so those ids are discoverable externally. (Panes already export their id as `AGWINTERM_SESSION_ID` inside the process, so a script in a pane can zoom its own pane.)

## Evidence (screenshot attached in chat)
Split a session (paneCount=2, focusedPane=1), read `paneIds` from `tree`, then `font inc --target <paneIds[0]>` ×9 — the **non-focused left pane** grows large while the active right pane stays normal. Proves it targets the specific pane, not the active one.
```
paneCount=2 focusedPane=1 paneIds=61548f37-…, 0dc62f20-…
zooming pane 61548f37-…   -> left pane enlarged, right pane unchanged
```

## Tests
- `dotnet test Agwinterm.slnx` → **148 passed / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k