### PR TITLE
feat(claude): quick action — restart current Claude in YOLO mode

### DIFF
--- a/src/Agwinterm.Ctl/Program.cs
+++ b/src/Agwinterm.Ctl/Program.cs
@@ -206,6 +206,7 @@ switch (area)
         }
         break;
     case "claude" when sub == "adopt": cmd = "claude.adopt"; break; // bind existing claude convos to their panes
+    case "claude" when sub == "yolo": cmd = "claude.yolo"; target = DefaultTarget(); break; // restart the target pane's claude in --dangerously-skip-permissions, resumed
     case "theme" when sub == "list": cmd = "theme.list"; break;
     case "theme" when sub == "set":
         cmd = "theme.set";

--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -199,6 +199,8 @@ public sealed class ControlServer : IDisposable
                     return host.SessionBind(target, GetString(args, "agent") ?? "claude") ? Ok("bound") : Err("session not found");
                 case "claude.adopt":
                     return Ok(host.AdoptClaude());
+                case "claude.yolo":
+                    return Ok(host.RestartClaudeYolo(target));
                 case "workspace.focus": host.WorkspaceFocus(GetString(args, "op") ?? "toggle"); return Ok("focus");
                 case "session.background":
                     return Ok(host.SessionBackground(target, GetString(args, "action") ?? "set",

--- a/src/Agwinterm.Pty/ISessionHost.cs
+++ b/src/Agwinterm.Pty/ISessionHost.cs
@@ -165,6 +165,10 @@ public interface ISessionHost
     /// resume that conversation on restart (for sessions started before the launcher wrapper). Returns a summary.</summary>
     string AdoptClaude();
 
+    /// <summary>Restart the target pane's Claude in YOLO mode (--dangerously-skip-permissions), resuming its
+    /// current conversation, and persist that as the pane's relaunch command. Null target = the active pane.</summary>
+    string RestartClaudeYolo(string? target);
+
     /// <summary>Focus/unfocus the active workspace (hide the others in the sidebar tree): op = on|off|toggle.</summary>
     void WorkspaceFocus(string op);
 
@@ -257,6 +261,7 @@ public sealed class SingleSessionHost : ISessionHost
     public bool SessionFlag(string? target, string op) => false;
     public bool SessionBind(string? target, string agent) => false;
     public string AdoptClaude() => "unsupported";
+    public string RestartClaudeYolo(string? target) => "unsupported";
     public void WorkspaceFocus(string op) { }
     public string SessionBackground(string? target, string action, string? path, int opacity, string? mode) => "unsupported";
     public string SessionSwitch(string op) => "unsupported";

--- a/src/Agwinterm.Win32/Program.Chrome.cs
+++ b/src/Agwinterm.Win32/Program.Chrome.cs
@@ -805,6 +805,7 @@ internal partial class Program
                 A("Install Command-Line Tool (PATH)", "", InstallCli);
                 A("Install Agent Status Hooks", "", InstallHooks);
                 A("Make Claude Sessions Resumable", "", MakeClaudeResumable);
+                A("Restart Claude in YOLO Mode", "", RestartClaudeYoloActive);
                 A("Install Agent Skill", "", InstallSkill);
                 A("Install Shell Integration", "", InstallShellIntegration);
                 A("Reload Keymap", "", ReloadKeymap);

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -558,6 +558,12 @@ internal partial class Program
 
         public string AdoptClaude() => InvokeOnUi(() => AdoptClaudeSessions());
 
+        public string RestartClaudeYolo(string? target) => InvokeOnUi(() =>
+        {
+            var p = string.IsNullOrEmpty(target) ? ActiveSurface() : (FindPaneById(target!)?.pane ?? ActiveSurface());
+            return p is null ? "no pane" : RestartClaudeYolo(p);
+        });
+
         public string SessionBackground(string? target, string action, string? path, int opacity, string? mode) => InvokeOnUi(() =>
         {
             var ses = FindSesForTarget(target);

--- a/src/Agwinterm.Win32/Program.Input.cs
+++ b/src/Agwinterm.Win32/Program.Input.cs
@@ -169,6 +169,8 @@ internal partial class Program
     private void InstallHooks() => RunInstaller(Agwinterm.Pty.AgentHooks.Install);
     /// <summary>Migrate pre-launcher Claude sessions: bind each pane to resume its current conversation.</summary>
     private void MakeClaudeResumable() => ShowToast(AdoptClaudeSessions(), 3200);
+    /// <summary>Restart the active pane's Claude in YOLO mode (--dangerously-skip-permissions), resumed.</summary>
+    private void RestartClaudeYoloActive() { var p = ActiveSurface(); ShowToast(p is null ? "no active pane" : RestartClaudeYolo(p), 2500); }
     /// <summary>Opt-in: install the agent skill (teaches agents to drive agwinterm via agwintermctl).</summary>
     private void InstallSkill() => RunInstaller(Agwinterm.Pty.AgentSkill.Install);
 

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -662,34 +662,74 @@ internal partial class Program
         return sb.ToString();
     }
 
+    /// <summary>A real filesystem cwd for a pane: live OSC-7 cwd if valid, else its launch dir.</summary>
+    private static string PaneCwd(Pane p)
+    {
+        string cwd = PrettyCwd(SafeCwd(p));
+        if (string.IsNullOrWhiteSpace(cwd) || !Directory.Exists(cwd)) cwd = p.StartCwd ?? "";
+        return cwd;
+    }
+
+    /// <summary>The id of the newest Claude conversation for a folder (its current session), or null if none.
+    /// Honors CLAUDE_CONFIG_DIR; uses the same project-dir encoding as Claude Code and the launcher wrapper.</summary>
+    private static string? NewestClaudeSessionId(string cwd)
+    {
+        if (string.IsNullOrWhiteSpace(cwd)) return null;
+        string? cfg = Environment.GetEnvironmentVariable("CLAUDE_CONFIG_DIR");
+        string projects = string.IsNullOrWhiteSpace(cfg)
+            ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".claude", "projects")
+            : Path.Combine(cfg, "projects");
+        string dir = Path.Combine(projects, EncodeClaudeProject(cwd));
+        if (!Directory.Exists(dir)) return null;
+        try
+        {
+            var newest = new DirectoryInfo(dir).GetFiles("*.jsonl").OrderByDescending(f => f.LastWriteTimeUtc).FirstOrDefault();
+            return newest is null ? null : Path.GetFileNameWithoutExtension(newest.Name);
+        }
+        catch { return null; }
+    }
+
+    /// <summary>Restart the Claude Code running in a pane in YOLO mode (--dangerously-skip-permissions),
+    /// resuming its current conversation. Sends a double Ctrl+C to quit the running Claude, then relaunches
+    /// resumed + dangerous, and persists that as the pane's relaunch command so restarts stay YOLO.</summary>
+    private string RestartClaudeYolo(Pane p)
+    {
+        string? id = NewestClaudeSessionId(PaneCwd(p));
+        // Resume the existing conversation if we found one; otherwise start a fresh YOLO session.
+        string cmd = id is null
+            ? "claude --dangerously-skip-permissions"
+            : $"claude --resume {id} --dangerously-skip-permissions";
+        p.AgentResume = cmd;   // future restarts stay YOLO
+        SaveState();
+        var pane = p;
+        _ = Task.Run(async () =>
+        {
+            // Quit the running Claude (Ctrl+C twice = exit), let the shell settle, then relaunch.
+            try { pane.S.Write(new byte[] { 0x03 }); } catch { }
+            await Task.Delay(350);
+            try { pane.S.Write(new byte[] { 0x03 }); } catch { }
+            await Task.Delay(1200);
+            try { pane.S.Write(System.Text.Encoding.UTF8.GetBytes(cmd + "\r")); } catch { }
+        });
+        return id is null ? "restarting Claude in YOLO mode (fresh session)" : "restarting Claude in YOLO mode (resumed)";
+    }
+
     /// <summary>One-time migration for sessions started BEFORE the claude launcher existed: for each pane,
     /// find the newest Claude transcript for its cwd (its current conversation) and bind the pane to resume
     /// exactly that on restart. Idempotent; re-running just refreshes the bindings. Returns a summary.</summary>
     internal string AdoptClaudeSessions()
     {
-        string? cfg = Environment.GetEnvironmentVariable("CLAUDE_CONFIG_DIR");
-        string projects = string.IsNullOrWhiteSpace(cfg)
-            ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".claude", "projects")
-            : Path.Combine(cfg, "projects");
-
         List<Pane> panes;
         lock (_workspaces) panes = _workspaces.SelectMany(w => w.Sessions).SelectMany(s => s.Panes).ToList();
 
         int adopted = 0;
         foreach (var p in panes)
         {
-            string cwd = PrettyCwd(SafeCwd(p));
-            if (string.IsNullOrWhiteSpace(cwd) || !Directory.Exists(cwd)) cwd = p.StartCwd ?? "";
-            if (string.IsNullOrWhiteSpace(cwd)) continue;
-            string dir = Path.Combine(projects, EncodeClaudeProject(cwd));
-            if (!Directory.Exists(dir)) continue;
-            FileInfo? newest = null;
-            try { newest = new DirectoryInfo(dir).GetFiles("*.jsonl").OrderByDescending(f => f.LastWriteTimeUtc).FirstOrDefault(); }
-            catch { }
-            if (newest is null) continue;
+            string? id = NewestClaudeSessionId(PaneCwd(p));
+            if (id is null) continue;
             // Store the full resume command; the restore path types it verbatim and the claude wrapper (or the
             // real CLI) honors --resume, so the exact conversation comes back on every relaunch.
-            p.AgentResume = "claude --resume " + Path.GetFileNameWithoutExtension(newest.Name);
+            p.AgentResume = "claude --resume " + id;
             adopted++;
         }
         if (adopted > 0) { SaveState(); RequestRedraw(); }

--- a/tests/Agwinterm.Pty.Tests/ControlApiTests.cs
+++ b/tests/Agwinterm.Pty.Tests/ControlApiTests.cs
@@ -172,6 +172,16 @@ public class ControlApiTests
     }
 
     [Fact]
+    public void ClaudeYolo_RestartsWithDangerousFlag()
+    {
+        var (server, host) = New();
+        var r = Dispatch(server, "claude.yolo", target: "s1");
+        Assert.True(Ok(r));
+        Assert.Contains("YOLO", Result(r));
+        Assert.Contains("--dangerously-skip-permissions", host.ActiveSess!.AgentResume);
+    }
+
+    [Fact]
     public void CloseSession_RemovesIt()
     {
         var (server, host) = New();

--- a/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
+++ b/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
@@ -124,6 +124,7 @@ internal sealed class FakeSessionHost : ISessionHost
     public bool SessionFlag(string? target, string op) { if (op == "clear") { foreach (var s in Workspaces.SelectMany(w => w.Sessions)) s.Flagged = false; return true; } var x = Find(target); if (x is null) return false; x.Flagged = op switch { "on" => true, "off" => false, "toggle" => !x.Flagged, _ => x.Flagged }; return true; }
     public bool SessionBind(string? target, string agent) { var s = Find(target); if (s is null) return false; s.AgentResume = string.IsNullOrWhiteSpace(agent) || agent == "none" ? null : agent; return true; }
     public string AdoptClaude() { int n = 0; foreach (var s in Workspaces.SelectMany(w => w.Sessions)) { s.AgentResume = "claude --resume x"; n++; } return $"adopted {n}"; }
+    public string RestartClaudeYolo(string? target) { var s = Find(target); if (s is null) return "no pane"; s.AgentResume = "claude --resume x --dangerously-skip-permissions"; return "restarting Claude in YOLO mode (resumed)"; }
     public void WorkspaceFocus(string op) { }
     public string SessionBackground(string? target, string action, string? path, int opacity, string? mode) => Find(target) is not null ? "ok" : "no session";
     public string SessionSwitch(string op) => ActiveSess?.Name ?? "";


### PR DESCRIPTION
Your requested quick action. Resumed sessions came back in normal-permission mode because the relaunch didn't carry `--dangerously-skip-permissions`; this adds an on-demand way to bump the current session to YOLO.

## What it does
**Restart Claude in YOLO Mode** — palette action, `agwintermctl claude yolo`, and a `claude.yolo` control verb. On the active (or `--target`) pane it:
1. Quits the running Claude (sends Ctrl+C twice),
2. Relaunches `claude --resume <current-conversation> --dangerously-skip-permissions` (resumes the same conversation, now YOLO),
3. **Persists** that as the pane's relaunch command, so every future agwinterm restart keeps it YOLO.

If no transcript matches the folder, it starts a fresh `claude --dangerously-skip-permissions`.

Self-contained: works whether or not the `claude` wrapper is installed (the bare CLI honors `--resume`/the flag).

## Verification (live, isolated dev instance)
```
YOLO: restarting Claude in YOLO mode (resumed)
  'yolotest' AgentResume = 'claude --resume aaaabbbb-...-ffff00001111 --dangerously-skip-permissions'
RESULT: persisted resumed+YOLO relaunch: True
```
`dotnet build` clean; **156/156** tests pass (added a `claude.yolo` contract test).

Note: the double-Ctrl+C exit is most reliable when Claude is idle at its prompt (the normal case when you invoke this). If Claude is mid-task, interrupt it first.

Follow-up incoming: I also found a real 0.13.0 bug while testing — a Debug build launched from *inside* a release session inherits the release identity (via `AGWINTERM_APP_ID`) and collides instead of using `agwinterm-dev`. Fixing that next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)