### PR TITLE
feat(claude): Update Claude Code workflow — version awareness, overlay update, session restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ the real thing: **[github.com/umputun/agterm](https://github.com/umputun/agterm)
   no guessing which shell was which. Already had Claude running before installing this? Run
   `agwintermctl claude adopt` (or palette → *Make Claude Sessions Resumable*) once to bind your
   existing conversations to their panes.
+- **Update Claude Code** (palette → *Update Claude Code*, or `agwintermctl claude update`): agwinterm
+  quietly notices when a new Claude Code ships (npm registry; `claude-update-check = false` to opt
+  out), then — on your command — runs `claude update` in an overlay terminal and **restarts every
+  running Claude session**, each resuming its own conversation (YOLO panes stay YOLO).
 - **A scriptable control API**: `agwintermctl` (or newline-JSON over a named pipe) — any language can
   drive it, including full **read-back** (tree with split ratios + pane ids, window state, session
   output). Opt-in installers for the **agent skill** and **Claude Code / Codex status hooks**.

--- a/src/Agwinterm.Core/TerminalConfig.cs
+++ b/src/Agwinterm.Core/TerminalConfig.cs
@@ -70,6 +70,11 @@ public sealed class TerminalConfig
     /// background (agterm's Dock bounce, #215): "none" (default) | "once" | "until-focused".</summary>
     public string NotificationFlash { get; set; } = "none";
 
+    /// <summary>Periodically check the npm registry for a newer Claude Code release and surface a
+    /// hint (toast + palette) when one ships. Awareness only — the update itself always stays a
+    /// manual, visible <c>claude update</c> (palette → "Update Claude Code").</summary>
+    public bool ClaudeUpdateCheck { get; set; } = true;
+
     /// <summary>Characters that DELIMIT words for double-click selection (in addition to whitespace).
     /// Empty = whitespace only (double-click grabs a whole path/URL). WT's wordDelimiters analog.</summary>
     public string WordDelimiters { get; set; } = "";
@@ -214,6 +219,11 @@ public sealed class TerminalConfig
         # none | once | until-focused
         notification-flash = none
 
+        # Check the npm registry in the background for a newer Claude Code release and show a hint
+        # when one ships. Updating is always manual: palette -> "Update Claude Code" (which runs
+        # `claude update` in an overlay terminal, then restarts your Claude sessions).
+        claude-update-check = true
+
         # Blocked sound: play a sound whenever a session enters the "blocked" agent status (needs
         # your attention). Empty / off / none = silent. Accepts a system-sound name (beep, asterisk,
         # exclamation, hand, question), a Windows sound-event alias, or a path to a .wav file.
@@ -329,6 +339,7 @@ public sealed class TerminalConfig
                 case "notification-flash":
                     if (val is "none" or "once" or "until-focused") cfg.NotificationFlash = val;
                     break;
+                case "claude-update-check": cfg.ClaudeUpdateCheck = ParseBool(val, cfg.ClaudeUpdateCheck); break;
                 case "word-delimiters": cfg.WordDelimiters = val; break;
                 case "desktop-notifications": cfg.DesktopNotifications = ParseBool(val, cfg.DesktopNotifications); break;
                 case "blocked-sound": cfg.BlockedSound = val; break;

--- a/src/Agwinterm.Ctl/Program.cs
+++ b/src/Agwinterm.Ctl/Program.cs
@@ -207,6 +207,7 @@ switch (area)
         break;
     case "claude" when sub == "adopt": cmd = "claude.adopt"; break; // bind existing claude convos to their panes
     case "claude" when sub == "yolo": cmd = "claude.yolo"; target = DefaultTarget(); break; // restart the target pane's claude in --dangerously-skip-permissions, resumed
+    case "claude" when sub == "update": cmd = "claude.update"; break; // run `claude update` in an overlay, then restart live claude panes
     case "theme" when sub == "list": cmd = "theme.list"; break;
     case "theme" when sub == "set":
         cmd = "theme.set";

--- a/src/Agwinterm.Pty/ClaudeIntegration.cs
+++ b/src/Agwinterm.Pty/ClaudeIntegration.cs
@@ -45,6 +45,9 @@ public static class ClaudeIntegration
             # don't inject or bind — just pass through untouched. Permission-mode flags are remembered in
             # the binding so a restored session comes back with the same mode (e.g. YOLO stays YOLO).
             $ctl = $false; $yolo = $false
+            # CLI subcommands (update/doctor/mcp/...) are maintenance verbs, not conversations —
+            # injecting --resume/--session-id would mangle them. Pass through untouched.
+            if ($args.Count -gt 0 -and "$($args[0])" -match '^(update|doctor|mcp|config|install|migrate-installer|setup-token|plugin|agents)$') { $ctl = $true }
             foreach ($a in $args) {
               if ($a -in '-r','--resume','-c','--continue','--session-id','-p','--print') { $ctl = $true }
               if ($a -eq '--dangerously-skip-permissions') { $yolo = $true }

--- a/src/Agwinterm.Pty/ClaudeUpdate.cs
+++ b/src/Agwinterm.Pty/ClaudeUpdate.cs
@@ -1,0 +1,91 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace Agwinterm.Pty;
+
+/// <summary>
+/// Claude Code version awareness for the "Update Claude Code" workflow: what's installed
+/// (<c>claude --version</c>), what's shipped (the npm registry — Claude Code releases are published
+/// as <c>@anthropic-ai/claude-code</c> for every install flavor, so its <c>latest</c> tag is the
+/// authoritative "a new version is out" signal), and a tolerant version compare. Pure helpers only —
+/// the update itself always runs as a visible <c>claude update</c> in a terminal, never silently.
+/// </summary>
+public static class ClaudeUpdate
+{
+    public const string RegistryUrl = "https://registry.npmjs.org/@anthropic-ai/claude-code/latest";
+
+    /// <summary>Extract a dotted version from CLI output (e.g. "2.1.14 (Claude Code)"), or null.</summary>
+    public static string? ParseVersion(string? output)
+    {
+        if (string.IsNullOrWhiteSpace(output)) return null;
+        var m = Regex.Match(output, @"\d+\.\d+\.\d+(?:-[0-9A-Za-z.]+)?");
+        return m.Success ? m.Value : null;
+    }
+
+    /// <summary>The "version" field of an npm registry <c>/latest</c> document, or null.</summary>
+    public static string? LatestFromRegistryJson(string json)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            return doc.RootElement.TryGetProperty("version", out var v) && v.ValueKind == JsonValueKind.String
+                ? ParseVersion(v.GetString()) : null;
+        }
+        catch { return null; }
+    }
+
+    /// <summary>Whether <paramref name="candidate"/> is strictly newer than <paramref name="current"/>.
+    /// Numeric per-segment compare ("2.0.10" &gt; "2.0.9"); any unparseable side compares as not-newer,
+    /// so a weird string can never nag the user or trigger an update loop.</summary>
+    public static bool IsNewer(string? candidate, string? current)
+    {
+        int[]? a = Segments(candidate), b = Segments(current);
+        if (a is null || b is null) return false;
+        for (int i = 0; i < 3; i++)
+            if (a[i] != b[i]) return a[i] > b[i];
+        return false;
+    }
+
+    private static int[]? Segments(string? v)
+    {
+        if (string.IsNullOrWhiteSpace(v)) return null;
+        int dash = v.IndexOf('-');                      // ignore any prerelease tail
+        if (dash > 0) v = v[..dash];
+        var parts = v.Split('.');
+        if (parts.Length != 3) return null;
+        var seg = new int[3];
+        for (int i = 0; i < 3; i++)
+            if (!int.TryParse(parts[i], out seg[i]) || seg[i] < 0) return null;
+        return seg;
+    }
+
+    /// <summary>Run <c>claude --version</c> and parse the result, or null when claude isn't installed
+    /// (resolved via cmd.exe so PATHEXT covers claude.exe / claude.cmd / npm shims alike).</summary>
+    public static string? InstalledVersion(int timeoutMs = 10000)
+    {
+        try
+        {
+            var psi = new System.Diagnostics.ProcessStartInfo("cmd.exe", "/c claude --version")
+            { RedirectStandardOutput = true, RedirectStandardError = true, UseShellExecute = false, CreateNoWindow = true };
+            using var p = System.Diagnostics.Process.Start(psi);
+            if (p is null) return null;
+            string outp = p.StandardOutput.ReadToEnd();
+            if (!p.WaitForExit(timeoutMs)) { try { p.Kill(); } catch { } return null; }
+            return ParseVersion(outp);
+        }
+        catch { return null; }
+    }
+
+    /// <summary>Fetch the latest shipped Claude Code version from the npm registry, or null on any
+    /// network/parse failure (offline must stay silent — awareness is best-effort).</summary>
+    public static async Task<string?> FetchLatestAsync()
+    {
+        try
+        {
+            using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(15) };
+            http.DefaultRequestHeaders.UserAgent.ParseAdd("agwinterm");
+            return LatestFromRegistryJson(await http.GetStringAsync(RegistryUrl).ConfigureAwait(false));
+        }
+        catch { return null; }
+    }
+}

--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -201,6 +201,8 @@ public sealed class ControlServer : IDisposable
                     return Ok(host.AdoptClaude());
                 case "claude.yolo":
                     return Ok(host.RestartClaudeYolo(target));
+                case "claude.update":
+                    return Ok(host.UpdateClaude());
                 case "workspace.focus": host.WorkspaceFocus(GetString(args, "op") ?? "toggle"); return Ok("focus");
                 case "session.background":
                     return Ok(host.SessionBackground(target, GetString(args, "action") ?? "set",

--- a/src/Agwinterm.Pty/ISessionHost.cs
+++ b/src/Agwinterm.Pty/ISessionHost.cs
@@ -169,6 +169,11 @@ public interface ISessionHost
     /// current conversation, and persist that as the pane's relaunch command. Null target = the active pane.</summary>
     string RestartClaudeYolo(string? target);
 
+    /// <summary>The Update Claude Code workflow: run <c>claude update</c> in an overlay terminal over the
+    /// active session, then restart every pane with a live Claude so the new version is picked up
+    /// (each resumes its own conversation). Returns an ack / error string.</summary>
+    string UpdateClaude();
+
     /// <summary>Focus/unfocus the active workspace (hide the others in the sidebar tree): op = on|off|toggle.</summary>
     void WorkspaceFocus(string op);
 
@@ -262,6 +267,7 @@ public sealed class SingleSessionHost : ISessionHost
     public bool SessionBind(string? target, string agent) => false;
     public string AdoptClaude() => "unsupported";
     public string RestartClaudeYolo(string? target) => "unsupported";
+    public string UpdateClaude() => "unsupported";
     public void WorkspaceFocus(string op) { }
     public string SessionBackground(string? target, string action, string? path, int opacity, string? mode) => "unsupported";
     public string SessionSwitch(string op) => "unsupported";

--- a/src/Agwinterm.Win32/Program.Chrome.cs
+++ b/src/Agwinterm.Win32/Program.Chrome.cs
@@ -806,6 +806,13 @@ internal partial class Program
                 A("Install Agent Status Hooks", "", InstallHooks);
                 A("Make Claude Sessions Resumable", "", MakeClaudeResumable);
                 A("Restart Claude in YOLO Mode", "", RestartClaudeYoloActive);
+                _palAll.Add(new PalItem
+                {
+                    Label = "Update Claude Code" + (_claudeLatest is { } cl ? $"  — v{cl} available" : ""),
+                    Secondary = "runs `claude update` in an overlay, then restarts your Claude sessions",
+                    Search = "update claude code upgrade version",
+                    Run = () => ShowToast(UpdateClaudeCode(), 2500),
+                });
                 A("Install Agent Skill", "", InstallSkill);
                 A("Install Shell Integration", "", InstallShellIntegration);
                 A("Reload Keymap", "", ReloadKeymap);

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -564,6 +564,8 @@ internal partial class Program
             return p is null ? "no pane" : RestartClaudeYolo(p);
         });
 
+        public string UpdateClaude() => InvokeOnUi(() => UpdateClaudeCode());
+
         public string SessionBackground(string? target, string action, string? path, int opacity, string? mode) => InvokeOnUi(() =>
         {
             var ses = FindSesForTarget(target);

--- a/src/Agwinterm.Win32/Program.Services.cs
+++ b/src/Agwinterm.Win32/Program.Services.cs
@@ -822,7 +822,7 @@ internal partial class Program
         "restore-commands", "restore-buffer", "blocked-sound", "omp-theme", "omp-integration", "prompt-engine", "starship-theme",
         "new-session-dir-mode", "confirm-close-session", "compact-toolbar", "toolbar-mode", "notification-badges",
         "attention-button", "status-color-active", "status-color-blocked", "status-color-completed",
-        "paste-protection", "clipboard-write", "notification-flash",
+        "paste-protection", "clipboard-write", "notification-flash", "claude-update-check",
     };
 
     /// <summary>Rewrite (or append) a single `key = value` line in agwinterm.conf, preserving the rest.</summary>
@@ -884,6 +884,7 @@ internal partial class Program
         "toolbar-mode" => ToolbarModeResolved,
         "notification-badges" => _config.NotificationBadges ? "true" : "false",
         "notification-flash" => _config.NotificationFlash,
+        "claude-update-check" => _config.ClaudeUpdateCheck ? "true" : "false",
         "paste-protection" => _config.PasteProtection ? "true" : "false",
         "clipboard-write" => _config.ClipboardWrite ? "true" : "false",
         "attention-button" => _config.AttentionButton ? "true" : "false",

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -794,28 +794,165 @@ internal partial class Program
                 ? "claude --dangerously-skip-permissions"
                 : $"claude --resume {id} --dangerously-skip-permissions";
             Post(() => { pane.AgentResume = cmd; SaveState(); });   // future restarts stay YOLO
-            // Quit the running Claude (Ctrl+C twice = exit), wait for it to actually be gone, then relaunch.
-            try { pane.S.Write(new byte[] { 0x03 }); } catch { }
-            await Task.Delay(350);
-            try { pane.S.Write(new byte[] { 0x03 }); } catch { }
-            // A fixed delay raced Claude's exit on slow machines — the typed relaunch landed in Claude's
-            // own prompt instead of the shell. Poll the shell's child processes until the foreground
-            // command (Claude's node) is gone, capped so a hung/ignoring process can't stall us forever.
-            int shellPid = pane.S.ChildProcessId ?? 0;
-            bool sawIdle = false;
-            if (shellPid > 0)
-                for (int i = 0; i < 100; i++)   // ≤ 30s
-                {
-                    await Task.Delay(300);
-                    bool? busy = HasLiveChildProcess(shellPid);
-                    if (busy is null) break;               // snapshot failed → fixed-delay fallback below
-                    if (busy is false) { sawIdle = true; break; }
-                }
-            if (!sawIdle) await Task.Delay(1200);           // old behavior when we couldn't confirm the exit
-            await Task.Delay(300);                          // let the shell repaint its prompt and start reading input
-            try { pane.S.Write(System.Text.Encoding.UTF8.GetBytes(cmd + "\r")); } catch { }
+            await QuitClaudeAndRelaunch(pane, cmd);
         });
         return "restarting Claude in YOLO mode";
+    }
+
+    /// <summary>Quit the Claude running in a pane and type <paramref name="cmd"/> into the freed shell.
+    /// Sends Ctrl+C twice (= Claude's exit), then WAITS for the foreground child to actually be gone —
+    /// a fixed delay raced Claude's exit on slow machines and the relaunch landed in Claude's own
+    /// prompt instead of the shell. Polling is capped so a hung/ignoring process can't stall forever.</summary>
+    private async Task QuitClaudeAndRelaunch(Pane pane, string cmd)
+    {
+        try { pane.S.Write(new byte[] { 0x03 }); } catch { }
+        await Task.Delay(350);
+        try { pane.S.Write(new byte[] { 0x03 }); } catch { }
+        int shellPid = pane.S.ChildProcessId ?? 0;
+        bool sawIdle = false;
+        if (shellPid > 0)
+            for (int i = 0; i < 100; i++)   // ≤ 30s
+            {
+                await Task.Delay(300);
+                bool? busy = HasLiveChildProcess(shellPid);
+                if (busy is null) break;               // snapshot failed → fixed-delay fallback below
+                if (busy is false) { sawIdle = true; break; }
+            }
+        if (!sawIdle) await Task.Delay(1200);           // old behavior when we couldn't confirm the exit
+        await Task.Delay(300);                          // let the shell repaint its prompt and start reading input
+        try { pane.S.Write(System.Text.Encoding.UTF8.GetBytes(cmd + "\r")); } catch { }
+    }
+
+    /// <summary>One background version check ("be aware when a new Claude Code ships"): compare the
+    /// installed CLI against the npm registry; when a NEW newer version appears, toast once and arm
+    /// the palette hint. Silent when claude isn't installed, offline, or already current.</summary>
+    private async Task CheckClaudeUpdateOnce()
+    {
+        string? installed = Agwinterm.Pty.ClaudeUpdate.InstalledVersion();
+        if (installed is null) return;
+        string? latest = await Agwinterm.Pty.ClaudeUpdate.FetchLatestAsync();
+        if (latest is null) return;
+        if (!Agwinterm.Pty.ClaudeUpdate.IsNewer(latest, installed)) { _claudeLatest = null; return; }
+        bool fresh = !string.Equals(_claudeLatest, latest, StringComparison.Ordinal);
+        _claudeLatest = latest;
+        if (fresh) Post(() => ShowToast($"Claude Code {latest} is out (you have {installed}) — palette → Update Claude Code", 6000));
+    }
+
+    /// <summary>The "Update Claude Code" workflow (palette / <c>agwintermctl claude update</c>):
+    /// check installed vs shipped, run <c>claude update</c> in an overlay terminal over the active
+    /// session (visible progress), and when it exits cleanly restart every pane with a live Claude
+    /// so the new version is picked up — each resumes its own conversation, YOLO stays YOLO.</summary>
+    private string UpdateClaudeCode()
+    {
+        var ses = _active;
+        if (ses is null) return "open a session first";
+        if (_claudeUpdating) return "Claude Code update already running";
+        _claudeUpdating = true;
+        _ = Task.Run(async () =>
+        {
+            string? installed = Agwinterm.Pty.ClaudeUpdate.InstalledVersion();
+            if (installed is null)
+            {
+                Post(() => { _claudeUpdating = false; ShowToast("claude not found on PATH — install Claude Code first", 4000); });
+                return;
+            }
+            string? latest = await Agwinterm.Pty.ClaudeUpdate.FetchLatestAsync();
+            if (latest is not null && !Agwinterm.Pty.ClaudeUpdate.IsNewer(latest, installed))
+            {
+                Post(() => { _claudeUpdating = false; _claudeLatest = null; ShowToast($"Claude Code {installed} is already the latest", 4000); });
+                return;
+            }
+            // A newer version shipped — or the registry was unreachable, in which case `claude update`
+            // itself is the authority (it no-ops harmlessly when already current).
+            Post(() =>
+            {
+                OverlayOpen(ses, "claude update", 60, wait: true);
+                var ovl = ses.Overlay;
+                if (ovl is null) { _claudeUpdating = false; return; }
+                ShowToast(latest is null ? $"running claude update (you have {installed})…"
+                                         : $"updating Claude Code {installed} → {latest}…", 4000);
+                int fired = 0;   // one-shot: the event and the already-exited fallback can race
+                void Once(int code) { if (Interlocked.Exchange(ref fired, 1) == 0) OnClaudeUpdateExited(code, installed); }
+                ovl.S.Exited += Once;
+                if (ovl.S.HasExited) Once(ovl.S.ExitCode ?? 0);
+            });
+        });
+        return "updating Claude Code…";
+    }
+
+    /// <summary>Continuation for the update overlay: verify the install actually moved, then fan out
+    /// the session restarts. Never restarts on a failed or no-op update — bouncing every Claude for
+    /// nothing is worse than asking the user to re-run.</summary>
+    private void OnClaudeUpdateExited(int code, string wasInstalled)
+    {
+        _ = Task.Run(() =>
+        {
+            try
+            {
+                if (code != 0)
+                {
+                    Post(() => ShowToast($"claude update failed (exit {code}) — sessions not restarted", 5000));
+                    return;
+                }
+                string? now = Agwinterm.Pty.ClaudeUpdate.InstalledVersion();
+                if (now is null || !Agwinterm.Pty.ClaudeUpdate.IsNewer(now, wasInstalled))
+                {
+                    Post(() => ShowToast($"Claude Code unchanged ({now ?? wasInstalled}) — sessions not restarted", 5000));
+                    return;
+                }
+                Post(() => { _claudeLatest = null; RequestRedraw(); });
+                int n = RestartAllClaudeSessions();
+                Post(() => ShowToast(n == 0
+                    ? $"Claude Code updated {wasInstalled} → {now} (no running Claude sessions to restart)"
+                    : $"Claude Code updated {wasInstalled} → {now} — restarting {n} Claude session(s)…", 6000));
+            }
+            finally { _claudeUpdating = false; }
+        });
+    }
+
+    /// <summary>Restart every pane whose shell is currently running Claude Code (foreground-child
+    /// evidence), so a freshly-installed version is picked up. Relaunch command precedence: the pane's
+    /// bound AgentResume (the wrapper re-binds and resumes by pane id) → derived from the running
+    /// command line (explicit --resume id + permission flags survive) → the pane's own transcript →
+    /// bare "claude" (the wrapper resolves the conversation). Runs OFF the UI thread. Returns the
+    /// number of panes being restarted.</summary>
+    private int RestartAllClaudeSessions()
+    {
+        var panes = new List<Pane>();
+        lock (_workspaces)
+            foreach (var s in _workspaces.SelectMany(w => w.Sessions))
+            {
+                panes.AddRange(s.Panes);
+                if (s.Scratch is { } sc) panes.Add(sc);   // claude runs in scratch terminals too
+            }
+        if (_quick is { } q) panes.Add(q);
+
+        var byPid = CaptureForegroundCommands(
+            panes.Select(p => p.S.ChildProcessId).Where(id => id is > 0).Select(id => id!.Value), timeoutMs: 15000);
+
+        int n = 0;
+        foreach (var p in panes)
+        {
+            if (p.S.ChildProcessId is not int pid || !byPid.TryGetValue(pid, out var running)) continue;
+            if (!System.Text.RegularExpressions.Regex.IsMatch(running, @"(?i)\bclaude\b")) continue;
+            string cmd = p.AgentResume ?? DeriveClaudeRelaunch(p, running);
+            var pane = p;
+            Post(() => { pane.AgentResume = cmd; SaveState(); });
+            _ = QuitClaudeAndRelaunch(pane, cmd);
+            n++;
+        }
+        return n;
+    }
+
+    /// <summary>Build a relaunch command for a Claude pane with no binding, from the running command
+    /// line: keep its permission mode, resume an explicit id or the pane's own transcript. Falls back
+    /// to bare "claude" — inside agwinterm the launcher wrapper resolves the pane's conversation.</summary>
+    private static string DeriveClaudeRelaunch(Pane pane, string running)
+    {
+        bool yolo = running.Contains("--dangerously-skip-permissions", StringComparison.Ordinal);
+        string? id = ExtractClaudeSessionArg(running);
+        if (id is null && ClaudeTranscriptExists(PaneCwd(pane), pane.Id)) id = pane.Id;
+        return "claude" + (id is null ? "" : $" --resume {id}") + (yolo ? " --dangerously-skip-permissions" : "");
     }
 
     /// <summary>One-time migration for sessions started BEFORE the claude launcher existed: for each pane,

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -86,6 +86,9 @@ internal partial class Program : ISessionHost, IWindowHost
     private int _overlayExitCode;        // the last overlay program's exit code
     private readonly System.Threading.ManualResetEventSlim _overlayDone = new(false); // signalled on overlay exit (for --block)
     private static ControlServer? _control;
+    // Update Claude Code workflow: one run at a time + the newest version the background check saw.
+    private volatile bool _claudeUpdating;
+    private volatile string? _claudeLatest;   // non-null = a newer Claude Code has shipped
 
     // ---- Multi-session model (agterm workspaces -> sessions), mirrors the WinUI shell ----
     private readonly List<Workspace> _workspaces = new(); // source of truth; guarded by lock(_workspaces)
@@ -1050,6 +1053,16 @@ internal partial class Program : ISessionHost, IWindowHost
             {
                 Agwinterm.Pty.ClaudeIntegration.RefreshIfInstalled();
                 Agwinterm.Pty.GenericAgentInstaller.RefreshIfInstalled();
+            });
+            // Claude Code update awareness: startup + every 12h, quiet on failure/offline. The knob
+            // is re-read every cycle so `config set claude-update-check` applies without a restart.
+            _ = Task.Run(async () =>
+            {
+                while (true)
+                {
+                    if (_config.ClaudeUpdateCheck) await CheckClaudeUpdateOnce();
+                    await Task.Delay(TimeSpan.FromHours(12));
+                }
             });
             // Default-terminal handoff (T2-13): register the COM class factory so conhost can hand
             // console sessions to this instance. Each handoff opens a new attached session.

--- a/tests/Agwinterm.Core.Tests/TerminalConfigTests.cs
+++ b/tests/Agwinterm.Core.Tests/TerminalConfigTests.cs
@@ -46,6 +46,15 @@ public class TerminalConfigTests
     }
 
     [Fact]
+    public void ClaudeUpdateCheck_ParsesAndIsDocumented()
+    {
+        Assert.True(TerminalConfig.Parse("").ClaudeUpdateCheck);   // default: awareness on, update stays manual
+        Assert.False(TerminalConfig.Parse("claude-update-check = false").ClaudeUpdateCheck);
+        Assert.True(TerminalConfig.Parse("claude-update-check = on").ClaudeUpdateCheck);
+        Assert.Contains("claude-update-check", TerminalConfig.DefaultText);
+    }
+
+    [Fact]
     public void ParsesValues_IgnoresCommentsAndUnknown()
     {
         var c = TerminalConfig.Parse(

--- a/tests/Agwinterm.Pty.Tests/AgentHooksTests.cs
+++ b/tests/Agwinterm.Pty.Tests/AgentHooksTests.cs
@@ -84,6 +84,22 @@ public class AgentHooksTests
     }
 
     [Fact]
+    public void ClaudeLauncher_PassesSubcommandsThroughUntouched()
+    {
+        // `claude update` / `claude doctor` / `claude mcp` are maintenance verbs, not conversations —
+        // the wrapper must NOT rewrite them into `claude --resume <paneId> update`.
+        string block = ClaudeIntegration.Block;
+        var m = System.Text.RegularExpressions.Regex.Match(block, @"\$args\[0\]\)"" -match '([^']+)'");
+        Assert.True(m.Success, "subcommand passthrough guard missing from the wrapper");
+        string re = m.Groups[1].Value;
+        Assert.Matches(re, "update");
+        Assert.Matches(re, "doctor");
+        Assert.Matches(re, "mcp");
+        Assert.DoesNotMatch(re, "fix the login bug");   // a positional prompt still gets session binding
+        Assert.DoesNotMatch(re, "updates");             // anchored — only the exact verb passes through
+    }
+
+    [Fact]
     public void GenericAgentRegex_CoversPiWithWordBoundarySafety()
     {
         // agterm #208: Pi agent status. The bridge matches '^\s*(RE)\b', so 'pi' must be in the

--- a/tests/Agwinterm.Pty.Tests/ClaudeUpdateTests.cs
+++ b/tests/Agwinterm.Pty.Tests/ClaudeUpdateTests.cs
@@ -1,0 +1,38 @@
+using Agwinterm.Pty;
+
+namespace Agwinterm.Pty.Tests;
+
+public class ClaudeUpdateTests
+{
+    [Theory]
+    [InlineData("2.1.14 (Claude Code)", "2.1.14")]
+    [InlineData("Claude Code 1.0.55", "1.0.55")]
+    [InlineData("2.0.0-beta.3\n", "2.0.0-beta.3")]
+    [InlineData("no version here", null)]
+    [InlineData("", null)]
+    [InlineData(null, null)]
+    public void ParseVersion_ExtractsDottedVersion(string? output, string? expected)
+        => Assert.Equal(expected, ClaudeUpdate.ParseVersion(output));
+
+    [Fact]
+    public void LatestFromRegistryJson_ReadsVersionField()
+    {
+        Assert.Equal("2.1.15", ClaudeUpdate.LatestFromRegistryJson(
+            "{\"name\":\"@anthropic-ai/claude-code\",\"version\":\"2.1.15\"}"));
+        Assert.Null(ClaudeUpdate.LatestFromRegistryJson("{\"name\":\"x\"}"));
+        Assert.Null(ClaudeUpdate.LatestFromRegistryJson("not json"));
+    }
+
+    [Theory]
+    [InlineData("2.0.10", "2.0.9", true)]          // numeric per-segment, not lexicographic
+    [InlineData("2.1.0", "2.0.99", true)]
+    [InlineData("3.0.0", "2.9.9", true)]
+    [InlineData("2.0.9", "2.0.9", false)]          // equal is not newer
+    [InlineData("2.0.8", "2.0.9", false)]          // a downgrade is never "newer"
+    [InlineData("2.0.10-beta.1", "2.0.9", true)]   // prerelease tail ignored for ordering
+    [InlineData("weird", "2.0.9", false)]          // unparseable never nags / never triggers
+    [InlineData("2.0.10", null, false)]
+    [InlineData(null, "2.0.9", false)]
+    public void IsNewer_ComparesNumerically(string? candidate, string? current, bool expected)
+        => Assert.Equal(expected, ClaudeUpdate.IsNewer(candidate, current));
+}

--- a/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
+++ b/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
@@ -125,6 +125,7 @@ internal sealed class FakeSessionHost : ISessionHost
     public bool SessionBind(string? target, string agent) { var s = Find(target); if (s is null) return false; s.AgentResume = string.IsNullOrWhiteSpace(agent) || agent == "none" ? null : agent; return true; }
     public string AdoptClaude() { int n = 0; foreach (var s in Workspaces.SelectMany(w => w.Sessions)) { s.AgentResume = "claude --resume x"; n++; } return $"adopted {n}"; }
     public string RestartClaudeYolo(string? target) { var s = Find(target); if (s is null) return "no pane"; s.AgentResume = "claude --resume x --dangerously-skip-permissions"; return "restarting Claude in YOLO mode (resumed)"; }
+    public string UpdateClaude() => "updating Claude Code…";
     public void WorkspaceFocus(string op) { }
     public string SessionBackground(string? target, string action, string? path, int opacity, string? mode) => Find(target) is not null ? "ok" : "no session";
     public string SessionSwitch(string op) => ActiveSess?.Name ?? "";


### PR DESCRIPTION
## What

Boris''s ask: *"workflow to update claude code — run the update in a new terminal, restart agwinterm claude sessions to pick up the new claude code, and be aware when a new claude code version is shipped."* All three pieces:

**1. Version awareness** — a background check (startup + every 12h) compares `claude --version` against the npm registry (`@anthropic-ai/claude-code` `latest` — authoritative for every install flavor). When a new version ships: one toast (`Claude Code 2.1.211 is out (you have 2.1.205) — palette → Update Claude Code`) and a `— vX.Y.Z available` hint on the palette entry. Quiet when offline/uninstalled/current. New config key **`claude-update-check`** (default `true`; wired into `TerminalConfig.Parse`, `DefaultText`, `ConfigKeys` **and** `config.get` — the 0.14.0 lesson).

**2. The update runs in a new terminal** — palette → **Update Claude Code** (or `agwintermctl claude update`, control verb `claude.update`) opens an overlay terminal running `claude update` with live output (`wait` mode, exit code visible).

**3. Sessions restart to pick up the new binary** — after the overlay exits 0 **and** the installed version verifiably moved, every pane whose shell has a live Claude foreground child is restarted: double Ctrl+C, poll until the child is actually gone (slow-laptop safe — same machinery as YOLO restart, now shared via `QuitClaudeAndRelaunch`), then type the relaunch. Command precedence: bound `AgentResume` → derived from the running command line (explicit `--resume` id and `--dangerously-skip-permissions` survive — YOLO stays YOLO) → the pane''s own transcript → bare `claude` (the wrapper resolves it). Failed or no-op updates never bounce sessions.

## Wrapper bug found & fixed on the way

`claude update` typed in a normal pane was mangled by the launcher wrapper into `claude --resume <paneId> update`. Subcommands (`update|doctor|mcp|config|install|migrate-installer|setup-token|plugin|agents`) now pass through untouched; the fix reaches installed profiles via the existing startup stale-block refresh.

## Evidence

- **Unit: 211/211** (146 Core + 65 Pty) — new: ClaudeUpdate parse/compare/registry-json matrix, wrapper subcommand passthrough (anchored: `update` passes, `updates`/prompts don''t), `claude-update-check` config.
- **E2E on the dev instance** with a fake `claude.cmd` shim on PATH (0.0.1 → `update` writes a marker → 9.9.9), fake "running Claude" carrying `--resume=<uuid>` in its command line:
  - `claude update` verb → overlay showed the update output, `exited (0)`
  - the Claude pane got `^C`, then typed **`claude --resume 11111111-2222-3333-4444-555555555555`** (id extracted from the running command line) → resumed; `AgentResume` persisted in state; the idle session was left untouched
  - fresh launch → startup toast **"Claude Code 2.1.211 is out (you have 0.0.1)"** (real npm registry) + palette **"Update Claude Code — v2.1.211 available"**
  - screenshots delivered in chat (gh can''t attach images)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k