### PR TITLE
feat(dashboard): Ctrl+Shift+D grid overlay of live sessions (agterm #202)

### DIFF
--- a/src/Agwinterm.Win32/Dashboard.cs
+++ b/src/Agwinterm.Win32/Dashboard.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Vortice.Direct2D1;
+using Vortice.Mathematics;
+using static Agwinterm.Win32.Win32;
+
+namespace Agwinterm.Win32;
+
+/// <summary>
+/// Dashboard grid overlay (agterm #202): Ctrl+Shift+D tiles the most-recently-used sessions as a grid
+/// of live terminal surfaces over the content area. Arrow keys move a highlight; Enter or double-click
+/// drops into the highlighted session; Esc closes. View-only — the grid owns input while it's up.
+/// </summary>
+internal partial class Program
+{
+    private bool _dashboardOpen;
+    private readonly List<Ses> _dashSessions = new();
+    private int _dashSel;
+    private readonly List<Rect> _dashCells = new();   // per-cell rects, for mouse hit-testing
+    private const int DashMax = 9;
+
+    private void ToggleDashboard() { if (_dashboardOpen) CloseDashboard(); else OpenDashboard(); }
+
+    private void OpenDashboard()
+    {
+        EnsureMru();
+        var order = _mru.Select(FindSes).Where(s => s is not null).Cast<Ses>().Take(DashMax).ToList();
+        if (order.Count == 0) { ShowToast("No sessions to show"); return; }
+        _dashSessions.Clear(); _dashSessions.AddRange(order);
+        _dashSel = Math.Max(0, _dashSessions.FindIndex(s => ReferenceEquals(s, _active)));
+        _dashboardOpen = true;
+        Uia.Announce($"Dashboard, {_dashSessions.Count} sessions. Arrow keys to move, Enter to open, Escape to close.");
+        RequestRedraw();
+    }
+
+    private void CloseDashboard() { if (!_dashboardOpen) return; _dashboardOpen = false; RequestRedraw(); }
+
+    private static (int cols, int rows) DashGrid(int n)
+    {
+        int cols = (int)Math.Ceiling(Math.Sqrt(n));
+        int rows = (int)Math.Ceiling(n / (double)cols);
+        return (cols, rows);
+    }
+
+    private void DrawDashboard(ID2D1HwndRenderTarget rt, ID2D1SolidColorBrush brush)
+    {
+        if (!_dashboardOpen) return;
+        _dashCells.Clear();
+        var (ax, ay, aw, ah) = ContentArea();
+        brush.Color = C4(_theme.DefaultBackground);
+        rt.FillRectangle(new Rect(ax, ay, aw, ah), brush);
+
+        int n = _dashSessions.Count;
+        var (cols, rows) = DashGrid(n);
+        const float pad = 8f, labelH = 20f, footH = 22f;
+        float gridH = ah - footH;
+        float cellW = (aw - pad * (cols + 1)) / cols;
+        float cellH = (gridH - pad * (rows + 1)) / rows;
+
+        // One uniform font size for the whole grid: shrink so the largest session's cols×rows fit a cell.
+        const float BASE = 14f;
+        var (_, cwB, chB) = Metrics(BASE);
+        int maxCols = 1, maxRows = 1;
+        foreach (var s in _dashSessions)
+            lock (s.S.SyncRoot) { maxCols = Math.Max(maxCols, s.S.Emulator.Screen.Cols); maxRows = Math.Max(maxRows, s.S.Emulator.Screen.Rows); }
+        float termW = MathF.Max(1f, cellW - 8f), termH = MathF.Max(1f, cellH - labelH - 6f);
+        float fs = Math.Clamp(MathF.Floor(MathF.Min(termW / maxCols / cwB * BASE, termH / maxRows / chB * BASE)), 5f, BASE);
+        var (fmt, cw, ch) = Metrics(fs);
+
+        for (int i = 0; i < n; i++)
+        {
+            int col = i % cols, row = i / cols;
+            float cx = ax + pad + col * (cellW + pad);
+            float cy = ay + pad + row * (cellH + pad);
+            bool sel = i == _dashSel;
+            var s = _dashSessions[i];
+            _dashCells.Add(new Rect(cx, cy, cellW, cellH));
+
+            brush.Color = C4(_theme.DefaultBackground);
+            rt.FillRectangle(new Rect(cx, cy, cellW, cellH), brush);
+
+            // Title strip
+            brush.Color = sel ? ChromeAccent : Mix(C4(_theme.DefaultBackground), ChromeDim, 0.5f);
+            rt.FillRectangle(new Rect(cx, cy, cellW, labelH), brush);
+            brush.Color = sel ? new Color4(1f, 1f, 1f, 1f) : ChromeText;
+            rt.DrawText($"{s.Ws.Name} / {s.Name}", _uiSmall, new Rect(cx + 6f, cy + 1f, cellW - 12f, labelH - 1f), brush, DrawTextOptions.Clip);
+
+            // Live terminal preview, clipped to the cell body
+            float tx = cx + 4f, ty = cy + labelH + 2f, tw = MathF.Max(1f, cellW - 8f), th = MathF.Max(1f, cellH - labelH - 6f);
+            rt.PushAxisAlignedClip(new Rect(tx, ty, tw, th), AntialiasMode.Aliased);
+            RenderTerminal(s.S, tx, ty, fmt, cw, ch, 0);
+            rt.PopAxisAlignedClip();
+
+            brush.Color = sel ? ChromeAccent : PalBorder;
+            rt.DrawRectangle(new Rect(cx, cy, cellW, cellH), brush, sel ? 2f : 1f);
+        }
+
+        brush.Color = ChromeDim;
+        rt.DrawText("Dashboard — arrows move · Enter open · Esc close", _uiSmall,
+            new Rect(ax + 8f, ay + ah - footH + 3f, aw - 16f, footH - 4f), brush);
+    }
+
+    /// <summary>Key handling while the dashboard is up; swallows everything (view-only, modal).</summary>
+    private bool DashboardKey(int vk)
+    {
+        var (cols, _) = DashGrid(_dashSessions.Count);
+        int n = _dashSessions.Count;
+        switch (vk)
+        {
+            case VK_ESCAPE: CloseDashboard(); return true;
+            case VK_RETURN: case VK_SPACE:
+                if (_dashSel >= 0 && _dashSel < n) { var s = _dashSessions[_dashSel]; CloseDashboard(); SetActive(s); }
+                return true;
+            case VK_LEFT: if (_dashSel % cols != 0) DashSelect(_dashSel - 1); return true;
+            case VK_RIGHT: if (_dashSel % cols != cols - 1 && _dashSel + 1 < n) DashSelect(_dashSel + 1); return true;
+            case VK_UP: if (_dashSel - cols >= 0) DashSelect(_dashSel - cols); return true;
+            case VK_DOWN: if (_dashSel + cols < n) DashSelect(_dashSel + cols); return true;
+            case VK_HOME: DashSelect(0); return true;
+            case VK_END: DashSelect(n - 1); return true;
+        }
+        return true;
+    }
+
+    private void DashSelect(int i)
+    {
+        if (i < 0 || i >= _dashSessions.Count || i == _dashSel) return;
+        _dashSel = i;
+        Uia.Announce(_dashSessions[i].Name);
+        RequestRedraw();
+    }
+
+    /// <summary>Mouse in the dashboard: single click highlights a cell, double-click drops into it.</summary>
+    private void DashboardClick(int mx, int my, bool doubleClick)
+    {
+        for (int i = 0; i < _dashCells.Count; i++)
+        {
+            var c = _dashCells[i];
+            if (mx >= c.Left && mx < c.Right && my >= c.Top && my < c.Bottom)
+            {
+                if (doubleClick) { var s = _dashSessions[i]; CloseDashboard(); SetActive(s); }
+                else DashSelect(i);
+                return;
+            }
+        }
+    }
+}

--- a/src/Agwinterm.Win32/Program.Input.cs
+++ b/src/Agwinterm.Win32/Program.Input.cs
@@ -913,6 +913,10 @@ internal partial class Program
             if (!altScreen) { OpenHelp(); return true; }
         }
 
+        // Dashboard grid overlay (agterm #202): Ctrl+Shift+D toggles it; while open it owns the keyboard.
+        if (ctrl && shift && !alt && vk == 0x44 /* D */) { ToggleDashboard(); return true; }
+        if (_dashboardOpen) return DashboardKey(vk);
+
         // Focus zones (F6): the sidebar zone owns the keyboard while active; plain F6 from the terminal
         // lifts focus out to the sidebar (the accessible "leave the terminal" gesture).
         if (_chromeFocus) return SidebarZoneKey(vk);

--- a/src/Agwinterm.Win32/Program.Render.cs
+++ b/src/Agwinterm.Win32/Program.Render.cs
@@ -518,6 +518,31 @@ internal partial class Program
         rt.BeginDraw();
         rt.Clear(C4(_theme.DefaultBackground));
 
+        // Dashboard grid overlay replaces the terminal content while it's up (agterm #202); the sidebar
+        // and title bar still render below.
+        if (_dashboardOpen) DrawDashboard(rt, brush);
+        else DrawWindowContent(rt, brush);
+        if (!_windowActive && _config.UnfocusedDim > 0)   // dim the content region when the window isn't focused
+        {
+            var (dx, dy, dw, dh) = ContentArea();
+            brush.Color = new Color4(0f, 0f, 0f, Math.Clamp(_config.UnfocusedDim, 0, 90) / 100f);
+            rt.FillRectangle(new Rect(dx, dy, dw, dh), brush);
+        }
+        DrawSidebar(rt, brush);
+        DrawTitleBar(rt, brush);
+        DrawSearchBar(rt, brush);
+        DrawToast(rt, brush);
+        DrawButtonTip(rt, brush);
+        DrawHelp(rt, brush);   // topmost overlay
+        DrawLeaderHint(rt, brush);
+        DrawPalette(rt, brush);
+        DrawSettingsPanel(rt, brush);
+        DrawSwitcher(rt, brush);
+    }
+
+    /// <summary>The normal terminal content: the active session's pane grid, or a cover/quick/overlay panel.</summary>
+    private void DrawWindowContent(ID2D1HwndRenderTarget rt, ID2D1SolidColorBrush brush)
+    {
         // Quick terminal (kind 2) and a sized floating overlay (kind 3) both render as a centered
         // panel over the live main window — a "tool window" look. Scratch (1) / full overlay fill.
         bool floatingPanel = _cover is not null && ((_coverKind == 3 && _ovlOwner is { OverlaySizePercent: > 0 }) || _coverKind == 2);
@@ -548,22 +573,6 @@ internal partial class Program
                 if (_coverKind == 3) DrawOverlayFooter(rt, brush);          // overlay-only footer
             }
         }
-        if (!_windowActive && _config.UnfocusedDim > 0)   // dim the content region when the window isn't focused
-        {
-            var (dx, dy, dw, dh) = ContentArea();
-            brush.Color = new Color4(0f, 0f, 0f, Math.Clamp(_config.UnfocusedDim, 0, 90) / 100f);
-            rt.FillRectangle(new Rect(dx, dy, dw, dh), brush);
-        }
-        DrawSidebar(rt, brush);
-        DrawTitleBar(rt, brush);
-        DrawSearchBar(rt, brush);
-        DrawToast(rt, brush);
-        DrawButtonTip(rt, brush);
-        DrawHelp(rt, brush);   // topmost overlay
-        DrawLeaderHint(rt, brush);
-        DrawPalette(rt, brush);
-        DrawSettingsPanel(rt, brush);
-        DrawSwitcher(rt, brush);
     }
 
     /// <summary>The Ctrl+Tab switcher HUD: a centered panel listing sessions in recency order with the

--- a/src/Agwinterm.Win32/Program.WndProc.cs
+++ b/src/Agwinterm.Win32/Program.WndProc.cs
@@ -279,6 +279,7 @@ internal partial class Program
                     }
                     if (_setOpen) { SettingsClick(mx, my); return IntPtr.Zero; }
                     if (_palette != PaletteKind.None) { PaletteClick(mx, my); return IntPtr.Zero; }
+                    if (_dashboardOpen) { DashboardClick(mx, my, doubleClick: false); return IntPtr.Zero; }
                     // Notification banner: clicking it jumps to the raising session and dismisses.
                     if (_toastText is not null && _toastTarget is not null &&
                         mx >= _toastRect.Left && mx <= _toastRect.Right && my >= _toastRect.Top && my <= _toastRect.Bottom)
@@ -379,6 +380,7 @@ internal partial class Program
             case WM_LBUTTONDBLCLK:
                 {
                     int mx = LoWord(lParam), my = HiWord(lParam);
+                    if (_dashboardOpen) { DashboardClick(mx, my, doubleClick: true); return IntPtr.Zero; }
                     if (mx < (int)_sidebarW && my >= (int)TitleBarH && my < ClientH() - (int)FooterH)
                     {
                         var item = RowAt(my);


### PR DESCRIPTION
The headline agterm v0.12 feature.

## What
**Ctrl+Shift+D** tiles the most-recently-used sessions (up to 9) as a grid of **live** terminal previews over the content area:
- **Arrow keys** move a highlight (clamped, no wrapping); **Enter** or **double-click** drops into the highlighted session; **Esc** closes.
- **View-only** while up — the grid owns the keyboard, so session shortcuts don''t leak through.
- Cells **auto-size** their font so the largest session''s grid fits; each cell shows a `workspace / session` title strip. The sidebar and title bar stay visible.

## Evidence (screenshots attached in chat)
Four sessions with distinct output (`ONE`/`AAAA`/`BBBB`/`GGGG`) → a 2×2 grid of live previews with the selection accent on `gamma`; Right-arrow moves it to `beta`; Enter jumps in:
```
active after Enter: beta
```

## Notes / scope
MVP of agterm''s dashboard. Not included yet (easy follow-ups if wanted): the `agwintermctl dashboard <ids> [--close]` CLI and explicit `--font-size`/`--auto-size` flags — this version uses MRU sessions + auto font sizing.

## Tests
- `dotnet test Agwinterm.slnx` → **148 passed / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k