### PR TITLE
release: v0.13.1 — Claude YOLO quick action + dev-isolation fix

### DIFF
--- a/installer/agwinterm.iss
+++ b/installer/agwinterm.iss
@@ -2,7 +2,7 @@
 ; Build via installer\build.ps1 (publishes to stage\ then runs ISCC on this file).
 
 #define AppName    "agwinterm"
-#define AppVersion "0.13.0"
+#define AppVersion "0.13.1"
 #define AppExe     "Agwinterm.Win32.exe"
 #define AppPublisher "Boris Kudriashov"
 


### PR DESCRIPTION
Cuts **0.13.1**. Bumps `installer/agwinterm.iss`; tag `v0.13.1` triggers `release.yml`.

## What's in it
- **feat(claude): Restart Claude in YOLO Mode** (#84) — palette action + `agwintermctl claude yolo`. Quits the current Claude and relaunches it **resumed** with `--dangerously-skip-permissions`, persisted so restarts stay YOLO.
- **fix(dev): Debug builds are always `agwinterm-dev`** (#86) — even launched from inside a release session, so dev builds never collide with the installed release.

## After merge
Tag `v0.13.1` → `release.yml` builds installer + portable exe with Sigstore provenance; winget/choco best-effort; Scoop auto-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)