### PR TITLE
chore(release): bump version to 0.14.0

### DIFF
--- a/installer/agwinterm.iss
+++ b/installer/agwinterm.iss
@@ -2,7 +2,7 @@
 ; Build via installer\build.ps1 (publishes to stage\ then runs ISCC on this file).
 
 #define AppName    "agwinterm"
-#define AppVersion "0.13.5"
+#define AppVersion "0.14.0"
 #define AppExe     "Agwinterm.Win32.exe"
 #define AppPublisher "Boris Kudriashov"
 


### PR DESCRIPTION
0.14.0 — the host-action seam (libghostty-style architecture) + clipboard/paste policy.

- **refactor(core):** `IHostActions` — one explicit interface between emulator and app; sequences with host effects can no longer be silently dropped (#97)
- **feat(core):** unhandled-VT-sequence tap via `AGWINTERM_VT_LOG=<path>` — protocol gaps become observable; findings tracked in #98 (#97)
- **feat(clipboard):** `paste-protection` (default on) — confirm interactive pastes with newlines/control chars; bracketed-paste-aware; scripted pastes never prompt (#100)
- **feat(clipboard):** `clipboard-write` — allow/deny OSC 52 writes; denials logged (#100)

Minor bump (0.14): new architecture seam + new default-on paste behavior.

Tag `v0.14.0` after merge to trigger the release build.