### PR TITLE
chore(release): bump version to 0.13.5

### DIFF
--- a/installer/agwinterm.iss
+++ b/installer/agwinterm.iss
@@ -2,7 +2,7 @@
 ; Build via installer\build.ps1 (publishes to stage\ then runs ISCC on this file).
 
 #define AppName    "agwinterm"
-#define AppVersion "0.13.4"
+#define AppVersion "0.13.5"
 #define AppExe     "Agwinterm.Win32.exe"
 #define AppPublisher "Boris Kudriashov"
 


### PR DESCRIPTION
0.13.5 — per-pane Claude conversation resolution.

- **fix(claude):** panes sharing a folder no longer all resume the same conversation — YOLO restart and `claude adopt` now prefer per-pane evidence (the pane's own transcript, then the running Claude's explicit id) over the folder's newest transcript, and adopt dedupes ids across panes (#95)
- **fix(ctl):** pane-targeted verbs (e.g. `claude yolo`) accept id prefixes instead of silently acting on the active pane (#95)

Tag `v0.13.5` after merge to trigger the release build.