### PR TITLE
chore(release): bump version to 0.13.4

### DIFF
--- a/installer/agwinterm.iss
+++ b/installer/agwinterm.iss
@@ -2,7 +2,7 @@
 ; Build via installer\build.ps1 (publishes to stage\ then runs ISCC on this file).
 
 #define AppName    "agwinterm"
-#define AppVersion "0.13.3"
+#define AppVersion "0.13.4"
 #define AppExe     "Agwinterm.Win32.exe"
 #define AppPublisher "Boris Kudriashov"
 


### PR DESCRIPTION
0.13.4 — clipboard works inside Claude Code (and other mouse-mode TUIs).

- **feat(clipboard):** OSC 52 clipboard-write support (write-only, query read-back refused, 4MB cap) — Claude Code's auto-copy-on-select now lands in the system clipboard (#93)
- **fix(clipboard):** paste-on-right-click wins over app mouse reporting, so the setting works inside Claude Code; no orphan button-2 release leaks to the app after a paste (#93)

Tag `v0.13.4` after merge to trigger the release build.