### PR TITLE
feat(dev): isolate dev builds from the installed release (separate data dir + pipe)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,24 @@ dotnet run --project src/Agwinterm.Win32 -c Release
 ./installer/build-portable.ps1
 ```
 
+### Dev builds run side-by-side with the installed release
+
+A **Debug** build uses a separate instance identity, `agwinterm-dev`, so it keeps its **own** data
+dir (`%LOCALAPPDATA%\agwinterm-dev`: config, sessions, keymap, themes) and its **own** control pipe —
+it never touches, or fights over the pipe with, your installed **Release** (`agwinterm`). So you can
+daily-drive the release and run dev builds at the same time.
+
+```powershell
+dotnet run --project src/Agwinterm.Win32           # Debug -> the "agwinterm-dev" instance
+agwintermctl --pipe agwinterm-dev tree             # drive the dev instance from outside
+agwintermctl tree                                  # (default pipe) drives the release
+```
+
+Inside any session, `AGWINTERM_PIPE` is already set, so a bare `agwintermctl` auto-targets the
+instance it's running in. Force a specific identity with `--app-id <name>` or `AGWINTERM_APP_ID`
+(handy for a second throwaway instance). Dev builds also skip registering as the default-terminal
+COM server, so they never intercept the release's console handoffs.
+
 ## Control it from anything (`agwintermctl`)
 
 agwinterm is scriptable through a local named pipe speaking newline-delimited JSON, with

--- a/src/Agwinterm.Ctl/Program.cs
+++ b/src/Agwinterm.Ctl/Program.cs
@@ -348,7 +348,10 @@ if (area != "window" && Opt("window") is { } winSel) req["window"] = winSel;
 if (cargs.Count > 0) req["args"] = cargs;
 string requestJson = JsonSerializer.Serialize(req);
 
+// --pipe is an alias for --socket (matches the app's --pipe flag); AGWINTERM_PIPE is set inside
+// every agwinterm session, so ctl run from within a session auto-targets that instance (dev or release).
 string pipeName = options.TryGetValue("socket", out var s) ? s
+    : options.TryGetValue("pipe", out var pp) ? pp
     : Environment.GetEnvironmentVariable("AGWINTERM_PIPE") ?? "agwinterm";
 
 try

--- a/src/Agwinterm.Pty/OmpThemes.cs
+++ b/src/Agwinterm.Pty/OmpThemes.cs
@@ -21,7 +21,7 @@ public static class OmpThemes
             Path.Combine(Env("LOCALAPPDATA") ?? "", "Programs", "oh-my-posh", "themes"),          // winget
             Path.Combine(Env("USERPROFILE") ?? "", "scoop", "apps", "oh-my-posh", "current", "themes"), // scoop
             Path.Combine(Env("ProgramData") ?? "", "chocolatey", "lib", "oh-my-posh", "tools", "themes"), // choco
-            Path.Combine(Env("LOCALAPPDATA") ?? "", "agwinterm", "omp-themes"),   // agwinterm-downloaded pack (Store installs ship no themes dir)
+            Path.Combine(Env("LOCALAPPDATA") ?? "", Env("AGWINTERM_APP_ID") ?? "agwinterm", "omp-themes"), // agwinterm-downloaded pack (per instance id; Store installs ship no themes dir)
         })
         {
             if (string.IsNullOrWhiteSpace(d)) continue;

--- a/src/Agwinterm.Win32/Program.Chrome.cs
+++ b/src/Agwinterm.Win32/Program.Chrome.cs
@@ -850,7 +850,7 @@ internal partial class Program
                     _palAll.Add(new PalItem { Label = nm, Search = nm, Data = p, Run = () => ApplyOmp(p, persist: true) });
                 }
                 // Our downloaded pack in use: offer a refresh (new omp releases add/update themes).
-                if (Directory.Exists(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "agwinterm", "omp-themes")))
+                if (Directory.Exists(Path.Combine(AppDir, "omp-themes")))
                     _palAll.Add(new PalItem { Label = "Update themes pack…",
                         Secondary = "re-download the official themes from the latest oh-my-posh release",
                         Search = "update refresh download themes pack", Run = DownloadOmpThemes });

--- a/src/Agwinterm.Win32/Program.Input.cs
+++ b/src/Agwinterm.Win32/Program.Input.cs
@@ -314,8 +314,7 @@ internal partial class Program
         return _leaderPending ? "pending" : "idle"; // "state"
     }
 
-    private static string KeymapPath => Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "agwinterm", "keymap.conf");
+    private static string KeymapPath => Path.Combine(AppDir, "keymap.conf");
 
     private static void LoadKeymap()
     {

--- a/src/Agwinterm.Win32/Program.Services.cs
+++ b/src/Agwinterm.Win32/Program.Services.cs
@@ -135,8 +135,8 @@ internal partial class Program
                 uID = 1,
                 uFlags = NIF_INFO | (_trayAdded ? 0u : (NIF_ICON | NIF_TIP)),
                 hIcon = _trayAdded ? IntPtr.Zero : LoadIconW(IntPtr.Zero, (IntPtr)32512), // IDI_APPLICATION
-                szTip = "agwinterm",
-                szInfoTitle = string.IsNullOrEmpty(title) ? "agwinterm" : title,
+                szTip = AppName,
+                szInfoTitle = string.IsNullOrEmpty(title) ? AppName : title,
                 szInfo = body.Length == 0 ? " " : body,
                 dwInfoFlags = 0,
             };
@@ -250,7 +250,7 @@ internal partial class Program
 
         // 3. Title at the terminal's leading edge (right of the sidebar): a SINGLE centered row
         // showing the path (agterm-style): custom name -> program OSC title -> full cwd path.
-        string title = _active is not null ? SessionDisplayName(_active) : "agwinterm";
+        string title = _active is not null ? SessionDisplayName(_active) : AppName;
         // 4. Attention bell (can be hidden via settings; when hidden it reserves no space).
         bool showBell = _config.AttentionButton;
         float titleX = _sidebarW > 0 ? _sidebarW + 10f : togX + togW + 8f;
@@ -677,7 +677,7 @@ internal partial class Program
         {
             try
             {
-                string dir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "agwinterm", "omp-themes");
+                string dir = Path.Combine(AppDir, "omp-themes");
                 Directory.CreateDirectory(dir);
                 using var http = new System.Net.Http.HttpClient();
                 http.DefaultRequestHeaders.UserAgent.ParseAdd("agwinterm");
@@ -905,7 +905,7 @@ internal partial class Program
 
         // Bundled themes ship in themes/ next to the exe; user themes live under LOCALAPPDATA.
         string bundledDir = Path.Combine(AppContext.BaseDirectory, "themes");
-        string userDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "agwinterm", "themes");
+        string userDir = Path.Combine(AppDir, "themes");
         foreach (var dir in new[] { bundledDir, userDir })
         {
             try
@@ -1016,8 +1016,10 @@ internal partial class Program
 
     private static readonly JsonSerializerOptions _stateJson = new() { WriteIndented = true };
 
+    // Data root: %LOCALAPPDATA%\<instance-id> — "agwinterm" for the release, "agwinterm-dev" for dev builds,
+    // so the two keep separate config, sessions, themes, keymap, and window library. See Program._appId.
     private static string AppDir => Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "agwinterm");
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), AppName);
     private static string WindowsIndexPath => Path.Combine(AppDir, "windows.json");
     private static string LegacyStatePath => Path.Combine(AppDir, "state.json");
     private static string BackgroundsDir => Path.Combine(AppDir, "backgrounds"); // copied per-session watermark images
@@ -1100,8 +1102,7 @@ internal partial class Program
 
     private List<Pane> PanesOf(Ses s) { lock (_workspaces) return s.Panes.ToList(); }
 
-    private static string DenylistPath => Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "agwinterm", "restore-denylist.conf");
+    private static string DenylistPath => Path.Combine(AppDir, "restore-denylist.conf");
 
     /// <summary>Exe/process names (no extension) that restore-commands never re-runs. Seeds a starter file.</summary>
     private static HashSet<string> LoadDenylist()
@@ -1444,8 +1445,7 @@ internal partial class Program
         return true;
     }
 
-    private static string ConfigPath => Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "agwinterm", "agwinterm.conf");
+    private static string ConfigPath => Path.Combine(AppDir, "agwinterm.conf");
 
     private static TerminalConfig LoadOrCreateConfig()
     {

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -331,8 +331,39 @@ internal partial class Program : ISessionHost, IWindowHost
     // ---- CLI launch args (wt-style, applied to the first window): ----
     //   Agwinterm.Win32.exe [-p|--profile NAME] [-d|--dir PATH] [--maximized] [--fullscreen]
     private static bool _argNoRestore;   // --no-restore: fresh window, don't reopen the saved tree (elevated launch)
-    private static string _argPipe = "agwinterm";   // --pipe <name>: control-pipe name (isolate a test instance)
+    private static string? _argPipe;     // --pipe <name>: control-pipe name (default = the instance id)
     private static string? _argProfile;
+
+    // Instance identity: namespaces the data dir (%LOCALAPPDATA%\<id>), control pipe, and window/tray title
+    // so a dev build and the installed release keep entirely separate configs, sessions, and control surface
+    // and never step on each other. A Debug build defaults to "agwinterm-dev"; the shipped Release build is
+    // "agwinterm". Override with --app-id <name> or AGWINTERM_APP_ID for extra parallel instances.
+    private static readonly string _appId = ResolveAppId();
+    private static bool IsDev => _appId != "agwinterm";
+    internal static string AppName => _appId;
+
+    private static string ResolveAppId()
+    {
+        var args = Environment.GetCommandLineArgs();
+        for (int i = 1; i < args.Length - 1; i++)
+            if (args[i].Equals("--app-id", StringComparison.OrdinalIgnoreCase))
+                return SanitizeId(args[i + 1]);
+        if (Environment.GetEnvironmentVariable("AGWINTERM_APP_ID") is { Length: > 0 } env)
+            return SanitizeId(env);
+#if DEBUG
+        return "agwinterm-dev";
+#else
+        return "agwinterm";
+#endif
+    }
+
+    /// <summary>Reduce an app-id to a safe file/pipe token (letters, digits, dash, underscore, dot).</summary>
+    private static string SanitizeId(string s)
+    {
+        var chars = s.Trim().Where(c => char.IsLetterOrDigit(c) || c is '-' or '_' or '.').ToArray();
+        var id = new string(chars);
+        return string.IsNullOrEmpty(id) ? "agwinterm" : id;
+    }
     private static string? _argDir;
     private static bool _argMaximized, _argFullscreen;
 
@@ -348,6 +379,7 @@ internal partial class Program : ISessionHost, IWindowHost
                 case "--fullscreen": _argFullscreen = true; break;
                 case "--no-restore": _argNoRestore = true; break;
                 case "--pipe" when i + 1 < args.Length: _argPipe = args[++i]; break;
+                case "--app-id" when i + 1 < args.Length: ++i; break; // consumed by ResolveAppId (namespaces data dir + pipe)
                 // unknown args are ignored (forward compatibility)
             }
         }
@@ -359,6 +391,9 @@ internal partial class Program : ISessionHost, IWindowHost
     private static void Main(string[] args)
     {
         ParseLaunchArgs(args);
+        // Publish the resolved instance id so child processes and shared (Pty) helpers resolve the same
+        // data dir — and a nested agwinterm inherits the dev/release identity of the one that launched it.
+        Environment.SetEnvironmentVariable("AGWINTERM_APP_ID", _appId);
         SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
         // Process-global setup (config/themes/keymap + window class + shared D2D/DWrite objects).
         _config = LoadOrCreateConfig();
@@ -452,9 +487,9 @@ internal partial class Program : ISessionHost, IWindowHost
         if (_geoValid) ClampGeoToVisibleScreen(ref _geoX, ref _geoY, ref _geoW, ref _geoH);
         _creating = this;                    // so the WindowProc trampoline can resolve us during CreateWindowExW
         _hwnd = _geoValid
-            ? CreateWindowExW(0, ClassName, "agwinterm", WS_OVERLAPPEDWINDOW,
+            ? CreateWindowExW(0, ClassName, AppName, WS_OVERLAPPEDWINDOW,
                 _geoX, _geoY, _geoW, _geoH, IntPtr.Zero, IntPtr.Zero, hInstance, IntPtr.Zero)
-            : CreateWindowExW(0, ClassName, "agwinterm", WS_OVERLAPPEDWINDOW,
+            : CreateWindowExW(0, ClassName, AppName, WS_OVERLAPPEDWINDOW,
                 CW_USEDEFAULT, CW_USEDEFAULT, 1040, 660, IntPtr.Zero, IntPtr.Zero, hInstance, IntPtr.Zero);
         _creating = null;
         if (_hwnd == IntPtr.Zero)
@@ -1002,13 +1037,15 @@ internal partial class Program : ISessionHost, IWindowHost
         // One control server for the whole app (one pipe); it resolves --window through the library.
         if (_control is null)
         {
-            _control = new ControlServer(this, this, _argPipe);
+            _control = new ControlServer(this, this, _argPipe ?? _appId);
             _control.Start();
             // Default-terminal handoff (T2-13): register the COM class factory so conhost can hand
             // console sessions to this instance. Each handoff opens a new attached session.
             DefTerm.OnHandoff = args => Post(() =>
                 CreateSession(Guid.NewGuid().ToString(), null, null, ActiveWorkspace(), makeActive: true, handoff: args));
-            try { DefTerm.RegisterServer(); } catch { /* defterm not registered / unsupported */ }
+            // Dev builds don't register as the default-terminal COM server — that CLSID is owned by the
+            // installed release, and a dev instance must not intercept the OS's console handoffs.
+            if (!IsDev) { try { DefTerm.RegisterServer(); } catch { /* defterm not registered / unsupported */ } }
             // UIA (T2-14): expose the active pane's visible text to screen readers.
             Uia.GetVisibleText = () =>
             {


### PR DESCRIPTION
So you can daily-drive the installed **release** and let me run **dev builds** at the same time without them fighting.

## The problem
A dev build and the installed release shared **everything** that matters for coexistence:
- the data dir `%LOCALAPPDATA%\agwinterm` (config, sessions, window library) — a dev run could clobber your real state
- the `agwinterm` control pipe — `agwintermctl` round-robined between the two instances non-deterministically (I actually leaked test sessions into your live window earlier because of this)

## The fix — an instance identity
- **Debug builds default to `agwinterm-dev`**; the shipped **Release** stays `agwinterm`.
- It namespaces **the data dir** (`%LOCALAPPDATA%\<id>` — config, sessions, keymap, themes, denylist, omp-themes), **the control pipe** (default = id), and the **window/tray title**.
- Dev builds **skip default-terminal COM registration**, so they never intercept the release's console handoffs.
- Override with `--app-id <name>` or `AGWINTERM_APP_ID` for extra throwaway instances.
- `agwintermctl` now accepts `--pipe` as an alias for `--socket` (matches the app's flag); the app exports `AGWINTERM_APP_ID` so children + shared helpers resolve the same instance.

## Usage
```powershell
dotnet run --project src/Agwinterm.Win32     # -> the agwinterm-dev instance (own data + pipe)
agwintermctl --pipe agwinterm-dev tree       # drive dev from outside
agwintermctl tree                            # (default) drives the release
```
Inside any session `AGWINTERM_PIPE` is set, so a bare `agwintermctl` auto-targets the instance it runs in.

## Verification (live, side-by-side with your running release)
Launched the Debug build with **no flags**:
```
DEV (--socket agwinterm-dev) tree:  workspace 1 / session 1        # fresh, isolated
REL (--socket agwinterm)     tree:  docxy / agwinterm (your claude sessions)   # untouched
release windows.json mtime: unchanged   (UNTOUCHED: True)
new dir created: %LOCALAPPDATA%\agwinterm-dev  (own agwinterm.conf, keymap.conf, profiles.json, windows\)
```
`dotnet build` clean; **154/154** tests pass.

Note: this is the first time I could safely run a live instance beside your release — which is exactly the point of the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)