### PR TITLE
feat(pty-host): host process + session protocol — pty-host Phase 2a (#105)

### DIFF
--- a/src/Agwinterm.Core/TerminalEmulator.cs
+++ b/src/Agwinterm.Core/TerminalEmulator.cs
@@ -819,6 +819,26 @@ public sealed class TerminalEmulator : IParserPerformer
         return lines;
     }
 
+    /// <summary>Serialize the terminal's MODE state (not content) as VT sequences that reproduce it
+    /// when fed to a fresh emulator — the pty-host reattach handshake. Content is carried separately
+    /// (scrollback seed + a ConPTY repaint); modes must travel explicitly or a reattached view
+    /// wouldn't know, e.g., that the running app enabled mouse reporting or bracketed paste.
+    /// Covers exactly the private modes this emulator tracks; extend alongside SetPrivateMode.</summary>
+    public string DumpModes()
+    {
+        var sb = new System.Text.StringBuilder();
+        if (IsAltScreen) sb.Append("\x1b[?1049h");
+        if (!CursorVisible) sb.Append("\x1b[?25l");
+        if (_mouseClick) sb.Append("\x1b[?1000h");
+        if (_mouseDrag) sb.Append("\x1b[?1002h");
+        if (_mouseMotion) sb.Append("\x1b[?1003h");
+        if (_mouseSgr) sb.Append("\x1b[?1006h");
+        if (BracketedPaste) sb.Append("\x1b[?2004h");
+        if (Title.Length > 0) sb.Append("\x1b]0;").Append(Title).Append('\x07');
+        if (Cwd.Length > 0) sb.Append("\x1b]7;").Append(Cwd).Append('\x07');
+        return sb.ToString();
+    }
+
     /// <summary>Seed the scrollback with plain-text lines (dimmed) — restores a prior session's buffer
     /// above the fresh shell without touching the live screen.</summary>
     public void SeedScrollback(IReadOnlyList<string> lines)

--- a/src/Agwinterm.Pty/PtyHostClient.cs
+++ b/src/Agwinterm.Pty/PtyHostClient.cs
@@ -1,0 +1,173 @@
+using System.IO.Pipes;
+using System.Text;
+using System.Text.Json;
+
+namespace Agwinterm.Pty;
+
+/// <summary>Result of <see cref="PtyHostClient.Attach"/>: the connected data stream plus everything
+/// a fresh view needs to reconstruct the session (see PtyHostServer for the reattach model).</summary>
+public sealed record PtyHostAttachment(
+    Stream Data, int Cols, int Rows, int? ChildPid, bool HasExited, int? ExitCode,
+    string Modes, IReadOnlyList<string> Scrollback) : IDisposable
+{
+    public void Dispose() => Data.Dispose();
+}
+
+/// <summary>One hosted session as reported by <c>list</c>.</summary>
+public sealed record PtyHostSessionInfo(
+    string Id, int Cols, int Rows, int? ChildPid, bool HasExited, int? ExitCode, string Title, bool Attached);
+
+/// <summary>
+/// Client for the pty-host control pipe (#105, Phase 2a). Thread-safe: control requests are
+/// serialized over one pipe connection. Used by tests today and by the server session backend
+/// (Phase 2b) tomorrow.
+/// </summary>
+public sealed class PtyHostClient : IDisposable
+{
+    private readonly NamedPipeClientStream _pipe;
+    private readonly StreamReader _reader;
+    private readonly StreamWriter _writer;
+    private readonly object _io = new();
+
+    private PtyHostClient(NamedPipeClientStream pipe)
+    {
+        _pipe = pipe;
+        _reader = new StreamReader(pipe, Encoding.UTF8, false, 4096, leaveOpen: true);
+        _writer = new StreamWriter(pipe, new UTF8Encoding(false), 4096, leaveOpen: true) { AutoFlush = true };
+    }
+
+    /// <summary>Whether a pty-host is answering for this app id (cheap probe, no handshake).</summary>
+    public static bool IsRunning(string appId)
+    {
+        try
+        {
+            using var probe = new NamedPipeClientStream(".", PtyHostServer.ControlPipeName(appId), PipeDirection.InOut);
+            probe.Connect(200);
+            return true;
+        }
+        catch { return false; }
+    }
+
+    /// <summary>Connect and handshake. Throws on timeout or protocol mismatch — a version mismatch
+    /// must fail loudly at the seam, never surface as garbled sessions later.</summary>
+    public static PtyHostClient Connect(string appId, int timeoutMs = 3000)
+    {
+        var pipe = new NamedPipeClientStream(".", PtyHostServer.ControlPipeName(appId), PipeDirection.InOut, PipeOptions.Asynchronous);
+        pipe.Connect(timeoutMs);
+        var client = new PtyHostClient(pipe);
+        try
+        {
+            using var doc = client.Request($"{{\"cmd\":\"hello\",\"protocol\":{PtyHostServer.ProtocolVersion}}}");
+            return client;
+        }
+        catch { client.Dispose(); throw; }
+    }
+
+    /// <summary>Create a session on the host (not attached yet — call <see cref="Attach"/>).</summary>
+    public string Create(string id, int cols, int rows, string app, string[] args,
+        string? cwd = null, IReadOnlyDictionary<string, string>? env = null, bool verbatim = false)
+    {
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms))
+        {
+            w.WriteStartObject();
+            w.WriteString("cmd", "create");
+            w.WriteString("id", id);
+            w.WriteNumber("cols", cols); w.WriteNumber("rows", rows);
+            w.WriteString("app", app);
+            if (verbatim) w.WriteBoolean("verbatim", true);
+            w.WriteStartArray("args");
+            foreach (var a in args) w.WriteStringValue(a);
+            w.WriteEndArray();
+            if (cwd is not null) w.WriteString("cwd", cwd);
+            if (env is not null)
+            {
+                w.WriteStartObject("env");
+                foreach (var kv in env) w.WriteString(kv.Key, kv.Value);
+                w.WriteEndObject();
+            }
+            w.WriteEndObject();
+        }
+        using var doc = Request(Encoding.UTF8.GetString(ms.ToArray()));
+        return doc.RootElement.GetProperty("id").GetString()!;
+    }
+
+    /// <summary>Attach to a session: returns its state snapshot plus the connected data stream
+    /// (write = child stdin, read = raw ConPTY output; EOF = child exited or superseded).
+    /// <paramref name="repaint"/> asks the host for the ConPTY resize-jiggle — pass true when
+    /// reattaching an existing view, false right after <see cref="Create"/>.</summary>
+    public PtyHostAttachment Attach(string id, bool repaint = false, int timeoutMs = 5000)
+    {
+        using var doc = Request($"{{\"cmd\":\"attach\",\"id\":{JsonSerializer.Serialize(id)},\"repaint\":{(repaint ? "true" : "false")}}}");
+        var root = doc.RootElement;
+        string pipeName = root.GetProperty("pipe").GetString()!;
+        var scrollback = new List<string>();
+        foreach (var e in root.GetProperty("scrollback").EnumerateArray()) scrollback.Add(e.GetString() ?? "");
+        var data = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+        data.Connect(timeoutMs);
+        return new PtyHostAttachment(
+            data,
+            root.GetProperty("cols").GetInt32(), root.GetProperty("rows").GetInt32(),
+            root.TryGetProperty("childPid", out var p) ? p.GetInt32() : null,
+            root.GetProperty("hasExited").GetBoolean(),
+            root.TryGetProperty("exitCode", out var ec) ? ec.GetInt32() : null,
+            root.GetProperty("modes").GetString() ?? "",
+            scrollback);
+    }
+
+    public void Resize(string id, int cols, int rows)
+        => Request($"{{\"cmd\":\"resize\",\"id\":{JsonSerializer.Serialize(id)},\"cols\":{cols},\"rows\":{rows}}}").Dispose();
+
+    public void Detach(string id)
+        => Request($"{{\"cmd\":\"detach\",\"id\":{JsonSerializer.Serialize(id)}}}").Dispose();
+
+    public void Kill(string id)
+        => Request($"{{\"cmd\":\"kill\",\"id\":{JsonSerializer.Serialize(id)}}}").Dispose();
+
+    public IReadOnlyList<PtyHostSessionInfo> List()
+    {
+        using var doc = Request("{\"cmd\":\"list\"}");
+        var list = new List<PtyHostSessionInfo>();
+        foreach (var e in doc.RootElement.GetProperty("sessions").EnumerateArray())
+            list.Add(new PtyHostSessionInfo(
+                e.GetProperty("id").GetString()!,
+                e.GetProperty("cols").GetInt32(), e.GetProperty("rows").GetInt32(),
+                e.TryGetProperty("childPid", out var p) ? p.GetInt32() : null,
+                e.GetProperty("hasExited").GetBoolean(),
+                e.TryGetProperty("exitCode", out var ec) ? ec.GetInt32() : null,
+                e.GetProperty("title").GetString() ?? "",
+                e.GetProperty("attached").GetBoolean()));
+        return list;
+    }
+
+    /// <summary>Ask the host process to tear down every session and exit.</summary>
+    public void Shutdown()
+    {
+        try { Request("{\"cmd\":\"shutdown\"}").Dispose(); } catch (IOException) { /* host died mid-reply — that IS the outcome */ }
+    }
+
+    /// <summary>One request/response over the control pipe. Throws on transport errors and on
+    /// <c>ok:false</c> replies (the error message travels in the exception).</summary>
+    private JsonDocument Request(string line)
+    {
+        string? reply;
+        lock (_io)
+        {
+            _writer.WriteLine(line);
+            reply = _reader.ReadLine();
+        }
+        if (reply is null) throw new IOException("pty-host closed the control pipe");
+        var doc = JsonDocument.Parse(reply);
+        if (doc.RootElement.TryGetProperty("ok", out var ok) && ok.ValueKind == JsonValueKind.True) return doc;
+        string err = doc.RootElement.TryGetProperty("error", out var e) ? e.GetString() ?? "unknown error" : "unknown error";
+        doc.Dispose();
+        throw new InvalidOperationException("pty-host: " + err);
+    }
+
+    public void Dispose()
+    {
+        try { _reader.Dispose(); } catch { }
+        try { _writer.Dispose(); } catch { }
+        try { _pipe.Dispose(); } catch { }
+    }
+}

--- a/src/Agwinterm.Pty/PtyHostServer.cs
+++ b/src/Agwinterm.Pty/PtyHostServer.cs
@@ -1,0 +1,351 @@
+using System.IO.Pipes;
+using System.Text;
+using System.Text.Json;
+
+namespace Agwinterm.Pty;
+
+/// <summary>
+/// The pty-host: a headless server that OWNS terminal sessions so they survive UI restarts and
+/// crashes (#105, Phase 2a). Runs inside <c>Agwinterm.Win32.exe --pty-host</c> (or in-process for
+/// tests — the pipes are real either way).
+///
+/// Wire model:
+///  - ONE control pipe (<c>&lt;appId&gt;-ptyhost</c>): newline-JSON request/response, same style as
+///    the control API. Verbs: hello (version handshake), create, attach, detach, resize, kill,
+///    list, shutdown.
+///  - Per ATTACH, one full-duplex DATA pipe (name returned by attach): client→host bytes are child
+///    stdin (keystrokes verbatim), host→client bytes are raw ConPTY output. One attached client per
+///    session; a new attach supersedes the previous data pipe. The data pipe closing from the host
+///    side means the child exited (ask <c>list</c> for the code); closing from the client side is a
+///    detach — the session keeps running.
+///
+/// Reattach v1 (deliberately simple, mirrors the existing restart-restore semantics): the attach
+/// response carries the host emulator's scrollback as PLAIN TEXT (client seeds it dimmed, like
+/// buffer restore) plus the mode state as synthesized VT (<see cref="Agwinterm.Core.TerminalEmulator.DumpModes"/>);
+/// then a ConPTY resize-jiggle makes the child's TUI repaint the live screen in full color. Full
+/// attributed-grid serialization can replace the text seed later without a protocol change.
+/// </summary>
+public sealed class PtyHostServer : IDisposable
+{
+    public const int ProtocolVersion = 1;
+    public static string ControlPipeName(string appId) => appId + "-ptyhost";
+
+    private readonly string _appId;
+    private readonly CancellationTokenSource _cts = new();
+    private readonly TaskCompletionSource _done = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly object _lock = new();                       // guards _sessions
+    private readonly Dictionary<string, Hosted> _sessions = new(StringComparer.OrdinalIgnoreCase);
+
+    private sealed class Hosted
+    {
+        public required string Id;
+        public required TerminalSession S;
+        public readonly object DataLock = new();                 // guards Data + writes to it
+        public NamedPipeServerStream? Data;                      // the currently-attached client
+    }
+
+    public PtyHostServer(string appId)
+    {
+        _appId = appId;
+        _ = AcceptLoopAsync(_cts.Token);
+    }
+
+    /// <summary>Completes when a client asks for <c>shutdown</c> — the host process exits then.</summary>
+    public Task Completion => _done.Task;
+
+    private async Task AcceptLoopAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            var pipe = new NamedPipeServerStream(
+                ControlPipeName(_appId), PipeDirection.InOut,
+                NamedPipeServerStream.MaxAllowedServerInstances,
+                PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+            try { await pipe.WaitForConnectionAsync(ct).ConfigureAwait(false); }
+            catch (OperationCanceledException) { pipe.Dispose(); break; }
+            catch (IOException) { pipe.Dispose(); continue; }
+            _ = HandleControlClientAsync(pipe, ct);
+        }
+    }
+
+    private async Task HandleControlClientAsync(NamedPipeServerStream pipe, CancellationToken ct)
+    {
+        using (pipe)
+        {
+            using var reader = new StreamReader(pipe, Encoding.UTF8, false, 4096, leaveOpen: true);
+            using var writer = new StreamWriter(pipe, new UTF8Encoding(false), 4096, leaveOpen: true) { AutoFlush = true };
+            try
+            {
+                string? line;
+                while ((line = await reader.ReadLineAsync(ct).ConfigureAwait(false)) != null)
+                {
+                    if (line.Length == 0) continue;
+                    await writer.WriteLineAsync(Dispatch(line).AsMemory(), ct).ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException) { }
+            catch (IOException) { }
+        }
+    }
+
+    /// <summary>Handle one request line; returns the JSON response line. Public for testing.</summary>
+    public string Dispatch(string requestJson)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(requestJson);
+            var root = doc.RootElement;
+            string cmd = root.TryGetProperty("cmd", out var c) ? c.GetString() ?? "" : "";
+            return cmd switch
+            {
+                "hello" => HandleHello(root),
+                "create" => HandleCreate(root),
+                "attach" => HandleAttach(root),
+                "detach" => WithSession(root, h => { CloseData(h); return Ok(); }),
+                "resize" => HandleResize(root),
+                "kill" => HandleKill(root),
+                "list" => HandleList(),
+                "shutdown" => HandleShutdown(),
+                _ => Err($"unknown command '{cmd}'"),
+            };
+        }
+        catch (JsonException) { return Err("invalid JSON"); }
+        catch (Exception ex) { return Err(ex.Message); }
+    }
+
+    private string HandleHello(JsonElement root)
+    {
+        // The handshake is the protocol's forward-compat seam: a client offering a DIFFERENT major
+        // version is refused loudly (never half-understood), and the reply names ours so the client
+        // can decide (e.g. a newer UI telling the user to let the old host drain).
+        int theirs = root.TryGetProperty("protocol", out var p) && p.TryGetInt32(out int v) ? v : -1;
+        return theirs == ProtocolVersion
+            ? Ok(w => { w.WriteNumber("protocol", ProtocolVersion); w.WriteNumber("pid", Environment.ProcessId); })
+            : Err($"protocol mismatch: host={ProtocolVersion} client={theirs}");
+    }
+
+    private string HandleCreate(JsonElement root)
+    {
+        string id = GetString(root, "id") ?? Guid.NewGuid().ToString();
+        int cols = GetInt(root, "cols", 120), rows = GetInt(root, "rows", 30);
+        string app = GetString(root, "app") ?? "";
+        if (app.Length == 0) return Err("create needs args.app");
+        string[] args = root.TryGetProperty("args", out var av) && av.ValueKind == JsonValueKind.Array
+            ? av.EnumerateArray().Select(e => e.GetString() ?? "").ToArray() : Array.Empty<string>();
+        string? cwd = GetString(root, "cwd");
+        bool verbatim = root.TryGetProperty("verbatim", out var vb) && vb.ValueKind == JsonValueKind.True;
+        Dictionary<string, string>? env = null;
+        if (root.TryGetProperty("env", out var ev) && ev.ValueKind == JsonValueKind.Object)
+        {
+            env = new Dictionary<string, string>();
+            foreach (var kv in ev.EnumerateObject()) env[kv.Name] = kv.Value.GetString() ?? "";
+        }
+
+        var session = new TerminalSession(cols, rows);
+        var hosted = new Hosted { Id = id, S = session };
+        lock (_lock)
+        {
+            if (_sessions.ContainsKey(id)) { session.Dispose(); return Err($"session '{id}' already exists"); }
+            _sessions[id] = hosted;
+        }
+        // Forward raw output to whichever client is attached; child exit closes the data pipe (EOF
+        // is the client's exit signal — the code is in `list`).
+        session.RawOutput += chunk =>
+        {
+            lock (hosted.DataLock)
+            {
+                var d = hosted.Data;
+                if (d is null) return;
+                try { d.Write(chunk); d.Flush(); }
+                catch { CloseDataLocked(hosted); }   // client vanished mid-write → plain detach
+            }
+        };
+        session.Exited += _ => CloseData(hosted);
+        _ = session.StartAsync(app, args, verbatimCommandLine: verbatim, extraEnv: env, cwd: cwd);
+        return Ok(w => w.WriteString("id", id));
+    }
+
+    private string HandleAttach(JsonElement root) => WithSession(root, hosted =>
+    {
+        bool repaint = root.TryGetProperty("repaint", out var rp) && rp.ValueKind == JsonValueKind.True;
+        string dataName = ControlPipeName(_appId) + "-d-" + Guid.NewGuid().ToString("N")[..8];
+        var data = new NamedPipeServerStream(dataName, PipeDirection.InOut, 1,
+            PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+
+        // Snapshot content + modes UNDER the session lock, before any new output can race the seed.
+        List<string> scrollback = new();
+        string modes;
+        var s = hosted.S;
+        lock (s.SyncRoot)
+        {
+            for (int i = 0; i < s.Emulator.HistoryCount; i++) scrollback.Add(s.Emulator.DumpHistoryRow(i));
+            modes = s.Emulator.DumpModes();
+        }
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                using var connectTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+                await data.WaitForConnectionAsync(connectTimeout.Token).ConfigureAwait(false);
+            }
+            catch { data.Dispose(); return; }              // client never came — abandon this attach
+            lock (hosted.DataLock) { CloseDataLocked(hosted); hosted.Data = data; }
+            if (hosted.S.HasExited) { CloseData(hosted); return; }   // exited while attaching → immediate EOF
+            if (repaint) JiggleRepaint(hosted.S);
+            await PumpInputAsync(hosted, data).ConfigureAwait(false);
+        });
+
+        return Ok(w =>
+        {
+            w.WriteString("pipe", dataName);
+            w.WriteNumber("cols", s.Cols); w.WriteNumber("rows", s.Rows);
+            if (s.ChildProcessId is int pid) w.WriteNumber("childPid", pid);
+            w.WriteBoolean("hasExited", s.HasExited);
+            if (s.ExitCode is int ec) w.WriteNumber("exitCode", ec);
+            w.WriteString("modes", modes);
+            w.WriteStartArray("scrollback");
+            foreach (var line in scrollback) w.WriteStringValue(line);
+            w.WriteEndArray();
+        });
+    });
+
+    /// <summary>Client→host side of a data pipe: bytes are the child's stdin. EOF/error = detach;
+    /// the session keeps running unattached.</summary>
+    private static async Task PumpInputAsync(Hosted hosted, NamedPipeServerStream data)
+    {
+        var buf = new byte[16 * 1024];
+        try
+        {
+            while (true)
+            {
+                int n = await data.ReadAsync(buf).ConfigureAwait(false);
+                if (n <= 0) break;
+                try { hosted.S.Write(buf.AsSpan(0, n)); } catch { break; }   // child gone
+            }
+        }
+        catch (IOException) { }
+        catch (ObjectDisposedException) { }
+        lock (hosted.DataLock) if (ReferenceEquals(hosted.Data, data)) CloseDataLocked(hosted);
+    }
+
+    /// <summary>The classic ConPTY repaint trick: a real row-count change makes conhost re-emit the
+    /// whole viewport (colors, cursor, alt screen) to the freshly-attached client. A plain re-send
+    /// of the same size is deduped by ConPTY, hence the jiggle.</summary>
+    private static void JiggleRepaint(TerminalSession s)
+    {
+        int cols = s.Cols, rows = s.Rows;
+        try
+        {
+            s.Resize(cols, Math.Max(2, rows - 1));
+            Thread.Sleep(60);                                    // let conhost process the first resize
+            s.Resize(cols, rows);
+        }
+        catch { }
+    }
+
+    private string HandleResize(JsonElement root) => WithSession(root, h =>
+    {
+        int cols = GetInt(root, "cols", 0), rows = GetInt(root, "rows", 0);
+        if (cols <= 0 || rows <= 0) return Err("resize needs cols/rows");
+        h.S.Resize(cols, rows);
+        return Ok();
+    });
+
+    private string HandleKill(JsonElement root) => WithSession(root, h =>
+    {
+        lock (_lock) _sessions.Remove(h.Id);
+        CloseData(h);
+        try { h.S.Dispose(); } catch { }
+        return Ok();
+    });
+
+    private string HandleList()
+    {
+        List<Hosted> all;
+        lock (_lock) all = _sessions.Values.ToList();
+        return Ok(w =>
+        {
+            w.WriteStartArray("sessions");
+            foreach (var h in all)
+            {
+                w.WriteStartObject();
+                w.WriteString("id", h.Id);
+                w.WriteNumber("cols", h.S.Cols); w.WriteNumber("rows", h.S.Rows);
+                if (h.S.ChildProcessId is int pid) w.WriteNumber("childPid", pid);
+                w.WriteBoolean("hasExited", h.S.HasExited);
+                if (h.S.ExitCode is int ec) w.WriteNumber("exitCode", ec);
+                lock (h.S.SyncRoot) w.WriteString("title", h.S.Emulator.Title);
+                bool attached; lock (h.DataLock) attached = h.Data is not null;
+                w.WriteBoolean("attached", attached);
+                w.WriteEndObject();
+            }
+            w.WriteEndArray();
+        });
+    }
+
+    private string HandleShutdown()
+    {
+        // Tear down AFTER the reply has a moment to flush — disposing inline races the response
+        // off the pipe (the client would see EOF instead of the ack).
+        _ = Task.Run(async () => { await Task.Delay(100); Dispose(); });
+        return Ok();
+    }
+
+    private string WithSession(JsonElement root, Func<Hosted, string> act)
+    {
+        string? id = GetString(root, "id");
+        if (id is null) return Err("missing id");
+        Hosted? h;
+        lock (_lock) _sessions.TryGetValue(id, out h);
+        return h is null ? Err($"no session '{id}'") : act(h);
+    }
+
+    private void CloseData(Hosted h) { lock (h.DataLock) CloseDataLocked(h); }
+    private static void CloseDataLocked(Hosted h)
+    {
+        try { h.Data?.Dispose(); } catch { }
+        h.Data = null;
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        List<Hosted> all;
+        lock (_lock) { all = _sessions.Values.ToList(); _sessions.Clear(); }
+        foreach (var h in all) { CloseData(h); try { h.S.Dispose(); } catch { } }
+        _done.TrySetResult();
+    }
+
+    // ---- JSON helpers (same shapes as the control API) ----
+    private static string? GetString(JsonElement e, string name)
+        => e.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
+    private static int GetInt(JsonElement e, string name, int fallback)
+        => e.TryGetProperty(name, out var v) && v.TryGetInt32(out int i) ? i : fallback;
+
+    private static string Ok(Action<Utf8JsonWriter>? body = null)
+    {
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms))
+        {
+            w.WriteStartObject();
+            w.WriteBoolean("ok", true);
+            body?.Invoke(w);
+            w.WriteEndObject();
+        }
+        return Encoding.UTF8.GetString(ms.ToArray());
+    }
+
+    private static string Err(string message)
+    {
+        using var ms = new MemoryStream();
+        using (var w = new Utf8JsonWriter(ms))
+        {
+            w.WriteStartObject();
+            w.WriteBoolean("ok", false);
+            w.WriteString("error", message);
+            w.WriteEndObject();
+        }
+        return Encoding.UTF8.GetString(ms.ToArray());
+    }
+}

--- a/src/Agwinterm.Pty/TerminalSession.cs
+++ b/src/Agwinterm.Pty/TerminalSession.cs
@@ -24,6 +24,11 @@ public sealed class TerminalSession : ISession
     /// <summary>Raised (on a background thread) after each chunk of output is fed to the emulator.</summary>
     public event Action? OutputReceived;
 
+    /// <summary>Raw-output tap (pty-host): each ConPTY chunk, verbatim, after it fed the emulator.
+    /// The copy is made only while subscribed. Raised on the pump thread — a slow handler stalls
+    /// THIS session's feed, so consumers must be quick or buffer themselves.</summary>
+    public event Action<byte[]>? RawOutput;
+
     /// <summary>Push-based agent status (set via the control API), and a change notification.</summary>
     public AgentStatus Status { get; private set; } = AgentStatus.Idle;
     public event Action? StatusChanged;
@@ -260,6 +265,7 @@ public sealed class TerminalSession : ISession
                 if (DumpPath is not null)
                     lock (_sync) System.IO.File.AppendAllBytes(DumpPath, buffer.AsSpan(0, n).ToArray());
                 lock (_sync) Emulator.Feed(buffer.AsSpan(0, n));
+                if (RawOutput is { } tap) tap(buffer[..n]);
                 OutputReceived?.Invoke();
             }
         }

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -381,6 +381,7 @@ internal partial class Program : ISessionHost, IWindowHost
     }
     private static string? _argDir;
     private static bool _argMaximized, _argFullscreen;
+    private static bool _argPtyHost;   // run as the headless pty-host (#105) instead of a window
 
     private static void ParseLaunchArgs(string[] args)
     {
@@ -394,6 +395,7 @@ internal partial class Program : ISessionHost, IWindowHost
                 case "--fullscreen": _argFullscreen = true; break;
                 case "--no-restore": _argNoRestore = true; break;
                 case "--pipe" when i + 1 < args.Length: _argPipe = args[++i]; break;
+                case "--pty-host": _argPtyHost = true; break;
                 case "--app-id" when i + 1 < args.Length: ++i; break; // consumed by ResolveAppId (namespaces data dir + pipe)
                 // unknown args are ignored (forward compatibility)
             }
@@ -409,6 +411,15 @@ internal partial class Program : ISessionHost, IWindowHost
         // Publish the resolved instance id so child processes and shared (Pty) helpers resolve the same
         // data dir — and a nested agwinterm inherits the dev/release identity of the one that launched it.
         Environment.SetEnvironmentVariable("AGWINTERM_APP_ID", _appId);
+        // The pty-host ROLE (#105): same exe, no window — a headless server owning terminal sessions
+        // so they survive UI restarts/crashes. The UI (Phase 2b) spawns and talks to it; nothing
+        // below (config, D2D, window class, control server) applies to this process.
+        if (_argPtyHost)
+        {
+            using var ptyHost = new Agwinterm.Pty.PtyHostServer(_argPipe ?? _appId);
+            ptyHost.Completion.Wait();
+            return;
+        }
         SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
         // Process-global setup (config/themes/keymap + window class + shared D2D/DWrite objects).
         _config = LoadOrCreateConfig();

--- a/tests/Agwinterm.Pty.Tests/PtyHostTests.cs
+++ b/tests/Agwinterm.Pty.Tests/PtyHostTests.cs
@@ -1,0 +1,173 @@
+using Agwinterm.Core;
+using Agwinterm.Pty;
+
+namespace Agwinterm.Pty.Tests;
+
+/// <summary>Pty-host integration tests (#105, Phase 2a): a real PtyHostServer over real named pipes
+/// hosting real child processes — only the process boundary of `--pty-host` is elided.</summary>
+public class PtyHostTests : IDisposable
+{
+    private readonly string _appId = "agwinterm-test-" + Guid.NewGuid().ToString("N")[..8];
+    private readonly PtyHostServer _server;
+
+    public PtyHostTests() => _server = new PtyHostServer(_appId);
+    public void Dispose() => _server.Dispose();
+
+    private static string ReadUntil(Stream data, Func<string, bool> done, int timeoutMs = 15000)
+    {
+        var all = new System.Text.StringBuilder();
+        var buf = new byte[16 * 1024];
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (sw.ElapsedMilliseconds < timeoutMs)
+        {
+            var read = data.ReadAsync(buf, 0, buf.Length);
+            if (!read.Wait(Math.Max(1, timeoutMs - (int)sw.ElapsedMilliseconds))) break;
+            if (read.Result <= 0) break;
+            all.Append(System.Text.Encoding.UTF8.GetString(buf, 0, read.Result));
+            if (done(all.ToString())) return all.ToString();
+        }
+        return all.ToString();
+    }
+
+    [Fact]
+    public void Hello_RejectsProtocolMismatch()
+    {
+        Assert.Contains("\"ok\":true", _server.Dispatch($"{{\"cmd\":\"hello\",\"protocol\":{PtyHostServer.ProtocolVersion}}}"));
+        Assert.Contains("protocol mismatch", _server.Dispatch("{\"cmd\":\"hello\",\"protocol\":999}"));
+        Assert.Contains("protocol mismatch", _server.Dispatch("{\"cmd\":\"hello\"}"));
+    }
+
+    [Fact]
+    public void CreateAttachTypeReadKill_RoundTrips()
+    {
+        using var client = PtyHostClient.Connect(_appId);
+        string id = client.Create(Guid.NewGuid().ToString(), 100, 24, "cmd.exe", new[] { "/q" }, verbatim: true);
+        using var att = client.Attach(id);
+        Assert.False(att.HasExited);
+        Assert.True(att.ChildPid > 0);
+
+        // Type through the data pipe; the echo must come back as raw ConPTY output.
+        byte[] line = System.Text.Encoding.UTF8.GetBytes("echo host+work\r");
+        att.Data.Write(line); att.Data.Flush();
+        string seen = ReadUntil(att.Data, s => s.Contains("host+work", StringComparison.Ordinal));
+        Assert.Contains("host+work", seen);
+
+        client.Kill(id);
+        Assert.Empty(client.List());
+    }
+
+    [Fact]
+    public void DetachedSessionSurvives_ReattachSeedsScrollbackAndStreams()
+    {
+        using var client = PtyHostClient.Connect(_appId);
+        string id = client.Create(Guid.NewGuid().ToString(), 100, 24, "cmd.exe", new[] { "/q" }, verbatim: true);
+
+        using (var first = client.Attach(id))
+        {
+            first.Data.Write("echo before-detach\r"u8.ToArray()); first.Data.Flush();
+            ReadUntil(first.Data, s => s.Contains("before-detach"));
+        }   // disposing the data pipe = detach; the shell must keep running
+
+        var info = Assert.Single(client.List());
+        Assert.False(info.HasExited);
+        Assert.False(info.Attached);
+
+        // Output printed while NOBODY is attached must not be lost — it lands in the host emulator...
+        Thread.Sleep(300);
+
+        // ...and a reattach hands it back: the scrollback+grid snapshot contains the earlier echo.
+        using var second = client.Attach(id, repaint: true);
+        var emu = new TerminalEmulator(second.Cols, second.Rows);
+        emu.SeedScrollback(second.Scrollback);
+        emu.Feed(System.Text.Encoding.UTF8.GetBytes(second.Modes));
+        bool inHistory = second.Scrollback.Any(l => l.Contains("before-detach"));
+        // The live viewport arrives via the repaint jiggle on the new data pipe.
+        string live = ReadUntil(second.Data, s => s.Contains("before-detach"), timeoutMs: 8000);
+        Assert.True(inHistory || live.Contains("before-detach"),
+            $"echo lost across detach/reattach (history={inHistory}, live={live.Length} chars)");
+
+        // The revived stream is fully interactive.
+        second.Data.Write("echo after-reattach\r"u8.ToArray()); second.Data.Flush();
+        Assert.Contains("after-reattach", ReadUntil(second.Data, s => s.Contains("after-reattach")));
+
+        client.Kill(id);
+    }
+
+    [Fact]
+    public void ChildExit_ClosesDataPipe_AndListReportsCode()
+    {
+        using var client = PtyHostClient.Connect(_appId);
+        string id = client.Create(Guid.NewGuid().ToString(), 80, 24, "cmd.exe", new[] { "/q", "/c", "exit", "42" }, verbatim: true);
+        using var att = client.Attach(id);
+        // EOF on the data pipe is the exit signal...
+        ReadUntil(att.Data, _ => false, timeoutMs: 10000);
+        // ...and the exit code travels via list.
+        var info = Assert.Single(client.List());
+        Assert.True(info.HasExited);
+        Assert.Equal(42, info.ExitCode);
+        client.Kill(id);
+    }
+
+    [Fact]
+    public void Resize_ReachesTheSession()
+    {
+        using var client = PtyHostClient.Connect(_appId);
+        string id = client.Create(Guid.NewGuid().ToString(), 80, 24, "cmd.exe", new[] { "/q" }, verbatim: true);
+        client.Resize(id, 132, 40);
+        var info = Assert.Single(client.List());
+        Assert.Equal((132, 40), (info.Cols, info.Rows));
+        client.Kill(id);
+    }
+
+    [Fact]
+    public void DuplicateCreate_IsRefused()
+    {
+        using var client = PtyHostClient.Connect(_appId);
+        string id = client.Create("fixed-id", 80, 24, "cmd.exe", new[] { "/q" }, verbatim: true);
+        Assert.Throws<InvalidOperationException>(() => client.Create("fixed-id", 80, 24, "cmd.exe", new[] { "/q" }));
+        client.Kill(id);
+    }
+
+    [Fact]
+    public void Shutdown_KillsSessionsAndCompletes()
+    {
+        var server = new PtyHostServer(_appId + "-sd");
+        using var client = PtyHostClient.Connect(_appId + "-sd");
+        client.Create(Guid.NewGuid().ToString(), 80, 24, "cmd.exe", new[] { "/q" }, verbatim: true);
+        client.Shutdown();
+        Assert.True(server.Completion.Wait(5000), "shutdown must complete the host");
+    }
+}
+
+public class DumpModesTests
+{
+    [Fact]
+    public void DumpModes_RoundTripsToAFreshEmulator()
+    {
+        var a = new TerminalEmulator(80, 24);
+        a.Feed("\x1b[?1002h\x1b[?1006h\x1b[?2004h\x1b[?25l\x1b]0;my title\x07\x1b]7;file://PC/C:/work\x07"u8);
+        var b = new TerminalEmulator(80, 24);
+        b.Feed(System.Text.Encoding.UTF8.GetBytes(a.DumpModes()));
+        Assert.True(b.MouseReporting);
+        Assert.True(b.MouseReportsMotion);
+        Assert.True(b.MouseSgr);
+        Assert.True(b.BracketedPaste);
+        Assert.False(b.CursorVisible);
+        Assert.Equal("my title", b.Title);
+        Assert.Equal("file://PC/C:/work", b.Cwd);
+        Assert.False(b.IsAltScreen);
+
+        // And a clean terminal dumps (nearly) nothing.
+        Assert.Equal("", new TerminalEmulator(80, 24).DumpModes());
+    }
+
+    [Fact]
+    public void DumpModes_CarriesAltScreen()
+    {
+        var a = new TerminalEmulator(80, 24);
+        a.Feed("\x1b[?1049h"u8);
+        var b = new TerminalEmulator(80, 24);
+        b.Feed(System.Text.Encoding.UTF8.GetBytes(a.DumpModes()));
+        Assert.True(b.IsAltScreen);
+    }
+}


### PR DESCRIPTION
## What

The headless half of the pty-host (#105, first of ~4 Phase-2 PRs): **`Agwinterm.Win32.exe --pty-host`** runs a windowless server that *owns* terminal sessions, so they can survive UI restarts and crashes. **No UI integration yet** — nothing changes for users; Phase 2b plugs this into the `ISessionBackend` seam from #108 behind the `session-host` knob.

### Wire model

- **One control pipe** (`<appId>-ptyhost`, newline-JSON in the control-API style): `hello` (hard version handshake — mismatches fail loudly, never garble), `create`, `attach`, `detach`, `resize`, `kill`, `list`, `shutdown`.
- **One data pipe per attach** (full duplex, raw bytes): client→host is child stdin, host→client is verbatim ConPTY output. Host-side EOF = child exited (code travels via `list`); client-side EOF = detach — **the session keeps running**. One attached client per session; a new attach supersedes the old pipe.

### Reattach model (v1, deliberately simple)

The attach response carries the host emulator''s scrollback as **plain text** (the client seeds it dimmed — exactly the existing restart buffer-restore semantics) plus **mode state as synthesized VT** (new `TerminalEmulator.DumpModes()`: alt screen, cursor visibility, mouse `1000/1002/1003/1006`, bracketed paste, title, OSC-7 cwd), then a **ConPTY resize-jiggle** makes the running app repaint the live viewport in full color on the new pipe. Attributed-grid serialization can replace the text seed later **without a protocol change**.

### Supporting pieces

- `TerminalSession.RawOutput` — opt-in raw-chunk tap (copies only while subscribed) so the host forwards ConPTY bytes verbatim while its authoritative emulator stays fed.
- `PtyHostClient` — typed control-pipe client (tests today, the Phase-2b backend tomorrow).
- `--pty-host` parsed before any window/config/D2D setup; the process exits on `shutdown`.

## Evidence

- **237/237 tests.** Integration tests run a real `PtyHostServer` over **real named pipes with real child processes**: create→attach→type→echo round-trip; detach → session survives → reattach hands back scrollback + modes and streams live; child exit = data-pipe EOF + exit code via `list`; resize; duplicate-create refused; shutdown completes the host. `DumpModes` round-trips into a fresh emulator (incl. alt screen).
- **Exe-level E2E** (the process boundary tests elide): headless start (`MainWindowHandle == 0`), handshake ack with host pid, `protocol=99` rejected with a named mismatch, **the session survived its creating client''s death**, `shutdown` acked `{"ok":true}` then exit code 0.
- Gotcha honored: cmd.exe switches need verbatim command lines under Porta quoting — the protocol carries a `verbatim` flag (matches the existing `TerminalSessionTests` precedent).

## What''s next (separate PRs)

2b: `ServerSessionBackend` implementing `ISession` over this protocol (client-side emulator replica). 2c: reconnect + adoption on UI start. 2d: the experimental Settings toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k