### PR TITLE
feat: agterm v0.14.1 parity — dashboard polish, taskbar flash, title-bar popovers, AGW_PANE, pi hooks

### DIFF
--- a/src/Agwinterm.Core/TerminalConfig.cs
+++ b/src/Agwinterm.Core/TerminalConfig.cs
@@ -66,6 +66,10 @@ public sealed class TerminalConfig
     /// Reads are always refused regardless. Default on.</summary>
     public bool ClipboardWrite { get; set; } = true;
 
+    /// <summary>Flash the taskbar button when a notification arrives while the window is in the
+    /// background (agterm's Dock bounce, #215): "none" (default) | "once" | "until-focused".</summary>
+    public string NotificationFlash { get; set; } = "none";
+
     /// <summary>Characters that DELIMIT words for double-click selection (in addition to whitespace).
     /// Empty = whitespace only (double-click grabs a whole path/URL). WT's wordDelimiters analog.</summary>
     public string WordDelimiters { get; set; } = "";
@@ -206,6 +210,10 @@ public sealed class TerminalConfig
         # (the in-app banner + sidebar badge always show regardless). Set false to suppress the OS toast.
         desktop-notifications = true
 
+        # Flash the taskbar button when a notification arrives while the window is in the background:
+        # none | once | until-focused
+        notification-flash = none
+
         # Blocked sound: play a sound whenever a session enters the "blocked" agent status (needs
         # your attention). Empty / off / none = silent. Accepts a system-sound name (beep, asterisk,
         # exclamation, hand, question), a Windows sound-event alias, or a path to a .wav file.
@@ -318,6 +326,9 @@ public sealed class TerminalConfig
                 case "copy-on-ctrl-c": cfg.CopyOnCtrlC = ParseBool(val, cfg.CopyOnCtrlC); break;
                 case "paste-protection": cfg.PasteProtection = ParseBool(val, cfg.PasteProtection); break;
                 case "clipboard-write": cfg.ClipboardWrite = ParseBool(val, cfg.ClipboardWrite); break;
+                case "notification-flash":
+                    if (val is "none" or "once" or "until-focused") cfg.NotificationFlash = val;
+                    break;
                 case "word-delimiters": cfg.WordDelimiters = val; break;
                 case "desktop-notifications": cfg.DesktopNotifications = ParseBool(val, cfg.DesktopNotifications); break;
                 case "blocked-sound": cfg.BlockedSound = val; break;

--- a/src/Agwinterm.Pty/ClaudeIntegration.cs
+++ b/src/Agwinterm.Pty/ClaudeIntegration.cs
@@ -63,18 +63,10 @@ public static class ClaudeIntegration
     internal enum BlockState { Missing, Current, Stale, Corrupted }
 
     /// <summary>Classify the launcher block inside profile text; for <see cref="BlockState.Stale"/>,
-    /// <paramref name="updated"/> is the profile text with the block replaced by the current version.</summary>
+    /// <paramref name="updated"/> is the profile text with the block replaced by the current version.
+    /// (Thin wrapper over the shared <see cref="ProfileBlocks"/> logic.)</summary>
     internal static BlockState InspectBlock(string existing, out string updated)
-    {
-        updated = existing;
-        int b = existing.IndexOf(Begin, StringComparison.Ordinal);
-        if (b < 0) return BlockState.Missing;
-        int e = existing.IndexOf(End, b, StringComparison.Ordinal);
-        if (e < 0) return BlockState.Corrupted;
-        if (existing[b..(e + End.Length)] == Block) return BlockState.Current;
-        updated = existing[..b] + Block + existing[(e + End.Length)..];
-        return BlockState.Stale;
-    }
+        => (BlockState)ProfileBlocks.Inspect(existing, Begin, End, Block, out updated);
 
     /// <summary>Append the block to the profile if not already present; replace an installed block whose
     /// content is stale (older wrapper version). Idempotent. Returns a summary.</summary>
@@ -107,16 +99,5 @@ public static class ClaudeIntegration
     /// <summary>Refresh the installed block to the current version if (and only if) an older one is present —
     /// run at startup so wrapper fixes reach users who installed the launcher once and never re-ran install.
     /// Never installs fresh (that stays opt-in via install.hooks). Returns null when nothing changed.</summary>
-    public static string? RefreshIfInstalled()
-    {
-        try
-        {
-            string path = ShellIntegrationInstaller.ProfilePath();
-            if (!File.Exists(path)) return null;
-            if (InspectBlock(File.ReadAllText(path), out string updated) != BlockState.Stale) return null;
-            File.WriteAllText(path, updated);
-            return "claude launcher updated -> " + path;
-        }
-        catch { return null; }    // best-effort: a locked/readonly profile must not break startup
-    }
+    public static string? RefreshIfInstalled() => ProfileBlocks.RefreshIfInstalled(Begin, End, Block, "claude launcher");
 }

--- a/src/Agwinterm.Pty/GenericAgentInstaller.cs
+++ b/src/Agwinterm.Pty/GenericAgentInstaller.cs
@@ -21,7 +21,7 @@ public static class GenericAgentInstaller
         """
         if ($env:AGWINTERM -eq '1' -and -not $global:__agwAgent) {
           $global:__agwAgent = $true
-          if (-not $env:AGWINTERM_AGENT_RE) { $env:AGWINTERM_AGENT_RE = 'claude|codex|aider|gemini|cursor|copilot|goose|opencode|amp' }
+          if (-not $env:AGWINTERM_AGENT_RE) { $env:AGWINTERM_AGENT_RE = 'claude|codex|aider|gemini|cursor|copilot|goose|opencode|amp|pi' }
           function global:__agwStatus([string]$s) {
             if (-not $env:AGWINTERM_SESSION_ID) { return }
             $pipe = if ($env:AGWINTERM_PIPE) { $env:AGWINTERM_PIPE } else { 'agwinterm' }
@@ -52,15 +52,22 @@ public static class GenericAgentInstaller
         }
         """ + "\n" + End;
 
-    /// <summary>Append the block to the profile if not already present. Idempotent. Returns a summary.</summary>
+    /// <summary>Append the block to the profile if not already present; replace an installed block whose
+    /// content is stale (older bridge version — e.g. before pi joined the default agent regex). Idempotent.</summary>
     public static string Install()
     {
         string path = ShellIntegrationInstaller.ProfilePath();
         try
         {
             string existing = File.Exists(path) ? File.ReadAllText(path) : "";
-            if (existing.Contains(Begin))
-                return "generic agent status already installed -> " + path;
+            switch (ProfileBlocks.Inspect(existing, Begin, End, Block, out string updated))
+            {
+                case ProfileBlockState.Current: return "generic agent status already installed -> " + path;
+                case ProfileBlockState.Corrupted: return "generic agent block is corrupted (no end sentinel) — fix " + path + " by hand";
+                case ProfileBlockState.Stale:
+                    File.WriteAllText(path, updated);
+                    return "updated generic agent status to the current version -> " + path;
+            }
 
             Directory.CreateDirectory(Path.GetDirectoryName(path)!);
             string sep = existing.Length == 0 ? "" : (existing.EndsWith("\n") ? "\n" : "\n\n");
@@ -72,4 +79,7 @@ public static class GenericAgentInstaller
             return "failed to install generic agent status: " + ex.Message;
         }
     }
+
+    /// <summary>Refresh an already-installed block at startup (never installs fresh).</summary>
+    public static string? RefreshIfInstalled() => ProfileBlocks.RefreshIfInstalled(Begin, End, Block, "generic agent bridge");
 }

--- a/src/Agwinterm.Pty/ProfileBlocks.cs
+++ b/src/Agwinterm.Pty/ProfileBlocks.cs
@@ -1,0 +1,45 @@
+using System.IO;
+
+namespace Agwinterm.Pty;
+
+/// <summary>State of a sentinel-delimited block inside a PowerShell profile.</summary>
+public enum ProfileBlockState { Missing, Current, Stale, Corrupted }
+
+/// <summary>
+/// Shared logic for the guarded, sentinel-delimited blocks agwinterm appends to the user's
+/// PowerShell profile (claude launcher, generic agent bridge, …): classify the installed block
+/// against the current version and produce the spliced replacement for a stale one, so installer
+/// re-runs and startup refreshes update old blocks instead of silently keeping them.
+/// </summary>
+public static class ProfileBlocks
+{
+    /// <summary>Classify the block delimited by <paramref name="begin"/>/<paramref name="end"/> inside
+    /// profile text; for <see cref="ProfileBlockState.Stale"/>, <paramref name="updated"/> is the
+    /// profile text with the block replaced by <paramref name="block"/>.</summary>
+    public static ProfileBlockState Inspect(string existing, string begin, string end, string block, out string updated)
+    {
+        updated = existing;
+        int b = existing.IndexOf(begin, StringComparison.Ordinal);
+        if (b < 0) return ProfileBlockState.Missing;
+        int e = existing.IndexOf(end, b, StringComparison.Ordinal);
+        if (e < 0) return ProfileBlockState.Corrupted;
+        if (existing[b..(e + end.Length)] == block) return ProfileBlockState.Current;
+        updated = existing[..b] + block + existing[(e + end.Length)..];
+        return ProfileBlockState.Stale;
+    }
+
+    /// <summary>Refresh an already-installed block to the current version (refresh-only: never
+    /// installs fresh; best-effort). Returns a summary line, or null when nothing changed.</summary>
+    public static string? RefreshIfInstalled(string begin, string end, string block, string what)
+    {
+        try
+        {
+            string path = ShellIntegrationInstaller.ProfilePath();
+            if (!File.Exists(path)) return null;
+            if (Inspect(File.ReadAllText(path), begin, end, block, out string updated) != ProfileBlockState.Stale) return null;
+            File.WriteAllText(path, updated);
+            return what + " updated -> " + path;
+        }
+        catch { return null; }    // a locked/readonly profile must not break startup
+    }
+}

--- a/src/Agwinterm.Win32/Dashboard.cs
+++ b/src/Agwinterm.Win32/Dashboard.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Agwinterm.Core;
 using Vortice.Direct2D1;
 using Vortice.Mathematics;
 using static Agwinterm.Win32.Win32;
@@ -90,8 +91,20 @@ internal partial class Program
             // Title strip
             brush.Color = sel ? ChromeAccent : Mix(C4(_theme.DefaultBackground), ChromeDim, 0.5f);
             rt.FillRectangle(new Rect(cx, cy, cellW, labelH), brush);
+            // Agent-status glyph at the strip's right edge (agterm #209) — a session needing
+            // attention stands out in the grid. Idle draws nothing.
+            var st = AggStatus(s);
+            float titleRight = cellW - 12f;
+            if (st != AgentStatus.Idle)
+            {
+                var dot = StatusDot(st);
+                if (AggBlink(s) && !_cursorOn) dot = new Color4(dot.R, dot.G, dot.B, 0.30f); // pulse with the cursor clock
+                brush.Color = dot;
+                rt.FillEllipse(new Ellipse(new System.Numerics.Vector2(cx + cellW - 12f, cy + labelH / 2f), 4.5f, 4.5f), brush);
+                titleRight -= 14f;
+            }
             brush.Color = sel ? new Color4(1f, 1f, 1f, 1f) : ChromeText;
-            rt.DrawText($"{s.Ws.Name} / {s.Name}", _uiSmall, new Rect(cx + 6f, cy + 1f, cellW - 12f, labelH - 1f), brush, DrawTextOptions.Clip);
+            rt.DrawText($"{s.Ws.Name} / {s.Name}", _uiSmall, new Rect(cx + 6f, cy + 1f, titleRight, labelH - 1f), brush, DrawTextOptions.Clip);
 
             // Live terminal preview, clipped to the cell body
             float tx = cx + 4f, ty = cy + labelH + 2f, tw = MathF.Max(1f, cellW - 8f), th = MathF.Max(1f, cellH - labelH - 6f);
@@ -104,7 +117,7 @@ internal partial class Program
         }
 
         brush.Color = ChromeDim;
-        rt.DrawText("Dashboard — arrows move · Enter open · Esc close", _uiSmall,
+        rt.DrawText("Dashboard — arrows move · Enter/click open · Esc close", _uiSmall,
             new Rect(ax + 8f, ay + ah - footH + 3f, aw - 16f, footH - 4f), brush);
     }
 
@@ -137,7 +150,8 @@ internal partial class Program
         RequestRedraw();
     }
 
-    /// <summary>Mouse in the dashboard: single click highlights a cell, double-click drops into it.</summary>
+    /// <summary>Mouse in the dashboard: a single click enters the cell (agterm #217) — the active
+    /// frame flashes onto the clicked cell first so the click reads as acknowledged, then we jump.</summary>
     private void DashboardClick(int mx, int my, bool doubleClick)
     {
         for (int i = 0; i < _dashCells.Count; i++)
@@ -145,8 +159,17 @@ internal partial class Program
             var c = _dashCells[i];
             if (mx >= c.Left && mx < c.Right && my >= c.Top && my < c.Bottom)
             {
-                if (doubleClick) { var s = _dashSessions[i]; CloseDashboard(); SetActive(s); }
-                else DashSelect(i);
+                DashSelect(i);   // highlight now — the acknowledge flash
+                int hit = i;
+                _ = System.Threading.Tasks.Task.Run(async () =>
+                {
+                    await System.Threading.Tasks.Task.Delay(130);
+                    Post(() =>
+                    {
+                        if (!_dashboardOpen || hit >= _dashSessions.Count) return;
+                        var s = _dashSessions[hit]; CloseDashboard(); SetActive(s);
+                    });
+                });
                 return;
             }
         }

--- a/src/Agwinterm.Win32/Keymap.cs
+++ b/src/Agwinterm.Win32/Keymap.cs
@@ -85,7 +85,8 @@ internal static class Keymap
         #            (independent OS process — open a URL, launch an external tool)
         #
         # tokens (expanded in <text>) + matching $AGW_* env vars given to the process:
-        #   {AGW_SESSION} {AGW_SESSION_ID} {AGW_WORKSPACE} {AGW_CWD} {AGW_PANE_ID} {AGW_APP}
+        #   {AGW_SESSION} {AGW_SESSION_ID} {AGW_WORKSPACE} {AGW_CWD} {AGW_PANE_ID} {AGW_PANE} {AGW_APP}
+        #   ({AGW_PANE} = the surface the command fired from: left / right / scratch / overlay / quick)
         #
         # actions: new_session new_workspace close_session next_session previous_session
         #          toggle_sidebar rename_session delete_workspace session_palette

--- a/src/Agwinterm.Win32/Program.Chrome.cs
+++ b/src/Agwinterm.Win32/Program.Chrome.cs
@@ -1354,7 +1354,9 @@ internal partial class Program
         "toggle" => "Toggle sidebar",
         "add-session" => "New session",
         "new-workspace" => "New workspace",
-        "attention" => "Next attention",
+        "attention" => "Attention",
+        "recent" => "Recent sessions",
+        "dashboard" => "Dashboard",
         "scratch" => "Scratch terminal",
         "split" => "Split pane",
         "quick terminal" => "Quick terminal",
@@ -1405,7 +1407,9 @@ internal partial class Program
             case "toggle": ToggleSidebar(); break;
             case "add-session": TogglePalette(PaletteKind.NewSession); break;   // themed picker: profiles + Open Directory…
             case "new-workspace": CreateWorkspace(Guid.NewGuid().ToString(), null); break;
-            case "attention": GoToNextAttention(1); break;
+            case "attention": ShowAttentionPopover(); break;   // popover of waiting sessions (agterm #212)
+            case "recent": ShowRecentPopover(); break;         // popover of recent sessions (agterm #212)
+            case "dashboard": ToggleDashboard(); break;        // title-bar dashboard button (agterm #217)
             case "scratch": if (_active is not null) ScratchOp(_active, "toggle"); break;
             case "split": SplitOp("toggle"); break;   // title-bar split button toggles the split on/off
             case "quick terminal": QuickOp("toggle"); break;
@@ -1414,6 +1418,65 @@ internal partial class Program
             case "settings": OpenSettingsWindow(); break;
             default: ShowToast(a + " not implemented yet"); break;
         }
+    }
+
+    /// <summary>Screen point just under a title-bar button (popover anchor); falls back to the
+    /// title bar's left edge if the button isn't currently laid out.</summary>
+    private (int sx, int sy) TitleButtonAnchor(string action)
+    {
+        float x = 8f;
+        foreach (var b in _titleButtons) if (b.action == action) { x = b.x0; break; }
+        var pt = new POINT { x = (int)x, y = (int)TitleBarH };
+        ClientToScreen(_hwnd, ref pt);
+        return (pt.x, pt.y);
+    }
+
+    /// <summary>Title-bar attention popover (agterm #212): the sessions that need attention,
+    /// most urgent first — click one to jump. Replaces the bell's old jump-to-next click.</summary>
+    private void ShowAttentionPopover()
+    {
+        var att = AllSessions().Where(s => AggStatus(s) != AgentStatus.Idle)
+            .OrderBy(s => AggStatus(s) == AgentStatus.Blocked ? 0 : AggStatus(s) == AgentStatus.Active ? 1 : 2)
+            .ToList();
+        var items = new List<PalItem>();
+        if (att.Count == 0) items.Add(new PalItem { Label = "No sessions need attention", Run = null });
+        foreach (var s in att)
+        {
+            var sx = s;
+            items.Add(new PalItem
+            {
+                Label = sx.Name,
+                Secondary = $"{sx.Ws.Name}  ·  {AggStatus(sx).ToString().ToLowerInvariant()}",
+                Dot = AggStatus(sx),
+                Run = () => { lock (_workspaces) sx.Ws.Expanded = true; SetActive(sx); },
+            });
+        }
+        var (ax, ay) = TitleButtonAnchor("attention");
+        ShowMenuWindow(items, ax, ay);
+    }
+
+    /// <summary>Title-bar recent-sessions popover (agterm #212): most-recently-used sessions,
+    /// current first — for jumping around while the sidebar is hidden.</summary>
+    private void ShowRecentPopover()
+    {
+        EnsureMru();
+        var recent = _mru.Select(FindSes).Where(s => s is not null).Cast<Ses>().Take(9).ToList();
+        var items = new List<PalItem>();
+        if (recent.Count == 0) items.Add(new PalItem { Label = "No recent sessions", Run = null });
+        foreach (var s in recent)
+        {
+            var sx = s;
+            var st = AggStatus(sx);
+            items.Add(new PalItem
+            {
+                Label = ReferenceEquals(sx, _active) ? sx.Name + "  (current)" : sx.Name,
+                Secondary = sx.Ws.Name,
+                Dot = st == AgentStatus.Idle ? null : st,
+                Run = () => { lock (_workspaces) sx.Ws.Expanded = true; SetActive(sx); },
+            });
+        }
+        var (ax, ay) = TitleButtonAnchor("recent");
+        ShowMenuWindow(items, ax, ay);
     }
 
     private void ToggleSidebar()

--- a/src/Agwinterm.Win32/Program.Input.cs
+++ b/src/Agwinterm.Win32/Program.Input.cs
@@ -223,19 +223,38 @@ internal partial class Program
         return "agwintermctl";
     }
 
-    /// <summary>The {AGW_*} / $AGW_* values for a session context (active by default).</summary>
-    private static Dictionary<string, string> AgwValues(Ses? ses) => new(StringComparer.Ordinal)
+    /// <summary>The {AGW_*} / $AGW_* values for a session context (active by default). AGW_PANE names
+    /// the surface the command fired from — left/right/scratch/overlay/quick (agterm #210's $AGT_PANE) —
+    /// and AGW_PANE_ID is that surface's id, so a keybinding can route a follow-up ctl call back into it.</summary>
+    private Dictionary<string, string> AgwValues(Ses? ses)
     {
-        ["AGW_SESSION"] = ses?.Name ?? "",
-        ["AGW_SESSION_ID"] = ses?.Id ?? "",
-        ["AGW_WORKSPACE"] = ses?.Ws.Name ?? "",
-        ["AGW_CWD"] = RawCwdOf(ses),
-        ["AGW_PANE_ID"] = ses?.ActivePane.Id ?? "",
-        ["AGW_APP"] = CtlPath(),
-    };
+        var surface = ActiveSurface();
+        string paneName = "";
+        if (surface is not null && ses is not null)
+        {
+            if (_coverKind == 1 && ReferenceEquals(surface, ses.Scratch)) paneName = "scratch";
+            else if (_coverKind == 3 && ReferenceEquals(surface, ses.Overlay)) paneName = "overlay";
+            else if (_coverKind == 2 && ReferenceEquals(surface, _quick)) paneName = "quick";
+            else
+            {
+                int idx = ses.Panes.IndexOf(surface);
+                paneName = idx == 0 ? "left" : idx > 0 ? "right" : "";
+            }
+        }
+        return new(StringComparer.Ordinal)
+        {
+            ["AGW_SESSION"] = ses?.Name ?? "",
+            ["AGW_SESSION_ID"] = ses?.Id ?? "",
+            ["AGW_WORKSPACE"] = ses?.Ws.Name ?? "",
+            ["AGW_CWD"] = RawCwdOf(ses),
+            ["AGW_PANE_ID"] = surface?.Id ?? ses?.ActivePane.Id ?? "",
+            ["AGW_PANE"] = paneName,
+            ["AGW_APP"] = CtlPath(),
+        };
+    }
 
     /// <summary>Expand {AGW_*} tokens; unknown {AGW_*} tokens expand to "".</summary>
-    private static string ExpandAgwTokens(string text, Ses? ses)
+    private string ExpandAgwTokens(string text, Ses? ses)
     {
         if (string.IsNullOrEmpty(text) || text.IndexOf("{AGW_", StringComparison.Ordinal) < 0) return text;
         var vals = AgwValues(ses);
@@ -244,7 +263,7 @@ internal partial class Program
     }
 
     /// <summary>$AGW_* environment (+ AGWINTERM=1) for a launched custom-command process.</summary>
-    private static Dictionary<string, string> AgwEnv(Ses? ses)
+    private Dictionary<string, string> AgwEnv(Ses? ses)
     {
         var d = AgwValues(ses);
         d["AGWINTERM"] = "1";

--- a/src/Agwinterm.Win32/Program.Services.cs
+++ b/src/Agwinterm.Win32/Program.Services.cs
@@ -76,6 +76,19 @@ internal partial class Program
         _toastTarget = ses;                       // clicking the banner jumps to the raising session
         SetTimer(_hwnd, (IntPtr)2, 4000, IntPtr.Zero);
         if (_config.DesktopNotifications) TrayNotify(title, body);
+        // Background notification → taskbar flash (agterm's opt-in Dock bounce, #215).
+        if (!_windowActive && _config.NotificationFlash != "none")
+        {
+            var fw = new FLASHWINFO
+            {
+                cbSize = (uint)System.Runtime.InteropServices.Marshal.SizeOf<FLASHWINFO>(),
+                hwnd = _hwnd,
+                // once: a brief tray+caption blink; until-focused: keep flashing until the window is foregrounded.
+                dwFlags = _config.NotificationFlash == "once" ? FLASHW_ALL : FLASHW_ALL | FLASHW_TIMERNOFG,
+                uCount = _config.NotificationFlash == "once" ? 2u : 0u,
+            };
+            FlashWindowEx(ref fw);
+        }
         RequestRedraw();
     }
 
@@ -239,13 +252,15 @@ internal partial class Program
             rt.DrawText(GlyphSidebar, _iconFont, new Rect(togX, 0, togW, TitleBarH), brush);
         }
 
-        // 6. Right group (pinned left of the caption buttons): scratch, split, | , quick-terminal, gear.
+        // 6. Right group (pinned left of the caption buttons): scratch, split, | , dashboard,
+        // quick-terminal, gear — dashboard grouped with quick behind the separator (agterm #217).
         float bw = 38f;
         float rgRight = cw - 3 * CaptionBtnW - 6f;   // right edge of the gear
         float gearX = rgRight - bw;
         float quickX = gearX - bw;
-        float divX = quickX - 5f;                    // hairline divider in the gap
-        float splitX = quickX - 10f - bw;
+        float dashX = quickX - bw;
+        float divX = dashX - 5f;                     // hairline divider in the gap
+        float splitX = dashX - 10f - bw;
         float scratchX = splitX - bw;
 
         // 3. Title at the terminal's leading edge (right of the sidebar): a SINGLE centered row
@@ -283,6 +298,14 @@ internal partial class Program
                 bellBase = new Color4(bellBase.R, bellBase.G, bellBase.B, 0.30f); // pulse when a blinking session needs attention
             var c = ChromeBtnBg(rt, brush, bellX, 0, bellW, TitleBarH, "attention", _titleButtons, bellBase);
             DrawBellGlyph(rt, brush, bellX + bellW / 2f, TitleBarH / 2f, c);
+            // Recent-sessions clock next to the bell, only when the sidebar is hidden (agterm #212 —
+            // the sidebar itself is the recents list when visible). Opens the recent-sessions popover.
+            if (_sidebarW <= 0)
+            {
+                float clockX = bellX + bellW + 2f;
+                var cc = ChromeBtnBg(rt, brush, clockX, 0, bellW, TitleBarH, "recent", _titleButtons, ChromeDim);
+                DrawClockGlyph(rt, brush, clockX + bellW / 2f, TitleBarH / 2f, cc);
+            }
         }
 
         // scratch (rounded rectangle; filled when active)
@@ -300,6 +323,11 @@ internal partial class Program
         // hairline divider between per-session toggles and the window-level quick terminal
         brush.Color = WithA(ChromeText, 0.25f);
         rt.DrawLine(new System.Numerics.Vector2(divX, 12f), new System.Numerics.Vector2(divX, TitleBarH - 12f), brush, 1f);
+        // dashboard grid (accent while open) — agterm #217
+        {
+            var c = ChromeBtnBg(rt, brush, dashX, 0, bw, TitleBarH, "dashboard", _titleButtons, _dashboardOpen ? ChromeAccent : ChromeDim);
+            DrawDashGlyph(rt, brush, dashX + bw / 2f, TitleBarH / 2f, c);
+        }
         // quick terminal (accent when active)
         bool quickOn = _coverKind == 2;
         {
@@ -360,6 +388,29 @@ internal partial class Program
         g.Dispose();
         rt.FillEllipse(new Ellipse(new System.Numerics.Vector2(cx, cy + 5.4f), 1.4f, 1.4f), brush);   // clapper
         rt.FillEllipse(new Ellipse(new System.Numerics.Vector2(cx, cy - 6.6f), 1.1f, 1.1f), brush);   // top nub
+    }
+
+    /// <summary>Dashboard glyph: a 2×2 grid of cells (agterm #217's title-bar dashboard button).</summary>
+    private void DrawDashGlyph(ID2D1HwndRenderTarget rt, ID2D1SolidColorBrush brush, float cx, float cy, Color4 color)
+    {
+        brush.Color = color;
+        for (int r = 0; r < 2; r++)
+            for (int c = 0; c < 2; c++)
+                rt.DrawRoundedRectangle(new RoundedRectangle
+                {
+                    Rect = new Rect(cx - 7f + c * 8f, cy - 6f + r * 8f, 6f, 5f),
+                    RadiusX = 1.2f,
+                    RadiusY = 1.2f,
+                }, brush, 1.3f);
+    }
+
+    /// <summary>Recent-sessions clock glyph (agterm #212's title-bar recents button).</summary>
+    private void DrawClockGlyph(ID2D1HwndRenderTarget rt, ID2D1SolidColorBrush brush, float cx, float cy, Color4 color)
+    {
+        brush.Color = color;
+        rt.DrawEllipse(new Ellipse(new System.Numerics.Vector2(cx, cy), 6.2f, 6.2f), brush, 1.4f);
+        rt.DrawLine(new System.Numerics.Vector2(cx, cy), new System.Numerics.Vector2(cx, cy - 3.6f), brush, 1.3f);       // hour hand up
+        rt.DrawLine(new System.Numerics.Vector2(cx, cy), new System.Numerics.Vector2(cx + 2.8f, cy + 1.4f), brush, 1.3f); // minute hand
     }
 
     /// <summary>Split glyph: two side-by-side panes (right pane filled when split is active).</summary>
@@ -771,6 +822,7 @@ internal partial class Program
         "restore-commands", "restore-buffer", "blocked-sound", "omp-theme", "omp-integration", "prompt-engine", "starship-theme",
         "new-session-dir-mode", "confirm-close-session", "compact-toolbar", "toolbar-mode", "notification-badges",
         "attention-button", "status-color-active", "status-color-blocked", "status-color-completed",
+        "paste-protection", "clipboard-write", "notification-flash",
     };
 
     /// <summary>Rewrite (or append) a single `key = value` line in agwinterm.conf, preserving the rest.</summary>
@@ -831,6 +883,9 @@ internal partial class Program
         "compact-toolbar" => _config.CompactToolbar ? "true" : "false",
         "toolbar-mode" => ToolbarModeResolved,
         "notification-badges" => _config.NotificationBadges ? "true" : "false",
+        "notification-flash" => _config.NotificationFlash,
+        "paste-protection" => _config.PasteProtection ? "true" : "false",
+        "clipboard-write" => _config.ClipboardWrite ? "true" : "false",
         "attention-button" => _config.AttentionButton ? "true" : "false",
         "status-color-active" => _config.StatusColorActive,
         "status-color-blocked" => _config.StatusColorBlocked,

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -1044,9 +1044,13 @@ internal partial class Program : ISessionHost, IWindowHost
         {
             _control = new ControlServer(this, this, _argPipe ?? _appId);
             _control.Start();
-            // Keep an already-installed claude launcher current (wrapper fixes ship with the app but the
-            // block lives in the user's profile). Refresh-only: never installs fresh, best-effort.
-            _ = Task.Run(Agwinterm.Pty.ClaudeIntegration.RefreshIfInstalled);
+            // Keep already-installed profile blocks current (fixes ship with the app but the blocks
+            // live in the user's profile). Refresh-only: never installs fresh, best-effort.
+            _ = Task.Run(() =>
+            {
+                Agwinterm.Pty.ClaudeIntegration.RefreshIfInstalled();
+                Agwinterm.Pty.GenericAgentInstaller.RefreshIfInstalled();
+            });
             // Default-terminal handoff (T2-13): register the COM class factory so conhost can hand
             // console sessions to this instance. Each handoff opens a new attached session.
             DefTerm.OnHandoff = args => Post(() =>

--- a/src/Agwinterm.Win32/Settings.cs
+++ b/src/Agwinterm.Win32/Settings.cs
@@ -147,6 +147,7 @@ internal partial class Program
         Sec(2, "Notifications");
         Tog(2, "desktop-notifications", "Desktop notifications (OS tray)");
         Tog(2, "notification-badges", "Unread badges on sidebar rows");
+        Drop(2, "notification-flash", "Flash taskbar when in background", new[] { "None", "Once", "Until focused" }, new[] { "none", "once", "until-focused" });
         Tog(2, "attention-button", "Title-bar attention indicator");
 
         // Agent Status

--- a/src/Agwinterm.Win32/Win32.cs
+++ b/src/Agwinterm.Win32/Win32.cs
@@ -102,6 +102,13 @@ internal static class Win32
 
     [DllImport("user32.dll")]
     public static extern bool SetForegroundWindow(IntPtr hWnd);
+
+    // Taskbar-button flash (agterm's Dock bounce analog, #215).
+    [StructLayout(LayoutKind.Sequential)]
+    public struct FLASHWINFO { public uint cbSize; public IntPtr hwnd; public uint dwFlags; public uint uCount; public uint dwTimeout; }
+    [DllImport("user32.dll")]
+    public static extern bool FlashWindowEx(ref FLASHWINFO pwfi);
+    public const uint FLASHW_STOP = 0, FLASHW_CAPTION = 1, FLASHW_TRAY = 2, FLASHW_ALL = 3, FLASHW_TIMERNOFG = 12;
     public const uint TPM_RETURNCMD = 0x0100, TPM_RIGHTBUTTON = 0x0002, TPM_LEFTALIGN = 0x0000, TPM_BOTTOMALIGN = 0x0020;
     public const uint MF_STRING = 0x0000, MF_POPUP = 0x0010, MF_SEPARATOR = 0x0800, MF_GRAYED = 0x0001;
     public const uint BIF_RETURNONLYFSDIRS = 0x0001, BIF_NEWDIALOGSTYLE = 0x0040;

--- a/tests/Agwinterm.Core.Tests/TerminalConfigTests.cs
+++ b/tests/Agwinterm.Core.Tests/TerminalConfigTests.cs
@@ -36,6 +36,16 @@ public class TerminalConfigTests
     }
 
     [Fact]
+    public void NotificationFlash_ParsesValidValuesRejectsUnknown()
+    {
+        Assert.Equal("none", TerminalConfig.Parse("").NotificationFlash);   // default: off (agterm #215)
+        Assert.Equal("once", TerminalConfig.Parse("notification-flash = once").NotificationFlash);
+        Assert.Equal("until-focused", TerminalConfig.Parse("notification-flash = until-focused").NotificationFlash);
+        Assert.Equal("none", TerminalConfig.Parse("notification-flash = bogus").NotificationFlash);
+        Assert.Contains("notification-flash", TerminalConfig.DefaultText);
+    }
+
+    [Fact]
     public void ParsesValues_IgnoresCommentsAndUnknown()
     {
         var c = TerminalConfig.Parse(

--- a/tests/Agwinterm.Pty.Tests/AgentHooksTests.cs
+++ b/tests/Agwinterm.Pty.Tests/AgentHooksTests.cs
@@ -84,6 +84,31 @@ public class AgentHooksTests
     }
 
     [Fact]
+    public void GenericAgentRegex_CoversPiWithWordBoundarySafety()
+    {
+        // agterm #208: Pi agent status. The bridge matches '^\s*(RE)\b', so 'pi' must be in the
+        // default set — and the \b anchor means 'pip install' must NOT light the status.
+        Assert.Contains("|pi'", GenericAgentInstaller.Block);
+        string re = System.Text.RegularExpressions.Regex.Match(GenericAgentInstaller.Block,
+            @"AGWINTERM_AGENT_RE = '([^']+)'").Groups[1].Value;
+        Assert.Matches(@"^\s*(" + re + @")\b", "pi do something");
+        Assert.DoesNotMatch(@"^\s*(" + re + @")\b", "pip install requests");
+    }
+
+    [Fact]
+    public void GenericAgentInstaller_SharesStaleBlockReplacement()
+    {
+        // Same Missing/Current/Stale/Corrupted machinery as the claude launcher (ProfileBlocks).
+        string begin = "# >>> agwinterm generic agent status >>>";
+        Assert.StartsWith(begin, GenericAgentInstaller.Block);
+        string stale = "# before\n" + begin + "\nold bridge\n# <<< agwinterm generic agent status <<<\n# after\n";
+        Assert.Equal(ProfileBlockState.Stale, ProfileBlocks.Inspect(stale,
+            begin, "# <<< agwinterm generic agent status <<<", GenericAgentInstaller.Block, out string updated));
+        Assert.Contains(GenericAgentInstaller.Block, updated);
+        Assert.DoesNotContain("old bridge", updated);
+    }
+
+    [Fact]
     public void InspectBlock_MissingCurrentStaleCorrupted()
     {
         // Missing: no sentinel at all.


### PR DESCRIPTION
Round-4 gap closure vs upstream agterm **v0.13.0–v0.14.1** (we were synced through v0.12.1). One PR, all gaps.

| agterm | Ported as |
|---|---|
| #209 | Agent-status glyph on each dashboard cell (pulses with the blink clock; idle draws nothing) |
| #217 | Dashboard: **single click enters** after an acknowledge flash; **title-bar dashboard button** grouped with quick terminal behind the separator, accented while open; footer text updated. (Modal titles: N/A — our title bar stays visible in dashboard mode.) |
| #215 | `notification-flash = none\|once\|until-focused` — taskbar `FlashWindowEx` when a notification arrives while the window is in the background (the Dock-bounce analog). Settings ▸ Notifications picker. Off by default, matching upstream. |
| #212 | Attention bell now opens a **popover of waiting sessions** (was jump-to-next; the `next_attention` keymap action is unchanged); a **recent-sessions clock** appears when the sidebar is hidden, opening an MRU popover. Both reuse the themed menu window. |
| #210 | `{AGW_PANE}` / `$AGW_PANE` names the surface a custom command fired from (`left`/`right`/`scratch`/`overlay`/`quick`); `AGW_PANE_ID` is now that surface's id (was: the session's active pane even when fired from a cover) |
| #208 | `pi` joins the default generic-agent regex (word-boundary safe — `pip install` can't match); the generic bridge gets the same stale-block replacement + startup refresh as the claude launcher via a shared `ProfileBlocks` helper |

**Also fixed:** `config.set` rejected `paste-protection`/`clipboard-write` (0.14.0 oversight — the keys parsed from file but weren't in `ConfigKeys`); `config.get` answers all three new keys.

**Not ported, by design:** #213 (stale surface token — our status lives on the session object and aggregates live each frame; the bug shape doesn't exist), #207/#228 (pointer-shape protocol → tracked in the #98 audit; ConPTY forwarding unverified), #221/#224/#229 (docs/tests/site).

## Verification

**Unit: 193/193 pass** (new: `notification-flash` parse/defaults/template; pi regex word-boundary matrix incl. the `pip install` negative; generic-bridge stale-block replacement).

**Live E2E (dev instance):**
1. Title bar shows the new dashboard button; clicking a dashboard cell **once** jumped to it (`tree` confirms active switch) ✅ *(screenshot in comments)*
2. Dashboard cells show status dots — blocked=orange, active=blue ✅
3. Sidebar hidden → clock appears; clicking it opened the MRU popover; clicking `beta` jumped (`active: beta`) ✅
4. `command run 'echo [{AGW_PANE}/{AGW_PANE_ID}]'` → `[left/<pane-id>]` in a single pane, `[right]` after split+focus-right ✅
5. Startup refresh rewrote the installed generic-agent profile block — `amp|pi` now present in the user profile without re-running install ✅
6. `config set/get notification-flash` round-trips all three values ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k