### PR TITLE
fix(sidebar): stop names overlapping the status dot at larger font sizes

### DIFF
--- a/src/Agwinterm.Win32/Program.Chrome.cs
+++ b/src/Agwinterm.Win32/Program.Chrome.cs
@@ -57,7 +57,10 @@ internal partial class Program
         rt.FillRectangle(new Rect(0, TitleBarH, _sidebarW, ClientH()), brush);
 
         float rowsBottom = ClientH() - FooterH; // stop the list above the footer toolbar
-        float rowH = _cellH + 8f;
+        // Row height tracks the LARGER of the terminal cell and the sidebar font, so enlarging the
+        // sidebar font gives the names room to breathe instead of cramping them into a cell-sized row.
+        float sbPx = System.Math.Clamp(_config.SidebarFontSize, 9, 20);
+        float rowH = MathF.Max(_cellH + 8f, MathF.Ceiling(sbPx * 1.5f) + 6f);
         float y = TitleBarH + PadY;
 
         if (_sidebarMode == SidebarMode.Flagged) { DrawFlaggedList(rt, brush, ref y, rowH, rowsBottom); }
@@ -96,7 +99,8 @@ internal partial class Program
             brush.Color = SbHeaderText;
             rt.DrawText(expanded ? "▾" : "▸", _format, TextRect(6f, y, 18f, rowH), brush); // chevron (mono, top-aligned)
             if (!ReferenceEquals(_editing, ws)) // the rename box covers the name while editing
-                rt.DrawText(ws.Name, _sidebarFont, new Rect(24f, y, _sidebarW - 48f, rowH), brush);
+                // Clip + ellipsis so a long workspace name (or enlarged font) stops before the session count.
+                rt.DrawText(ws.Name, _sidebarFont, new Rect(24f, y, _sidebarW - 56f, rowH), brush, DrawTextOptions.Clip);
             rt.DrawText(sessions.Count.ToString(), _sidebarSmall, new Rect(_sidebarW - 28f, y, 22f, rowH), brush);
             _sidebarRows.Add((y, y + rowH, true, ws));
             y += rowH;
@@ -177,7 +181,8 @@ internal partial class Program
         bool isDrag = _dragging && ReferenceEquals(s, _dragItem);
         brush.Color = isDrag ? new Color4(0.5f, 0.53f, 0.57f, 0.45f) : (active ? SbActiveText : SbDimText);
         if (!ReferenceEquals(_editing, s)) // the rename box covers the name while editing
-            rt.DrawText(s.Name, _sidebarFont, new Rect(nameX, y, _sidebarW - nameX - 22f, rowH), brush);
+            // Clip + ellipsis-trim so a long name (or an enlarged sidebar font) never spills over the dot.
+            rt.DrawText(s.Name, _sidebarFont, new Rect(nameX, y, _sidebarW - nameX - 22f, rowH), brush, DrawTextOptions.Clip);
         // Unread-notification count badge, just left of the status circle (can be hidden; the count still tracks).
         int unread = UnreadOf(s);
         if (unread > 0 && _config.NotificationBadges)

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -237,6 +237,7 @@ internal partial class Program : ISessionHost, IWindowHost
     private static IDWriteTextFormat _uiSmallCenter = null!;   // horizontally centered (panel buttons)
     private static IDWriteTextFormat _uiTitle = null!;      // single centered title-bar line (vertically centered + ellipsized)
     private static IDWriteInlineObject _ellipsis = null!;   // "…" trimming sign for the title (kept alive)
+    private static IDWriteInlineObject? _sidebarEllipsis;   // "…" trimming sign for sidebar names (rebuilt with the font)
     private static IDWriteTextFormat _iconFont = null!;
     private static IDWriteTextFormat _iconSmall = null!;   // small Fluent glyphs (e.g. the row flag marker)
 
@@ -555,8 +556,13 @@ internal partial class Program : ISessionHost, IWindowHost
     {
         float px = System.Math.Clamp(_config.SidebarFontSize, 9, 20);
         _sidebarFont?.Dispose(); _sidebarSmall?.Dispose();
+        try { _sidebarEllipsis?.Dispose(); } catch { }
         _sidebarFont = NewChromeFormat("Segoe UI", px, center: false);
         _sidebarSmall = NewChromeFormat("Segoe UI", System.Math.Max(9f, px - 1.5f), center: false);
+        // Trim over-long names with a "…" (esp. once the font is enlarged) so they never spill over the
+        // right-aligned status dot. Paired with DrawTextOptions.Clip at the draw sites.
+        _sidebarEllipsis = _dwrite.CreateEllipsisTrimmingSign(_sidebarFont);
+        _sidebarFont.SetTrimming(new Trimming { Granularity = TrimmingGranularity.Character }, _sidebarEllipsis);
     }
 
     private static IDWriteTextFormat NewChromeFormat(string family, float px, bool center)


### PR DESCRIPTION
## The bug
Increasing the sidebar font size made the hierarchy text (session / workspace names) **overlap the status dots** on the right.

## Cause
Two things, both exposed by a larger font:
1. Names were drawn with `WordWrapping.NoWrap` and **no clip** — Direct2D doesn't clip to the layout rect by default, so a name wider than its box drew one line straight **past the box edge, over the dot**. A bigger font widened names that previously fit.
2. Row height was `_cellH + 8` — tied to the **terminal** cell height, not the sidebar font — so enlarging the sidebar font gave the names no extra room (cramped).

## Fix
- Give `_sidebarFont` an **ellipsis trimming sign** and draw names with `DrawTextOptions.Clip`, so a long or enlarged name truncates with `…` **before** the dot (session rows) and before the session-count (workspace headers). Tightened the workspace-name box so it clears the count.
- Row height is now `max(cell-based, sidebar-font-based)`, so a larger sidebar font gets vertical breathing room too.

Same pattern already used elsewhere in the chrome: `DrawTextOptions.Clip` in the menu/palette/dashboard, and ellipsis trimming on the title bar (`CreateEllipsisTrimmingSign` + `SetTrimming`).

## Verification
- `dotnet build` clean. The trimming/clip APIs are the ones already used at runtime for the title bar and menus, so no new runtime surface.
- I couldn't grab a live screenshot this time: your app is running the shipped 0.12.1 binary (which wouldn't show the fix), and I can't safely stand up a second instance beside it (shared control pipe + non-isolated state). Easy to eyeball once released — bump the sidebar font in Settings and long names should show `…` and clear the dots. If you close the app at some point, I can also run an isolated screenshot to confirm before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)