### PR TITLE
feat(update): agwinterm self-update — channel-aware, SHA-256-verified, restart-with-restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ the real thing: **[github.com/umputun/agterm](https://github.com/umputun/agterm)
   quietly notices when a new Claude Code ships (npm registry; `claude-update-check = false` to opt
   out), then — on your command — runs `claude update` in an overlay terminal and **restarts every
   running Claude session**, each resuming its own conversation (YOLO panes stay YOLO).
+- **agwinterm self-update** (palette → *Update agwinterm*, or `agwintermctl app update`): notices new
+  releases on GitHub (`update-check = false` to opt out), then — on your command — downloads the
+  right artifact for your install (installer or portable exe), **verifies its SHA-256** against the
+  release digest, restarts, and your sessions restore. scoop/chocolatey installs are never touched —
+  the hint points at your package manager instead.
 - **A scriptable control API**: `agwintermctl` (or newline-JSON over a named pipe) — any language can
   drive it, including full **read-back** (tree with split ratios + pane ids, window state, session
   output). Opt-in installers for the **agent skill** and **Claude Code / Codex status hooks**.

--- a/src/Agwinterm.Core/TerminalConfig.cs
+++ b/src/Agwinterm.Core/TerminalConfig.cs
@@ -75,6 +75,11 @@ public sealed class TerminalConfig
     /// manual, visible <c>claude update</c> (palette → "Update Claude Code").</summary>
     public bool ClaudeUpdateCheck { get; set; } = true;
 
+    /// <summary>Periodically check GitHub for a newer agwinterm release and surface a hint (toast +
+    /// palette) when one ships. Awareness only — applying it stays a manual palette action
+    /// ("Update agwinterm"), which downloads, verifies, restarts, and restores sessions.</summary>
+    public bool UpdateCheck { get; set; } = true;
+
     /// <summary>Characters that DELIMIT words for double-click selection (in addition to whitespace).
     /// Empty = whitespace only (double-click grabs a whole path/URL). WT's wordDelimiters analog.</summary>
     public string WordDelimiters { get; set; } = "";
@@ -224,6 +229,12 @@ public sealed class TerminalConfig
         # `claude update` in an overlay terminal, then restarts your Claude sessions).
         claude-update-check = true
 
+        # Check GitHub in the background for a newer agwinterm release and show a hint when one
+        # ships. Applying it is always manual: palette -> "Update agwinterm" (downloads the release,
+        # verifies its SHA-256, restarts, and your sessions restore). Installs managed by a package
+        # manager (scoop/chocolatey) are never self-updated - the hint points at the manager instead.
+        update-check = true
+
         # Blocked sound: play a sound whenever a session enters the "blocked" agent status (needs
         # your attention). Empty / off / none = silent. Accepts a system-sound name (beep, asterisk,
         # exclamation, hand, question), a Windows sound-event alias, or a path to a .wav file.
@@ -340,6 +351,7 @@ public sealed class TerminalConfig
                     if (val is "none" or "once" or "until-focused") cfg.NotificationFlash = val;
                     break;
                 case "claude-update-check": cfg.ClaudeUpdateCheck = ParseBool(val, cfg.ClaudeUpdateCheck); break;
+                case "update-check": cfg.UpdateCheck = ParseBool(val, cfg.UpdateCheck); break;
                 case "word-delimiters": cfg.WordDelimiters = val; break;
                 case "desktop-notifications": cfg.DesktopNotifications = ParseBool(val, cfg.DesktopNotifications); break;
                 case "blocked-sound": cfg.BlockedSound = val; break;

--- a/src/Agwinterm.Ctl/Program.cs
+++ b/src/Agwinterm.Ctl/Program.cs
@@ -208,6 +208,7 @@ switch (area)
     case "claude" when sub == "adopt": cmd = "claude.adopt"; break; // bind existing claude convos to their panes
     case "claude" when sub == "yolo": cmd = "claude.yolo"; target = DefaultTarget(); break; // restart the target pane's claude in --dangerously-skip-permissions, resumed
     case "claude" when sub == "update": cmd = "claude.update"; break; // run `claude update` in an overlay, then restart live claude panes
+    case "app" when sub == "update": cmd = "app.update"; break; // self-update agwinterm (download+verify latest release, restart, sessions restore)
     case "theme" when sub == "list": cmd = "theme.list"; break;
     case "theme" when sub == "set":
         cmd = "theme.set";

--- a/src/Agwinterm.Pty/AppUpdate.cs
+++ b/src/Agwinterm.Pty/AppUpdate.cs
@@ -1,0 +1,181 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+
+namespace Agwinterm.Pty;
+
+/// <summary>Which kind of agwinterm install is running — decides how (or whether) self-update applies.</summary>
+public enum UpdateChannel
+{
+    /// <summary>Inno per-user install under %LOCALAPPDATA%\Programs\agwinterm → silent setup.exe re-run.</summary>
+    Installed,
+    /// <summary>A bare portable exe anywhere else → rename-swap the exe in place.</summary>
+    Portable,
+    /// <summary>scoop / chocolatey layout → hands off; the package manager owns the files.</summary>
+    PackageManager,
+}
+
+/// <summary>One downloadable file of a GitHub release.</summary>
+public sealed record ReleaseAsset(string Name, string Url, string? Sha256);
+
+/// <summary>A GitHub release: the version its tag names plus its assets.</summary>
+public sealed record ReleaseInfo(string Version, IReadOnlyList<ReleaseAsset> Assets);
+
+/// <summary>
+/// agwinterm self-update: channel detection, release lookup (GitHub releases API — the same source
+/// every install flavor ships from), SHA-256-verified downloads (release assets carry a digest; we
+/// have no Authenticode cert, so the digest check is the integrity gate), and the tiny apply-helper
+/// script that swaps binaries AFTER the app has exited. Applying is never silent-background: the
+/// user triggers it, the app saves state, exits, and relaunches restored.
+/// </summary>
+public static class AppUpdate
+{
+    public const string DefaultApiUrl = "https://api.github.com/repos/yeroo/agwinterm/releases/latest";
+
+    /// <summary>Test seam: a local FILE PATH here (instead of an URL) is read as the API response,
+    /// and asset "URLs" that are local paths are copied instead of downloaded — lets E2E runs
+    /// exercise the whole pipeline hermetically.</summary>
+    public const string ApiEnvVar = "AGWINTERM_UPDATE_API";
+
+    /// <summary>Classify the running install from its own exe path. <paramref name="localAppData"/>
+    /// is a parameter for testability (%LOCALAPPDATA% in production).</summary>
+    public static UpdateChannel DetectChannel(string exePath, string localAppData)
+    {
+        if (exePath.Contains(@"\scoop\apps\", StringComparison.OrdinalIgnoreCase) ||
+            exePath.Contains(@"\chocolatey\", StringComparison.OrdinalIgnoreCase) ||
+            exePath.Contains(@"\WindowsApps\", StringComparison.OrdinalIgnoreCase))
+            return UpdateChannel.PackageManager;
+        string installDir = Path.Combine(localAppData, "Programs", "agwinterm") + Path.DirectorySeparatorChar;
+        return exePath.StartsWith(installDir, StringComparison.OrdinalIgnoreCase)
+            ? UpdateChannel.Installed : UpdateChannel.Portable;
+    }
+
+    /// <summary>Parse a GitHub /releases/latest document into version + assets (digest "sha256:hex"
+    /// → hex). Null on any shape mismatch — an update must never proceed on a guess.</summary>
+    public static ReleaseInfo? ParseRelease(string json)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            string? ver = root.TryGetProperty("tag_name", out var t) ? ClaudeUpdate.ParseVersion(t.GetString()) : null;
+            if (ver is null || !root.TryGetProperty("assets", out var assets) || assets.ValueKind != JsonValueKind.Array)
+                return null;
+            var list = new List<ReleaseAsset>();
+            foreach (var a in assets.EnumerateArray())
+            {
+                string? name = a.TryGetProperty("name", out var n) ? n.GetString() : null;
+                string? url = a.TryGetProperty("browser_download_url", out var u) ? u.GetString() : null;
+                string? dig = a.TryGetProperty("digest", out var d) && d.ValueKind == JsonValueKind.String ? d.GetString() : null;
+                if (dig is not null && dig.StartsWith("sha256:", StringComparison.OrdinalIgnoreCase)) dig = dig[7..];
+                else dig = null;   // unknown digest algorithm → treat as absent (fail closed later)
+                if (name is not null && url is not null) list.Add(new ReleaseAsset(name, url, dig));
+            }
+            return new ReleaseInfo(ver, list);
+        }
+        catch { return null; }
+    }
+
+    /// <summary>The release asset a channel updates from: the setup exe for installed copies, the
+    /// portable exe otherwise. Null when the release carries no such asset (or for package managers,
+    /// which never self-update).</summary>
+    public static ReleaseAsset? PickAsset(ReleaseInfo release, UpdateChannel channel) => channel switch
+    {
+        UpdateChannel.Installed => release.Assets.FirstOrDefault(a =>
+            a.Name.StartsWith("agwinterm-setup-", StringComparison.OrdinalIgnoreCase) &&
+            a.Name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)),
+        UpdateChannel.Portable => release.Assets.FirstOrDefault(a =>
+            a.Name.StartsWith("agwinterm-portable-", StringComparison.OrdinalIgnoreCase) &&
+            a.Name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)),
+        _ => null,
+    };
+
+    /// <summary>Fetch and parse the latest release, or null on any failure (offline stays silent).
+    /// Honors the <see cref="ApiEnvVar"/> test seam (URL override, or a local JSON file path).</summary>
+    public static async Task<ReleaseInfo?> FetchLatestAsync()
+    {
+        try
+        {
+            string api = Environment.GetEnvironmentVariable(ApiEnvVar) is { Length: > 0 } o ? o : DefaultApiUrl;
+            string json;
+            if (!api.StartsWith("http", StringComparison.OrdinalIgnoreCase) && File.Exists(api))
+                json = await File.ReadAllTextAsync(api).ConfigureAwait(false);
+            else
+            {
+                using var http = NewHttp();
+                json = await http.GetStringAsync(api).ConfigureAwait(false);
+            }
+            return ParseRelease(json);
+        }
+        catch { return null; }
+    }
+
+    /// <summary>Download an asset to <paramref name="destPath"/> and verify its SHA-256 against the
+    /// release digest. FAIL-CLOSED: no digest, digest mismatch, or any IO error → false and the file
+    /// is deleted. Local-path "URLs" are copied (test seam).</summary>
+    public static async Task<bool> DownloadVerifiedAsync(ReleaseAsset asset, string destPath)
+    {
+        if (string.IsNullOrEmpty(asset.Sha256)) return false;
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(destPath)!);
+            if (!asset.Url.StartsWith("http", StringComparison.OrdinalIgnoreCase) && File.Exists(asset.Url))
+                File.Copy(asset.Url, destPath, overwrite: true);
+            else
+            {
+                using var http = NewHttp();
+                await using var src = await http.GetStreamAsync(asset.Url).ConfigureAwait(false);
+                await using var dst = File.Create(destPath);
+                await src.CopyToAsync(dst).ConfigureAwait(false);
+            }
+            string actual;
+            await using (var f = File.OpenRead(destPath))
+                actual = Convert.ToHexString(await SHA256.HashDataAsync(f).ConfigureAwait(false));
+            if (actual.Equals(asset.Sha256, StringComparison.OrdinalIgnoreCase)) return true;
+            File.Delete(destPath);
+            return false;
+        }
+        catch
+        {
+            try { File.Delete(destPath); } catch { }
+            return false;
+        }
+    }
+
+    /// <summary>The apply helper, written next to the download and run detached: waits for the app
+    /// process to exit, applies the channel's swap, relaunches the SAME exe path. The portable swap
+    /// renames the running exe aside (allowed while it runs) rather than overwriting; the app deletes
+    /// the ".old" leftover on its next start.</summary>
+    public static string HelperScript => """
+        param([int]$ProcId, [string]$Channel, [string]$Payload, [string]$Exe)
+        function Log([string]$m) { try { Add-Content -Path ($Payload + '.log') -Value ("{0:HH:mm:ss.fff} {1}" -f (Get-Date), $m) } catch { } }
+        Log "wait pid=$ProcId channel=$Channel"
+        try { Wait-Process -Id $ProcId -Timeout 120 -ErrorAction SilentlyContinue } catch { }
+        if (Get-Process -Id $ProcId -ErrorAction SilentlyContinue) { Log 'ABORT: app never exited'; exit 1 }
+        Start-Sleep -Milliseconds 500
+        Log 'app exited; applying'
+        if ($Channel -eq 'installed') {
+          Start-Process $Payload -ArgumentList '/VERYSILENT','/NORESTART','/SUPPRESSMSGBOXES' -Wait
+          Log 'setup finished'
+        } else {
+          $old = $Exe + '.old'
+          Remove-Item $old -Force -ErrorAction SilentlyContinue
+          $moved = $false
+          for ($i = 0; $i -lt 20 -and -not $moved; $i++) {   # straggler/AV locks: retry ~10s
+            try { Move-Item $Exe $old -Force -ErrorAction Stop; $moved = $true } catch { Log ("rename-aside failed: " + $_.Exception.Message); Start-Sleep -Milliseconds 500 }
+          }
+          if (-not $moved) { Log 'GIVING UP: exe still locked'; exit 1 }   # never delete the payload on failure
+          try { Move-Item $Payload $Exe -Force -ErrorAction Stop; Log 'swap done' }
+          catch { Log ("swap-in failed, rolling back: " + $_.Exception.Message); Move-Item $old $Exe -Force; exit 1 }
+        }
+        Start-Process $Exe
+        Log 'relaunched'
+        """;
+
+    private static HttpClient NewHttp()
+    {
+        var http = new HttpClient { Timeout = TimeSpan.FromMinutes(5) };
+        http.DefaultRequestHeaders.UserAgent.ParseAdd("agwinterm");   // GitHub API requires a UA
+        http.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github+json");
+        return http;
+    }
+}

--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -203,6 +203,8 @@ public sealed class ControlServer : IDisposable
                     return Ok(host.RestartClaudeYolo(target));
                 case "claude.update":
                     return Ok(host.UpdateClaude());
+                case "app.update":
+                    return Ok(host.UpdateApp());
                 case "workspace.focus": host.WorkspaceFocus(GetString(args, "op") ?? "toggle"); return Ok("focus");
                 case "session.background":
                     return Ok(host.SessionBackground(target, GetString(args, "action") ?? "set",

--- a/src/Agwinterm.Pty/ISessionHost.cs
+++ b/src/Agwinterm.Pty/ISessionHost.cs
@@ -174,6 +174,11 @@ public interface ISessionHost
     /// (each resumes its own conversation). Returns an ack / error string.</summary>
     string UpdateClaude();
 
+    /// <summary>The agwinterm self-update workflow: download + SHA-256-verify the latest release for
+    /// this install channel (installer / portable; package-manager installs are refused with a hint),
+    /// then exit, swap, relaunch — sessions restore. Returns an ack / error string.</summary>
+    string UpdateApp();
+
     /// <summary>Focus/unfocus the active workspace (hide the others in the sidebar tree): op = on|off|toggle.</summary>
     void WorkspaceFocus(string op);
 
@@ -268,6 +273,7 @@ public sealed class SingleSessionHost : ISessionHost
     public string AdoptClaude() => "unsupported";
     public string RestartClaudeYolo(string? target) => "unsupported";
     public string UpdateClaude() => "unsupported";
+    public string UpdateApp() => "unsupported";
     public void WorkspaceFocus(string op) { }
     public string SessionBackground(string? target, string action, string? path, int opacity, string? mode) => "unsupported";
     public string SessionSwitch(string op) => "unsupported";

--- a/src/Agwinterm.Win32/Program.AppUpdate.cs
+++ b/src/Agwinterm.Win32/Program.AppUpdate.cs
@@ -1,0 +1,115 @@
+using System.Diagnostics;
+using Agwinterm.Pty;
+using static Agwinterm.Win32.Win32;
+
+namespace Agwinterm.Win32;
+
+// agwinterm self-update ("Update agwinterm" palette action / `agwintermctl app update`):
+// check GitHub releases → download the channel's asset → verify SHA-256 → save state → exit all
+// windows gracefully → a detached helper swaps the binary and relaunches → sessions restore.
+// Package-manager installs (scoop/choco) are never self-updated — we only point at the manager.
+internal partial class Program
+{
+    /// <summary>The running exe (Environment.ProcessPath — Assembly.Location is empty in the
+    /// single-file portable build).</summary>
+    private static string AppExePath => Environment.ProcessPath ?? "";
+
+    /// <summary>Version to compare against releases: the stamped InformationalVersion ("dev" in
+    /// unstamped builds, which never triggers). AGWINTERM_VERSION_OVERRIDE is a test seam.</summary>
+    private static string AppCurrentVersion()
+        => Environment.GetEnvironmentVariable("AGWINTERM_VERSION_OVERRIDE") is { Length: > 0 } o
+            ? o : _termProgramVersion;
+
+    private static UpdateChannel AppChannel()
+        => AppUpdate.DetectChannel(AppExePath, Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData));
+
+    private static string UpdatesDir => Path.Combine(AppDir, "updates");
+
+    /// <summary>Startup housekeeping: drop the ".old" exe a portable swap left behind and any
+    /// downloaded payloads from previous updates. Best-effort — a still-locked file waits for the
+    /// next start.</summary>
+    private static void CleanupUpdateLeftovers()
+    {
+        try { if (AppExePath.Length > 0 && File.Exists(AppExePath + ".old")) File.Delete(AppExePath + ".old"); } catch { }
+        try { if (Directory.Exists(UpdatesDir)) Directory.Delete(UpdatesDir, recursive: true); } catch { }
+    }
+
+    /// <summary>One background check ("be aware when a new agwinterm ships"): GitHub latest release
+    /// vs the running version. New version → one toast per version + the palette hint. The package-
+    /// manager toast points at the manager instead of the palette action.</summary>
+    private async Task CheckAppUpdateOnce()
+    {
+        string cur = AppCurrentVersion();
+        var rel = await AppUpdate.FetchLatestAsync();
+        if (rel is null) return;                                   // offline stays silent
+        if (!ClaudeUpdate.IsNewer(rel.Version, cur)) { _appLatest = null; return; }
+        bool fresh = !string.Equals(_appLatest, rel.Version, StringComparison.Ordinal);
+        _appLatest = rel.Version;
+        if (!fresh) return;
+        string msg = AppChannel() == UpdateChannel.PackageManager
+            ? $"agwinterm {rel.Version} is out — update via your package manager (e.g. scoop update agwinterm)"
+            : $"agwinterm {rel.Version} is out (you have {cur}) — palette → Update agwinterm";
+        Post(() => ShowToast(msg, 6000));
+    }
+
+    /// <summary>The self-update workflow. Fail-closed at every step (no digest / bad digest / missing
+    /// asset → abort with a toast, nothing applied); on success the app exits itself and the helper
+    /// swaps + relaunches, so the user comes back to restored sessions on the new version.</summary>
+    private string UpdateAgwinterm()
+    {
+        var channel = AppChannel();
+        if (channel == UpdateChannel.PackageManager)
+            return "this agwinterm is managed by a package manager — update with scoop/choco";
+        if (AppExePath.Length == 0) return "cannot resolve the running exe path";
+        if (_appUpdating) return "agwinterm update already running";
+        _appUpdating = true;
+        _ = Task.Run(async () =>
+        {
+            void Toast(string m) => Post(() => ShowToast(m, 5000));
+            bool applying = false;
+            try
+            {
+                string cur = AppCurrentVersion();
+                var rel = await AppUpdate.FetchLatestAsync();
+                if (rel is null) { Toast("agwinterm update check failed (offline or rate-limited) — try again later"); return; }
+                if (!ClaudeUpdate.IsNewer(rel.Version, cur))
+                { _appLatest = null; Toast($"agwinterm {cur} is already the latest"); return; }
+                var asset = AppUpdate.PickAsset(rel, channel);
+                if (asset is null) { Toast($"release {rel.Version} has no {(channel == UpdateChannel.Installed ? "setup" : "portable")} asset"); return; }
+                if (string.IsNullOrEmpty(asset.Sha256)) { Toast("release asset carries no SHA-256 digest — refusing an unverifiable update"); return; }
+                Toast($"downloading agwinterm {rel.Version}…");
+                string payload = Path.Combine(UpdatesDir, asset.Name);
+                if (!await AppUpdate.DownloadVerifiedAsync(asset, payload))
+                { Toast("download failed SHA-256 verification — update aborted"); return; }
+
+                string helper = Path.Combine(UpdatesDir, "apply-update.ps1");
+                await File.WriteAllTextAsync(helper, AppUpdate.HelperScript);
+                applying = true;                                    // hand-off: flag stays up until exit
+                Post(() =>
+                {
+                    ShowToast($"agwinterm {cur} → {rel.Version} — restarting…", 4000);
+                    var psi = new ProcessStartInfo("powershell.exe",
+                        $"-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File \"{helper}\" " +
+                        $"-ProcId {Environment.ProcessId} -Channel {(channel == UpdateChannel.Installed ? "installed" : "portable")} " +
+                        $"-Payload \"{payload}\" -Exe \"{AppExePath}\"")
+                    { UseShellExecute = false, CreateNoWindow = true };
+                    try { Process.Start(psi); } catch (Exception ex) { ShowToast("failed to start the update helper: " + ex.Message, 6000); _appUpdating = false; return; }
+                    QuitAllWindowsForUpdate();
+                });
+            }
+            finally { if (!applying) _appUpdating = false; }
+        });
+        return "updating agwinterm…";
+    }
+
+    /// <summary>Close every window of this process gracefully (each WM_DESTROY saves its tree; the
+    /// last one quits). <see cref="_updateQuitting"/> keeps multi-window state marked open so ALL
+    /// windows come back after the relaunch — a normal explicit close marks a window non-reopening.</summary>
+    private static void QuitAllWindowsForUpdate()
+    {
+        _updateQuitting = true;
+        List<Program> wins;
+        lock (_windowIndex) wins = _byId.Values.ToList();
+        foreach (var w in wins) w.Post(() => DestroyWindow(w._hwnd));
+    }
+}

--- a/src/Agwinterm.Win32/Program.Chrome.cs
+++ b/src/Agwinterm.Win32/Program.Chrome.cs
@@ -813,6 +813,18 @@ internal partial class Program
                     Search = "update claude code upgrade version",
                     Run = () => ShowToast(UpdateClaudeCode(), 2500),
                 });
+                _palAll.Add(new PalItem
+                {
+                    Label = "Update agwinterm" + (_appLatest is { } av ? $"  — v{av} available" : ""),
+                    Secondary = AppChannel() switch
+                    {
+                        Agwinterm.Pty.UpdateChannel.PackageManager => "managed by scoop/chocolatey — update with the package manager",
+                        Agwinterm.Pty.UpdateChannel.Installed => "downloads the new installer, restarts — sessions restore",
+                        _ => "swaps the portable exe, restarts — sessions restore",
+                    },
+                    Search = "update agwinterm upgrade version self",
+                    Run = () => ShowToast(UpdateAgwinterm(), 3000),
+                });
                 A("Install Agent Skill", "", InstallSkill);
                 A("Install Shell Integration", "", InstallShellIntegration);
                 A("Reload Keymap", "", ReloadKeymap);

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -566,6 +566,8 @@ internal partial class Program
 
         public string UpdateClaude() => InvokeOnUi(() => UpdateClaudeCode());
 
+        public string UpdateApp() => InvokeOnUi(() => UpdateAgwinterm());
+
         public string SessionBackground(string? target, string action, string? path, int opacity, string? mode) => InvokeOnUi(() =>
         {
             var ses = FindSesForTarget(target);

--- a/src/Agwinterm.Win32/Program.Services.cs
+++ b/src/Agwinterm.Win32/Program.Services.cs
@@ -822,7 +822,7 @@ internal partial class Program
         "restore-commands", "restore-buffer", "blocked-sound", "omp-theme", "omp-integration", "prompt-engine", "starship-theme",
         "new-session-dir-mode", "confirm-close-session", "compact-toolbar", "toolbar-mode", "notification-badges",
         "attention-button", "status-color-active", "status-color-blocked", "status-color-completed",
-        "paste-protection", "clipboard-write", "notification-flash", "claude-update-check",
+        "paste-protection", "clipboard-write", "notification-flash", "claude-update-check", "update-check",
     };
 
     /// <summary>Rewrite (or append) a single `key = value` line in agwinterm.conf, preserving the rest.</summary>
@@ -885,6 +885,7 @@ internal partial class Program
         "notification-badges" => _config.NotificationBadges ? "true" : "false",
         "notification-flash" => _config.NotificationFlash,
         "claude-update-check" => _config.ClaudeUpdateCheck ? "true" : "false",
+        "update-check" => _config.UpdateCheck ? "true" : "false",
         "paste-protection" => _config.PasteProtection ? "true" : "false",
         "clipboard-write" => _config.ClipboardWrite ? "true" : "false",
         "attention-button" => _config.AttentionButton ? "true" : "false",

--- a/src/Agwinterm.Win32/Program.WndProc.cs
+++ b/src/Agwinterm.Win32/Program.WndProc.cs
@@ -546,12 +546,16 @@ internal partial class Program
                 lock (_windowIndex)
                 {
                     _byId.Remove(Id);
-                    int otherOpen = _windowIndex.Count(m => m.IsOpen && m.Id != Id);
-                    lastWindow = otherOpen == 0;
+                    // "Last window" must count LIVE windows (_byId), not index metas: an update-quit
+                    // keeps metas IsOpen=true (so they reopen after relaunch), which would make the
+                    // meta count never reach zero and leave a windowless process running forever.
+                    lastWindow = _byId.Count == 0;
                     var meta = _windowIndex.FirstOrDefault(m => m.Id == Id);
                     // Explicit close (others remain) -> mark closed so it won't auto-reopen. App quit
                     // (this was the last open window) -> keep IsOpen=true so it reopens next launch.
-                    if (meta is not null && !lastWindow) meta.IsOpen = false;
+                    // Update-quit closes every window in sequence — those must ALL reopen after the
+                    // relaunch, so it never marks any of them closed.
+                    if (meta is not null && !lastWindow && !_updateQuitting) meta.IsOpen = false;
                     if (ReferenceEquals(Frontmost, this))
                     {
                         var nf = _byId.Values.FirstOrDefault();

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -89,6 +89,10 @@ internal partial class Program : ISessionHost, IWindowHost
     // Update Claude Code workflow: one run at a time + the newest version the background check saw.
     private volatile bool _claudeUpdating;
     private volatile string? _claudeLatest;   // non-null = a newer Claude Code has shipped
+    // agwinterm self-update: same pattern, app-wide (static — one process, many windows).
+    private static volatile bool _appUpdating;
+    private static volatile string? _appLatest;      // non-null = a newer agwinterm release exists
+    private static volatile bool _updateQuitting;    // closing all windows to apply an update
 
     // ---- Multi-session model (agterm workspaces -> sessions), mirrors the WinUI shell ----
     private readonly List<Workspace> _workspaces = new(); // source of truth; guarded by lock(_workspaces)
@@ -1054,13 +1058,16 @@ internal partial class Program : ISessionHost, IWindowHost
                 Agwinterm.Pty.ClaudeIntegration.RefreshIfInstalled();
                 Agwinterm.Pty.GenericAgentInstaller.RefreshIfInstalled();
             });
-            // Claude Code update awareness: startup + every 12h, quiet on failure/offline. The knob
-            // is re-read every cycle so `config set claude-update-check` applies without a restart.
+            // Update awareness (Claude Code + agwinterm itself): startup + every 12h, quiet on
+            // failure/offline. Knobs are re-read every cycle so `config set ...-check` applies
+            // without a restart. Also sweep leftovers of a previously applied self-update.
             _ = Task.Run(async () =>
             {
+                CleanupUpdateLeftovers();
                 while (true)
                 {
                     if (_config.ClaudeUpdateCheck) await CheckClaudeUpdateOnce();
+                    if (_config.UpdateCheck) await CheckAppUpdateOnce();
                     await Task.Delay(TimeSpan.FromHours(12));
                 }
             });

--- a/tests/Agwinterm.Core.Tests/TerminalConfigTests.cs
+++ b/tests/Agwinterm.Core.Tests/TerminalConfigTests.cs
@@ -55,6 +55,18 @@ public class TerminalConfigTests
     }
 
     [Fact]
+    public void UpdateCheck_ParsesAndIsDocumented()
+    {
+        Assert.True(TerminalConfig.Parse("").UpdateCheck);         // default: awareness on, applying stays manual
+        Assert.False(TerminalConfig.Parse("update-check = false").UpdateCheck);
+        Assert.Contains("update-check", TerminalConfig.DefaultText);
+        // The two knobs are independent.
+        var c = TerminalConfig.Parse("update-check = false\nclaude-update-check = true\n");
+        Assert.False(c.UpdateCheck);
+        Assert.True(c.ClaudeUpdateCheck);
+    }
+
+    [Fact]
     public void ParsesValues_IgnoresCommentsAndUnknown()
     {
         var c = TerminalConfig.Parse(

--- a/tests/Agwinterm.Pty.Tests/AppUpdateTests.cs
+++ b/tests/Agwinterm.Pty.Tests/AppUpdateTests.cs
@@ -1,0 +1,101 @@
+using Agwinterm.Pty;
+
+namespace Agwinterm.Pty.Tests;
+
+public class AppUpdateTests
+{
+    private const string LocalAppData = @"C:\Users\x\AppData\Local";
+
+    [Theory]
+    [InlineData(@"C:\Users\x\AppData\Local\Programs\agwinterm\Agwinterm.Win32.exe", UpdateChannel.Installed)]
+    [InlineData(@"C:\Users\x\AppData\Local\PROGRAMS\AGWINTERM\Agwinterm.Win32.exe", UpdateChannel.Installed)]   // case-insensitive
+    [InlineData(@"C:\Users\x\scoop\apps\agwinterm\current\agwinterm.exe", UpdateChannel.PackageManager)]
+    [InlineData(@"C:\ProgramData\chocolatey\lib\agwinterm\tools\agwinterm.exe", UpdateChannel.PackageManager)]
+    [InlineData(@"D:\tools\agwinterm.exe", UpdateChannel.Portable)]
+    [InlineData(@"C:\Users\x\Downloads\agwinterm-portable-0.14.1-win-x64.exe", UpdateChannel.Portable)]
+    [InlineData(@"C:\Users\x\AppData\Local\Programs\agwinterm-fork\agwinterm.exe", UpdateChannel.Portable)]     // prefix, not our dir
+    public void DetectChannel_ClassifiesByExePath(string exe, UpdateChannel expected)
+        => Assert.Equal(expected, AppUpdate.DetectChannel(exe, LocalAppData));
+
+    private const string ReleaseJson = """
+        {
+          "tag_name": "v0.14.1",
+          "assets": [
+            { "name": "agwinterm-portable-0.14.1-win-x64.exe",
+              "browser_download_url": "https://github.com/yeroo/agwinterm/releases/download/v0.14.1/agwinterm-portable-0.14.1-win-x64.exe",
+              "digest": "sha256:06cb165d5aaf9088c2b44d8a3fd99e620477a07a198858ec923486b5697449ef" },
+            { "name": "agwinterm-setup-0.14.1.exe",
+              "browser_download_url": "https://github.com/yeroo/agwinterm/releases/download/v0.14.1/agwinterm-setup-0.14.1.exe",
+              "digest": "sha256:167cb39f16dbf3fcd6623a9c79107b16bd0a3285d01094745d562e77ae7271fe" }
+          ]
+        }
+        """;
+
+    [Fact]
+    public void ParseRelease_ReadsVersionAssetsAndDigests()
+    {
+        var rel = AppUpdate.ParseRelease(ReleaseJson);
+        Assert.NotNull(rel);
+        Assert.Equal("0.14.1", rel!.Version);   // tag v-prefix stripped
+        Assert.Equal(2, rel.Assets.Count);
+        Assert.Equal("06cb165d5aaf9088c2b44d8a3fd99e620477a07a198858ec923486b5697449ef",
+            rel.Assets[0].Sha256);              // "sha256:" prefix stripped
+    }
+
+    [Fact]
+    public void ParseRelease_FailsClosed()
+    {
+        Assert.Null(AppUpdate.ParseRelease("not json"));
+        Assert.Null(AppUpdate.ParseRelease("{\"tag_name\":\"nightly\"}"));            // unparseable version
+        Assert.Null(AppUpdate.ParseRelease("{\"tag_name\":\"v1.0.0\"}"));             // no assets array
+        // Unknown digest algorithm → asset kept but digest dropped (download will refuse it).
+        var rel = AppUpdate.ParseRelease(
+            "{\"tag_name\":\"v1.0.0\",\"assets\":[{\"name\":\"agwinterm-setup-1.0.0.exe\",\"browser_download_url\":\"https://x/y.exe\",\"digest\":\"sha512:abc\"}]}");
+        Assert.NotNull(rel);
+        Assert.Null(rel!.Assets[0].Sha256);
+    }
+
+    [Fact]
+    public void PickAsset_MatchesChannelToArtifact()
+    {
+        var rel = AppUpdate.ParseRelease(ReleaseJson)!;
+        Assert.Equal("agwinterm-setup-0.14.1.exe", AppUpdate.PickAsset(rel, UpdateChannel.Installed)!.Name);
+        Assert.Equal("agwinterm-portable-0.14.1-win-x64.exe", AppUpdate.PickAsset(rel, UpdateChannel.Portable)!.Name);
+        Assert.Null(AppUpdate.PickAsset(rel, UpdateChannel.PackageManager));   // managers own their files
+    }
+
+    [Fact]
+    public async Task DownloadVerified_LocalSeam_AcceptsGoodRejectsBadDigest()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "agwinterm-test-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(dir);
+        try
+        {
+            string src = Path.Combine(dir, "payload.bin");
+            await File.WriteAllBytesAsync(src, new byte[] { 1, 2, 3, 4 });
+            string good = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(new byte[] { 1, 2, 3, 4 })).ToLowerInvariant();
+
+            string dst = Path.Combine(dir, "out.bin");
+            Assert.True(await AppUpdate.DownloadVerifiedAsync(new ReleaseAsset("payload.bin", src, good), dst));
+            Assert.True(File.Exists(dst));
+
+            string dst2 = Path.Combine(dir, "out2.bin");
+            Assert.False(await AppUpdate.DownloadVerifiedAsync(new ReleaseAsset("payload.bin", src, new string('0', 64)), dst2));
+            Assert.False(File.Exists(dst2));                       // mismatch → deleted
+
+            Assert.False(await AppUpdate.DownloadVerifiedAsync(new ReleaseAsset("payload.bin", src, null), Path.Combine(dir, "out3.bin")));   // no digest → fail closed
+        }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { } }
+    }
+
+    [Fact]
+    public void HelperScript_SwapsSafely()
+    {
+        string s = AppUpdate.HelperScript;
+        Assert.Contains("Wait-Process", s);                        // never swap under a live process
+        Assert.Contains("/VERYSILENT", s);                         // installed channel: silent per-user setup
+        Assert.Contains("$Exe + '.old'", s);                       // portable channel: rename-aside, not overwrite
+        Assert.Contains("Move-Item $old $Exe", s);                 // rollback path restores the app on failure
+        Assert.Contains("Start-Process $Exe", s);                  // relaunch the same path either way
+    }
+}

--- a/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
+++ b/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
@@ -126,6 +126,7 @@ internal sealed class FakeSessionHost : ISessionHost
     public string AdoptClaude() { int n = 0; foreach (var s in Workspaces.SelectMany(w => w.Sessions)) { s.AgentResume = "claude --resume x"; n++; } return $"adopted {n}"; }
     public string RestartClaudeYolo(string? target) { var s = Find(target); if (s is null) return "no pane"; s.AgentResume = "claude --resume x --dangerously-skip-permissions"; return "restarting Claude in YOLO mode (resumed)"; }
     public string UpdateClaude() => "updating Claude Code…";
+    public string UpdateApp() => "updating agwinterm…";
     public void WorkspaceFocus(string op) { }
     public string SessionBackground(string? target, string action, string? path, int opacity, string? mode) => Find(target) is not null ? "ok" : "no session";
     public string SessionSwitch(string op) => ActiveSess?.Name ?? "";


### PR DESCRIPTION
## What

Boris''s ask: auto-update for agwinterm itself, with different behavior for portable vs installed. (The hot-swap/assembly-unload idea was evaluated and rejected — see #105 for the long-term pty-host play.)

**Channel detection from the running exe''s path:**

| Channel | Action |
|---|---|
| `%LOCALAPPDATA%\Programs\agwinterm` | download `agwinterm-setup-<v>.exe`, run `/VERYSILENT` (per-user, no admin), relaunch |
| scoop / chocolatey / WindowsApps | **refused** with a hint — the package manager owns the files |
| anywhere else (portable) | download the portable exe, **rename the running exe aside** (allowed on Windows), move the payload in, relaunch; `.old` swept on next start; rollback restores the old exe if the swap fails |

**Integrity (we ship unsigned):** every download is verified against the GitHub release asset''s SHA-256 `digest`, fail-closed — no digest, wrong digest, or missing asset aborts with a toast and applies nothing. Downloads via HttpClient carry no mark-of-the-web, so the silent setup re-run doesn''t trip SmartScreen.

**Awareness:** startup + 12h check of the GitHub releases API → one toast per new version + a `— vX.Y.Z available` hint on the palette entry. New config key **`update-check`** (default `true`, wired into Parse + DefaultText + ConfigKeys + config.get). Applying is always manual: palette → *Update agwinterm* or `agwintermctl app update`.

**Apply flow:** save state → exit all windows gracefully (each persists its tree) → detached helper waits for the PID (aborts if the app never exits), swaps, relaunches → sessions and bound Claude conversations restore. Test seams: `AGWINTERM_UPDATE_API` (URL or local JSON), `AGWINTERM_VERSION_OVERRIDE`.

## Bug found & fixed on the way

`WM_DESTROY` computed "last window" from index metas (`IsOpen`). An update-quit intentionally keeps metas open so every window reopens after relaunch — which made the meta count never reach zero: no `PostQuitMessage`, a windowless process alive forever, and the update helper waiting on it. Now counts **live** windows (`_byId`). Normal close verified unchanged (process exits after the last window).

## Evidence

- **Unit: 224/224** — channel matrix (incl. case-insensitivity and the `agwinterm-fork` prefix trap), release-JSON fail-closed parse, per-channel asset pick, on-disk digest accept/reject, helper-script invariants, config key.
- **E2E** on a fake portable install (dev build copy) updated from a fake local release (payload = exe + tail bytes, real digest), two windows open:
  - `app update` → old process exited, **exe hash == payload hash** (swap verified), `.old` + updates dir swept on relaunch, **both windows reopened**
  - relaunched palette shows *Update agwinterm — v9.9.9 available* (screenshot in chat)
  - regression: closing all windows normally still exits the process
- Real-API awareness path shares the code with the Claude-update feature verified in #104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k