### PR TITLE
chore(release): bump version to 0.14.1

### DIFF
--- a/installer/agwinterm.iss
+++ b/installer/agwinterm.iss
@@ -2,7 +2,7 @@
 ; Build via installer\build.ps1 (publishes to stage\ then runs ISCC on this file).
 
 #define AppName    "agwinterm"
-#define AppVersion "0.14.0"
+#define AppVersion "0.14.1"
 #define AppExe     "Agwinterm.Win32.exe"
 #define AppPublisher "Boris Kudriashov"
 


### PR DESCRIPTION
0.14.1 — agterm v0.14.1 feature parity (#102).

- **dashboard:** status glyphs on cells; single-click enter with acknowledge flash; title-bar dashboard button (agterm #209/#217)
- **notifications:** `notification-flash = none|once|until-focused` taskbar flash + Settings picker (agterm #215)
- **chrome:** attention-bell popover; recent-sessions clock popover when sidebar hidden (agterm #212)
- **commands:** `{AGW_PANE}` fired-from surface + corrected `AGW_PANE_ID` (agterm #210)
- **agents:** `pi` in the generic regex; profile blocks auto-refresh at startup (agterm #208)
- **fix:** `config.set` accepts `paste-protection`/`clipboard-write`

Tag `v0.14.1` after merge to trigger the release build.