### PR TITLE
chore(release): bump version to 0.13.3

### DIFF
--- a/installer/agwinterm.iss
+++ b/installer/agwinterm.iss
@@ -2,7 +2,7 @@
 ; Build via installer\build.ps1 (publishes to stage\ then runs ISCC on this file).
 
 #define AppName    "agwinterm"
-#define AppVersion "0.13.2"
+#define AppVersion "0.13.3"
 #define AppExe     "Agwinterm.Win32.exe"
 #define AppPublisher "Boris Kudriashov"
 


### PR DESCRIPTION
0.13.3 — Claude YOLO persistence + relaunch reliability.

- **fix(claude):** `--dangerously-skip-permissions` survives save/restore — the launcher wrapper binds the full relaunch command; stale installed wrapper blocks are replaced on install and auto-refreshed at app startup (#90)
- **fix(claude):** "Restart Claude in YOLO Mode" waits for Claude to actually exit (child-process probe) instead of a fixed delay, so the relaunch can't land in the still-running Claude's prompt on slow machines (#90)

Tag `v0.13.3` after merge to trigger the release build.