### PR TITLE
fix(dev): a Debug build is always the dev instance, even launched from inside release

### DIFF
--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -336,23 +336,27 @@ internal partial class Program : ISessionHost, IWindowHost
 
     // Instance identity: namespaces the data dir (%LOCALAPPDATA%\<id>), control pipe, and window/tray title
     // so a dev build and the installed release keep entirely separate configs, sessions, and control surface
-    // and never step on each other. A Debug build defaults to "agwinterm-dev"; the shipped Release build is
-    // "agwinterm". Override with --app-id <name> or AGWINTERM_APP_ID for extra parallel instances.
+    // and never step on each other. A Debug build is ALWAYS "agwinterm-dev"; the shipped Release build is
+    // "agwinterm". Override with --app-id <name>; a Release build also inherits AGWINTERM_APP_ID (nesting).
     private static readonly string _appId = ResolveAppId();
     private static bool IsDev => _appId != "agwinterm";
     internal static string AppName => _appId;
 
     private static string ResolveAppId()
     {
+        // An explicit --app-id always wins.
         var args = Environment.GetCommandLineArgs();
         for (int i = 1; i < args.Length - 1; i++)
             if (args[i].Equals("--app-id", StringComparison.OrdinalIgnoreCase))
                 return SanitizeId(args[i + 1]);
-        if (Environment.GetEnvironmentVariable("AGWINTERM_APP_ID") is { Length: > 0 } env)
-            return SanitizeId(env);
 #if DEBUG
+        // A Debug build is dev PERIOD — it must not adopt a release identity just because it was launched
+        // from inside a release session (which exports AGWINTERM_APP_ID), or it would collide with it.
         return "agwinterm-dev";
 #else
+        // Release: inherit AGWINTERM_APP_ID so a nested agwinterm shares its parent's identity, else default.
+        if (Environment.GetEnvironmentVariable("AGWINTERM_APP_ID") is { Length: > 0 } env)
+            return SanitizeId(env);
         return "agwinterm";
 #endif
     }


### PR DESCRIPTION
A real bug I hit while testing on 0.13.0.

## The bug
#81 made the app export `AGWINTERM_APP_ID` into every session's env so nested/child instances inherit the identity. But that means a **Debug build launched from a terminal inside the installed Release** inherits `AGWINTERM_APP_ID=agwinterm` and adopts the **release** identity — colliding on the release's data dir and control pipe. That's exactly what the isolation was supposed to prevent, and it bit both my automated testing and would bite anyone running `dotnet run` from inside their release agwinterm.

## The fix
Reorder identity resolution so a **Debug build is unconditionally `agwinterm-dev`** (only an explicit `--app-id` overrides). Release builds still inherit `AGWINTERM_APP_ID` for legitimate nesting.

**Release compilation is unchanged** (`arg > env > "agwinterm"`), so zero risk to the shipped build — only Debug behavior changes.

## Verification (live)
With `AGWINTERM_APP_ID=agwinterm` in the environment (as it is inside a release session), a no-flag Debug build now serves `\.\pipe\agwinterm-dev` **alongside** the release's `\.\pipe\agwinterm` — no collision:
```
inherited AGWINTERM_APP_ID = 'agwinterm'
pipes after launching Debug build (no flags): \.\pipe\agwinterm, \.\pipe\agwinterm-dev
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)