### PR TITLE
feat(clipboard): policy knobs at the host seam — paste protection + OSC 52 allow/deny

### DIFF
--- a/src/Agwinterm.Core/PastePolicy.cs
+++ b/src/Agwinterm.Core/PastePolicy.cs
@@ -1,0 +1,43 @@
+namespace Agwinterm.Core;
+
+/// <summary>
+/// Paste-protection classifier (the pure, testable half — enforcement lives at the host seam,
+/// mirroring the Ghostty/Windows Terminal model). Decides whether pasting a given text into a
+/// terminal warrants a user confirmation before any bytes reach the shell.
+/// </summary>
+public static class PastePolicy
+{
+    /// <summary>
+    /// True when pasting <paramref name="text"/> warrants a confirmation:
+    /// it contains a newline — a shell executes each completed line immediately, so a multi-line
+    /// paste is effectively "run this script now" — or a non-whitespace C0 control character / DEL
+    /// (escape-sequence injection, e.g. a smuggled ESC that could fake bracketed-paste terminators).
+    /// When the application has bracketed paste on (<paramref name="bracketedPaste"/>), newlines are
+    /// delivered as one quoted unit and are safe; control characters still warrant a warning there,
+    /// because an embedded ESC can terminate the bracket early and inject.
+    /// </summary>
+    public static bool NeedsWarning(string text, bool bracketedPaste)
+    {
+        foreach (char c in text)
+        {
+            if (c is '\r' or '\n') { if (!bracketedPaste) return true; }
+            else if (c < 0x20 && c != '\t') return true;   // C0 controls (ESC, BEL, …); tab is ordinary text
+            else if (c == '\x7f') return true;             // DEL
+        }
+        return false;
+    }
+
+    /// <summary>Number of lines the text pastes as (for the "Paste N lines?" prompt):
+    /// line breaks (\r\n, \r or \n) + 1.</summary>
+    public static int LineCount(string text)
+    {
+        int lines = 1;
+        for (int i = 0; i < text.Length; i++)
+        {
+            char c = text[i];
+            if (c == '\r') { lines++; if (i + 1 < text.Length && text[i + 1] == '\n') i++; }
+            else if (c == '\n') lines++;
+        }
+        return lines;
+    }
+}

--- a/src/Agwinterm.Core/TerminalConfig.cs
+++ b/src/Agwinterm.Core/TerminalConfig.cs
@@ -55,6 +55,17 @@ public sealed class TerminalConfig
     /// sending an interrupt to the shell. With no selection, Ctrl+C still interrupts. Default on.</summary>
     public bool CopyOnCtrlC { get; set; } = true;
 
+    /// <summary>Warn before an interactive paste whose text contains newlines (a shell runs each
+    /// completed line immediately) or control characters (escape injection). Bracketed-paste-aware:
+    /// multi-line into a bracketed-paste app doesn't warn. Scripted pastes via the control API never
+    /// prompt. Default on (Windows Terminal / Ghostty behavior).</summary>
+    public bool PasteProtection { get; set; } = true;
+
+    /// <summary>Allow programs to write the system clipboard via OSC 52 (e.g. Claude Code's
+    /// auto-copy-on-select). Set false to deny; denials are visible in AGWINTERM_VT_LOG.
+    /// Reads are always refused regardless. Default on.</summary>
+    public bool ClipboardWrite { get; set; } = true;
+
     /// <summary>Characters that DELIMIT words for double-click selection (in addition to whitespace).
     /// Empty = whitespace only (double-click grabs a whole path/URL). WT's wordDelimiters analog.</summary>
     public string WordDelimiters { get; set; } = "";
@@ -179,6 +190,14 @@ public sealed class TerminalConfig
         # an interrupt. With nothing selected, Ctrl+C still interrupts the shell.
         copy-on-ctrl-c = true
 
+        # Warn before pasting text with newlines (a shell runs each line immediately) or control
+        # characters. Pastes into bracketed-paste apps and scripted control-API pastes never prompt.
+        paste-protection = true
+
+        # Allow programs to write the system clipboard via OSC 52 (e.g. Claude Code's auto-copy).
+        # Reads are always refused regardless of this setting.
+        clipboard-write = true
+
         # Extra word-delimiter characters for double-click selection (besides whitespace).
         # Empty = whitespace only, so double-click grabs a whole path or URL. Example: /\.:;,="'()[]{}
         word-delimiters =
@@ -297,6 +316,8 @@ public sealed class TerminalConfig
                 case "right-click-paste": cfg.RightClickPaste = ParseBool(val, cfg.RightClickPaste); break;
                 case "copy-on-select": cfg.CopyOnSelect = ParseBool(val, cfg.CopyOnSelect); break;
                 case "copy-on-ctrl-c": cfg.CopyOnCtrlC = ParseBool(val, cfg.CopyOnCtrlC); break;
+                case "paste-protection": cfg.PasteProtection = ParseBool(val, cfg.PasteProtection); break;
+                case "clipboard-write": cfg.ClipboardWrite = ParseBool(val, cfg.ClipboardWrite); break;
                 case "word-delimiters": cfg.WordDelimiters = val; break;
                 case "desktop-notifications": cfg.DesktopNotifications = ParseBool(val, cfg.DesktopNotifications); break;
                 case "blocked-sound": cfg.BlockedSound = val; break;

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -461,7 +461,7 @@ internal partial class Program
         public string SessionPaste(string? target, string? text) => InvokeOnUi(() =>
         {
             var p = PaneForTarget(target); if (p is null) return "no session";
-            PasteTextInto(p, text ?? ClipboardGet());
+            PasteTextInto(p, text ?? ClipboardGet(), interactive: false);   // scripted: never prompt (agents)
             return "pasted";
         });
 

--- a/src/Agwinterm.Win32/Program.Input.cs
+++ b/src/Agwinterm.Win32/Program.Input.cs
@@ -737,11 +737,22 @@ internal partial class Program
 
     private void PasteInto(Pane pane) => PasteTextInto(pane, ClipboardGet());
 
-    /// <summary>Paste literal text into a pane, honoring bracketed-paste mode (shared by Ctrl+V and the API).</summary>
-    private void PasteTextInto(Pane pane, string t)
+    /// <summary>Paste literal text into a pane, honoring bracketed-paste mode (shared by Ctrl+V and the API).
+    /// Interactive pastes are guarded by paste-protection (confirm on newlines/control chars — a shell runs
+    /// each completed line immediately); scripted control-API pastes pass <paramref name="interactive"/>=false
+    /// and never prompt, so agents are unaffected.</summary>
+    private void PasteTextInto(Pane pane, string t, bool interactive = true)
     {
         if (pane.ReadOnly) { ShowToast("pane is read-only"); return; }
         if (t.Length == 0) return;
+        if (interactive && _config.PasteProtection && PastePolicy.NeedsWarning(t, pane.S.Emulator.BracketedPaste))
+        {
+            int lines = PastePolicy.LineCount(t);
+            string msg = lines > 1
+                ? $"Paste {lines} lines into the terminal? A shell may run them immediately."
+                : "The clipboard text contains control characters. Paste anyway?";
+            if (MessageBoxW(_hwnd, msg, "Paste", MB_YESNO | MB_ICONQUESTION) != IDYES) return;
+        }
         t = t.Replace("\r\n", "\r").Replace("\n", "\r");
         if (pane.S.Emulator.BracketedPaste) t = "\x1b[200~" + t + "\x1b[201~";
         pane.ScrollOffset = 0; pane.S.NotifyActivity();

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -222,7 +222,13 @@ internal partial class Program
         public PaneHost(Program app, Pane pane, TerminalSession s) { _app = app; _pane = pane; _s = s; }
         public void Notify(string title, string body) => _app.Post(() => _app.OnNotified(_pane, title, body));
         public void Progress(int state, int value) => _app.Post(() => _app.OnProgress(state, value));   // OSC 9;4 -> taskbar
-        public void ClipboardWrite(string text) => _app.Post(() => _app.ClipboardSet(text));            // OSC 52 -> system clipboard
+        public void ClipboardWrite(string text)                                                        // OSC 52 -> system clipboard
+        {
+            // Policy at the seam (Ghostty's clipboard-write = allow|deny): the emulator emits the
+            // action unconditionally; the host decides. Denials are visible in the VT log.
+            if (!Program._config.ClipboardWrite) { VtLog.Write(_pane.Id, "OSC", $"52 clipboard write DENIED by config ({text.Length} chars)"); return; }
+            _app.Post(() => _app.ClipboardSet(text));
+        }
         public void Respond(string reply) { _s.NotifyActivity(); _s.Write(Encoding.UTF8.GetBytes(reply)); } // query reply -> PTY
         public void Unhandled(string kind, string detail) => VtLog.Write(_pane.Id, kind, detail);       // AGWINTERM_VT_LOG tap
     }

--- a/tests/Agwinterm.Core.Tests/PastePolicyTests.cs
+++ b/tests/Agwinterm.Core.Tests/PastePolicyTests.cs
@@ -1,0 +1,64 @@
+using Agwinterm.Core;
+
+namespace Agwinterm.Core.Tests;
+
+/// <summary>Paste-protection classifier: what warrants a confirmation before bytes reach the shell.</summary>
+public class PastePolicyTests
+{
+    // ---- Safe pastes: never prompt ----
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("hello world")]
+    [InlineData("git commit -m \"fix: quotes are fine\"")]
+    [InlineData("col1\tcol2\tcol3")]                       // tabs are ordinary text
+    [InlineData("ünïcode — emoji 🚀 fullwidth ｗｉｄｅ")]     // non-ASCII is not a control char
+    public void PlainSingleLineText_NeverWarns(string text)
+    {
+        Assert.False(PastePolicy.NeedsWarning(text, bracketedPaste: false));
+        Assert.False(PastePolicy.NeedsWarning(text, bracketedPaste: true));
+    }
+
+    // ---- Newlines: the "shell runs each line immediately" hazard ----
+
+    [Theory]
+    [InlineData("line1\nline2")]
+    [InlineData("line1\r\nline2")]
+    [InlineData("line1\rline2")]
+    [InlineData("cmd\n")]           // a single trailing newline still executes the line
+    public void MultiLine_WarnsWithoutBracketedPaste(string text)
+        => Assert.True(PastePolicy.NeedsWarning(text, bracketedPaste: false));
+
+    [Theory]
+    [InlineData("line1\nline2")]
+    [InlineData("line1\r\nline2")]
+    [InlineData("a\rb\rc\r")]
+    public void MultiLine_SafeUnderBracketedPaste(string text)
+        => Assert.False(PastePolicy.NeedsWarning(text, bracketedPaste: true));
+
+    // ---- Control characters: escape injection, dangerous even under bracketed paste ----
+
+    [Theory]
+    [InlineData("evil\x1b[201~rm -rf ~\x1b[200~")]  // smuggled bracketed-paste terminator
+    [InlineData("bell\a")]
+    [InlineData("del\x7f")]
+    [InlineData("\x01ctrl-a")]
+    public void ControlCharacters_WarnEvenUnderBracketedPaste(string text)
+    {
+        Assert.True(PastePolicy.NeedsWarning(text, bracketedPaste: false));
+        Assert.True(PastePolicy.NeedsWarning(text, bracketedPaste: true));
+    }
+
+    // ---- Line counting for the prompt message ----
+
+    [Theory]
+    [InlineData("", 1)]
+    [InlineData("one line", 1)]
+    [InlineData("a\nb", 2)]
+    [InlineData("a\r\nb", 2)]       // CRLF is ONE break, not two
+    [InlineData("a\rb", 2)]
+    [InlineData("a\n", 2)]
+    [InlineData("a\r\nb\nc\rd", 4)]
+    public void LineCount_CountsBreaksPlusOne(string text, int expected)
+        => Assert.Equal(expected, PastePolicy.LineCount(text));
+}

--- a/tests/Agwinterm.Core.Tests/TerminalConfigTests.cs
+++ b/tests/Agwinterm.Core.Tests/TerminalConfigTests.cs
@@ -13,6 +13,26 @@ public class TerminalConfigTests
         Assert.Equal(CursorStyle.Bar, c.CursorStyle);
         Assert.True(c.CursorBlink);
         Assert.Equal(530, c.CursorBlinkMs);
+        Assert.True(c.PasteProtection);   // WT/Ghostty default: warn on risky pastes
+        Assert.True(c.ClipboardWrite);    // OSC 52 writes allowed by default
+    }
+
+    [Fact]
+    public void ClipboardPolicyKeys_Parse()
+    {
+        var c = TerminalConfig.Parse("paste-protection = false\nclipboard-write = false\n");
+        Assert.False(c.PasteProtection);
+        Assert.False(c.ClipboardWrite);
+        var on = TerminalConfig.Parse("paste-protection = on\nclipboard-write = yes\n");
+        Assert.True(on.PasteProtection);
+        Assert.True(on.ClipboardWrite);
+    }
+
+    [Fact]
+    public void Template_DocumentsClipboardPolicyKeys()
+    {
+        Assert.Contains("paste-protection", TerminalConfig.DefaultText);
+        Assert.Contains("clipboard-write", TerminalConfig.DefaultText);
     }
 
     [Fact]


### PR DESCRIPTION
Phase 2 of the libghostty-style refactor, rebased onto main after #97 merged (replaces the auto-closed stacked #99).

## New config keys

| Key | Default | Behavior |
|---|---|---|
| `paste-protection` | `true` | Interactive pastes containing **newlines** (a shell runs each completed line immediately) or **control characters** (escape injection, e.g. a smuggled `ESC[201~` bracketed-paste terminator) get a Yes/No confirmation. Bracketed-paste-aware: multi-line into a bracketed-paste app is one quoted unit → no prompt; control chars still prompt. **Scripted control-API pastes never prompt** — agents unaffected. |
| `clipboard-write` | `true` | Set `false` to deny programs writing the system clipboard via OSC 52. Enforced in the `PaneHost` seam; denials logged to `AGWINTERM_VT_LOG`. Reads remain always-refused regardless. |

The paste classifier is a pure Core helper (`PastePolicy.NeedsWarning` / `LineCount`) so the decision logic is exhaustively unit-testable; the Win32 side only owns the dialog.

## Verification

**Unit — 190/190 pass, 25 new:**
- `PastePolicy` matrix: plain/unicode/tab text never warns; `\n`/`\r\n`/`\r` warn without bracketed paste and are safe with it; ESC/BEL/DEL/C0 warn even under bracketed paste (bracket-escape injection); CRLF counted as one line break.
- Config: defaults on, key parsing (`false`/`on`/`yes`), template documents both keys.

**Live (dev instance):**
- `clipboard-write = false` → OSC 52 from a real pane **denied**: clipboard untouched, `OSC 52 clipboard write DENIED by config (16 chars)` in the VT log ✅
- Scripted multi-line `agwintermctl session paste` → landed instantly, **no prompt** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k