### PR TITLE
feat(dashboard): agwintermctl dashboard CLI + --font-size (agterm #202 follow-up)

### DIFF
--- a/src/Agwinterm.Ctl/Program.cs
+++ b/src/Agwinterm.Ctl/Program.cs
@@ -261,6 +261,14 @@ switch (area)
         if (sub is not ("inc" or "dec" or "reset")) { Console.Error.WriteLine("usage: agwintermctl font inc|dec|reset [--target ID]"); return 2; }
         cargs["op"] = sub;
         break;
+    case "dashboard":
+        // agwintermctl dashboard [<id> ...] [--close] [--font-size N | --auto-size]
+        cmd = "dashboard";
+        var dashIds = positionals.Skip(1).ToList();   // session ids after "dashboard"
+        if (dashIds.Count > 0) cargs["ids"] = string.Join(",", dashIds);
+        if (options.ContainsKey("close")) cargs["close"] = true;
+        if (Opt("font-size") is { } dfs && int.TryParse(dfs, out var dfsn)) cargs["font-size"] = dfsn;   // omit / --auto-size => auto
+        break;
     case "window":
         // agwintermctl window new|list|select|close|delete|rename|resize|move|zoom [<window>] ...
         cmd = "window." + sub;

--- a/src/Agwinterm.Pty/AgentSkill.cs
+++ b/src/Agwinterm.Pty/AgentSkill.cs
@@ -151,6 +151,7 @@ public static class AgentSkill
         ## Splits, font, sidebar, theme
         - `agwintermctl session split on|off|toggle` · `session focus left|right|other` · `session resize --split-ratio 0.7` (or `--grow-left/--grow-right N`)
         - `agwintermctl font inc|dec|reset [--target <id>]`      — font zoom; target a session (active pane) or a specific split/scratch/quick pane by its id (see `tree` paneIds)
+        - `agwintermctl dashboard [<id> ...] [--close] [--font-size N]` — grid overlay of live sessions (no ids = most-recent; `--close` dismisses; Ctrl+Shift+D toggles it in the UI)
         - `agwintermctl sidebar show|hide|toggle|expand|collapse`
         - `agwintermctl session background set <image> [--opacity 0..100] [--mode fit|fill|center|tile]` — a faint per-session
           watermark drawn behind the terminal (the image is copied into app data); `session background clear` removes it.

--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -136,6 +136,7 @@ public sealed class ControlServer : IDisposable
                 case "session.close": return host.CloseSession(target ?? "active") ? Ok("closed") : Err("session not found");
                 case "workspace.new": return Ok(host.NewWorkspace(GetString(args, "name")));
                 case "font": return host.SetFontSize(target, GetString(args, "op") ?? "") ? Ok("font") : Err("session not found");
+                case "dashboard": return host.Dashboard(GetBool(args, "close"), GetString(args, "ids"), GetInt(args, "font-size", 0)) ? Ok("dashboard") : Err("dashboard unavailable");
 
                 // ---- Wave A1: verb parity ----
                 case "session.go": host.SessionGo(GetString(args, "dir") ?? "next"); return Ok("go");

--- a/src/Agwinterm.Pty/ISessionHost.cs
+++ b/src/Agwinterm.Pty/ISessionHost.cs
@@ -56,6 +56,9 @@ public interface ISessionHost
 
     /// <summary>Adjust a session's font zoom: op = "inc" | "dec" | "reset". Returns false if the target isn't found.</summary>
     bool SetFontSize(string? target, string op);
+    /// <summary>Open/close the dashboard grid: ids = comma/space-separated session ids (empty = MRU),
+    /// close dismisses it, fontSize pins a cell font size (0 = auto).</summary>
+    bool Dashboard(bool close, string? ids, int fontSize);
 
     // ---- Wave A1: verb parity for existing features (all marshal to the UI thread) ----
 
@@ -203,6 +206,7 @@ public sealed class SingleSessionHost : ISessionHost
     public bool CloseSession(string target) => false;
     public string NewWorkspace(string? name) => "ws";
     public bool SetFontSize(string? target, string op) => false; // no per-session font zoom in the single-session host
+    public bool Dashboard(bool close, string? ids, int fontSize) => false; // no dashboard in the single-session host
 
     // Wave A1 verbs — no-ops for the single-session test adapter.
     public void SessionGo(string dir) { }

--- a/src/Agwinterm.Win32/Dashboard.cs
+++ b/src/Agwinterm.Win32/Dashboard.cs
@@ -17,17 +17,22 @@ internal partial class Program
     private bool _dashboardOpen;
     private readonly List<Ses> _dashSessions = new();
     private int _dashSel;
+    private int _dashFontPin;   // 0 = auto-size to fit; >0 = pinned font size (agwintermctl --font-size)
     private readonly List<Rect> _dashCells = new();   // per-cell rects, for mouse hit-testing
     private const int DashMax = 9;
 
     private void ToggleDashboard() { if (_dashboardOpen) CloseDashboard(); else OpenDashboard(); }
 
-    private void OpenDashboard()
+    /// <summary>Open the dashboard over the given sessions (null/empty = the most-recently-used ones),
+    /// optionally pinning a font size (0 = auto-size to fit).</summary>
+    private void OpenDashboard(List<Ses>? sessions = null, int fontPin = 0)
     {
-        EnsureMru();
-        var order = _mru.Select(FindSes).Where(s => s is not null).Cast<Ses>().Take(DashMax).ToList();
+        List<Ses> order;
+        if (sessions is { Count: > 0 }) order = sessions.Take(DashMax).ToList();
+        else { EnsureMru(); order = _mru.Select(FindSes).Where(s => s is not null).Cast<Ses>().Take(DashMax).ToList(); }
         if (order.Count == 0) { ShowToast("No sessions to show"); return; }
         _dashSessions.Clear(); _dashSessions.AddRange(order);
+        _dashFontPin = fontPin > 0 ? Math.Clamp(fontPin, 4, 40) : 0;
         _dashSel = Math.Max(0, _dashSessions.FindIndex(s => ReferenceEquals(s, _active)));
         _dashboardOpen = true;
         Uia.Announce($"Dashboard, {_dashSessions.Count} sessions. Arrow keys to move, Enter to open, Escape to close.");
@@ -65,7 +70,9 @@ internal partial class Program
         foreach (var s in _dashSessions)
             lock (s.S.SyncRoot) { maxCols = Math.Max(maxCols, s.S.Emulator.Screen.Cols); maxRows = Math.Max(maxRows, s.S.Emulator.Screen.Rows); }
         float termW = MathF.Max(1f, cellW - 8f), termH = MathF.Max(1f, cellH - labelH - 6f);
-        float fs = Math.Clamp(MathF.Floor(MathF.Min(termW / maxCols / cwB * BASE, termH / maxRows / chB * BASE)), 5f, BASE);
+        float fs = _dashFontPin > 0
+            ? _dashFontPin   // pinned via --font-size (content may clip; the cell is clipped anyway)
+            : Math.Clamp(MathF.Floor(MathF.Min(termW / maxCols / cwB * BASE, termH / maxRows / chB * BASE)), 5f, BASE);
         var (fmt, cw, ch) = Metrics(fs);
 
         for (int i = 0; i < n; i++)

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -254,6 +254,22 @@ internal partial class Program
             return true;
         }
 
+        /// <summary>Control-API dashboard: open over explicit session ids (comma/space separated; empty =
+        /// most-recently-used), close it, and optionally pin a font size. (agterm #202 CLI.)</summary>
+        public bool Dashboard(bool close, string? ids, int fontSize)
+        {
+            Post(() =>
+            {
+                if (close) { CloseDashboard(); return; }
+                List<Ses>? list = null;
+                if (!string.IsNullOrWhiteSpace(ids))
+                    list = ids!.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries)
+                               .Select(id => Find(id)).Where(s => s is not null).Cast<Ses>().ToList();
+                OpenDashboard(list, fontSize);
+            });
+            return true;
+        }
+
         // ---- Wave A1 verbs ----
         public void SessionGo(string dir) => Post(() => SessionGoInternal(dir));
 

--- a/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
+++ b/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
@@ -73,6 +73,7 @@ internal sealed class FakeSessionHost : ISessionHost
     public string ProfilesList() => "default";
     public string ProfilesReload() => "1 profile loaded";
     public bool SetFontSize(string? target, string op) => Find(target) is not null;
+    public bool Dashboard(bool close, string? ids, int fontSize) => true;
 
     public void SessionGo(string dir) { }
     public bool SessionReorder(string? target, string dir) => Find(target) is not null;


### PR DESCRIPTION
Follow-up to the dashboard (#72), completing agterm''s dashboard surface.

## What
New control verb: **`agwintermctl dashboard [<id> ...] [--close] [--font-size N]`**
- No ids → opens over the most-recently-used sessions (same as Ctrl+Shift+D).
- Explicit **session ids** → opens over exactly those.
- **`--close`** dismisses it.
- **`--font-size N`** pins a cell font size; omit (or `--auto-size`) for auto-fit.

Wired through `ISessionHost.Dashboard` + `ControlServer` + the `Dashboard.cs` overlay (font pin honored in the render).

## Evidence (screenshot attached in chat)
`agwintermctl dashboard <alphaId> <betaId>` opened a 2-cell grid with **only** alpha (`AAAA`) and beta (`BBBB`) — session 1 excluded, proving explicit targeting. `--close` and `--font-size 7` also verified live.

## Tests
- `dotnet test Agwinterm.slnx` → **148 passed / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k