### PR TITLE
refactor(core): IHostActions seam + unhandled-sequence tap (libghostty apprt boundary)

### DIFF
--- a/src/Agwinterm.Core/IHostActions.cs
+++ b/src/Agwinterm.Core/IHostActions.cs
@@ -1,0 +1,34 @@
+namespace Agwinterm.Core;
+
+/// <summary>
+/// The host-action seam (libghostty's "apprt" boundary): everything the emulator needs the embedding
+/// application to DO — as opposed to grid state it exposes — lands here as one explicit interface.
+/// Adding an escape sequence with host-visible effects means adding a member here, which forces every
+/// embedder (and test fake) to decide what to do with it, instead of the sequence being silently
+/// dropped (how OSC 52 clipboard writes went missing for months).
+///
+/// All methods are called on the feed/pump thread, typically while the session lock is held —
+/// implementations must be cheap and marshal real work to their own thread.
+/// </summary>
+public interface IHostActions
+{
+    /// <summary>Desktop notification requested via OSC 9 (body only) or OSC 777 (title + body).</summary>
+    void Notify(string title, string body);
+
+    /// <summary>Taskbar progress via OSC 9;4 (ConEmu/Windows Terminal convention):
+    /// state 0 clear | 1 normal | 2 error | 3 indeterminate | 4 paused; value 0–100 for 1/2/4.</summary>
+    void Progress(int state, int value);
+
+    /// <summary>The program wrote the clipboard via OSC 52 (payload already base64-decoded).
+    /// Write-only by design: the emulator never asks the host to read the clipboard back.</summary>
+    void ClipboardWrite(string text);
+
+    /// <summary>Terminal response bytes that must be written back to the PTY as if typed
+    /// (e.g. the kitty keyboard-protocol flags query reply).</summary>
+    void Respond(string reply);
+
+    /// <summary>A syntactically valid escape sequence the emulator has no handler for. A debug tap:
+    /// hosts typically log it under an env flag (or no-op) — never user-visible. This is what turns
+    /// a protocol gap into one grep instead of a stack of symptom reports.</summary>
+    void Unhandled(string kind, string detail);
+}

--- a/src/Agwinterm.Core/TerminalEmulator.cs
+++ b/src/Agwinterm.Core/TerminalEmulator.cs
@@ -227,6 +227,8 @@ public sealed class TerminalEmulator : IParserPerformer
             case 9:                                              // HT
                 CursorCol = Math.Min(Screen.Cols - 1, ((CursorCol / 8) + 1) * 8);
                 break;
+            case 0: break; // NUL — historical padding, deliberately ignored (would flood the tap)
+            default: Host?.Unhandled("C0", $"0x{control:X2}"); break; // e.g. BEL 0x07 (no bell yet)
         }
     }
 
@@ -238,9 +240,10 @@ public sealed class TerminalEmulator : IParserPerformer
     /// <summary>Active Kitty keyboard flags (0 = legacy encoding).</summary>
     public int KeyboardFlags => _kbdStack.Count > 0 ? _kbdStack.Peek() : 0;
 
-    /// <summary>Raised when the terminal must write a reply to the shell (Kitty query response, etc.).
-    /// The host wires this to the PTY's input.</summary>
-    public event Action<string>? Respond;
+    /// <summary>The host-action seam: notifications, progress, clipboard writes, PTY responses and
+    /// unhandled-sequence taps all flow through this single interface (see <see cref="IHostActions"/>).
+    /// Null = headless (tests, buffer restore) — actions are dropped.</summary>
+    public IHostActions? Host { get; set; }
 
     public void CsiDispatch(char final, IReadOnlyList<int> parameters, char prefix)
     {
@@ -253,7 +256,7 @@ public sealed class TerminalEmulator : IParserPerformer
         {
             switch (prefix)
             {
-                case '?': Respond?.Invoke($"\x1b[?{KeyboardFlags}u"); break;   // report current flags
+                case '?': Host?.Respond($"\x1b[?{KeyboardFlags}u"); break;   // report current flags
                 case '>': _kbdStack.Push(parameters.Count > 0 ? parameters[0] : 0); break;
                 case '=':
                 {
@@ -273,6 +276,8 @@ public sealed class TerminalEmulator : IParserPerformer
         {
             if (final is 'h' or 'l')
                 SetPrivateMode(parameters, set: final == 'h');
+            else
+                Host?.Unhandled("CSI", $"? {string.Join(';', parameters)} {final}"); // e.g. DECRQM ?…$p
             return;
         }
 
@@ -302,6 +307,9 @@ public sealed class TerminalEmulator : IParserPerformer
             case 'P': DeleteChars(P(0, 1)); break;   // DCH
             case 'S': for (int i = 0; i < P(0, 1); i++) ScrollRegionUp(); break;   // SU
             case 'T': for (int i = 0; i < P(0, 1); i++) ScrollRegionDown(); break; // SD
+            default:
+                Host?.Unhandled("CSI", $"{(prefix == '\0' ? "" : prefix + " ")}{string.Join(';', parameters)} {final}");
+                break;
         }
     }
 
@@ -314,6 +322,7 @@ public sealed class TerminalEmulator : IParserPerformer
             case 'D': Index(); break;            // IND
             case 'M': ReverseIndex(); break;     // RI
             case 'E': CursorCol = 0; Index(); break; // NEL
+            default: Host?.Unhandled("ESC", final.ToString()); break;
         }
     }
 
@@ -340,6 +349,7 @@ public sealed class TerminalEmulator : IParserPerformer
                 case 1003: _mouseMotion = set; break;  // any-motion tracking
                 case 1006: _mouseSgr = set; break;     // SGR extended mouse encoding
                 case 2004: BracketedPaste = set; break; // bracketed paste
+                default: Host?.Unhandled("MODE", $"?{mode} {(set ? 'h' : 'l')}"); break;
             }
         }
     }
@@ -415,7 +425,13 @@ public sealed class TerminalEmulator : IParserPerformer
     /// Kitty ids (which are app-chosen positive numbers).</summary>
     private int _sixelSeq = -1;
 
-    public void DcsDispatch(byte[] data) => PlaceSixel(data);
+    public void DcsDispatch(byte[] data)
+    {
+        if (PlaceSixel(data)) return;
+        // Identify non-sixel DCS by its readable prefix (DECRQSS starts "$q", XTGETTCAP "+q", …).
+        string head = Encoding.ASCII.GetString(data, 0, Math.Min(16, data.Length));
+        Host?.Unhandled("DCS", $"{data.Length} bytes \"{head}\"");
+    }
 
     /// <summary>Decode a sixel DCS payload and place it at the cursor (advancing below it). Returns
     /// false if it isn't a valid sixel. Reused by the out-of-band control path (ConPTY strips DCS
@@ -435,7 +451,11 @@ public sealed class TerminalEmulator : IParserPerformer
 
     public void ApcDispatch(string data)
     {
-        if (data.Length == 0 || data[0] != 'G') return; // only Kitty graphics (_G...)
+        if (data.Length == 0 || data[0] != 'G') // only Kitty graphics (_G...)
+        {
+            Host?.Unhandled("APC", data.Length > 24 ? data[..24] + "…" : data);
+            return;
+        }
         string body = data[1..];
         int semi = body.IndexOf(';');
         string control = semi >= 0 ? body[..semi] : body;
@@ -504,20 +524,6 @@ public sealed class TerminalEmulator : IParserPerformer
     private static int GetKittyInt(Dictionary<string, string> d, string key, int def)
         => d.TryGetValue(key, out var v) && int.TryParse(v, out var n) ? n : def;
 
-    /// <summary>Raised when the program requests a desktop notification via OSC 9 or OSC 777
-    /// (title, body). Fires on the feed/pump thread — consumers must marshal to their UI thread.</summary>
-    public event Action<string, string>? Notified;
-
-    /// <summary>Raised for OSC 9;4 progress reports (ConEmu/Windows Terminal convention):
-    /// (state, value) where state = 0 clear | 1 normal | 2 error | 3 indeterminate | 4 paused,
-    /// value = 0–100 for state 1/2/4. Fires on the feed/pump thread.</summary>
-    public event Action<int, int>? Progress;
-
-    /// <summary>Raised when the program writes the clipboard via OSC 52 (decoded text) — e.g. Claude
-    /// Code's auto-copy-on-select. Write-only: read-back queries ("?") are ignored, so a hostile app
-    /// can never exfiltrate the clipboard. Fires on the feed/pump thread.</summary>
-    public event Action<string>? ClipboardWrite;
-
     /// <summary>Strip C0/C1 control characters (and DEL) from an OSC payload. OSC strings feed the
     /// window title, the tracked cwd (later expanded into custom-command text), and notification
     /// toasts — embedded control bytes there are a terminal/shell-injection vector, so they are
@@ -557,15 +563,15 @@ public sealed class TerminalEmulator : IParserPerformer
                     var pp = text.Split(';');
                     int pState = pp.Length > 1 && int.TryParse(pp[1], out int s9) ? s9 : 0;
                     int pValue = pp.Length > 2 && int.TryParse(pp[2], out int v9) ? Math.Clamp(v9, 0, 100) : 0;
-                    Progress?.Invoke(pState, pValue);
+                    Host?.Progress(pState, pValue);
                     break;
                 }
-                Notified?.Invoke("", text);
+                Host?.Notify("", text);
                 break;
             case 777: // OSC 777 ; notify ; <title> ; <body>
                 var parts = text.Split(';');
                 if (parts.Length >= 2 && parts[0] == "notify")
-                    Notified?.Invoke(parts[1], parts.Length >= 3 ? string.Join(';', parts[2..]) : "");
+                    Host?.Notify(parts[1], parts.Length >= 3 ? string.Join(';', parts[2..]) : "");
                 break;
             case 52: // OSC 52 ; Pc ; Pd — program writes the clipboard (base64 payload). Pc (which
             {        // selection) is ignored: everything goes to the system clipboard, like WT.
@@ -581,11 +587,14 @@ public sealed class TerminalEmulator : IParserPerformer
                     // Tolerate unpadded base64 (some emitters strip '=').
                     string decoded = System.Text.Encoding.UTF8.GetString(
                         Convert.FromBase64String(data.PadRight((data.Length + 3) & ~3, '=')));
-                    if (decoded.Length > 0) ClipboardWrite?.Invoke(decoded);
+                    if (decoded.Length > 0) Host?.ClipboardWrite(decoded);
                 }
                 catch (FormatException) { /* malformed base64 — drop */ }
                 break;
             }
+            default:
+                Host?.Unhandled("OSC", $"{command};{(text.Length > 40 ? text[..40] + "…" : text)}");
+                break;
         }
     }
 

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -78,10 +78,7 @@ internal partial class Program
         };
         // An explicit --sound on session.status: play its spec (null => default alert).
         session.SoundRequested += PlayStatusSound;
-        session.Emulator.Notified += (title, body) => Post(() => OnNotified(pane, title, body));
-        session.Emulator.Progress += (st, val) => Post(() => OnProgress(st, val));   // OSC 9;4 -> taskbar
-        session.Emulator.ClipboardWrite += text => Post(() => ClipboardSet(text));   // OSC 52 -> system clipboard (e.g. Claude Code auto-copy)
-        session.Emulator.Respond += reply => { session.NotifyActivity(); session.Write(Encoding.UTF8.GetBytes(reply)); };   // Kitty query response -> PTY
+        session.Emulator.Host = new PaneHost(this, pane, session);   // the host-action seam (see IHostActions)
         session.Exited += _ => Post(() => OnPaneProcessExited(pane));   // split survivor promotion (agterm #121)
         var env = new Dictionary<string, string>
         {
@@ -214,6 +211,20 @@ internal partial class Program
             _ = session.StartAsync(cmd, ShellArgs(), extraEnv: env, cwd: pcwd, deElevate: deElevate);        // wrap + omp (cwd-in-title)
         else
             _ = session.StartAsync(cmd, pargs ?? Array.Empty<string>(), extraEnv: env, cwd: pcwd, deElevate: deElevate); // raw shell
+    }
+
+    /// <summary>Per-pane implementation of the emulator's host-action seam. Emulator calls arrive on
+    /// the feed/pump thread (under the session lock) — UI-touching actions marshal via Post; Respond
+    /// writes straight back to the PTY (it must not wait on the UI thread).</summary>
+    private sealed class PaneHost : IHostActions
+    {
+        private readonly Program _app; private readonly Pane _pane; private readonly TerminalSession _s;
+        public PaneHost(Program app, Pane pane, TerminalSession s) { _app = app; _pane = pane; _s = s; }
+        public void Notify(string title, string body) => _app.Post(() => _app.OnNotified(_pane, title, body));
+        public void Progress(int state, int value) => _app.Post(() => _app.OnProgress(state, value));   // OSC 9;4 -> taskbar
+        public void ClipboardWrite(string text) => _app.Post(() => _app.ClipboardSet(text));            // OSC 52 -> system clipboard
+        public void Respond(string reply) { _s.NotifyActivity(); _s.Write(Encoding.UTF8.GetBytes(reply)); } // query reply -> PTY
+        public void Unhandled(string kind, string detail) => VtLog.Write(_pane.Id, kind, detail);       // AGWINTERM_VT_LOG tap
     }
 
     [DllImport("kernel32.dll")] private static extern IntPtr GetCurrentProcess();

--- a/src/Agwinterm.Win32/VtLog.cs
+++ b/src/Agwinterm.Win32/VtLog.cs
@@ -1,0 +1,24 @@
+namespace Agwinterm.Win32;
+
+/// <summary>
+/// Env-gated unhandled-VT-sequence log: set AGWINTERM_VT_LOG=&lt;path&gt; and every escape sequence the
+/// emulator has no handler for is appended there (timestamp, pane, kind, detail). Off (null path) it
+/// costs one null check per unhandled sequence. This is the debug tap that turns a protocol gap into
+/// one grep — e.g. the OSC 52 clipboard drop would have shown up as `OSC 52;c;…` on the first run.
+/// </summary>
+internal static class VtLog
+{
+    private static readonly string? _path = Environment.GetEnvironmentVariable("AGWINTERM_VT_LOG") is { Length: > 0 } p ? p : null;
+    private static readonly object _lock = new();
+
+    public static void Write(string paneId, string kind, string detail)
+    {
+        if (_path is null) return;
+        try
+        {
+            string line = $"{DateTime.Now:HH:mm:ss.fff} [{(paneId.Length >= 8 ? paneId[..8] : paneId)}] {kind,-4} {detail}\n";
+            lock (_lock) System.IO.File.AppendAllText(_path, line);
+        }
+        catch { /* best-effort diagnostics — never disturb the terminal */ }
+    }
+}

--- a/tests/Agwinterm.Core.Tests/KittyKeyboardTests.cs
+++ b/tests/Agwinterm.Core.Tests/KittyKeyboardTests.cs
@@ -51,11 +51,10 @@ public class KittyKeyboardTests
     public void Query_RespondsWithCurrentFlags()
     {
         var t = new TerminalEmulator(40, 5);
-        string? reply = null;
-        t.Respond += r => reply = r;
+        var host = new RecordingHost(); t.Host = host;
         t.Feed(Encoding.UTF8.GetBytes("\x1b[>7u"));   // enable flags 7
         t.Feed(Encoding.UTF8.GetBytes("\x1b[?u"));    // query
-        Assert.Equal("\x1b[?7u", reply);
+        Assert.Equal("\x1b[?7u", host.Responses.Single());
     }
 
     [Fact]

--- a/tests/Agwinterm.Core.Tests/OscTests.cs
+++ b/tests/Agwinterm.Core.Tests/OscTests.cs
@@ -44,22 +44,18 @@ public class OscTests
     public void Osc9_FiresNotifiedWithBody()
     {
         var t = new TerminalEmulator(40, 3);
-        string? gotTitle = null, gotBody = null;
-        t.Notified += (title, body) => { gotTitle = title; gotBody = body; };
+        var host = new RecordingHost(); t.Host = host;
         t.Feed(Encoding.UTF8.GetBytes("\x1b]9;build finished\x07"));
-        Assert.Equal("", gotTitle);
-        Assert.Equal("build finished", gotBody);
+        Assert.Equal(new[] { ("", "build finished") }, host.Notifications.ToArray());
     }
 
     [Fact]
     public void Osc777_NotifyFiresNotifiedWithTitleAndBody()
     {
         var t = new TerminalEmulator(40, 3);
-        string? gotTitle = null, gotBody = null;
-        t.Notified += (title, body) => { gotTitle = title; gotBody = body; };
+        var host = new RecordingHost(); t.Host = host;
         t.Feed(Encoding.UTF8.GetBytes("\x1b]777;notify;npm;tests passed\x07"));
-        Assert.Equal("npm", gotTitle);
-        Assert.Equal("tests passed", gotBody);
+        Assert.Equal(new[] { ("npm", "tests passed") }, host.Notifications.ToArray());
     }
 
     [Fact]
@@ -98,10 +94,9 @@ public class OscTests
     public void OscNotification_StripsControlCharacters()
     {
         var t = new TerminalEmulator(40, 3);
-        string? gotBody = null;
-        t.Notified += (_, body) => gotBody = body;
+        var host = new RecordingHost(); t.Host = host;
         t.OscDispatch(9, "line1\r\nline2");
-        Assert.Equal("line1line2", gotBody);
+        Assert.Equal("line1line2", host.Notifications.Single().Body);
     }
 
     // OSC 9;4 (ConEmu/Windows Terminal progress) must fire Progress, NOT a notification toast.
@@ -110,34 +105,29 @@ public class OscTests
     public void Osc9_4_FiresProgressNotNotification()
     {
         var t = new TerminalEmulator(40, 3);
-        int? st = null, val = null; bool notified = false;
-        t.Progress += (s, v) => { st = s; val = v; };
-        t.Notified += (_, _) => notified = true;
+        var host = new RecordingHost(); t.Host = host;
         t.OscDispatch(9, "4;1;62");
-        Assert.Equal(1, st);
-        Assert.Equal(62, val);
-        Assert.False(notified);
+        Assert.Equal(new[] { (1, 62) }, host.ProgressReports.ToArray());
+        Assert.Empty(host.Notifications);
     }
 
     [Fact]
     public void Osc9_4_ClearAndClamp()
     {
         var t = new TerminalEmulator(40, 3);
-        var got = new List<(int, int)>();
-        t.Progress += (s, v) => got.Add((s, v));
+        var host = new RecordingHost(); t.Host = host;
         t.OscDispatch(9, "4;1;250");
         t.OscDispatch(9, "4;0");
-        Assert.Equal(new[] { (1, 100), (0, 0) }, got.ToArray());
+        Assert.Equal(new[] { (1, 100), (0, 0) }, host.ProgressReports.ToArray());
     }
 
     [Fact]
     public void Osc9_PlainMessage_StillNotifies()
     {
         var t = new TerminalEmulator(40, 3);
-        string? body = null;
-        t.Notified += (_, b) => body = b;
+        var host = new RecordingHost(); t.Host = host;
         t.OscDispatch(9, "42 done");
-        Assert.Equal("42 done", body);
+        Assert.Equal("42 done", host.Notifications.Single().Body);
     }
 
     // FTCS (OSC 133) shell-integration marks: prompt/output boundaries + exit codes.
@@ -181,9 +171,9 @@ public class OscTests
     private static (TerminalEmulator t, List<string> writes) ClipboardHarness()
     {
         var t = new TerminalEmulator(40, 3);
-        var writes = new List<string>();
-        t.ClipboardWrite += s => writes.Add(s);
-        return (t, writes);
+        var host = new RecordingHost();
+        t.Host = host;
+        return (t, host.ClipboardWrites);
     }
 
     [Fact]
@@ -223,5 +213,38 @@ public class OscTests
         string b64 = Convert.ToBase64String(Encoding.UTF8.GetBytes("primary"));
         t.Feed(Encoding.UTF8.GetBytes($"\x1b]52;p;{b64}\x07"));     // "p" (primary) still lands
         Assert.Equal(new[] { "primary" }, writes);
+    }
+
+    // ---- The unhandled-sequence tap: protocol gaps must be observable, never silent ----
+
+    [Fact]
+    public void UnhandledOsc_ReportsThroughHostTap()
+    {
+        var t = new TerminalEmulator(40, 3);
+        var host = new RecordingHost(); t.Host = host;
+        t.Feed(Encoding.UTF8.GetBytes("\x1b]8;;https://example.com\x1b\\"));   // OSC 8 hyperlink (not implemented)
+        var u = Assert.Single(host.Unhandleds);
+        Assert.Equal("OSC", u.Kind);
+        Assert.StartsWith("8;", u.Detail);
+    }
+
+    [Fact]
+    public void UnhandledCsiEscAndMode_ReportThroughHostTap()
+    {
+        var t = new TerminalEmulator(40, 3);
+        var host = new RecordingHost(); t.Host = host;
+        t.Feed(Encoding.UTF8.GetBytes("\x1b[3 q"));       // DECSCUSR (not implemented; space intermediate dropped by parser)
+        t.Feed(Encoding.UTF8.GetBytes("\x1b[?2026h"));    // synchronized output mode (not implemented)
+        Assert.Contains(host.Unhandleds, u => u.Kind == "MODE" && u.Detail == "?2026 h");
+        Assert.NotEmpty(host.Unhandleds);
+    }
+
+    [Fact]
+    public void HandledSequences_DoNotTouchTheTap()
+    {
+        var t = new TerminalEmulator(40, 3);
+        var host = new RecordingHost(); t.Host = host;
+        t.Feed(Encoding.UTF8.GetBytes("hello\r\n\x1b[2J\x1b[H\x1b[31mred\x1b[0m\x1b]2;title\x07\x1b[?25l\x1b[?1049h\x1b[?1049l"));
+        Assert.Empty(host.Unhandleds);
     }
 }

--- a/tests/Agwinterm.Core.Tests/RecordingHost.cs
+++ b/tests/Agwinterm.Core.Tests/RecordingHost.cs
@@ -1,0 +1,18 @@
+namespace Agwinterm.Core.Tests;
+
+/// <summary>Test fake for the emulator's host-action seam: records every action for assertions.
+/// Attach with <c>emulator.Host = host</c>.</summary>
+public sealed class RecordingHost : IHostActions
+{
+    public readonly List<(string Title, string Body)> Notifications = new();
+    public readonly List<(int State, int Value)> ProgressReports = new();
+    public readonly List<string> ClipboardWrites = new();
+    public readonly List<string> Responses = new();
+    public readonly List<(string Kind, string Detail)> Unhandleds = new();
+
+    public void Notify(string title, string body) => Notifications.Add((title, body));
+    public void Progress(int state, int value) => ProgressReports.Add((state, value));
+    public void ClipboardWrite(string text) => ClipboardWrites.Add(text);
+    public void Respond(string reply) => Responses.Add(reply);
+    public void Unhandled(string kind, string detail) => Unhandleds.Add((kind, detail));
+}


### PR DESCRIPTION
Phase 1+3 of the libghostty-style refactor (option B from the clipboard postmortem): one explicit host-action interface between emulator and app, plus an observable tap for protocol gaps.

## What changed

**`IHostActions` (the apprt seam).** The emulator's ad-hoc events — `Notified`, `Progress`, `ClipboardWrite`, `Respond` — are consolidated into a single interface set via `emulator.Host`. The forcing function: an escape sequence with host-visible effects now requires an interface member, which every embedder and test fake must implement — a sequence can no longer be silently dropped the way OSC 52 was. Win32 implements it as a per-pane `PaneHost` adapter (UI work marshals via `Post`; `Respond` writes straight to the PTY).

**`Unhandled(kind, detail)` tap.** Every dispatch default — C0, CSI, ESC, DECSET/DECRST, OSC, DCS, APC — now reports syntactically-valid-but-unhandled sequences through the seam. The host logs them when `AGWINTERM_VT_LOG=<path>` is set; disabled it costs one null check. NUL is deliberately ignored (historical padding would flood the log).

## The tap already paid for itself

First live boot of a single pwsh pane logged:

```
MODE ?9001 h     ← win32-input-mode, requested by every shell at startup
MODE ?1004 h     ← focus reporting, requested by every shell at startup
CSI  3 q         ← DECSCUSR cursor style
MODE ?2026 h     ← synchronized output (TUI flicker reduction)
C0   0x07        ← BEL (no bell support)
```

Five real protocol gaps, none previously observable. These feed the Phase-4 audit (issues to follow).

## Verification

- 165/165 tests pass (3 new: unhandled OSC/CSI/MODE report through the tap; a fully-handled stream keeps the tap silent).
- **Live E2E (dev instance):** `AGWINTERM_VT_LOG` captured the gaps above from a real ConPTY pane; OSC 52 clipboard write still lands through the new seam (`seam v2` reached the Windows clipboard). Note: OSC 8 sent from a pane never reaches our emulator — ConPTY consumes hyperlinks itself; the emulator-side tap for unknown OSC is unit-tested.
- No behavior change intended anywhere else: same actions, same marshaling, reorganized plumbing.

Follow-ups (planned): policy knobs at the seam (`clipboard-write` allow/deny, paste protection), then the protocol audit vs Ghostty's action list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k