### PR TITLE
release: v0.12.1

### DIFF
--- a/installer/agwinterm.iss
+++ b/installer/agwinterm.iss
@@ -2,7 +2,7 @@
 ; Build via installer\build.ps1 (publishes to stage\ then runs ISCC on this file).
 
 #define AppName    "agwinterm"
-#define AppVersion "0.12.0"
+#define AppVersion "0.12.1"
 #define AppExe     "Agwinterm.Win32.exe"
 #define AppPublisher "Boris Kudriashov"
 


### PR DESCRIPTION
Version bump 0.12.0 → 0.12.1. Patch release.

Tagging `v0.12.1` after merge triggers `release.yml`: installer + portable + Sigstore attestation + GitHub Release, plus best-effort winget/Chocolatey and Scoop Excavator pickup.

**Since v0.12.0:**
- Ctrl+C copies the selection (with a "Text copied" flash) instead of interrupting, when text is selected; gated by the new `copy-on-ctrl-c` setting (#75).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k