### PR TITLE
fix(clipboard): OSC 52 support + right-click paste wins over app mouse reporting

### DIFF
--- a/src/Agwinterm.Core/TerminalEmulator.cs
+++ b/src/Agwinterm.Core/TerminalEmulator.cs
@@ -513,6 +513,11 @@ public sealed class TerminalEmulator : IParserPerformer
     /// value = 0–100 for state 1/2/4. Fires on the feed/pump thread.</summary>
     public event Action<int, int>? Progress;
 
+    /// <summary>Raised when the program writes the clipboard via OSC 52 (decoded text) — e.g. Claude
+    /// Code's auto-copy-on-select. Write-only: read-back queries ("?") are ignored, so a hostile app
+    /// can never exfiltrate the clipboard. Fires on the feed/pump thread.</summary>
+    public event Action<string>? ClipboardWrite;
+
     /// <summary>Strip C0/C1 control characters (and DEL) from an OSC payload. OSC strings feed the
     /// window title, the tracked cwd (later expanded into custom-command text), and notification
     /// toasts — embedded control bytes there are a terminal/shell-injection vector, so they are
@@ -562,6 +567,25 @@ public sealed class TerminalEmulator : IParserPerformer
                 if (parts.Length >= 2 && parts[0] == "notify")
                     Notified?.Invoke(parts[1], parts.Length >= 3 ? string.Join(';', parts[2..]) : "");
                 break;
+            case 52: // OSC 52 ; Pc ; Pd — program writes the clipboard (base64 payload). Pc (which
+            {        // selection) is ignored: everything goes to the system clipboard, like WT.
+                int semi = text.IndexOf(';');
+                if (semi < 0) break;
+                string data = text[(semi + 1)..];
+                // "?" is a read-back query — never answered (clipboard exfiltration). Cap the payload
+                // so a runaway sequence can't balloon memory (4MB base64 ≈ 3MB text, far above any
+                // real selection).
+                if (data.Length == 0 || data == "?" || data.Length > 4_000_000) break;
+                try
+                {
+                    // Tolerate unpadded base64 (some emitters strip '=').
+                    string decoded = System.Text.Encoding.UTF8.GetString(
+                        Convert.FromBase64String(data.PadRight((data.Length + 3) & ~3, '=')));
+                    if (decoded.Length > 0) ClipboardWrite?.Invoke(decoded);
+                }
+                catch (FormatException) { /* malformed base64 — drop */ }
+                break;
+            }
         }
     }
 

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -80,6 +80,7 @@ internal partial class Program
         session.SoundRequested += PlayStatusSound;
         session.Emulator.Notified += (title, body) => Post(() => OnNotified(pane, title, body));
         session.Emulator.Progress += (st, val) => Post(() => OnProgress(st, val));   // OSC 9;4 -> taskbar
+        session.Emulator.ClipboardWrite += text => Post(() => ClipboardSet(text));   // OSC 52 -> system clipboard (e.g. Claude Code auto-copy)
         session.Emulator.Respond += reply => { session.NotifyActivity(); session.Write(Encoding.UTF8.GetBytes(reply)); };   // Kitty query response -> PTY
         session.Exited += _ => Post(() => OnPaneProcessExited(pane));   // split survivor promotion (agterm #121)
         var env = new Dictionary<string, string>

--- a/src/Agwinterm.Win32/Program.WndProc.cs
+++ b/src/Agwinterm.Win32/Program.WndProc.cs
@@ -413,14 +413,20 @@ internal partial class Program
                 if (InContent(lParam))
                 {
                     var em2 = _session?.Emulator;
-                    if (em2 is not null && em2.MouseReporting) SendMousePx(2, lParam, true);
-                    else if (_config.RightClickPaste && (PaneAt(LoWord(lParam), HiWord(lParam))?.pane ?? ActiveSurface()) is { } pp)
+                    // Paste-on-right-click (when enabled) wins over app mouse reporting: TUIs like
+                    // Claude Code keep mouse mode on the whole time, which used to make the setting
+                    // dead exactly where pasting matters most. Apps that need the right button can
+                    // still get it by turning the setting off.
+                    if (_config.RightClickPaste && (PaneAt(LoWord(lParam), HiWord(lParam))?.pane ?? ActiveSurface()) is { } pp)
                         PasteInto(pp);
+                    else if (em2 is not null && em2.MouseReporting) { SendMousePx(2, lParam, true); _rbtnForwarded = true; }
                     return IntPtr.Zero;
                 }
                 break; // sidebar/chrome: let DefWindowProc raise WM_CONTEXTMENU so the row menu shows
             case WM_RBUTTONUP:
-                if (InContent(lParam)) { SendMousePx(2, lParam, false); return IntPtr.Zero; }
+                // Only send the release if we forwarded the press — a paste must not leak an
+                // orphan button-2 release into the app.
+                if (InContent(lParam)) { if (_rbtnForwarded) { _rbtnForwarded = false; SendMousePx(2, lParam, false); } return IntPtr.Zero; }
                 break; // sidebar/chrome: fall through to DefWindowProc -> WM_CONTEXTMENU
 
             case WM_MOUSEMOVE:

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -146,6 +146,7 @@ internal partial class Program : ISessionHost, IWindowHost
     private float _hotAlpha;   // 0..1 hover-fill alpha (eased by the fade timer)
     private string? _pressBtn; // chrome button id pressed (fires on release over the same button)
     private bool _mouseTracking; // TrackMouseEvent armed (for WM_MOUSELEAVE)
+    private bool _rbtnForwarded; // right-button press was forwarded to the app (mouse reporting), so forward the release too
     private const int HoverTimer = 8;   // WM_TIMER id for the hover fade
     private bool _chromeDark = true; // active theme is dark (set by RecomputeChrome)
     private string? _toastText;

--- a/tests/Agwinterm.Core.Tests/OscTests.cs
+++ b/tests/Agwinterm.Core.Tests/OscTests.cs
@@ -175,4 +175,53 @@ public class OscTests
         var t = Feed("\x1b]2;normal title \u2014 \u00FCn\u00EFcode ok\x07");
         Assert.Equal("normal title \u2014 \u00FCn\u00EFcode ok", t.Title);
     }
+
+    // ---- OSC 52: program-initiated clipboard write (e.g. Claude Code's auto-copy-on-select) ----
+
+    private static (TerminalEmulator t, List<string> writes) ClipboardHarness()
+    {
+        var t = new TerminalEmulator(40, 3);
+        var writes = new List<string>();
+        t.ClipboardWrite += s => writes.Add(s);
+        return (t, writes);
+    }
+
+    [Fact]
+    public void Osc52_DecodesBase64AndFiresClipboardWrite()
+    {
+        var (t, writes) = ClipboardHarness();
+        string b64 = Convert.ToBase64String(Encoding.UTF8.GetBytes("hello clipboard"));
+        t.Feed(Encoding.UTF8.GetBytes($"\x1b]52;c;{b64}\x07"));
+        Assert.Equal(new[] { "hello clipboard" }, writes);
+    }
+
+    [Fact]
+    public void Osc52_ToleratesUnpaddedBase64AndUtf8()
+    {
+        var (t, writes) = ClipboardHarness();
+        // "\u00FCn\u00EFcode\u2122" encodes with padding; strip it to simulate emitters that drop '='.
+        string b64 = Convert.ToBase64String(Encoding.UTF8.GetBytes("\u00FCn\u00EFcode\u2122")).TrimEnd('=');
+        t.Feed(Encoding.UTF8.GetBytes($"\x1b]52;c;{b64}\x1b\\"));
+        Assert.Equal(new[] { "\u00FCn\u00EFcode\u2122" }, writes);
+    }
+
+    [Fact]
+    public void Osc52_IgnoresQueryEmptyAndMalformed()
+    {
+        var (t, writes) = ClipboardHarness();
+        t.Feed(Encoding.UTF8.GetBytes("\x1b]52;c;?\x07"));          // read-back query \u2014 never answered
+        t.Feed(Encoding.UTF8.GetBytes("\x1b]52;c;\x07"));           // empty payload
+        t.Feed(Encoding.UTF8.GetBytes("\x1b]52;c;!!notbase64!!\x07")); // malformed base64
+        t.Feed(Encoding.UTF8.GetBytes("\x1b]52;justonefield\x07")); // no payload separator
+        Assert.Empty(writes);
+    }
+
+    [Fact]
+    public void Osc52_SelectionTargetIsIgnoredEverythingGoesToClipboard()
+    {
+        var (t, writes) = ClipboardHarness();
+        string b64 = Convert.ToBase64String(Encoding.UTF8.GetBytes("primary"));
+        t.Feed(Encoding.UTF8.GetBytes($"\x1b]52;p;{b64}\x07"));     // "p" (primary) still lands
+        Assert.Equal(new[] { "primary" }, writes);
+    }
 }


### PR DESCRIPTION
Fixes the three clipboard failures reported against 0.13.2 in Claude Code sessions. One root cause behind all three: **Claude Code keeps mouse reporting enabled the whole time**, so agwinterm forwarded clicks/drags to the app and local selection never existed — and Claude's own copy path emits **OSC 52**, which the emulator silently dropped.

| Report | Cause | Fix |
|---|---|---|
| Paste on right click doesn't work | `WM_RBUTTONDOWN` checked `MouseReporting` **before** `RightClickPaste`, so Claude ate every right-click | Setting now wins; press forwarded only when it's off, release only forwarded when the press was |
| Auto-copy doesn't work though Claude says "copied 115 chars to clipboard" | Claude tracks its own selection and copies via OSC 52 → unimplemented, dropped | OSC 52 implemented: decode base64 → system clipboard (UI-thread marshalled) |
| Ctrl+C copy works ~1/20 | Ctrl+C only copies a *local* selection — impossible under mouse reporting (drags go to Claude); the 1/20 = moments Claude's mouse mode was off | Covered by OSC 52: drag-select in Claude now copies through Claude's own flow; shift+drag + Ctrl+C local path unchanged |

**Security posture for OSC 52:** write-only — read-back queries (`52;c;?`) are never answered, so an app can't exfiltrate the clipboard; payload capped at 4MB base64; malformed/empty payloads dropped. Selection target (`c`/`p`/`s`) ignored — everything goes to the system clipboard, matching Windows Terminal.

## Verification

**Unit:** 116/116 Core tests pass, incl. new OSC 52 tests (decode+fire, unpadded base64 + UTF-8, query/empty/malformed ignored, selection target ignored).

**Live E2E (dev instance, real ConPTY panes):**
1. Emitted `ESC]52;c;<base64>BEL` from PowerShell inside a pane (byte-identical to Claude Code's auto-copy) → **text landed in the Windows clipboard** ✅ (also proves ConPTY passes OSC 52 through)
2. Enabled mouse reporting in a pane (`ESC[?1000h`, Claude Code's state), put `PASTE-TEST-123` on the clipboard, synthesized a real `WM_RBUTTONDOWN/UP` into the window → **`PASTE-TEST-123` pasted at the prompt** instead of being swallowed as a forwarded mouse event ✅
3. Guard rails: query `?`, empty and malformed payloads leave the clipboard untouched (unit-tested; query also exercised live) ✅

The user's clipboard was backed up and restored around the E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k