### PR TITLE
fix(render): keep every session sized to the window so switching never blanks a Claude Code pane

### DIFF
--- a/src/Agwinterm.Win32/Program.Services.cs
+++ b/src/Agwinterm.Win32/Program.Services.cs
@@ -1265,6 +1265,7 @@ internal partial class Program
     private int _geoX, _geoY, _geoW, _geoH;
     private bool _geoMax;
     private bool _wasMaximized;
+    private bool _sizing;                 // inside an interactive resize drag (WM_ENTER/EXITSIZEMOVE)
     private bool _windowActive = true;   // window focus state (drives unfocused-dim)
 
     // ---- Fullscreen (F11 / toggle_fullscreen): borderless over the whole monitor ----

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -356,6 +356,17 @@ internal partial class Program
         return list;
     }
 
+    /// <summary>Regrid EVERY session (not just the active one) to the current window/sidebar size, so an
+    /// inactive session's PTY never lags behind the window. Without this, switching to a session that was
+    /// inactive during a resize would resize its PTY on activation — which clears a TUI's alt-screen buffer
+    /// and leaves the pane blank until the app repaints (and an idle Claude Code may not repaint until you
+    /// type). Keeping all sessions window-sized means switching never resizes, so it's instant and never blank.</summary>
+    private void RegridAllSessions()
+    {
+        foreach (var s in AllSessions()) RegridSession(s);
+        if (_cover is not null) RegridCover();
+    }
+
     /// <summary>Resize every pane's PTY grid to fit its column using the pane's own font metrics.</summary>
     private void RegridSession(Ses ses)
     {

--- a/src/Agwinterm.Win32/Program.WndProc.cs
+++ b/src/Agwinterm.Win32/Program.WndProc.cs
@@ -208,7 +208,12 @@ internal partial class Program
                     if (w > 0 && h > 0)
                     {
                         _rt.Resize(new SizeI(w, h));
-                        if (_active is not null) RegridSession(_active);
+                        // During an interactive drag, only the visible session tracks each tick (cheap +
+                        // responsive). A non-drag size change (maximize / snap / restore) is a settled size,
+                        // so sync EVERY session now — that keeps inactive PTYs window-sized and means a later
+                        // session-switch never resizes (no alt-screen clear, no blank pane on slow machines).
+                        if (_sizing) { if (_active is not null) RegridSession(_active); }
+                        else RegridAllSessions();
                         if (_cover is not null) RegridCover();
                         InvalidateRect(hwnd, IntPtr.Zero, false);
                     }
@@ -217,8 +222,14 @@ internal partial class Program
                 { bool z = IsZoomed(hwnd); if (z != _wasMaximized) { _wasMaximized = z; SaveState(); } }
                 return IntPtr.Zero;
 
+            case WM_ENTERSIZEMOVE:
+                _sizing = true;
+                return IntPtr.Zero;
+
             case WM_EXITSIZEMOVE:
-                SaveState(); // persist geometry after a manual move/resize drag
+                _sizing = false;
+                RegridAllSessions(); // drag settled: bring every inactive session up to the final size
+                SaveState();         // persist geometry after a manual move/resize drag
                 return IntPtr.Zero;
 
             case WM_KEYDOWN:

--- a/src/Agwinterm.Win32/Win32.cs
+++ b/src/Agwinterm.Win32/Win32.cs
@@ -55,6 +55,7 @@ internal static class Win32
     public const uint SWP_NOSIZE = 0x0001, SWP_NOMOVE = 0x0002, SWP_NOZORDER = 0x0004, SWP_NOACTIVATE = 0x0010, SWP_FRAMECHANGED = 0x0020;
 
     // Window move/resize + placement (for persisting geometry).
+    public const uint WM_ENTERSIZEMOVE = 0x0231;
     public const uint WM_EXITSIZEMOVE = 0x0232;
     public const int SIZE_RESTORED = 0, SIZE_MAXIMIZED = 2;
 


### PR DESCRIPTION
## The bug (slow work laptop)
Switching sessions back and forth would leave a Claude Code pane **blank** until it repainted — and if CC was **idle waiting for input**, it might never repaint, so the pane stayed blank.

## Cause
On window resize, only the **active** session's PTY was regridded (`WM_SIZE → RegridSession(_active)`). Inactive sessions kept their old grid. So switching to a session that was inactive during a resize ran `RegridSession` on activation → resized its PTY → **cleared the alt-screen buffer** → blank until the app redraws on SIGWINCH. An idle Ink app (Claude Code) doesn't redraw until it gets input, so the blank persisted. Slow hardware widened the gap.

## Fix
Keep **all** sessions sized to the window, the way a multiplexer does:
- **During an interactive drag** (`WM_ENTERSIZEMOVE`..`WM_EXITSIZEMOVE`) only the visible session tracks each `WM_SIZE` tick — cheap and responsive.
- **On drag-end, and on non-drag size changes** (maximize / snap / restore) → `RegridAllSessions()` brings every inactive session up to the settled size.

Now a **session-switch never resizes** — agwinterm paints its retained grid instantly, and the SIGWINCH that makes CC repaint happens at *resize* time (when CC's loop handles it), not at *switch* time. `SetActive`'s existing `RegridSession` becomes a no-op safety net.

## Verification
- `dotnet build` clean; **154/154** tests pass (112 Core + 42 Pty).
- This one repro's on your slow work laptop and is timing/hardware-dependent, so a live test on a fast machine wouldn't reproduce the original blank — the fix is by construction (switching no longer triggers a PTY resize). Best confirmed on the work laptop: resize/maximize the window, switch between Claude Code sessions a few times — no blank, no waiting for a render cycle.

Trade-off: on a resize *settle* (not per drag-tick), every backgrounded app gets one SIGWINCH and repaints off-screen — standard terminal/multiplexer behavior, negligible cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)