### PR TITLE
feat(agents): fix status-dot routing + transparent Claude session binding & auto-resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ the real thing: **[github.com/umputun/agterm](https://github.com/umputun/agterm)
   double-click to jump in; or drive it with `agwintermctl dashboard <ids>`.
 - **Agent status** per session (idle / active / blocked / completed) as a colored dot + title-bar
   bell — driven by your agent via hooks or the control API, with blink, auto-reset, and sounds.
+  Run `agwintermctl install hooks` (or the palette entry) once to wire Claude Code / Codex up.
+- **Claude Code session binding & auto-resume**: the same installer adds a transparent `claude`
+  wrapper (active only inside agwinterm) that ties Claude's session id to the agwinterm pane. You
+  just type `claude` — a fresh pane starts a bound session, and a pane that already has a transcript
+  **resumes** it. On restart, agwinterm re-launches each bound pane and the conversation comes back —
+  no guessing which shell was which.
 - **A scriptable control API**: `agwintermctl` (or newline-JSON over a named pipe) — any language can
   drive it, including full **read-back** (tree with split ratios + pane ids, window state, session
   output). Opt-in installers for the **agent skill** and **Claude Code / Codex status hooks**.

--- a/installer/README.md
+++ b/installer/README.md
@@ -35,7 +35,9 @@ It does **not** touch your `PATH`, profile, or config.
 Open the action palette (**Ctrl+Shift+P**) and run the **Install …** entries when you want them:
 
 - **Install Command-Line Tool (PATH)** — adds `agwintermctl` to your user `PATH` (so shells & AI agents can call it).
-- **Install Agent Status Hooks** — Claude Code / Codex / generic-agent status reporting.
+- **Install Agent Status Hooks** — Claude Code / Codex / generic-agent status reporting, plus a
+  transparent `claude` launcher that binds Claude's session id to the agwinterm pane so restart
+  auto-resumes the conversation.
 - **Install Agent Skill** — teaches agents to drive agwinterm via `agwintermctl`.
 - **Install Shell Integration** — a `$PROFILE` OSC-7 hook for live cwd (also works out of the box without this).
 

--- a/src/Agwinterm.Ctl/Program.cs
+++ b/src/Agwinterm.Ctl/Program.cs
@@ -169,6 +169,7 @@ switch (area)
                 break;
             case "focus": cargs["dir"] = rest.Count > 0 ? rest[0] : "right"; break;
             case "flag": cargs["op"] = rest.Count > 0 ? rest[0] : "toggle"; break; // on|off|toggle|clear
+            case "bind": cargs["agent"] = rest.Count > 0 ? rest[0] : "claude"; break; // bind a resumable agent (claude) | none to clear
             case "background": // session background set <path> [--opacity N] [--mode fit|fill|center|tile] | background clear
                 cargs["action"] = rest.Count > 0 ? rest[0] : "set";
                 if (rest.Count > 1) cargs["path"] = string.Join(' ', rest.Skip(1));

--- a/src/Agwinterm.Pty/AgentHooks.cs
+++ b/src/Agwinterm.Pty/AgentHooks.cs
@@ -40,7 +40,7 @@ public static class AgentHooks
           $c = New-Object System.IO.Pipes.NamedPipeClientStream('.', $pipe, [System.IO.Pipes.PipeDirection]::InOut)
           $c.Connect(1000)
           $w = New-Object System.IO.StreamWriter($c); $w.AutoFlush = $true
-          $w.WriteLine('{"cmd":"session.status","args":{"status":"' + $state + '"}}')
+          $w.WriteLine('{"cmd":"session.status","target":"' + $env:AGWINTERM_SESSION_ID + '","args":{"status":"' + $state + '"}}')
           $c.Dispose()
         } catch { }
         exit 0
@@ -56,7 +56,7 @@ public static class AgentHooks
           $c = New-Object System.IO.Pipes.NamedPipeClientStream('.', $pipe, [System.IO.Pipes.PipeDirection]::InOut)
           $c.Connect(1000)
           $w = New-Object System.IO.StreamWriter($c); $w.AutoFlush = $true
-          $w.WriteLine('{"cmd":"session.status","args":{"status":"' + $State + '"}}')
+          $w.WriteLine('{"cmd":"session.status","target":"' + $env:AGWINTERM_SESSION_ID + '","args":{"status":"' + $State + '"}}')
           $c.Dispose()
         } catch { }
         exit 0
@@ -170,6 +170,9 @@ public static class AgentHooks
             lines.Add("    " + tomlLine);
         }
         catch (Exception ex) { lines.Add("Codex: failed to write notify script: " + ex.Message); }
+
+        // --- Claude launcher: transparent `claude` wrapper (session-id binding + auto-resume) ---
+        lines.Add("Claude launcher: " + ClaudeIntegration.Install());
 
         // --- Generic agents: PowerShell-profile bridge keyed off $env:AGWINTERM_AGENT_RE ---
         lines.Add("Generic: " + GenericAgentInstaller.Install());

--- a/src/Agwinterm.Pty/ClaudeIntegration.cs
+++ b/src/Agwinterm.Pty/ClaudeIntegration.cs
@@ -1,0 +1,79 @@
+using System.IO;
+
+namespace Agwinterm.Pty;
+
+/// <summary>
+/// Installs the transparent Claude Code launcher: a guarded, sentinel-delimited block appended to the
+/// CurrentUser PowerShell profile that — only inside an agwinterm session ($env:AGWINTERM) — defines a
+/// <c>claude</c> function wrapping the real CLI. It binds Claude's session id to the agwinterm PANE id
+/// (which is a stable UUID that survives relaunch) so the two are the same identity: a fresh pane starts
+/// <c>claude --session-id &lt;paneId&gt;</c>, and a pane whose transcript already exists resumes with
+/// <c>claude --resume &lt;paneId&gt;</c>. It also tells agwinterm (via the control pipe, <c>session.bind</c>)
+/// to mark the pane as a resumable Claude session so restart re-launches it and the conversation comes back.
+/// The wrapper no-ops (passes straight through to the real CLI) outside agwinterm, when the id isn't a
+/// UUID, or when the user already passed a session-controlling flag. Idempotent.
+/// </summary>
+public static class ClaudeIntegration
+{
+    private const string Begin = "# >>> agwinterm claude integration >>>";
+    private const string End = "# <<< agwinterm claude integration <<<";
+
+    /// <summary>The guarded block appended to $PROFILE.</summary>
+    public static readonly string Block =
+        Begin + "\n" +
+        """
+        if ($env:AGWINTERM -eq '1' -and -not $global:__agwClaude) {
+          $global:__agwClaude = $true
+          function global:__agwBindClaude([string]$sid) {
+            if (-not $sid) { return }
+            $pipe = if ($env:AGWINTERM_PIPE) { $env:AGWINTERM_PIPE } else { 'agwinterm' }
+            try {
+              $c = New-Object System.IO.Pipes.NamedPipeClientStream('.', $pipe, [System.IO.Pipes.PipeDirection]::InOut)
+              $c.Connect(300)
+              $w = New-Object System.IO.StreamWriter($c); $w.AutoFlush = $true
+              $w.WriteLine('{"cmd":"session.bind","target":"' + $sid + '","args":{"agent":"claude"}}')
+              $c.Dispose()
+            } catch { }
+          }
+          function global:claude {
+            $sid = $env:AGWINTERM_SESSION_ID
+            # Resolve the real CLI (Application/.cmd/.exe or ExternalScript/.ps1) — never this function.
+            $real = Get-Command claude -CommandType Application,ExternalScript -ErrorAction SilentlyContinue | Select-Object -First 1
+            if (-not $real) { Write-Error 'claude: executable not found on PATH'; return }
+            $uuid = $sid -match '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+            # If the user is already steering the session (resume/continue/explicit id) or running headless,
+            # don't inject or bind — just pass through untouched.
+            $ctl = $false
+            foreach ($a in $args) { if ($a -in '-r','--resume','-c','--continue','--session-id','-p','--print') { $ctl = $true; break } }
+            if (-not $sid -or -not $uuid -or $ctl) { & $real.Source @args; return }
+            $cfg = if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $env:USERPROFILE '.claude' }
+            $enc = ($PWD.ProviderPath -replace '[^A-Za-z0-9]','-')   # Claude's per-project dir encoding
+            $tx  = Join-Path $cfg (Join-Path 'projects' (Join-Path $enc ($sid + '.jsonl')))
+            __agwBindClaude $sid
+            if (Test-Path -LiteralPath $tx) { & $real.Source --resume $sid @args }
+            else { & $real.Source --session-id $sid @args }
+          }
+        }
+        """ + "\n" + End;
+
+    /// <summary>Append the block to the profile if not already present. Idempotent. Returns a summary.</summary>
+    public static string Install()
+    {
+        string path = ShellIntegrationInstaller.ProfilePath();
+        try
+        {
+            string existing = File.Exists(path) ? File.ReadAllText(path) : "";
+            if (existing.Contains(Begin))
+                return "claude launcher already installed -> " + path;
+
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            string sep = existing.Length == 0 ? "" : (existing.EndsWith("\n") ? "\n" : "\n\n");
+            File.AppendAllText(path, sep + Block + "\n");
+            return "installed claude launcher (session-id binding + auto-resume) -> " + path;
+        }
+        catch (Exception ex)
+        {
+            return "failed to install claude launcher: " + ex.Message;
+        }
+    }
+}

--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -195,6 +195,8 @@ public sealed class ControlServer : IDisposable
                         ? Ok("notified") : Err("session not found");
                 case "session.flag":
                     return host.SessionFlag(target, GetString(args, "op") ?? "toggle") ? Ok("flag") : Err("session not found");
+                case "session.bind":
+                    return host.SessionBind(target, GetString(args, "agent") ?? "claude") ? Ok("bound") : Err("session not found");
                 case "workspace.focus": host.WorkspaceFocus(GetString(args, "op") ?? "toggle"); return Ok("focus");
                 case "session.background":
                     return Ok(host.SessionBackground(target, GetString(args, "action") ?? "set",

--- a/src/Agwinterm.Pty/GenericAgentInstaller.cs
+++ b/src/Agwinterm.Pty/GenericAgentInstaller.cs
@@ -29,7 +29,7 @@ public static class GenericAgentInstaller
               $c = New-Object System.IO.Pipes.NamedPipeClientStream('.', $pipe, [System.IO.Pipes.PipeDirection]::InOut)
               $c.Connect(300)
               $w = New-Object System.IO.StreamWriter($c); $w.AutoFlush = $true
-              $w.WriteLine('{"cmd":"session.status","args":{"status":"' + $s + '"}}')
+              $w.WriteLine('{"cmd":"session.status","target":"' + $env:AGWINTERM_SESSION_ID + '","args":{"status":"' + $s + '"}}')
               $c.Dispose()
             } catch { }
           }

--- a/src/Agwinterm.Pty/ISessionHost.cs
+++ b/src/Agwinterm.Pty/ISessionHost.cs
@@ -156,6 +156,11 @@ public interface ISessionHost
     /// Returns false if a per-session op targets a session that isn't found; "clear" always succeeds.</summary>
     bool SessionFlag(string? target, string op);
 
+    /// <summary>Bind a resumable agent (e.g. "claude") to the target pane so restart re-launches it and the
+    /// agent resumes its own session. <paramref name="agent"/> = "" or "none" clears the binding.
+    /// Returns false if the target pane isn't found.</summary>
+    bool SessionBind(string? target, string agent);
+
     /// <summary>Focus/unfocus the active workspace (hide the others in the sidebar tree): op = on|off|toggle.</summary>
     void WorkspaceFocus(string op);
 
@@ -246,6 +251,7 @@ public sealed class SingleSessionHost : ISessionHost
     public string SessionOverlay(string? target, string action, string? command, int sizePercent, bool wait, bool block) => "no overlay";
     public bool Notify(string? target, string? title, string body) => false;
     public bool SessionFlag(string? target, string op) => false;
+    public bool SessionBind(string? target, string agent) => false;
     public void WorkspaceFocus(string op) { }
     public string SessionBackground(string? target, string action, string? path, int opacity, string? mode) => "unsupported";
     public string SessionSwitch(string op) => "unsupported";

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -544,6 +544,18 @@ internal partial class Program
             return true;
         }
 
+        // Bind (or clear) a resumable agent on a specific pane, keyed by the pane id the caller used as
+        // its AGWINTERM_SESSION_ID. Persisted so restart re-launches the agent (which resumes itself).
+        public bool SessionBind(string? target, string agent)
+        {
+            if (string.IsNullOrEmpty(target)) return false;
+            var hit = FindPaneById(target!);
+            if (hit is null) return false;
+            string? val = string.IsNullOrWhiteSpace(agent) || agent.Equals("none", StringComparison.OrdinalIgnoreCase) ? null : agent.ToLowerInvariant();
+            Post(() => { hit.Value.pane.AgentResume = val; SaveState(); });
+            return true;
+        }
+
         public string SessionBackground(string? target, string action, string? path, int opacity, string? mode) => InvokeOnUi(() =>
         {
             var ses = FindSesForTarget(target);

--- a/src/Agwinterm.Win32/Program.Services.cs
+++ b/src/Agwinterm.Win32/Program.Services.cs
@@ -989,7 +989,7 @@ internal partial class Program
 
     // ---- Persistence: workspace/session tree + selection + sidebar state ----
 
-    private sealed class PaneState { public string Id { get; set; } = ""; public string Cwd { get; set; } = ""; public float FontSize { get; set; } public float Ratio { get; set; } = 1f; public string Command { get; set; } = ""; public List<string>? Buffer { get; set; } }
+    private sealed class PaneState { public string Id { get; set; } = ""; public string Cwd { get; set; } = ""; public float FontSize { get; set; } public float Ratio { get; set; } = 1f; public string Command { get; set; } = ""; public string? AgentResume { get; set; } public List<string>? Buffer { get; set; } }
     // Cwd/FontSize kept for backward-compat with pre-splits state.json (one pane per session).
     private sealed class SessionState { public string Id { get; set; } = ""; public string Name { get; set; } = ""; public string? CustomName { get; set; } public string? Profile { get; set; } public int Active { get; set; } public bool Flagged { get; set; } public List<PaneState> Panes { get; set; } = new(); public string Cwd { get; set; } = ""; public float FontSize { get; set; }
         // Wave F2: background watermark (BgFile = the copied file's name under backgrounds\; null = none).
@@ -1231,7 +1231,7 @@ internal partial class Program
                         List<string>? buf = null;
                         if (_config.RestoreBuffer)
                             try { lock (p.S.SyncRoot) buf = p.S.Emulator.DumpBuffer().TakeLast(500).ToList(); } catch { }  // cap the saved lines
-                        ss.Panes.Add(new PaneState { Id = p.Id, Cwd = cwd, FontSize = p.FontSize, Ratio = p.Ratio, Command = cmd, Buffer = buf });
+                        ss.Panes.Add(new PaneState { Id = p.Id, Cwd = cwd, FontSize = p.FontSize, Ratio = p.Ratio, Command = cmd, AgentResume = p.AgentResume, Buffer = buf });
                     }
                     wss.Sessions.Add(ss);
                 }
@@ -1360,7 +1360,10 @@ internal partial class Program
                     lock (_workspaces)
                     {
                         for (int i = 0; i < pl.Count && i < ses.Panes.Count; i++)
+                        {
                             ses.Panes[i].Ratio = pl[i].Ratio > 0 ? pl[i].Ratio : 1f;
+                            ses.Panes[i].AgentResume = string.IsNullOrWhiteSpace(pl[i].AgentResume) ? null : pl[i].AgentResume;
+                        }
                         ses.Active = Math.Clamp(s.Active, 0, ses.Panes.Count - 1);
                     }
                     // Buffer-content restore: seed each pane's scrollback (dimmed) above the fresh shell.
@@ -1383,12 +1386,28 @@ internal partial class Program
                     if (ReferenceEquals(_active, ses)) _session = ses.S;
                     RegridSession(ses);
 
+                    // First-class agent resume (always on, independent of restore-commands): re-launch each
+                    // pane's bound resumable agent once the shell is ready. The agent's launcher wrapper
+                    // (see ClaudeIntegration) re-binds to the same stable pane id and resumes its own session.
+                    for (int i = 0; i < pl.Count && i < ses.Panes.Count; i++)
+                    {
+                        string agent = pl[i].AgentResume ?? "";
+                        if (agent.Length == 0) continue;
+                        var apane = ses.Panes[i];
+                        _ = Task.Run(async () =>
+                        {
+                            await Task.Delay(2500); // let the shell/profile settle so the wrapper function is defined
+                            try { apane.S.Write(System.Text.Encoding.UTF8.GetBytes(agent + "\r")); } catch { }
+                        });
+                    }
+
                     // Opt-in: re-run each pane's captured foreground command once the shell is ready.
                     if (_config.RestoreCommands)
                     {
                         var deny = LoadDenylist();
                         for (int i = 0; i < pl.Count && i < ses.Panes.Count; i++)
                         {
+                            if (!string.IsNullOrWhiteSpace(pl[i].AgentResume)) continue; // agent panes handled above
                             string cmd = pl[i].Command ?? "";
                             if (cmd.Length == 0) continue;
                             string lead = StripExe(cmd.TrimStart('"').Split(' ', 2)[0]);

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -246,6 +246,7 @@ internal partial class Program : ISessionHost, IWindowHost
         public required string Id;
         public required TerminalSession S;
         public string? StartCwd;   // dir the shell was launched in (fallback cwd when OSC 7 is absent)
+        public string? AgentResume; // resumable agent bound to this pane (e.g. "claude") — relaunched on restart
         public float FontSize;     // per-pane font zoom (pt)
         public float Ratio = 1f;   // fraction of the session's content width (ratios in a session sum to 1)
         public int ScrollOffset;   // lines scrolled up from the live bottom (0 = live; clamped to HistoryCount)
@@ -328,6 +329,7 @@ internal partial class Program : ISessionHost, IWindowHost
     // ---- CLI launch args (wt-style, applied to the first window): ----
     //   Agwinterm.Win32.exe [-p|--profile NAME] [-d|--dir PATH] [--maximized] [--fullscreen]
     private static bool _argNoRestore;   // --no-restore: fresh window, don't reopen the saved tree (elevated launch)
+    private static string _argPipe = "agwinterm";   // --pipe <name>: control-pipe name (isolate a test instance)
     private static string? _argProfile;
     private static string? _argDir;
     private static bool _argMaximized, _argFullscreen;
@@ -343,6 +345,7 @@ internal partial class Program : ISessionHost, IWindowHost
                 case "--maximized": _argMaximized = true; break;
                 case "--fullscreen": _argFullscreen = true; break;
                 case "--no-restore": _argNoRestore = true; break;
+                case "--pipe" when i + 1 < args.Length: _argPipe = args[++i]; break;
                 // unknown args are ignored (forward compatibility)
             }
         }
@@ -992,7 +995,7 @@ internal partial class Program : ISessionHost, IWindowHost
         // One control server for the whole app (one pipe); it resolves --window through the library.
         if (_control is null)
         {
-            _control = new ControlServer(this, this, "agwinterm");
+            _control = new ControlServer(this, this, _argPipe);
             _control.Start();
             // Default-terminal handoff (T2-13): register the COM class factory so conhost can hand
             // console sessions to this instance. Each handoff opens a new attached session.

--- a/tests/Agwinterm.Pty.Tests/AgentHooksTests.cs
+++ b/tests/Agwinterm.Pty.Tests/AgentHooksTests.cs
@@ -50,4 +50,25 @@ public class AgentHooksTests
     {
         Assert.Null(AgentHooks.MergeClaudeSettings("{ not valid json", Wrapper));
     }
+
+    [Fact]
+    public void WrapperScript_RoutesStatusToItsOwnPane()
+    {
+        // The status push must carry a target = its own AGWINTERM_SESSION_ID; otherwise the server
+        // routes to the *focused* pane and multi-session status lands on the wrong dot.
+        Assert.Contains("\"target\":\"' + $env:AGWINTERM_SESSION_ID + '\"", AgentHooks.WrapperScript);
+        Assert.Contains("\"target\":\"' + $env:AGWINTERM_SESSION_ID + '\"", AgentHooks.CodexNotifyScript);
+        Assert.Contains("\"target\":\"' + $env:AGWINTERM_SESSION_ID + '\"", GenericAgentInstaller.Block);
+    }
+
+    [Fact]
+    public void ClaudeLauncher_BindsAndResumesBySessionId()
+    {
+        string block = ClaudeIntegration.Block;
+        Assert.Contains("function global:claude", block);
+        Assert.Contains("--session-id $sid", block);   // fresh session bound to the pane id
+        Assert.Contains("--resume $sid", block);        // resume when the transcript already exists
+        Assert.Contains("session.bind", block);          // marks the pane resumable in agwinterm
+        Assert.Contains("$env:AGWINTERM -eq '1'", block); // only active inside agwinterm
+    }
 }

--- a/tests/Agwinterm.Pty.Tests/ControlApiTests.cs
+++ b/tests/Agwinterm.Pty.Tests/ControlApiTests.cs
@@ -143,6 +143,25 @@ public class ControlApiTests
     }
 
     [Fact]
+    public void SessionBind_SetsAndClearsAgent()
+    {
+        var (server, host) = New();
+        var r = Dispatch(server, "session.bind", new { agent = "claude" }, target: "s1");
+        Assert.True(Ok(r));
+        Assert.Equal("claude", host.ActiveSess!.AgentResume);
+        Dispatch(server, "session.bind", new { agent = "none" }, target: "s1");
+        Assert.Null(host.ActiveSess.AgentResume);
+    }
+
+    [Fact]
+    public void SessionBind_UnknownTarget_Fails()
+    {
+        var (server, _) = New();
+        var r = Dispatch(server, "session.bind", new { agent = "claude" }, target: "nope");
+        Assert.False(Ok(r));
+    }
+
+    [Fact]
     public void CloseSession_RemovesIt()
     {
         var (server, host) = New();

--- a/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
+++ b/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
@@ -13,6 +13,7 @@ internal sealed class FakeSessionHost : ISessionHost
         public string Id = "", Name = "";
         public AgentStatus Status = AgentStatus.Idle;
         public bool Flagged, Overlay, ReadOnly;
+        public string? AgentResume;
         public int Notifications, PaneCount = 1, FocusedPane, OverlaySize;
         public List<double> Ratios = new() { 1.0 };
     }
@@ -121,6 +122,7 @@ internal sealed class FakeSessionHost : ISessionHost
     }
     public bool Notify(string? target, string? title, string body) { var s = Find(target); if (s is null) return false; s.Notifications++; return true; }
     public bool SessionFlag(string? target, string op) { if (op == "clear") { foreach (var s in Workspaces.SelectMany(w => w.Sessions)) s.Flagged = false; return true; } var x = Find(target); if (x is null) return false; x.Flagged = op switch { "on" => true, "off" => false, "toggle" => !x.Flagged, _ => x.Flagged }; return true; }
+    public bool SessionBind(string? target, string agent) { var s = Find(target); if (s is null) return false; s.AgentResume = string.IsNullOrWhiteSpace(agent) || agent == "none" ? null : agent; return true; }
     public void WorkspaceFocus(string op) { }
     public string SessionBackground(string? target, string action, string? path, int opacity, string? mode) => Find(target) is not null ? "ok" : "no session";
     public string SessionSwitch(string op) => ActiveSess?.Name ?? "";


### PR DESCRIPTION
Wires up the two agent-status pieces that were dark on both laptops.

## 1. Status dots routed to the wrong pane 🔴→🟢
The Claude / Codex / generic status wrappers pushed `session.status` with **no `target`**, so the server resolved it to the **focused** pane. With several agents open, whichever session you were *looking at* lit up — not the one that actually changed state. (The AgentSkill docs example had the target; the wrappers forgot it.)

**Fix:** all three wrappers now send `target = $env:AGWINTERM_SESSION_ID` (their own pane).

> Note: the dots were fully dark on my machines mainly because `install hooks` had never been run — without the hooks in `~/.claude/settings.json`, Claude never pushes status at all.

## 2. Claude session binding + auto-resume (first-class) 🔗
`install hooks` now also installs a **transparent `claude` wrapper** into `$PROFILE`, active only inside agwinterm. It makes Claude's session id == the agwinterm **pane id** (already a stable UUID that survives relaunch):

- fresh pane → `claude --session-id <paneId>`
- pane whose transcript already exists → `claude --resume <paneId>`
- passes straight through if you gave `-r/-c/--session-id/-p` yourself
- tells agwinterm to mark the pane resumable (new `session.bind` verb)

On **restart**, agwinterm re-launches every bound pane and Claude resumes its own conversation — no command-capture guessing which shell was which. Persisted per-pane (`agentResume`), independent of the restore-commands toggle.

You just type `claude` as always.

## Also
- `--pipe <name>` app arg so a test instance can own a distinct control pipe.

## Verification
Live, in an isolated instance (own `--pipe`): create alpha+beta, focus **alpha**, then push status **targeted at the other pane**:

```
sessions: session 1, alpha, beta
RESULT: alpha(focused).status=blocked  beta(target).status=active
ROUTING OK
PERSISTED agentResume='claude' on pane <beta-id>   # session.bind -> state.json
```

Screenshot (sidebar): **alpha** row = 🟠 blocked, **beta** row = 🔵 active — status landed on the *target*, not the focused row. (Sent to you in chat.)

- Transcript-path encoding (`~/.claude/projects/<cwd→dashes>/<id>.jsonl`) validated against this repo's real on-disk Claude project dir.
- The generated `$PROFILE` block parses cleanly under the PowerShell parser.
- `dotnet build Agwinterm.slnx` clean; **42/42** Pty tests pass (added: bind set/clear, unknown-target fail, wrapper-target routing, launcher-block content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)