### PR TITLE
release: v0.13.0 — Claude session resume + dev/release isolation

### DIFF
--- a/installer/agwinterm.iss
+++ b/installer/agwinterm.iss
@@ -2,7 +2,7 @@
 ; Build via installer\build.ps1 (publishes to stage\ then runs ISCC on this file).
 
 #define AppName    "agwinterm"
-#define AppVersion "0.12.1"
+#define AppVersion "0.13.0"
 #define AppExe     "Agwinterm.Win32.exe"
 #define AppPublisher "Boris Kudriashov"
 


### PR DESCRIPTION
Cuts **0.13.0**. Bumps `installer/agwinterm.iss` (single version source); tag `v0.13.0` triggers `release.yml`.

## What's in it (this session's work)
**Claude Code experience**
- Status-dot routing fix + transparent `claude` wrapper that binds Claude's session id to the pane and **auto-resumes on restart** (#77)
- `claude adopt` to migrate existing pre-launcher sessions into that scheme (#82)

**Fixes**
- Ctrl+C copies the mouse selection reliably in Claude Code — selection survives in-place repaints (#78)
- No blank pane when switching sessions (#79)
- Sidebar names no longer overlap the status dot at larger fonts (#80)

**Dev workflow**
- Dev builds run fully isolated from the installed release — separate data dir + control pipe `agwinterm-dev` (#81)

## After merge
Tag `v0.13.0` → `release.yml` builds the installer + portable exe, attaches them with Sigstore provenance, and best-efforts winget/choco (Scoop auto-updates via Excavator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)