### PR TITLE
refactor(pty): session-backend seam — pty-host Phase 1 (#105), zero behavior change

### DIFF
--- a/src/Agwinterm.App/MainWindow.xaml.cs
+++ b/src/Agwinterm.App/MainWindow.xaml.cs
@@ -28,7 +28,7 @@ public sealed partial class MainWindow : Window, ISessionHost
     {
         public required string Id;
         public required string Name;
-        public required TerminalSession S;
+        public required ISession S;
         public required Workspace Ws;
     }
 
@@ -44,7 +44,7 @@ public sealed partial class MainWindow : Window, ISessionHost
     private Ses? _activeRef;
     private object? _editing; // Ses or Workspace currently being renamed inline
     private bool _windowActive = true;
-    private TerminalSession? _session;   // mirrors the active session (rendering/input use this)
+    private ISession? _session;   // mirrors the active session (rendering/input use this)
     private bool _started;
     private ControlServer? _control;
 
@@ -207,7 +207,7 @@ public sealed partial class MainWindow : Window, ISessionHost
     {
         StartControlServerOnce();
         var (cols, rows) = ComputeGridSize();
-        var session = new TerminalSession(cols, rows);
+        var session = InProcessSessionBackend.Instance.Create(cols, rows);
         int ordinal;
         lock (_workspaces) ordinal = ws.Sessions.Count + 1;
         var ses = new Ses { Id = id, Name = name ?? $"session {ordinal}", S = session, Ws = ws };
@@ -239,7 +239,7 @@ public sealed partial class MainWindow : Window, ISessionHost
         else RebuildSidebar();
     }
 
-    private async Task StartSessionAsync(TerminalSession session, Dictionary<string, string> env, string? cwd)
+    private async Task StartSessionAsync(ISession session, Dictionary<string, string> env, string? cwd)
     {
         try { await session.StartAsync("powershell.exe", new[] { "-NoLogo" }, extraEnv: env, cwd: cwd); }
         catch (Exception ex) { Title = "agwinterm — shell failed: " + ex.Message; }
@@ -485,7 +485,7 @@ public sealed partial class MainWindow : Window, ISessionHost
         }
     }
 
-    public TerminalSession? Resolve(string? target) => Find(target)?.S;
+    public ISession? Resolve(string? target) => Find(target)?.S;
 
     public IReadOnlyList<WorkspaceSnapshot> Tree()
     {

--- a/src/Agwinterm.Core/TerminalConfig.cs
+++ b/src/Agwinterm.Core/TerminalConfig.cs
@@ -80,6 +80,11 @@ public sealed class TerminalConfig
     /// ("Update agwinterm"), which downloads, verifies, restarts, and restores sessions.</summary>
     public bool UpdateCheck { get; set; } = true;
 
+    /// <summary>Where terminal sessions live: "in-process" (default — the UI process owns the
+    /// ConPTYs) or "server" (reserved: a separate pty-host process so sessions survive UI updates
+    /// and crashes — issue #105; falls back to in-process until it ships).</summary>
+    public string SessionHost { get; set; } = "in-process";
+
     /// <summary>Characters that DELIMIT words for double-click selection (in addition to whitespace).
     /// Empty = whitespace only (double-click grabs a whole path/URL). WT's wordDelimiters analog.</summary>
     public string WordDelimiters { get; set; } = "";
@@ -235,6 +240,12 @@ public sealed class TerminalConfig
         # manager (scoop/chocolatey) are never self-updated - the hint points at the manager instead.
         update-check = true
 
+        # Where terminal sessions live. "in-process" (default): the window process owns them.
+        # "server" (EXPERIMENTAL, not shipped yet - see github issue #105): a separate pty-host
+        # process owns them, so shells survive UI updates and crashes; falls back to in-process
+        # until it ships.
+        session-host = in-process
+
         # Blocked sound: play a sound whenever a session enters the "blocked" agent status (needs
         # your attention). Empty / off / none = silent. Accepts a system-sound name (beep, asterisk,
         # exclamation, hand, question), a Windows sound-event alias, or a path to a .wav file.
@@ -352,6 +363,9 @@ public sealed class TerminalConfig
                     break;
                 case "claude-update-check": cfg.ClaudeUpdateCheck = ParseBool(val, cfg.ClaudeUpdateCheck); break;
                 case "update-check": cfg.UpdateCheck = ParseBool(val, cfg.UpdateCheck); break;
+                case "session-host":
+                    if (val is "in-process" or "server") cfg.SessionHost = val;
+                    break;
                 case "word-delimiters": cfg.WordDelimiters = val; break;
                 case "desktop-notifications": cfg.DesktopNotifications = ParseBool(val, cfg.DesktopNotifications); break;
                 case "blocked-sound": cfg.BlockedSound = val; break;

--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -21,7 +21,7 @@ public sealed class ControlServer : IDisposable
 
     // Per-session record of the last content signature transmitted for each image id, so an
     // unchanged image can be re-placed (a=p) instead of re-transmitted (a=T) on every frame.
-    private readonly ConditionalWeakTable<TerminalSession, Dictionary<int, long>> _txState = new();
+    private readonly ConditionalWeakTable<ISession, Dictionary<int, long>> _txState = new();
 
     public ControlServer(ISessionHost host, string pipeName = "agwinterm")
     {
@@ -38,7 +38,7 @@ public sealed class ControlServer : IDisposable
     }
 
     /// <summary>Convenience: serve a single fixed session (tests / simple hosts).</summary>
-    public ControlServer(TerminalSession session, string pipeName = "agwinterm")
+    public ControlServer(ISession session, string pipeName = "agwinterm")
         : this(new SingleSessionHost(session), pipeName) { }
 
     public string PipeName => _pipeName;
@@ -324,13 +324,13 @@ public sealed class ControlServer : IDisposable
         return OkRaw(sb.ToString());
     }
 
-    private static string HandleWrite(TerminalSession s, JsonElement args)
+    private static string HandleWrite(ISession s, JsonElement args)
     {
         s.Inject(Encoding.UTF8.GetBytes(GetString(args, "text") ?? ""));
         return Ok("written");
     }
 
-    private static string HandleType(TerminalSession s, JsonElement args)
+    private static string HandleType(ISession s, JsonElement args)
     {
         string text = (GetString(args, "text") ?? "").Replace("\r\n", "\r").Replace('\n', '\r');
         s.Write(Encoding.UTF8.GetBytes(text));
@@ -338,7 +338,7 @@ public sealed class ControlServer : IDisposable
     }
 
     /// <summary>Dump the target session's active-pane buffer as plain text (trailing blank lines trimmed).</summary>
-    private static string HandleText(TerminalSession s)
+    private static string HandleText(ISession s)
     {
         var sb = new StringBuilder();
         lock (s.SyncRoot)
@@ -349,7 +349,7 @@ public sealed class ControlServer : IDisposable
         return Ok(sb.ToString().TrimEnd('\n'));
     }
 
-    private static string HandleStatus(TerminalSession s, JsonElement args)
+    private static string HandleStatus(ISession s, JsonElement args)
     {
         string st = (GetString(args, "status") ?? "").ToLowerInvariant();
         if (st.Length == 0) return Err("session.status requires args.status");
@@ -379,7 +379,7 @@ public sealed class ControlServer : IDisposable
         return Ok(status.ToString().ToLowerInvariant());
     }
 
-    private static string HandleImageShow(TerminalSession s, JsonElement args)
+    private static string HandleImageShow(ISession s, JsonElement args)
     {
         string? path = GetString(args, "path");
         if (path is null || !File.Exists(path)) return Err("image file not found: " + (path ?? "<null>"));
@@ -392,7 +392,7 @@ public sealed class ControlServer : IDisposable
         return Ok("shown");
     }
 
-    private static string HandleImageSixel(TerminalSession s, JsonElement args)
+    private static string HandleImageSixel(ISession s, JsonElement args)
     {
         string? path = GetString(args, "path");
         if (path is null || !File.Exists(path)) return Err("sixel file not found: " + (path ?? "<null>"));
@@ -404,13 +404,13 @@ public sealed class ControlServer : IDisposable
         return Ok("shown");
     }
 
-    private static string HandleImageClear(TerminalSession s)
+    private static string HandleImageClear(ISession s)
     {
         s.Inject(Encoding.ASCII.GetBytes("\x1b_Ga=d\x1b\\"));
         return Ok("cleared");
     }
 
-    private string HandleImageFrame(TerminalSession s, JsonElement args)
+    private string HandleImageFrame(ISession s, JsonElement args)
     {
         if (args.ValueKind != JsonValueKind.Object ||
             !args.TryGetProperty("images", out var images) || images.ValueKind != JsonValueKind.Array)

--- a/src/Agwinterm.Pty/ISession.cs
+++ b/src/Agwinterm.Pty/ISession.cs
@@ -1,0 +1,68 @@
+using Agwinterm.Core;
+using Microsoft.Win32.SafeHandles;
+
+namespace Agwinterm.Pty;
+
+/// <summary>
+/// The session handle the UI consumes — everything a pane needs from a live terminal session,
+/// independent of WHERE that session runs. Today the only implementation is
+/// <see cref="TerminalSession"/> (in-process ConPTY); the pty-host server backend (#105) will add
+/// a client-side implementation whose <see cref="Emulator"/> is a replica fed from the host
+/// process. This seam is the Phase-1 groundwork: code against it, never against the concrete type.
+///
+/// Threading contract (matches <see cref="TerminalSession"/> today): events are raised on
+/// background threads; renderers must hold <see cref="SyncRoot"/> while reading the emulator grid;
+/// <see cref="MutateLocked"/>/<see cref="Inject"/> take that lock internally.
+/// </summary>
+public interface ISession : IDisposable
+{
+    /// <summary>The screen model this session renders from. In-process: the live emulator; a
+    /// server backend supplies a client-side replica with the same contract.</summary>
+    TerminalEmulator Emulator { get; }
+    int Cols { get; }
+    int Rows { get; }
+
+    /// <summary>PID of the spawned shell process (null before start), for foreground-command capture.</summary>
+    int? ChildProcessId { get; }
+
+    /// <summary>Lock held while the emulator is mutated; renderers lock this while reading the grid.</summary>
+    object SyncRoot { get; }
+
+    /// <summary>Raised (background thread) after each chunk of output is fed to the emulator.</summary>
+    event Action? OutputReceived;
+
+    // ---- Agent status (push-based, via the control API) ----
+    AgentStatus Status { get; }
+    bool Blink { get; }
+    bool AutoReset { get; }
+    event Action? StatusChanged;
+    event Action<string?>? SoundRequested;
+    void SetStatus(AgentStatus status, bool blink = false, bool autoReset = false,
+        bool sound = false, string? soundName = null);
+    void NotifyActivity();
+
+    // ---- Lifecycle ----
+    /// <summary>Spawn <paramref name="app"/> and pump until it exits; returns the exit code.</summary>
+    Task<int> RunAsync(string app, string[] commandLine, bool verbatimCommandLine = false, CancellationToken ct = default);
+    /// <summary>Spawn an interactive shell and pump in the background until exit or dispose.</summary>
+    Task StartAsync(string app, string[] commandLine, bool verbatimCommandLine = false,
+        IReadOnlyDictionary<string, string>? extraEnv = null, string? cwd = null, bool deElevate = false, CancellationToken ct = default);
+    /// <summary>Adopt an externally-created pseudoconsole (default-terminal handoff). Inherently
+    /// handle-based: a server backend must duplicate the handles into the host process (Phase 2).</summary>
+    void Attach(SafeFileHandle conOut, SafeFileHandle conIn, SafeFileHandle signal, IntPtr clientProcess, int pid);
+    int? ExitCode { get; }
+    bool HasExited { get; }
+    /// <summary>Raised (background thread) when the child process exits, with its exit code.</summary>
+    event Action<int>? Exited;
+
+    // ---- I/O ----
+    /// <summary>Feed bytes into the EMULATOR only (display injection; never reaches the shell).</summary>
+    void Inject(ReadOnlySpan<byte> bytes);
+    /// <summary>Run a mutation against the emulator under <see cref="SyncRoot"/>.</summary>
+    void MutateLocked(Action<TerminalEmulator> mutate);
+    /// <summary>Send bytes to the shell's stdin (real keystrokes).</summary>
+    void Write(ReadOnlySpan<byte> bytes);
+    void Resize(int cols, int rows);
+    /// <summary>Thread-safe text snapshot of one visible row.</summary>
+    string SnapshotRow(int row);
+}

--- a/src/Agwinterm.Pty/ISessionHost.cs
+++ b/src/Agwinterm.Pty/ISessionHost.cs
@@ -26,7 +26,7 @@ public sealed record WindowStateSnapshot(bool SidebarVisible, bool Fullscreen, b
 /// </summary>
 public interface ISessionHost
 {
-    TerminalSession? Resolve(string? target);
+    ISession? Resolve(string? target);
 
     /// <summary>The full workspace→session tree.</summary>
     IReadOnlyList<WorkspaceSnapshot> Tree();
@@ -213,10 +213,10 @@ public interface ISessionHost
 /// <summary>Adapter exposing a single fixed session as an <see cref="ISessionHost"/> (tests / simple hosts).</summary>
 public sealed class SingleSessionHost : ISessionHost
 {
-    private readonly TerminalSession _session;
-    public SingleSessionHost(TerminalSession session) => _session = session;
+    private readonly ISession _session;
+    public SingleSessionHost(ISession session) => _session = session;
 
-    public TerminalSession? Resolve(string? target) => _session;
+    public ISession? Resolve(string? target) => _session;
     public IReadOnlyList<WorkspaceSnapshot> Tree() =>
         new[] { new WorkspaceSnapshot("ws", "workspace", true,
             new[] { new SessionSnapshot("single", "session", true, _session.Status) }) };

--- a/src/Agwinterm.Pty/SessionBackend.cs
+++ b/src/Agwinterm.Pty/SessionBackend.cs
@@ -1,0 +1,35 @@
+namespace Agwinterm.Pty;
+
+/// <summary>
+/// Where terminal sessions live. The UI creates every session through exactly one of these, chosen
+/// at startup from the <c>session-host</c> config key — never via <c>new TerminalSession</c>
+/// directly — so the pty-host server backend (#105, Phase 2) can slot in behind the same seam.
+/// </summary>
+public interface ISessionBackend
+{
+    /// <summary>Stable name for diagnostics/toasts ("in-process", later "server").</summary>
+    string Name { get; }
+
+    /// <summary>Create a session sized <paramref name="cols"/>×<paramref name="rows"/> (not yet started).</summary>
+    ISession Create(int cols, int rows);
+}
+
+/// <summary>Today's model: the UI process owns the ConPTY (a plain <see cref="TerminalSession"/>).</summary>
+public sealed class InProcessSessionBackend : ISessionBackend
+{
+    public static readonly InProcessSessionBackend Instance = new();
+    public string Name => "in-process";
+    public ISession Create(int cols, int rows) => new TerminalSession(cols, rows);
+}
+
+public static class SessionBackends
+{
+    /// <summary>Resolve the configured <c>session-host</c> value to a backend. "server" is reserved
+    /// for the pty-host process (#105) and falls back to in-process until it ships —
+    /// <paramref name="fellBack"/> lets the caller tell the user instead of silently ignoring it.</summary>
+    public static ISessionBackend Resolve(string? configured, out bool fellBack)
+    {
+        fellBack = string.Equals(configured, "server", StringComparison.OrdinalIgnoreCase);
+        return InProcessSessionBackend.Instance;
+    }
+}

--- a/src/Agwinterm.Pty/TerminalSession.cs
+++ b/src/Agwinterm.Pty/TerminalSession.cs
@@ -9,7 +9,7 @@ namespace Agwinterm.Pty;
 /// spawns the process, pumps its output into the emulator on a reader loop, and
 /// exposes a thread-safe view of the resulting grid.
 /// </summary>
-public sealed class TerminalSession : IDisposable
+public sealed class TerminalSession : ISession
 {
     private readonly object _sync = new();
     private IPtyConnection? _connection;

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -159,7 +159,7 @@ internal partial class Program
 
     // ---- ISessionHost bridge (Program is the host) so the control server / agwintermctl drive
     // this window. Un-scoped verbs act on this instance; the seam for future --window targeting. ----
-        public TerminalSession? Resolve(string? target)
+        public ISession? Resolve(string? target)
         {
             if (string.IsNullOrEmpty(target) || target == "active") return ActiveSurface()?.S;
             lock (_workspaces)

--- a/src/Agwinterm.Win32/Program.Render.cs
+++ b/src/Agwinterm.Win32/Program.Render.cs
@@ -312,7 +312,7 @@ internal partial class Program
     /// <summary>Draw one terminal surface (cells, images, cursor) at origin (ox,oy) with its font metrics.</summary>
     private Cell[] _cellSnap = Array.Empty<Cell>();   // reusable viewport snapshot; drawing reads it lock-free
 
-    private void RenderTerminal(TerminalSession session, float ox, float oy, IDWriteTextFormat fmt, float cw, float ch, int scrollOffset, Pane? selPane = null)
+    private void RenderTerminal(ISession session, float ox, float oy, IDWriteTextFormat fmt, float cw, float ch, int scrollOffset, Pane? selPane = null)
     {
         var rt = _rt!;
         var brush = _brush!;

--- a/src/Agwinterm.Win32/Program.Services.cs
+++ b/src/Agwinterm.Win32/Program.Services.cs
@@ -823,6 +823,7 @@ internal partial class Program
         "new-session-dir-mode", "confirm-close-session", "compact-toolbar", "toolbar-mode", "notification-badges",
         "attention-button", "status-color-active", "status-color-blocked", "status-color-completed",
         "paste-protection", "clipboard-write", "notification-flash", "claude-update-check", "update-check",
+        "session-host",
     };
 
     /// <summary>Rewrite (or append) a single `key = value` line in agwinterm.conf, preserving the rest.</summary>
@@ -886,6 +887,7 @@ internal partial class Program
         "notification-flash" => _config.NotificationFlash,
         "claude-update-check" => _config.ClaudeUpdateCheck ? "true" : "false",
         "update-check" => _config.UpdateCheck ? "true" : "false",
+        "session-host" => _config.SessionHost,
         "paste-protection" => _config.PasteProtection ? "true" : "false",
         "clipboard-write" => _config.ClipboardWrite ? "true" : "false",
         "attention-button" => _config.AttentionButton ? "true" : "false",

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -54,7 +54,7 @@ internal partial class Program
         bool deElevate = false, HandoffArgs? handoff = null)
     {
         var (cols, rows) = GridSizeFor(fontSize);
-        var session = new TerminalSession(cols, rows);
+        var session = _sessionBackend.Create(cols, rows);   // the ONLY session creation site (see ISessionBackend)
         session.Emulator.ScrollbackMax = _config.Scrollback;
         var pane = new Pane { Id = paneId, S = session, StartCwd = cwd, FontSize = fontSize };
         // New output only snaps this pane back to the live bottom and drops the selection when the buffer
@@ -195,7 +195,7 @@ internal partial class Program
     /// <summary>Launch a session's shell from its profile. PowerShell profiles (powershell.exe / pwsh) with
     /// no custom args get the OSC-7 cwd wrap + omp injection (today's default behavior); everything else
     /// (cmd, Git Bash, WSL, custom) launches its raw command + args. AGWINTERM_* env is passed regardless.</summary>
-    private void LaunchShell(TerminalSession session, string? profileName, Dictionary<string, string> env, string? cwd, bool deElevate = false)
+    private void LaunchShell(ISession session, string? profileName, Dictionary<string, string> env, string? cwd, bool deElevate = false)
     {
         var prof = ResolveProfile(profileName);
         string cmd = prof?.Command is { Length: > 0 } c ? c : "powershell.exe";
@@ -218,8 +218,8 @@ internal partial class Program
     /// writes straight back to the PTY (it must not wait on the UI thread).</summary>
     private sealed class PaneHost : IHostActions
     {
-        private readonly Program _app; private readonly Pane _pane; private readonly TerminalSession _s;
-        public PaneHost(Program app, Pane pane, TerminalSession s) { _app = app; _pane = pane; _s = s; }
+        private readonly Program _app; private readonly Pane _pane; private readonly ISession _s;
+        public PaneHost(Program app, Pane pane, ISession s) { _app = app; _pane = pane; _s = s; }
         public void Notify(string title, string body) => _app.Post(() => _app.OnNotified(_pane, title, body));
         public void Progress(int state, int value) => _app.Post(() => _app.OnProgress(state, value));   // OSC 9;4 -> taskbar
         public void ClipboardWrite(string text)                                                        // OSC 52 -> system clipboard

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -75,7 +75,7 @@ internal partial class Program : ISessionHost, IWindowHost
     private static Theme? _themeBeforePreview;                   // saved when the theme picker opens (Esc reverts)
     private static List<Theme> _allThemes = new();
     private static Agwinterm.Pty.ShellProfiles.Config _profileCfg = new();   // shell profiles (profiles.json); app-global
-    private TerminalSession? _session;   // mirrors the ACTIVE SURFACE (active pane, or a shown cover)
+    private ISession? _session;   // mirrors the ACTIVE SURFACE (active pane, or a shown cover)
     // Auxiliary "cover" terminal drawn over the content region: scratch (per-session) or quick (per-app).
     private Pane? _cover;                // the shown cover, or null
     private int _coverKind;              // 0 none, 1 scratch, 2 quick, 3 overlay
@@ -89,6 +89,9 @@ internal partial class Program : ISessionHost, IWindowHost
     // Update Claude Code workflow: one run at a time + the newest version the background check saw.
     private volatile bool _claudeUpdating;
     private volatile string? _claudeLatest;   // non-null = a newer Claude Code has shipped
+    // Where sessions live (pty-host seam, #105): chosen once at startup from `session-host`.
+    // Every session is created through this — never via `new TerminalSession` directly.
+    private static ISessionBackend _sessionBackend = InProcessSessionBackend.Instance;
     // agwinterm self-update: same pattern, app-wide (static — one process, many windows).
     private static volatile bool _appUpdating;
     private static volatile string? _appLatest;      // non-null = a newer agwinterm release exists
@@ -253,7 +256,7 @@ internal partial class Program : ISessionHost, IWindowHost
     private sealed class Pane
     {
         public required string Id;
-        public required TerminalSession S;
+        public required ISession S;
         public string? StartCwd;   // dir the shell was launched in (fallback cwd when OSC 7 is absent)
         public string? AgentResume; // resumable agent bound to this pane (e.g. "claude") — relaunched on restart
         public float FontSize;     // per-pane font zoom (pt)
@@ -293,7 +296,7 @@ internal partial class Program : ISessionHost, IWindowHost
         public Pane ActivePane => Panes[Math.Clamp(Active, 0, Panes.Count - 1)];
         // Back-compat shims: existing code that said ses.S / ses.FontSize / ses.StartCwd
         // now refers to the ACTIVE PANE, so most single-pane logic is unchanged.
-        public TerminalSession S => ActivePane.S;
+        public ISession S => ActivePane.S;
         public float FontSize { get => ActivePane.FontSize; set => ActivePane.FontSize = value; }
         public string? StartCwd { get => ActivePane.StartCwd; set => ActivePane.StartCwd = value; }
     }
@@ -409,6 +412,7 @@ internal partial class Program : ISessionHost, IWindowHost
         SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
         // Process-global setup (config/themes/keymap + window class + shared D2D/DWrite objects).
         _config = LoadOrCreateConfig();
+        _sessionBackend = SessionBackends.Resolve(_config.SessionHost, out bool sessionHostFellBack);
         _allThemes = LoadThemes();
         _theme = FindTheme(_config.Theme);
         LoadKeymap();
@@ -462,6 +466,10 @@ internal partial class Program : ISessionHost, IWindowHost
             front ??= w;
         }
         Frontmost = front!;
+        // `session-host = server` is reserved for the pty-host process (#105); say so instead of
+        // silently ignoring the key while Phase 2 is unbuilt.
+        if (sessionHostFellBack)
+            front!.Post(() => front.ShowToast("session-host = server isn't available yet (#105) — using in-process", 6000));
 
         while (GetMessageW(out MSG msg, IntPtr.Zero, 0, 0) > 0)
         {

--- a/tests/Agwinterm.Core.Tests/TerminalConfigTests.cs
+++ b/tests/Agwinterm.Core.Tests/TerminalConfigTests.cs
@@ -55,6 +55,15 @@ public class TerminalConfigTests
     }
 
     [Fact]
+    public void SessionHost_ParsesValidValuesRejectsUnknown()
+    {
+        Assert.Equal("in-process", TerminalConfig.Parse("").SessionHost);   // default: today's model
+        Assert.Equal("server", TerminalConfig.Parse("session-host = server").SessionHost);
+        Assert.Equal("in-process", TerminalConfig.Parse("session-host = bogus").SessionHost);
+        Assert.Contains("session-host", TerminalConfig.DefaultText);
+    }
+
+    [Fact]
     public void UpdateCheck_ParsesAndIsDocumented()
     {
         Assert.True(TerminalConfig.Parse("").UpdateCheck);         // default: awareness on, applying stays manual

--- a/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
+++ b/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
@@ -43,7 +43,7 @@ internal sealed class FakeSessionHost : ISessionHost
         t is null or "active" ? ActiveWs
         : Workspaces.FirstOrDefault(w => w.Id == t || w.Id.StartsWith(t) || string.Equals(w.Name, t, StringComparison.OrdinalIgnoreCase));
 
-    public TerminalSession? Resolve(string? target) => Find(target) is not null ? _session : null;
+    public ISession? Resolve(string? target) => Find(target) is not null ? _session : null;
 
     public IReadOnlyList<WorkspaceSnapshot> Tree() => Workspaces.Select(w => new WorkspaceSnapshot(
         w.Id, w.Name, ReferenceEquals(w, ActiveWs),

--- a/tests/Agwinterm.Pty.Tests/SessionBackendTests.cs
+++ b/tests/Agwinterm.Pty.Tests/SessionBackendTests.cs
@@ -1,0 +1,42 @@
+using Agwinterm.Pty;
+
+namespace Agwinterm.Pty.Tests;
+
+public class SessionBackendTests
+{
+    [Fact]
+    public void InProcessBackend_CreatesWorkingSessions()
+    {
+        using ISession s = InProcessSessionBackend.Instance.Create(20, 5);
+        Assert.Equal(20, s.Cols);
+        Assert.Equal(5, s.Rows);
+        // The handle drives the emulator through the interface alone (what a Phase-2 replica must honor).
+        s.Inject("hello"u8);
+        Assert.Equal("hello", s.SnapshotRow(0).TrimEnd());
+        s.Resize(30, 6);
+        Assert.Equal(30, s.Cols);
+        Assert.False(s.HasExited);   // never started — no phantom exit
+    }
+
+    [Fact]
+    public void Resolve_ServerFallsBackToInProcessAndSaysSo()
+    {
+        // "server" is reserved for the pty-host (#105). Until Phase 2 ships it must fall back —
+        // and report that it did, so the UI can tell the user instead of silently ignoring the key.
+        Assert.Same(InProcessSessionBackend.Instance, SessionBackends.Resolve("in-process", out bool fb1));
+        Assert.False(fb1);
+        Assert.Same(InProcessSessionBackend.Instance, SessionBackends.Resolve("server", out bool fb2));
+        Assert.True(fb2);
+        Assert.Same(InProcessSessionBackend.Instance, SessionBackends.Resolve(null, out bool fb3));
+        Assert.False(fb3);
+    }
+
+    [Fact]
+    public void ControlServer_AcceptsAnyISession()
+    {
+        // The single-session ControlServer ctor is part of the seam: it must take the interface.
+        using ISession s = InProcessSessionBackend.Instance.Create(80, 24);
+        using var server = new ControlServer(s, "agwinterm-test-" + Guid.NewGuid().ToString("N")[..8]);
+        Assert.NotNull(server);
+    }
+}


### PR DESCRIPTION
## What

Phase 1 of the agreed pty-host rollout (#105): extract the seam, change nothing observable.

- **`ISession`** — the session handle the UI consumes (emulator access under `SyncRoot`, agent status, lifecycle, I/O), independent of *where* the session runs. `TerminalSession` implements it unchanged; a Phase-2 server backend will implement it with a client-side emulator replica.
- **`ISessionBackend` / `InProcessSessionBackend`** — every session is now created through exactly **one** backend call site (`CreatePane`); `new TerminalSession` no longer exists outside the backend (grep-verified).
- **`session-host = in-process | server`** config key (validated, documented as experimental). `server` is reserved: until Phase 2 ships it **falls back to in-process with a visible toast** — never a silent ignore. No Settings toggle yet; that arrives when the knob does something (per the plan: shipping a dead toggle would mislead).
- Mechanical retyping to the interface across `Pane.S`/`Ses.S`, renderer, `PaneHost`, `ISessionHost.Resolve`, `ControlServer`, and the legacy WinUI shell.

## Why this shape

Same staging that worked for the `IHostActions` refactor: land the boundary quietly in a normal release, then build the risky half (`--pty-host` role, replica protocol, reconnect) behind it as opt-in. Two release artifacts stay two; the updater and package managers never learn the difference.

## Evidence

- **Unit: 228/228** — new seam tests drive a session through the interface alone (Inject → SnapshotRow, Resize, no phantom exit), backend resolve + fallback flag, ControlServer accepting `ISession`, config validation (unknown values rejected).
- **E2E smoke (dev instance):** type → echo → read, split, tree — identical behavior through the seam; `session-host = server` relaunch shows the fallback toast and the app runs normally in-process (screenshot in chat).
- Zero-behavior-change claim: no logic edits anywhere — only types, one construction-site indirection, and the new (inert-by-default) config key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k