### PR TITLE
release: v0.11.0

### DIFF
--- a/installer/agwinterm.iss
+++ b/installer/agwinterm.iss
@@ -2,7 +2,7 @@
 ; Build via installer\build.ps1 (publishes to stage\ then runs ISCC on this file).
 
 #define AppName    "agwinterm"
-#define AppVersion "0.10.1"
+#define AppVersion "0.11.0"
 #define AppExe     "Agwinterm.Win32.exe"
 #define AppPublisher "Boris Kudriashov"
 


### PR DESCRIPTION
Version bump 0.10.1 → 0.11.0 (single source: `installer/agwinterm.iss`). Minor bump for the feature batch since 0.10.0.

Tagging `v0.11.0` after merge triggers `release.yml`: installer + portable + Sigstore attestation + GitHub Release, plus the best-effort winget & Chocolatey publish jobs and Scoop Excavator pickup.

**Since v0.10.1 (agterm v0.11.0 parity):**
- Configurable sidebar font size (#65)
- Clear active agent-status on Ctrl+C / Escape (#66)
- Multi-session selection + batch actions (#67)
- `font` targeting a specific split/scratch/quick pane + `tree` paneIds (#68)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k