### PR TITLE
fix(selection): keep the mouse selection alive across in-place repaints (Ctrl+C copy in Claude Code)

### DIFF
--- a/src/Agwinterm.Core/TerminalEmulator.cs
+++ b/src/Agwinterm.Core/TerminalEmulator.cs
@@ -55,6 +55,12 @@ public sealed class TerminalEmulator : IParserPerformer
     /// <summary>Rows of scrollback available above the live screen (main screen only).</summary>
     public int HistoryCount => _history.Count;
 
+    /// <summary>Monotonic count of lines ever scrolled into history. Unlike <see cref="HistoryCount"/> this
+    /// keeps climbing after scrollback fills (eviction), so it's a reliable "the viewport content shifted"
+    /// signal. Stays flat during in-place repaints (TUIs like Claude Code redrawing without scrolling),
+    /// which lets a mouse selection survive those repaints.</summary>
+    public long ScrollGeneration { get; private set; }
+
     /// <summary>Read a scrolled-off cell; history row 0 is the oldest. Pads to the current width.</summary>
     public Cell GetHistoryCell(int historyRow, int col)
     {
@@ -69,6 +75,7 @@ public sealed class TerminalEmulator : IParserPerformer
         var row = new Cell[cols];
         Screen.CopyRowTo(0, row);
         _history.Add(row);
+        ScrollGeneration++;
         if (_history.Count > ScrollbackMax + TrimSlack)
         {
             int trim = _history.Count - ScrollbackMax;

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -57,9 +57,16 @@ internal partial class Program
         var session = new TerminalSession(cols, rows);
         session.Emulator.ScrollbackMax = _config.Scrollback;
         var pane = new Pane { Id = paneId, S = session, StartCwd = cwd, FontSize = fontSize };
-        // New output snaps this pane back to the live bottom (so output jumps you out of scrollback)
-        // and clears any selection (its absolute coordinates would otherwise shift under new history).
-        session.OutputReceived += () => { pane.ScrollOffset = 0; pane.ClearSel(); RequestRedraw(); };
+        // New output only snaps this pane back to the live bottom and drops the selection when the buffer
+        // ACTUALLY scrolled (a line pushed into history) — not on every repaint. TUIs like Claude Code
+        // redraw in place without scrolling, so a mouse selection now survives those frames and Ctrl+C can
+        // copy it (previously any repaint wiped the selection microseconds after you made it). #copy-selection
+        session.OutputReceived += () =>
+        {
+            long gen = session.Emulator.ScrollGeneration;
+            if (gen != pane.LastScrollGen) { pane.LastScrollGen = gen; pane.ScrollOffset = 0; pane.ClearSel(); }
+            RequestRedraw();
+        };
         // On a transition INTO blocked, play the configured blocked-sound (best-effort, off the UI thread).
         AgentStatus lastStatus = session.Status;
         session.StatusChanged += () =>

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -250,6 +250,7 @@ internal partial class Program : ISessionHost, IWindowHost
         public float FontSize;     // per-pane font zoom (pt)
         public float Ratio = 1f;   // fraction of the session's content width (ratios in a session sum to 1)
         public int ScrollOffset;   // lines scrolled up from the live bottom (0 = live; clamped to HistoryCount)
+        public long LastScrollGen; // emulator ScrollGeneration last seen on output (detects real scroll vs in-place repaint)
         public int Unread;         // unread desktop-notification count (OSC 9/777 / notify) since last visit
         public bool ReadOnly;      // block keyboard input to this pane (protect a running agent from stray keys)
         // Text selection (absolute line index: [0..HistoryCount) history, then the live grid rows).

--- a/tests/Agwinterm.Core.Tests/ScrollbackTests.cs
+++ b/tests/Agwinterm.Core.Tests/ScrollbackTests.cs
@@ -26,6 +26,34 @@ public class ScrollbackTests
     }
 
     [Fact]
+    public void ScrollGeneration_BumpsOnScroll_NotOnInPlaceRewrite()
+    {
+        var t = new TerminalEmulator(10, 3);
+        // Fill the 3 visible rows without overflowing — no scroll yet.
+        Feed(t, "L1\r\nL2\r\nL3");
+        long g0 = t.ScrollGeneration;
+
+        // In-place repaint: move the cursor home and rewrite the same region (what a TUI like Claude Code
+        // does every frame). CUP to 1;1, overwrite rows — this must NOT scroll, so the generation is flat.
+        Feed(t, "\x1b[1;1HR1\x1b[2;1HR2\x1b[3;1HR3");
+        Assert.Equal(g0, t.ScrollGeneration); // selection would survive this
+
+        // A genuine newline at the bottom row scrolls one line into history — generation advances.
+        Feed(t, "\r\nNEW");
+        Assert.True(t.ScrollGeneration > g0);
+    }
+
+    [Fact]
+    public void ScrollGeneration_KeepsClimbingAfterCap()
+    {
+        var t = new TerminalEmulator(10, 3) { ScrollbackMax = 50 };
+        for (int i = 0; i < 400; i++) Feed(t, "X\r\n");
+        // HistoryCount saturates near the cap, but the monotonic generation reflects every real scroll.
+        Assert.InRange(t.HistoryCount, 50, 50 + 512);
+        Assert.InRange(t.ScrollGeneration, 390, 400); // ~398 real scrolls (3-row screen), far above the 50-row cap
+    }
+
+    [Fact]
     public void ScrollbackCap_DropsOldest()
     {
         var t = new TerminalEmulator(10, 3) { ScrollbackMax = 100 };


### PR DESCRIPTION
## The bug
Select text in a Claude Code session, press **Ctrl+C** → copies maybe **1 in 20 tries**.

## Cause
Every `OutputReceived` frame ran `pane.ClearSel()`. Claude Code is an Ink TUI that **repaints in place many times a second** (spinner, status line, streaming), so the selection was wiped microseconds after you made it. By the time you hit Ctrl+C there was no selection, so it fell through to the interrupt path.

The `ClearSel()` was only ever needed when the buffer genuinely **scrolled** — a line pushed into history shifts the selection's absolute coordinates. In-place repaints don't scroll, so there was nothing to invalidate; the clear was pure collateral damage.

## Fix
Add a monotonic `ScrollGeneration` to the emulator, bumped in `PushHistory()` (the single choke point where a line scrolls into history). It keeps climbing even after scrollback fills and starts evicting — unlike `HistoryCount`, which saturates at the cap. `OutputReceived` now snaps-to-bottom + drops the selection **only when that generation actually advances**.

Result: selections survive TUI repaints and Ctrl+C copies reliably. Bonus — output no longer yanks you out of scrollback on every repaint frame, only when new lines actually arrive.

## Verification
- Core unit tests (added): generation stays **flat** across an in-place cursor-home rewrite, **bumps** on a real newline-scroll, and **keeps climbing past the scrollback cap**. 112/112 Core tests pass.
- Live mouse-drag-select in a TUI isn't something I can automate from here (no synthetic drag-select, and I can't safely run a second agwinterm beside your running one — shared control pipe + non-isolated state). This one's best confirmed on your machine: select in a Claude Code pane, Ctrl+C, and it should copy every time now (with the "Text copied" flash).

Follow-up (separate PR): the blank-pane-on-session-switch you mentioned — different root cause (only the active session regrids on window resize), investigating next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)