### PR TITLE
fix(claude): persist YOLO mode across save/restore + fix relaunch race on slow machines

### DIFF
--- a/src/Agwinterm.Pty/Agwinterm.Pty.csproj
+++ b/src/Agwinterm.Pty/Agwinterm.Pty.csproj
@@ -9,4 +9,7 @@
     <PackageReference Include="Porta.Pty" Version="1.0.7" />
     <ProjectReference Include="../Agwinterm.Core/Agwinterm.Core.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="Agwinterm.Pty.Tests" />
+  </ItemGroup>
 </Project>

--- a/src/Agwinterm.Pty/ClaudeIntegration.cs
+++ b/src/Agwinterm.Pty/ClaudeIntegration.cs
@@ -24,14 +24,14 @@ public static class ClaudeIntegration
         """
         if ($env:AGWINTERM -eq '1' -and -not $global:__agwClaude) {
           $global:__agwClaude = $true
-          function global:__agwBindClaude([string]$sid) {
+          function global:__agwBindClaude([string]$sid, [string]$agent = 'claude') {
             if (-not $sid) { return }
             $pipe = if ($env:AGWINTERM_PIPE) { $env:AGWINTERM_PIPE } else { 'agwinterm' }
             try {
               $c = New-Object System.IO.Pipes.NamedPipeClientStream('.', $pipe, [System.IO.Pipes.PipeDirection]::InOut)
               $c.Connect(300)
               $w = New-Object System.IO.StreamWriter($c); $w.AutoFlush = $true
-              $w.WriteLine('{"cmd":"session.bind","target":"' + $sid + '","args":{"agent":"claude"}}')
+              $w.WriteLine('{"cmd":"session.bind","target":"' + $sid + '","args":{"agent":"' + $agent + '"}}')
               $c.Dispose()
             } catch { }
           }
@@ -42,29 +42,56 @@ public static class ClaudeIntegration
             if (-not $real) { Write-Error 'claude: executable not found on PATH'; return }
             $uuid = $sid -match '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
             # If the user is already steering the session (resume/continue/explicit id) or running headless,
-            # don't inject or bind — just pass through untouched.
-            $ctl = $false
-            foreach ($a in $args) { if ($a -in '-r','--resume','-c','--continue','--session-id','-p','--print') { $ctl = $true; break } }
+            # don't inject or bind — just pass through untouched. Permission-mode flags are remembered in
+            # the binding so a restored session comes back with the same mode (e.g. YOLO stays YOLO).
+            $ctl = $false; $yolo = $false
+            foreach ($a in $args) {
+              if ($a -in '-r','--resume','-c','--continue','--session-id','-p','--print') { $ctl = $true }
+              if ($a -eq '--dangerously-skip-permissions') { $yolo = $true }
+            }
             if (-not $sid -or -not $uuid -or $ctl) { & $real.Source @args; return }
             $cfg = if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $env:USERPROFILE '.claude' }
             $enc = ($PWD.ProviderPath -replace '[^A-Za-z0-9]','-')   # Claude's per-project dir encoding
             $tx  = Join-Path $cfg (Join-Path 'projects' (Join-Path $enc ($sid + '.jsonl')))
-            __agwBindClaude $sid
+            __agwBindClaude $sid $(if ($yolo) { 'claude --dangerously-skip-permissions' } else { 'claude' })
             if (Test-Path -LiteralPath $tx) { & $real.Source --resume $sid @args }
             else { & $real.Source --session-id $sid @args }
           }
         }
         """ + "\n" + End;
 
-    /// <summary>Append the block to the profile if not already present. Idempotent. Returns a summary.</summary>
+    internal enum BlockState { Missing, Current, Stale, Corrupted }
+
+    /// <summary>Classify the launcher block inside profile text; for <see cref="BlockState.Stale"/>,
+    /// <paramref name="updated"/> is the profile text with the block replaced by the current version.</summary>
+    internal static BlockState InspectBlock(string existing, out string updated)
+    {
+        updated = existing;
+        int b = existing.IndexOf(Begin, StringComparison.Ordinal);
+        if (b < 0) return BlockState.Missing;
+        int e = existing.IndexOf(End, b, StringComparison.Ordinal);
+        if (e < 0) return BlockState.Corrupted;
+        if (existing[b..(e + End.Length)] == Block) return BlockState.Current;
+        updated = existing[..b] + Block + existing[(e + End.Length)..];
+        return BlockState.Stale;
+    }
+
+    /// <summary>Append the block to the profile if not already present; replace an installed block whose
+    /// content is stale (older wrapper version). Idempotent. Returns a summary.</summary>
     public static string Install()
     {
         string path = ShellIntegrationInstaller.ProfilePath();
         try
         {
             string existing = File.Exists(path) ? File.ReadAllText(path) : "";
-            if (existing.Contains(Begin))
-                return "claude launcher already installed -> " + path;
+            switch (InspectBlock(existing, out string updated))
+            {
+                case BlockState.Current: return "claude launcher already installed -> " + path;
+                case BlockState.Corrupted: return "claude launcher block is corrupted (no end sentinel) — fix " + path + " by hand";
+                case BlockState.Stale:
+                    File.WriteAllText(path, updated);
+                    return "updated claude launcher to the current version -> " + path;
+            }
 
             Directory.CreateDirectory(Path.GetDirectoryName(path)!);
             string sep = existing.Length == 0 ? "" : (existing.EndsWith("\n") ? "\n" : "\n\n");
@@ -75,5 +102,21 @@ public static class ClaudeIntegration
         {
             return "failed to install claude launcher: " + ex.Message;
         }
+    }
+
+    /// <summary>Refresh the installed block to the current version if (and only if) an older one is present —
+    /// run at startup so wrapper fixes reach users who installed the launcher once and never re-ran install.
+    /// Never installs fresh (that stays opt-in via install.hooks). Returns null when nothing changed.</summary>
+    public static string? RefreshIfInstalled()
+    {
+        try
+        {
+            string path = ShellIntegrationInstaller.ProfilePath();
+            if (!File.Exists(path)) return null;
+            if (InspectBlock(File.ReadAllText(path), out string updated) != BlockState.Stale) return null;
+            File.WriteAllText(path, updated);
+            return "claude launcher updated -> " + path;
+        }
+        catch { return null; }    // best-effort: a locked/readonly profile must not break startup
     }
 }

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -252,6 +252,34 @@ internal partial class Program
         });
     }
 
+    [DllImport("kernel32.dll", SetLastError = true)] private static extern IntPtr CreateToolhelp32Snapshot(uint flags, uint pid);
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode)] private static extern bool Process32FirstW(IntPtr snapshot, ref PROCESSENTRY32W entry);
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode)] private static extern bool Process32NextW(IntPtr snapshot, ref PROCESSENTRY32W entry);
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct PROCESSENTRY32W
+    {
+        public uint dwSize; public uint cntUsage; public uint th32ProcessID; public UIntPtr th32DefaultHeapID;
+        public uint th32ModuleID; public uint cntThreads; public uint th32ParentProcessID; public int pcPriClassBase;
+        public uint dwFlags; [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)] public string szExeFile;
+    }
+
+    /// <summary>Whether <paramref name="pid"/> has any live direct child process — i.e. the shell is still
+    /// running a foreground command. One Toolhelp snapshot pass (~ms), no WMI. Null when the snapshot
+    /// itself fails (caller should fall back to a fixed delay rather than treat it as "idle").</summary>
+    private static bool? HasLiveChildProcess(int pid)
+    {
+        IntPtr snap = CreateToolhelp32Snapshot(0x2 /*TH32CS_SNAPPROCESS*/, 0);
+        if (snap == IntPtr.Zero || snap == new IntPtr(-1)) return null;
+        try
+        {
+            var e = new PROCESSENTRY32W { dwSize = (uint)Marshal.SizeOf<PROCESSENTRY32W>() };
+            if (!Process32FirstW(snap, ref e)) return null;
+            do { if (e.th32ParentProcessID == (uint)pid) return true; } while (Process32NextW(snap, ref e));
+            return false;
+        }
+        finally { CloseHandle(snap); }
+    }
+
     /// <summary>True if this process is running elevated (admin). Uses the token's actual elevation
     /// state (TokenElevation), NOT group membership — a non-elevated admin user is correctly false.</summary>
     private static bool IsElevated()
@@ -704,11 +732,25 @@ internal partial class Program
         var pane = p;
         _ = Task.Run(async () =>
         {
-            // Quit the running Claude (Ctrl+C twice = exit), let the shell settle, then relaunch.
+            // Quit the running Claude (Ctrl+C twice = exit), wait for it to actually be gone, then relaunch.
             try { pane.S.Write(new byte[] { 0x03 }); } catch { }
             await Task.Delay(350);
             try { pane.S.Write(new byte[] { 0x03 }); } catch { }
-            await Task.Delay(1200);
+            // A fixed delay raced Claude's exit on slow machines — the typed relaunch landed in Claude's
+            // own prompt instead of the shell. Poll the shell's child processes until the foreground
+            // command (Claude's node) is gone, capped so a hung/ignoring process can't stall us forever.
+            int shellPid = pane.S.ChildProcessId ?? 0;
+            bool sawIdle = false;
+            if (shellPid > 0)
+                for (int i = 0; i < 100; i++)   // ≤ 30s
+                {
+                    await Task.Delay(300);
+                    bool? busy = HasLiveChildProcess(shellPid);
+                    if (busy is null) break;               // snapshot failed → fixed-delay fallback below
+                    if (busy is false) { sawIdle = true; break; }
+                }
+            if (!sawIdle) await Task.Delay(1200);           // old behavior when we couldn't confirm the exit
+            await Task.Delay(300);                          // let the shell repaint its prompt and start reading input
             try { pane.S.Write(System.Text.Encoding.UTF8.GetBytes(cmd + "\r")); } catch { }
         });
         return id is null ? "restarting Claude in YOLO mode (fresh session)" : "restarting Claude in YOLO mode (resumed)";

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -1043,6 +1043,9 @@ internal partial class Program : ISessionHost, IWindowHost
         {
             _control = new ControlServer(this, this, _argPipe ?? _appId);
             _control.Start();
+            // Keep an already-installed claude launcher current (wrapper fixes ship with the app but the
+            // block lives in the user's profile). Refresh-only: never installs fresh, best-effort.
+            _ = Task.Run(Agwinterm.Pty.ClaudeIntegration.RefreshIfInstalled);
             // Default-terminal handoff (T2-13): register the COM class factory so conhost can hand
             // console sessions to this instance. Each handoff opens a new attached session.
             DefTerm.OnHandoff = args => Post(() =>

--- a/tests/Agwinterm.Pty.Tests/AgentHooksTests.cs
+++ b/tests/Agwinterm.Pty.Tests/AgentHooksTests.cs
@@ -71,4 +71,38 @@ public class AgentHooksTests
         Assert.Contains("session.bind", block);          // marks the pane resumable in agwinterm
         Assert.Contains("$env:AGWINTERM -eq '1'", block); // only active inside agwinterm
     }
+
+    [Fact]
+    public void ClaudeLauncher_PersistsDangerouslySkipPermissionsInBinding()
+    {
+        // A YOLO-launched claude must restore as YOLO: the wrapper detects the flag and binds the
+        // full relaunch command, which the restore path types verbatim.
+        string block = ClaudeIntegration.Block;
+        Assert.Contains("'--dangerously-skip-permissions'", block);                       // flag detection
+        Assert.Contains("'claude --dangerously-skip-permissions'", block);                // bound relaunch command
+        Assert.Contains("\"agent\":\"' + $agent + '\"", block);                           // bind carries the command
+    }
+
+    [Fact]
+    public void InspectBlock_MissingCurrentStaleCorrupted()
+    {
+        // Missing: no sentinel at all.
+        Assert.Equal(ClaudeIntegration.BlockState.Missing, ClaudeIntegration.InspectBlock("# my profile\n", out _));
+
+        // Current: exactly the shipped block.
+        string profile = "# above\n" + ClaudeIntegration.Block + "\n# below\n";
+        Assert.Equal(ClaudeIntegration.BlockState.Current, ClaudeIntegration.InspectBlock(profile, out _));
+
+        // Stale: an older wrapper between the same sentinels gets replaced in place, neighbors intact.
+        string stale = "# above\n# >>> agwinterm claude integration >>>\nold wrapper\n# <<< agwinterm claude integration <<<\n# below\n";
+        Assert.Equal(ClaudeIntegration.BlockState.Stale, ClaudeIntegration.InspectBlock(stale, out string updated));
+        Assert.Contains(ClaudeIntegration.Block, updated);
+        Assert.DoesNotContain("old wrapper", updated);
+        Assert.StartsWith("# above\n", updated);
+        Assert.EndsWith("\n# below\n", updated);
+
+        // Corrupted: begin sentinel without end — leave alone, report.
+        Assert.Equal(ClaudeIntegration.BlockState.Corrupted,
+            ClaudeIntegration.InspectBlock("# >>> agwinterm claude integration >>>\nhalf a block", out _));
+    }
 }


### PR DESCRIPTION
Two fixes for the Claude YOLO flow, both reported against 0.13.2.

## 1. `--dangerously-skip-permissions` now survives save/restore

**Root cause:** the launcher wrapper always bound `session.bind agent=claude`, so a pane whose Claude was launched with `--dangerously-skip-permissions` restored as plain `claude` — the runtime flags never reached the binding.

**Fix:**
- The wrapper scans its args for `--dangerously-skip-permissions` and binds the full relaunch command (`claude --dangerously-skip-permissions`) when present; the restore path types the binding verbatim, so the session comes back in the same permission mode. Running plain `claude` later re-binds plain — the binding always tracks the latest launch.
- `ClaudeIntegration.Install()` now **replaces a stale installed block** (it used to skip whenever the sentinel existed, so wrapper fixes never reached existing installs).
- The app **refreshes an already-installed block at startup** (refresh-only, never installs fresh; best-effort) — no need to re-run `install hooks` after updating agwinterm.

**Limitation:** only launch-time flags can be detected. Switching to bypass mode *inside* Claude (shift+tab) is invisible to the wrapper; `claude adopt` also can't know the mode. Both are out of scope here.

## 2. YOLO restart no longer races Claude's exit

**Root cause:** `RestartClaudeYolo` waited a fixed 1200 ms between the double Ctrl+C and typing the relaunch. On slow machines Claude was still alive, so `claude --resume … --dangerously-skip-permissions` landed in Claude's own prompt instead of the shell.

**Fix:** poll the pane shell's **direct child processes** (one Toolhelp snapshot pass, measured ~9 ms) until the foreground command is gone — Claude's exe is a direct child of the shell — capped at 30 s, with the old fixed delay as fallback when the snapshot fails. Then a 300 ms grace for the prompt, then type. On an idle pane the first 300 ms check already reports no children, so the action stays fast.

## Verification

**Unit:** 46/46 Pty tests pass, including new tests for the wrapper flag-detection strings and the `InspectBlock` Missing/Current/Stale/Corrupted state machine (stale block replaced in place, neighbors preserved; corrupted left alone). Wrapper block parse-checked with the PowerShell language parser (0 errors) and the arg-scan logic exercised in real pwsh for 4 launch shapes.

**Live E2E (dev instance, real Claude):**
1. Old wrapper block in the profile was auto-updated at dev-app startup (refresh-only path) ✅
2. Typed `claude --dangerously-skip-permissions` in a fresh session → Claude booted showing **“bypass permissions on”** → state file bound `AgentResume: 'claude --dangerously-skip-permissions'` ✅
3. Closed and relaunched the app → pane auto-typed the bound command → wrapper attached the stable pane id → process cmdline: `claude.exe --session-id a5ec7c07-… --dangerously-skip-permissions`, UI again showing bypass mode ✅
4. `agwintermctl claude yolo` on the running pane → old Claude exited, child-probe waited until `claude.exe` was gone, relaunch typed at the real shell prompt (echo visible in dump), new `claude.exe` spawned 3 s later in bypass mode ✅
5. Toolhelp probe validated standalone: `True` with a live child, `False` after exit, ~9 ms/snapshot ✅

The slow-laptop timing itself can't be reproduced on this machine — the fix removes the timing assumption entirely rather than tuning the delay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k