### PR TITLE
fix(ctl): lock pane-list mutations against the control-pipe reader (#85)

### DIFF
--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -793,7 +793,7 @@ internal partial class Program
         float half = cur.Ratio / 2f;
         cur.Ratio = half; np.Ratio = half;
         int idx = ses.Panes.IndexOf(cur);
-        ses.Panes.Insert(idx + 1, np);
+        lock (_workspaces) ses.Panes.Insert(idx + 1, np);   // exclude the control-pipe reader mid-enumeration (issue #85)
         ses.Active = idx + 1;            // focus the new pane
         _session = ses.S;
         RegridSession(ses);
@@ -825,7 +825,7 @@ internal partial class Program
         var cur = ses.ActivePane;
         int idx = ses.Panes.IndexOf(cur);
         try { cur.S.Dispose(); } catch { }
-        ses.Panes.RemoveAt(idx);
+        lock (_workspaces) ses.Panes.RemoveAt(idx);   // exclude the control-pipe reader mid-enumeration (issue #85)
         float freed = cur.Ratio / ses.Panes.Count;
         foreach (var p in ses.Panes) p.Ratio += freed;   // redistribute the freed width
         ses.Active = Math.Clamp(idx, 0, ses.Panes.Count - 1);
@@ -1115,7 +1115,9 @@ internal partial class Program
         if (ses is null || ses.Panes.Count <= 1) return;
         var keep = ses.Panes[0];   // agterm: collapsing the split keeps the primary (left) pane, not whichever is focused
         foreach (var p in ses.Panes) if (!ReferenceEquals(p, keep)) { try { p.S.Dispose(); } catch { } }
-        ses.Panes.Clear(); ses.Panes.Add(keep); keep.Ratio = 1f; ses.Active = 0;
+        // Clear+Add as one atomic step so the control-pipe reader never sees an empty pane list (issue #85).
+        lock (_workspaces) { ses.Panes.Clear(); ses.Panes.Add(keep); }
+        keep.Ratio = 1f; ses.Active = 0;
         _session = ses.S;
         RegridSession(ses); RequestRedraw(); SaveState();
     }


### PR DESCRIPTION
Fixes #85.

## Root cause

The control server resolves `session text` (and every session-targeted verb) **on the pipe thread** by enumerating the pane lists under `lock(_workspaces)`:

```csharp
var panes = _workspaces.SelectMany(w => w.Sessions).SelectMany(s => s.Panes).ToList();
```

But three **UI-thread** paths structurally mutate a reachable session's `Panes` list *without* taking that lock, so the lock the readers hold protected nothing against them:

| Path | Op | Was locked? |
|---|---|---|
| `SplitActivePane` | `Panes.Insert` | ❌ |
| `CloseActivePane` | `Panes.RemoveAt` | ❌ |
| `CollapseToSinglePane` | `Panes.Clear()` + `Add` | ❌ |
| `OnPaneProcessExited` | `Panes.RemoveAt` | ✅ (already correct — the model) |

A `List<Pane>` mutated on the UI thread while the pipe thread enumerates it is a data race: the reader can throw, observe a **duplicated element** mid-array-shift, or read a torn/partial list — so `Resolve`/`Find` can hand back the wrong (or a blank, never-painted) session. That lines up with the issue's trigger (heavy scripted `session new`/`close`/split churn) and its **read-only** symptom (`tree`/`new`/`close` fine; only `session text` returned the degenerate near-blank dump).

## Fix

Take `lock(_workspaces)` around the three structural mutations, mirroring `OnPaneProcessExited`. The lock stays tight around the list op only — process spawn/dispose, regrid, redraw and `SaveState` remain outside it. No behavioural change on the happy path; it only closes the window where a concurrent control read could observe a half-mutated list.

## Verification

- `dotnet build src/Agwinterm.Win32` — clean (pre-existing warnings only).
- This is a concurrency fix with no visual surface; correctness is by inspection against the existing `lock(_workspaces)` reader contract, with `OnPaneProcessExited` as the in-tree precedent for the locked-mutation pattern.

## Caveat (carried over from the issue)

A per-call race explains intermittent wrong reads well, but not fully the *multi-minute sustained* window where every target was bad until further churn cleared it — that has the flavour of a persistent stale object I couldn't reproduce. If #85 recurs after this lands, the next step is an env-gated diagnostic (log `tree` + per-target dump sizes when a dump comes back suspiciously tiny) to capture it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)