### PR TITLE
chore(release): bump version to 0.13.2

### DIFF
--- a/installer/agwinterm.iss
+++ b/installer/agwinterm.iss
@@ -2,7 +2,7 @@
 ; Build via installer\build.ps1 (publishes to stage\ then runs ISCC on this file).
 
 #define AppName    "agwinterm"
-#define AppVersion "0.13.1"
+#define AppVersion "0.13.2"
 #define AppExe     "Agwinterm.Win32.exe"
 #define AppPublisher "Boris Kudriashov"
 


### PR DESCRIPTION
0.13.2 — session-text control-read reliability fix.

- **fix(ctl):** lock pane-list mutations (split / close-pane / collapse) against the control-pipe reader, so `session text` and other session-targeted verbs can't resolve to a torn/duplicated/blank session during heavy scripted session churn (#85, #88)

Tag `v0.13.2` after merge to trigger the release build.