### PR TITLE
feat(claude): `claude adopt` — migrate existing sessions to auto-resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ the real thing: **[github.com/umputun/agterm](https://github.com/umputun/agterm)
   wrapper (active only inside agwinterm) that ties Claude's session id to the agwinterm pane. You
   just type `claude` — a fresh pane starts a bound session, and a pane that already has a transcript
   **resumes** it. On restart, agwinterm re-launches each bound pane and the conversation comes back —
-  no guessing which shell was which.
+  no guessing which shell was which. Already had Claude running before installing this? Run
+  `agwintermctl claude adopt` (or palette → *Make Claude Sessions Resumable*) once to bind your
+  existing conversations to their panes.
 - **A scriptable control API**: `agwintermctl` (or newline-JSON over a named pipe) — any language can
   drive it, including full **read-back** (tree with split ratios + pane ids, window state, session
   output). Opt-in installers for the **agent skill** and **Claude Code / Codex status hooks**.

--- a/src/Agwinterm.Ctl/Program.cs
+++ b/src/Agwinterm.Ctl/Program.cs
@@ -205,6 +205,7 @@ switch (area)
             default: Console.Error.WriteLine($"unknown command '{area} {sub}'"); return 2;
         }
         break;
+    case "claude" when sub == "adopt": cmd = "claude.adopt"; break; // bind existing claude convos to their panes
     case "theme" when sub == "list": cmd = "theme.list"; break;
     case "theme" when sub == "set":
         cmd = "theme.set";

--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -197,6 +197,8 @@ public sealed class ControlServer : IDisposable
                     return host.SessionFlag(target, GetString(args, "op") ?? "toggle") ? Ok("flag") : Err("session not found");
                 case "session.bind":
                     return host.SessionBind(target, GetString(args, "agent") ?? "claude") ? Ok("bound") : Err("session not found");
+                case "claude.adopt":
+                    return Ok(host.AdoptClaude());
                 case "workspace.focus": host.WorkspaceFocus(GetString(args, "op") ?? "toggle"); return Ok("focus");
                 case "session.background":
                     return Ok(host.SessionBackground(target, GetString(args, "action") ?? "set",

--- a/src/Agwinterm.Pty/ISessionHost.cs
+++ b/src/Agwinterm.Pty/ISessionHost.cs
@@ -161,6 +161,10 @@ public interface ISessionHost
     /// Returns false if the target pane isn't found.</summary>
     bool SessionBind(string? target, string agent);
 
+    /// <summary>One-time migration: bind every pane that has an existing Claude transcript for its cwd to
+    /// resume that conversation on restart (for sessions started before the launcher wrapper). Returns a summary.</summary>
+    string AdoptClaude();
+
     /// <summary>Focus/unfocus the active workspace (hide the others in the sidebar tree): op = on|off|toggle.</summary>
     void WorkspaceFocus(string op);
 
@@ -252,6 +256,7 @@ public sealed class SingleSessionHost : ISessionHost
     public bool Notify(string? target, string? title, string body) => false;
     public bool SessionFlag(string? target, string op) => false;
     public bool SessionBind(string? target, string agent) => false;
+    public string AdoptClaude() => "unsupported";
     public void WorkspaceFocus(string op) { }
     public string SessionBackground(string? target, string action, string? path, int opacity, string? mode) => "unsupported";
     public string SessionSwitch(string op) => "unsupported";

--- a/src/Agwinterm.Win32/Program.Chrome.cs
+++ b/src/Agwinterm.Win32/Program.Chrome.cs
@@ -804,6 +804,7 @@ internal partial class Program
                 // Opt-in integrations (agterm's Help-menu trio + shell) — the installer stays minimal.
                 A("Install Command-Line Tool (PATH)", "", InstallCli);
                 A("Install Agent Status Hooks", "", InstallHooks);
+                A("Make Claude Sessions Resumable", "", MakeClaudeResumable);
                 A("Install Agent Skill", "", InstallSkill);
                 A("Install Shell Integration", "", InstallShellIntegration);
                 A("Reload Keymap", "", ReloadKeymap);

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -556,6 +556,8 @@ internal partial class Program
             return true;
         }
 
+        public string AdoptClaude() => InvokeOnUi(() => AdoptClaudeSessions());
+
         public string SessionBackground(string? target, string action, string? path, int opacity, string? mode) => InvokeOnUi(() =>
         {
             var ses = FindSesForTarget(target);

--- a/src/Agwinterm.Win32/Program.Input.cs
+++ b/src/Agwinterm.Win32/Program.Input.cs
@@ -167,6 +167,8 @@ internal partial class Program
     private void InstallCli() => RunInstaller(Agwinterm.Pty.CliInstaller.Install);
     /// <summary>Opt-in: install Claude Code / Codex / generic agent status hooks.</summary>
     private void InstallHooks() => RunInstaller(Agwinterm.Pty.AgentHooks.Install);
+    /// <summary>Migrate pre-launcher Claude sessions: bind each pane to resume its current conversation.</summary>
+    private void MakeClaudeResumable() => ShowToast(AdoptClaudeSessions(), 3200);
     /// <summary>Opt-in: install the agent skill (teaches agents to drive agwinterm via agwintermctl).</summary>
     private void InstallSkill() => RunInstaller(Agwinterm.Pty.AgentSkill.Install);
 

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -652,6 +652,52 @@ internal partial class Program
 
     /// <summary>Resolve a pane by id across split panes, per-session scratch/overlay, and the quick terminal
     /// (so <c>agwintermctl font --target &lt;paneId&gt;</c> can zoom a specific pane). Null if no pane matches.</summary>
+    /// <summary>Claude's per-project transcript dir name: the cwd with every non-alphanumeric byte turned
+    /// into '-' (matches the encoding in the ClaudeIntegration wrapper and Claude Code itself).</summary>
+    private static string EncodeClaudeProject(string path)
+    {
+        var sb = new StringBuilder(path.Length);
+        foreach (char c in path)
+            sb.Append((c is >= 'a' and <= 'z' or >= 'A' and <= 'Z' or >= '0' and <= '9') ? c : '-');
+        return sb.ToString();
+    }
+
+    /// <summary>One-time migration for sessions started BEFORE the claude launcher existed: for each pane,
+    /// find the newest Claude transcript for its cwd (its current conversation) and bind the pane to resume
+    /// exactly that on restart. Idempotent; re-running just refreshes the bindings. Returns a summary.</summary>
+    internal string AdoptClaudeSessions()
+    {
+        string? cfg = Environment.GetEnvironmentVariable("CLAUDE_CONFIG_DIR");
+        string projects = string.IsNullOrWhiteSpace(cfg)
+            ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".claude", "projects")
+            : Path.Combine(cfg, "projects");
+
+        List<Pane> panes;
+        lock (_workspaces) panes = _workspaces.SelectMany(w => w.Sessions).SelectMany(s => s.Panes).ToList();
+
+        int adopted = 0;
+        foreach (var p in panes)
+        {
+            string cwd = PrettyCwd(SafeCwd(p));
+            if (string.IsNullOrWhiteSpace(cwd) || !Directory.Exists(cwd)) cwd = p.StartCwd ?? "";
+            if (string.IsNullOrWhiteSpace(cwd)) continue;
+            string dir = Path.Combine(projects, EncodeClaudeProject(cwd));
+            if (!Directory.Exists(dir)) continue;
+            FileInfo? newest = null;
+            try { newest = new DirectoryInfo(dir).GetFiles("*.jsonl").OrderByDescending(f => f.LastWriteTimeUtc).FirstOrDefault(); }
+            catch { }
+            if (newest is null) continue;
+            // Store the full resume command; the restore path types it verbatim and the claude wrapper (or the
+            // real CLI) honors --resume, so the exact conversation comes back on every relaunch.
+            p.AgentResume = "claude --resume " + Path.GetFileNameWithoutExtension(newest.Name);
+            adopted++;
+        }
+        if (adopted > 0) { SaveState(); RequestRedraw(); }
+        return adopted == 0
+            ? "no adoptable Claude sessions found (no transcript matched any pane's folder)"
+            : $"adopted {adopted} Claude session(s) — restart agwinterm to resume them (or type the resume yourself now)";
+    }
+
     private (Pane pane, Ses? ses, bool cover)? FindPaneById(string id)
     {
         lock (_workspaces)

--- a/tests/Agwinterm.Pty.Tests/ControlApiTests.cs
+++ b/tests/Agwinterm.Pty.Tests/ControlApiTests.cs
@@ -162,6 +162,16 @@ public class ControlApiTests
     }
 
     [Fact]
+    public void ClaudeAdopt_BindsSessions()
+    {
+        var (server, host) = New();
+        var r = Dispatch(server, "claude.adopt");
+        Assert.True(Ok(r));
+        Assert.Contains("adopted", Result(r));
+        Assert.Equal("claude --resume x", host.ActiveSess!.AgentResume);
+    }
+
+    [Fact]
     public void CloseSession_RemovesIt()
     {
         var (server, host) = New();

--- a/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
+++ b/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
@@ -123,6 +123,7 @@ internal sealed class FakeSessionHost : ISessionHost
     public bool Notify(string? target, string? title, string body) { var s = Find(target); if (s is null) return false; s.Notifications++; return true; }
     public bool SessionFlag(string? target, string op) { if (op == "clear") { foreach (var s in Workspaces.SelectMany(w => w.Sessions)) s.Flagged = false; return true; } var x = Find(target); if (x is null) return false; x.Flagged = op switch { "on" => true, "off" => false, "toggle" => !x.Flagged, _ => x.Flagged }; return true; }
     public bool SessionBind(string? target, string agent) { var s = Find(target); if (s is null) return false; s.AgentResume = string.IsNullOrWhiteSpace(agent) || agent == "none" ? null : agent; return true; }
+    public string AdoptClaude() { int n = 0; foreach (var s in Workspaces.SelectMany(w => w.Sessions)) { s.AgentResume = "claude --resume x"; n++; } return $"adopted {n}"; }
     public void WorkspaceFocus(string op) { }
     public string SessionBackground(string? target, string action, string? path, int opacity, string? mode) => Find(target) is not null ? "ok" : "no session";
     public string SessionSwitch(string op) => ActiveSess?.Name ?? "";


### PR DESCRIPTION
The migration path you picked. Makes your **current** Claude sessions resumable when you upgrade.

## Why it's needed
The launcher (#77) binds **new** `claude` sessions by pane id. Sessions started **before** it existed live under Claude's own ids and aren't marked resumable, so they wouldn't come back on restart.

## What it does
`agwintermctl claude adopt` (or palette → **Make Claude Sessions Resumable**): for each pane it finds the **newest Claude transcript for that pane's folder** (its current conversation) and binds the pane to `claude --resume <that-id>`. On restart, agwinterm's restore path types that verbatim — the wrapper (or even the bare CLI) honors `--resume` — so the exact conversation returns. Idempotent; honors `CLAUDE_CONFIG_DIR`.

Your setup is the easy case: docxy and agwinterm are different folders, so each maps to exactly one conversation.

## Your upgrade flow (per laptop)
```
1. install the release
2. launch agwinterm            # your panes restore to their folders
3. agwintermctl install hooks  # status dots + claude wrapper
4. agwintermctl claude adopt   # bind each pane to its current conversation
5. restart agwinterm           # every session comes back, resumed + bound
```

## Verification (live, safe)
Ran on the isolated **dev** instance (`agwinterm-dev`) with a throwaway `CLAUDE_CONFIG_DIR`, so real `~/.claude` and the release were untouched:
```
planted transcript: <folder>\11112222-...-666677778888.jsonl
ADOPT: adopted 1 Claude session(s) — restart agwinterm to resume them
  session 'adopttest' pane.AgentResume = 'claude --resume 11112222-...-666677778888'
RESULT: bound the pane to the exact conversation: True
```
`dotnet build` clean; **155/155** tests pass (added a `claude.adopt` contract test).

Note: adopt binds any pane that has a transcript for its folder. If it ever binds one you didn't mean, clear it with `agwintermctl session bind none --target <id>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)