### PR TITLE
feat(pty-host): ServerSessionBackend — session-host=server goes live (Phase 2b, #105)

### DIFF
--- a/src/Agwinterm.Core/TerminalConfig.cs
+++ b/src/Agwinterm.Core/TerminalConfig.cs
@@ -81,8 +81,8 @@ public sealed class TerminalConfig
     public bool UpdateCheck { get; set; } = true;
 
     /// <summary>Where terminal sessions live: "in-process" (default — the UI process owns the
-    /// ConPTYs) or "server" (reserved: a separate pty-host process so sessions survive UI updates
-    /// and crashes — issue #105; falls back to in-process until it ships).</summary>
+    /// ConPTYs) or "server" (EXPERIMENTAL, #105 — a separate pty-host process owns them; the
+    /// long-term basis for sessions surviving UI updates/crashes).</summary>
     public string SessionHost { get; set; } = "in-process";
 
     /// <summary>Characters that DELIMIT words for double-click selection (in addition to whitespace).
@@ -241,9 +241,9 @@ public sealed class TerminalConfig
         update-check = true
 
         # Where terminal sessions live. "in-process" (default): the window process owns them.
-        # "server" (EXPERIMENTAL, not shipped yet - see github issue #105): a separate pty-host
-        # process owns them, so shells survive UI updates and crashes; falls back to in-process
-        # until it ships.
+        # "server" (EXPERIMENTAL - see github issue #105): a separate pty-host process owns them -
+        # the groundwork for shells surviving UI updates and crashes. In this phase closing a pane
+        # or the app still closes its sessions (survival + adoption land next).
         session-host = in-process
 
         # Blocked sound: play a sound whenever a session enters the "blocked" agent status (needs

--- a/src/Agwinterm.Pty/PtyHostClient.cs
+++ b/src/Agwinterm.Pty/PtyHostClient.cs
@@ -65,7 +65,7 @@ public sealed class PtyHostClient : IDisposable
 
     /// <summary>Create a session on the host (not attached yet — call <see cref="Attach"/>).</summary>
     public string Create(string id, int cols, int rows, string app, string[] args,
-        string? cwd = null, IReadOnlyDictionary<string, string>? env = null, bool verbatim = false)
+        string? cwd = null, IReadOnlyDictionary<string, string>? env = null, bool verbatim = false, bool deElevate = false)
     {
         using var ms = new MemoryStream();
         using (var w = new Utf8JsonWriter(ms))
@@ -76,6 +76,7 @@ public sealed class PtyHostClient : IDisposable
             w.WriteNumber("cols", cols); w.WriteNumber("rows", rows);
             w.WriteString("app", app);
             if (verbatim) w.WriteBoolean("verbatim", true);
+            if (deElevate) w.WriteBoolean("deElevate", true);
             w.WriteStartArray("args");
             foreach (var a in args) w.WriteStringValue(a);
             w.WriteEndArray();

--- a/src/Agwinterm.Pty/PtyHostServer.cs
+++ b/src/Agwinterm.Pty/PtyHostServer.cs
@@ -134,6 +134,7 @@ public sealed class PtyHostServer : IDisposable
             ? av.EnumerateArray().Select(e => e.GetString() ?? "").ToArray() : Array.Empty<string>();
         string? cwd = GetString(root, "cwd");
         bool verbatim = root.TryGetProperty("verbatim", out var vb) && vb.ValueKind == JsonValueKind.True;
+        bool deElevate = root.TryGetProperty("deElevate", out var de) && de.ValueKind == JsonValueKind.True;
         Dictionary<string, string>? env = null;
         if (root.TryGetProperty("env", out var ev) && ev.ValueKind == JsonValueKind.Object)
         {
@@ -161,7 +162,19 @@ public sealed class PtyHostServer : IDisposable
             }
         };
         session.Exited += _ => CloseData(hosted);
-        _ = session.StartAsync(app, args, verbatimCommandLine: verbatim, extraEnv: env, cwd: cwd);
+        // Await the spawn so a failure (bad exe, bad cwd) travels back as the create's error —
+        // fire-and-forget here would leave the client attached to a session that never lived.
+        try
+        {
+            session.StartAsync(app, args, verbatimCommandLine: verbatim, extraEnv: env, cwd: cwd, deElevate: deElevate)
+                .GetAwaiter().GetResult();
+        }
+        catch (Exception ex)
+        {
+            lock (_lock) _sessions.Remove(id);
+            try { session.Dispose(); } catch { }
+            return Err("spawn failed: " + ex.Message);
+        }
         return Ok(w => w.WriteString("id", id));
     }
 

--- a/src/Agwinterm.Pty/ServerSession.cs
+++ b/src/Agwinterm.Pty/ServerSession.cs
@@ -1,0 +1,259 @@
+using System.Diagnostics;
+using Agwinterm.Core;
+using Microsoft.Win32.SafeHandles;
+
+namespace Agwinterm.Pty;
+
+/// <summary>
+/// The pty-host session backend (#105, Phase 2b): sessions live in the <c>--pty-host</c> process;
+/// the UI holds <see cref="ServerSession"/> handles. Selected by <c>session-host = server</c>.
+/// Spawns the host on demand (same exe, host role) and connects lazily — construction is cheap and
+/// never touches the wire; the first <see cref="Create"/> does.
+/// </summary>
+public sealed class ServerSessionBackend : ISessionBackend, IDisposable
+{
+    private readonly string _appId;
+    private readonly string? _exePath;
+    private readonly object _lock = new();
+    private PtyHostClient? _client;
+
+    /// <param name="appId">Instance id — names the host's control pipe.</param>
+    /// <param name="exePath">The agwinterm exe to spawn with <c>--pty-host</c> when no host is
+    /// running; null = require an already-running host (tests).</param>
+    public ServerSessionBackend(string appId, string? exePath)
+    {
+        _appId = appId;
+        _exePath = exePath;
+    }
+
+    public string Name => "server";
+
+    public ISession Create(int cols, int rows)
+    {
+        EnsureClient();   // connect/spawn NOW so an unreachable host fails here, where callers can fall back
+        return new ServerSession(this, cols, rows);
+    }
+
+    internal PtyHostClient Client => EnsureClient();
+
+    private PtyHostClient EnsureClient()
+    {
+        lock (_lock)
+        {
+            if (_client is not null) return _client;
+            if (!PtyHostClient.IsRunning(_appId))
+            {
+                if (_exePath is null || !File.Exists(_exePath))
+                    throw new InvalidOperationException("no pty-host is running and no exe to spawn one");
+                var psi = new ProcessStartInfo(_exePath, $"--pty-host --pipe \"{_appId}\"")
+                { UseShellExecute = false, CreateNoWindow = true };
+                Process.Start(psi);
+                for (int i = 0; i < 50 && !PtyHostClient.IsRunning(_appId); i++) Thread.Sleep(100);
+            }
+            return _client = PtyHostClient.Connect(_appId);
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_lock) { _client?.Dispose(); _client = null; }
+    }
+}
+
+/// <summary>
+/// An <see cref="ISession"/> whose terminal lives in the pty-host process. The UI-side
+/// <see cref="Emulator"/> is a REPLICA fed by the host's raw ConPTY stream (the host keeps the
+/// authoritative one); input, resize, and lifecycle travel over the host protocol.
+///
+/// Phase 2b semantics: <see cref="Dispose"/> KILLS the hosted session — closing a pane behaves
+/// exactly like the in-process backend. Detach-and-survive (app quit leaves sessions running,
+/// next start adopts them) is Phase 2c, where dispose-for-quit and dispose-for-close diverge.
+/// </summary>
+public sealed class ServerSession : ISession
+{
+    private readonly object _sync = new();
+    private readonly ServerSessionBackend _backend;
+    private readonly string _id = Guid.NewGuid().ToString();
+    private Stream? _data;
+    private int? _childPid;
+    private volatile bool _started;
+    private volatile bool _disposed;
+
+    public TerminalEmulator Emulator { get; }
+    public int Cols { get; private set; }
+    public int Rows { get; private set; }
+    public int? ChildProcessId => _childPid;
+    public object SyncRoot => _sync;
+    public event Action? OutputReceived;
+
+    public int? ExitCode { get; private set; }
+    public bool HasExited { get; private set; }
+    public event Action<int>? Exited;
+
+    internal ServerSession(ServerSessionBackend backend, int cols, int rows)
+    {
+        _backend = backend;
+        Cols = cols;
+        Rows = rows;
+        Emulator = new TerminalEmulator(cols, rows);
+    }
+
+    // ---- Agent status: a UI-process concept (set via the control API), tracked locally exactly
+    // like TerminalSession — the host knows nothing about it. Kept duplicated (25 lines) rather
+    // than shared so the two implementations stay independently obvious.
+    public AgentStatus Status { get; private set; } = AgentStatus.Idle;
+    public bool Blink { get; private set; }
+    public bool AutoReset { get; private set; }
+    public event Action? StatusChanged;
+    public event Action<string?>? SoundRequested;
+
+    public void SetStatus(AgentStatus status, bool blink = false, bool autoReset = false,
+        bool sound = false, string? soundName = null)
+    {
+        bool newBlink = blink && status != AgentStatus.Idle;
+        bool newAuto = autoReset && status != AgentStatus.Idle;
+        bool changed = Status != status || Blink != newBlink || AutoReset != newAuto;
+        Status = status;
+        Blink = newBlink;
+        AutoReset = newAuto;
+        if (sound && status != AgentStatus.Idle)
+            try { SoundRequested?.Invoke(soundName); } catch { }
+        if (changed) StatusChanged?.Invoke();
+    }
+
+    public void NotifyActivity()
+    {
+        if (Status is AgentStatus.Blocked or AgentStatus.Completed)
+            SetStatus(AgentStatus.Idle);
+    }
+
+    // ---- Lifecycle ----
+
+    public async Task StartAsync(string app, string[] commandLine, bool verbatimCommandLine = false,
+        IReadOnlyDictionary<string, string>? extraEnv = null, string? cwd = null, bool deElevate = false,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            await Task.Run(() =>
+            {
+                var client = _backend.Client;
+                client.Create(_id, Cols, Rows, app, commandLine, cwd, extraEnv,
+                    verbatim: verbatimCommandLine, deElevate: deElevate);
+                var att = client.Attach(_id);
+                _data = att.Data;
+                _childPid = att.ChildPid;
+            }, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Same shape as TerminalSession's de-elevate failure: surface it IN the pane instead of
+            // leaving a dead surface (or crashing an unobserved fire-and-forget task).
+            var msg = $"\r\n\x1b[31m[agwinterm] pty-host session failed to start:\x1b[0m\r\n  {ex.Message}\r\n";
+            lock (_sync) Emulator.Feed(System.Text.Encoding.UTF8.GetBytes(msg));
+            OutputReceived?.Invoke();
+            ExitCode = 1; HasExited = true;
+            return;
+        }
+        _started = true;
+        _ = Task.Factory.StartNew(ReadLoop, CancellationToken.None,
+            TaskCreationOptions.LongRunning, TaskScheduler.Default);
+    }
+
+    public async Task<int> RunAsync(string app, string[] commandLine, bool verbatimCommandLine = false, CancellationToken ct = default)
+    {
+        var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Exited += code => tcs.TrySetResult(code);                    // subscribe BEFORE start: no exit race
+        await StartAsync(app, commandLine, verbatimCommandLine, ct: ct).ConfigureAwait(false);
+        if (HasExited) return ExitCode ?? 0;                         // failed to start / exited during attach
+        return await tcs.Task.ConfigureAwait(false);
+    }
+
+    /// <summary>Default-terminal handoff hands us raw HANDLES — they only mean something in this
+    /// process. Handoff panes are pinned to the in-process backend at the creation site.</summary>
+    public void Attach(SafeFileHandle conOut, SafeFileHandle conIn, SafeFileHandle signal, IntPtr clientProcess, int pid)
+        => throw new NotSupportedException("default-terminal handoff sessions run in-process");
+
+    /// <summary>Mirror of TerminalSession's pump, fed by the host's data pipe instead of ConPTY.</summary>
+    private void ReadLoop()
+    {
+        var data = _data!;
+        var buffer = new byte[64 * 1024];
+        try
+        {
+            while (true)
+            {
+                int n = data.Read(buffer, 0, buffer.Length);
+                if (n <= 0) break;
+                lock (_sync) Emulator.Feed(buffer.AsSpan(0, n));
+                OutputReceived?.Invoke();
+            }
+        }
+        catch (IOException) { }
+        catch (ObjectDisposedException) { }
+        OnStreamEnded();
+    }
+
+    /// <summary>Data-pipe EOF: the child exited, the session was killed, or the host died — ask the
+    /// host which (the exit code travels via <c>list</c>). A locally-initiated dispose is none of
+    /// these. An EOF for a session the host says is still alive is a supersede/detach: not an exit.</summary>
+    private void OnStreamEnded()
+    {
+        if (_disposed || HasExited) return;
+        int? code = null;
+        try
+        {
+            var info = _backend.Client.List().FirstOrDefault(i => i.Id == _id);
+            if (info is not null && !info.HasExited) return;         // detached, still running (2c territory)
+            code = info?.ExitCode;
+        }
+        catch { }                                                    // host gone → exited, code unknown
+        ExitCode = code;
+        HasExited = true;
+        try { Exited?.Invoke(code ?? 0); } catch { }
+    }
+
+    // ---- I/O ----
+
+    public void Inject(ReadOnlySpan<byte> bytes)
+    {
+        lock (_sync) Emulator.Feed(bytes);
+        OutputReceived?.Invoke();
+    }
+
+    public void MutateLocked(Action<TerminalEmulator> mutate)
+    {
+        lock (_sync) mutate(Emulator);
+        OutputReceived?.Invoke();
+    }
+
+    public void Write(ReadOnlySpan<byte> bytes)
+    {
+        var data = _data ?? throw new InvalidOperationException("Session not started.");
+        data.Write(bytes);
+        data.Flush();
+    }
+
+    public void Resize(int cols, int rows)
+    {
+        if (cols <= 0 || rows <= 0) return;
+        lock (_sync) Emulator.Resize(cols, rows);
+        Cols = cols;
+        Rows = rows;
+        if (_started && !HasExited)
+            try { _backend.Client.Resize(_id, cols, rows); } catch { }   // host gone → EOF path reports it
+    }
+
+    public string SnapshotRow(int row)
+    {
+        lock (_sync) return Emulator.DumpRow(row);
+    }
+
+    public void Dispose()
+    {
+        _disposed = true;
+        if (_started)
+            try { _backend.Client.Kill(_id); } catch { }             // Phase 2b: dispose = close = kill
+        try { _data?.Dispose(); } catch { }
+    }
+}

--- a/src/Agwinterm.Pty/SessionBackend.cs
+++ b/src/Agwinterm.Pty/SessionBackend.cs
@@ -24,12 +24,12 @@ public sealed class InProcessSessionBackend : ISessionBackend
 
 public static class SessionBackends
 {
-    /// <summary>Resolve the configured <c>session-host</c> value to a backend. "server" is reserved
-    /// for the pty-host process (#105) and falls back to in-process until it ships —
-    /// <paramref name="fellBack"/> lets the caller tell the user instead of silently ignoring it.</summary>
-    public static ISessionBackend Resolve(string? configured, out bool fellBack)
-    {
-        fellBack = string.Equals(configured, "server", StringComparison.OrdinalIgnoreCase);
-        return InProcessSessionBackend.Instance;
-    }
+    /// <summary>Resolve the configured <c>session-host</c> value to a backend. "server" (#105,
+    /// experimental) hosts sessions in the pty-host process — spawned on demand from
+    /// <paramref name="exePath"/> (the same exe, <c>--pty-host</c> role) under
+    /// <paramref name="appId"/>'s pipe namespace. Anything else = in-process.</summary>
+    public static ISessionBackend Resolve(string? configured, string appId, string? exePath)
+        => string.Equals(configured, "server", StringComparison.OrdinalIgnoreCase)
+            ? new ServerSessionBackend(appId, exePath)
+            : InProcessSessionBackend.Instance;
 }

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -54,7 +54,19 @@ internal partial class Program
         bool deElevate = false, HandoffArgs? handoff = null)
     {
         var (cols, rows) = GridSizeFor(fontSize);
-        var session = _sessionBackend.Create(cols, rows);   // the ONLY session creation site (see ISessionBackend)
+        // The ONLY session creation site (see ISessionBackend). Handoff panes are pinned in-process
+        // (their ConPTY handles only mean something here); an unreachable pty-host demotes the pane
+        // to in-process with a visible note rather than a dead surface.
+        ISession session;
+        if (handoff is not null) session = InProcessSessionBackend.Instance.Create(cols, rows);
+        else if (ReferenceEquals(_sessionBackend, InProcessSessionBackend.Instance)) session = _sessionBackend.Create(cols, rows);
+        else
+            try { session = _sessionBackend.Create(cols, rows); }
+            catch (Exception ex)
+            {
+                session = InProcessSessionBackend.Instance.Create(cols, rows);
+                ShowToast("pty-host unavailable (" + ex.Message + ") — session created in-process", 5000);
+            }
         session.Emulator.ScrollbackMax = _config.Scrollback;
         var pane = new Pane { Id = paneId, S = session, StartCwd = cwd, FontSize = fontSize };
         // New output only snaps this pane back to the live bottom and drops the selection when the buffer

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -423,7 +423,7 @@ internal partial class Program : ISessionHost, IWindowHost
         SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
         // Process-global setup (config/themes/keymap + window class + shared D2D/DWrite objects).
         _config = LoadOrCreateConfig();
-        _sessionBackend = SessionBackends.Resolve(_config.SessionHost, out bool sessionHostFellBack);
+        _sessionBackend = SessionBackends.Resolve(_config.SessionHost, _argPipe ?? _appId, AppExePath);
         _allThemes = LoadThemes();
         _theme = FindTheme(_config.Theme);
         LoadKeymap();
@@ -477,10 +477,10 @@ internal partial class Program : ISessionHost, IWindowHost
             front ??= w;
         }
         Frontmost = front!;
-        // `session-host = server` is reserved for the pty-host process (#105); say so instead of
-        // silently ignoring the key while Phase 2 is unbuilt.
-        if (sessionHostFellBack)
-            front!.Post(() => front.ShowToast("session-host = server isn't available yet (#105) — using in-process", 6000));
+        // Server mode is experimental (#105) — say so once at startup, so a flipped knob is never
+        // a silent mystery ("why is there a second agwinterm process?").
+        if (_sessionBackend is ServerSessionBackend)
+            front!.Post(() => front.ShowToast("session-host = server (experimental) — sessions live in the pty-host process", 6000));
 
         while (GetMessageW(out MSG msg, IntPtr.Zero, 0, 0) > 0)
         {

--- a/tests/Agwinterm.Pty.Tests/ServerSessionTests.cs
+++ b/tests/Agwinterm.Pty.Tests/ServerSessionTests.cs
@@ -1,0 +1,119 @@
+using Agwinterm.Pty;
+
+namespace Agwinterm.Pty.Tests;
+
+/// <summary>Phase 2b: the FULL ISession contract exercised over the pty-host wire — a real
+/// PtyHostServer, real named pipes, real child processes; only `--pty-host`'s process boundary is
+/// elided. These mirror what the UI does through the seam, so green here = panes work in server mode.</summary>
+public class ServerSessionTests : IDisposable
+{
+    private readonly string _appId = "agwinterm-test-" + Guid.NewGuid().ToString("N")[..8];
+    private readonly PtyHostServer _server;
+    private readonly ServerSessionBackend _backend;
+
+    public ServerSessionTests()
+    {
+        _server = new PtyHostServer(_appId);
+        _backend = new ServerSessionBackend(_appId, exePath: null);   // host already running (above)
+    }
+
+    public void Dispose() { _backend.Dispose(); _server.Dispose(); }
+
+    private static bool WaitFor(Func<bool> cond, int timeoutMs = 15000)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (sw.ElapsedMilliseconds < timeoutMs) { if (cond()) return true; Thread.Sleep(50); }
+        return cond();
+    }
+
+    private static string GridText(ISession s)
+    {
+        lock (s.SyncRoot) return string.Join("\n", s.Emulator.DumpBuffer());
+    }
+
+    [Fact]
+    public async Task TypeEcho_LandsInTheReplicaEmulator()
+    {
+        using var s = _backend.Create(100, 24);
+        Assert.Null(s.ChildProcessId);                                 // not started yet — mirrors TerminalSession
+        int outputEvents = 0;
+        s.OutputReceived += () => Interlocked.Increment(ref outputEvents);
+
+        await s.StartAsync("cmd.exe", new[] { "/q" }, verbatimCommandLine: true);
+        Assert.True(s.ChildProcessId > 0);
+        Assert.False(s.HasExited);
+
+        s.Write("echo replica+works\r"u8);
+        Assert.True(WaitFor(() => GridText(s).Contains("replica+works")),
+            "typed echo never reached the replica emulator; grid:\n" + GridText(s));
+        Assert.True(outputEvents > 0);
+    }
+
+    [Fact]
+    public async Task ExitCode_TravelsViaExitedEvent_AndRunAsync()
+    {
+        using var s = _backend.Create(80, 24);
+        var exited = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        s.Exited += code => exited.TrySetResult(code);
+        await s.StartAsync("cmd.exe", new[] { "/q", "/c", "exit", "5" }, verbatimCommandLine: true);
+        Assert.Equal(5, await exited.Task.WaitAsync(TimeSpan.FromSeconds(15)));
+        Assert.True(s.HasExited);
+        Assert.Equal(5, s.ExitCode);
+
+        using var r = _backend.Create(80, 24);
+        Assert.Equal(7, await r.RunAsync("cmd.exe", new[] { "/q", "/c", "exit", "7" }, verbatimCommandLine: true)
+            .WaitAsync(TimeSpan.FromSeconds(15)));
+    }
+
+    [Fact]
+    public async Task Resize_UpdatesReplicaAndHost()
+    {
+        using var s = _backend.Create(80, 24);
+        await s.StartAsync("cmd.exe", new[] { "/q" }, verbatimCommandLine: true);
+        s.Resize(132, 40);
+        Assert.Equal((132, 40), (s.Cols, s.Rows));
+        lock (s.SyncRoot) Assert.Equal(132, s.Emulator.Screen.Cols);
+        using var probe = PtyHostClient.Connect(_appId);
+        var info = Assert.Single(probe.List());
+        Assert.Equal((132, 40), (info.Cols, info.Rows));
+    }
+
+    [Fact]
+    public async Task Dispose_KillsTheHostedSession_Phase2bSemantics()
+    {
+        var s = _backend.Create(80, 24);
+        await s.StartAsync("cmd.exe", new[] { "/q" }, verbatimCommandLine: true);
+        s.Dispose();
+        using var probe = PtyHostClient.Connect(_appId);
+        Assert.True(WaitFor(() => probe.List().Count == 0, 5000),
+            "Phase 2b: closing a pane must kill its hosted session (survival is Phase 2c)");
+    }
+
+    [Fact]
+    public void PreStart_InjectAndSeedWork_ForTheRestorePath()
+    {
+        using var s = _backend.Create(80, 24);
+        // Restore seeds buffers and paints banners BEFORE the shell starts — must work replica-side.
+        lock (s.SyncRoot) s.Emulator.SeedScrollback(new[] { "restored line" });
+        s.Inject("hello"u8);
+        Assert.Contains("hello", GridText(s));
+        lock (s.SyncRoot) Assert.Equal(1, s.Emulator.HistoryCount);
+        Assert.Throws<InvalidOperationException>(() => s.Write("x"u8));   // not started — same contract as in-process
+    }
+
+    [Fact]
+    public void HandoffAttach_IsNotSupported()
+    {
+        using var s = _backend.Create(80, 24);
+        Assert.Throws<NotSupportedException>(() => s.Attach(null!, null!, null!, IntPtr.Zero, 0));
+    }
+
+    [Fact]
+    public async Task StartFailure_PaintsTheErrorIntoThePane()
+    {
+        using var s = _backend.Create(80, 24);
+        await s.StartAsync("definitely-not-a-real-exe-agw.exe", Array.Empty<string>());
+        Assert.True(WaitFor(() => s.HasExited, 10000));
+        Assert.Equal(1, s.ExitCode);
+    }
+}

--- a/tests/Agwinterm.Pty.Tests/SessionBackendTests.cs
+++ b/tests/Agwinterm.Pty.Tests/SessionBackendTests.cs
@@ -19,16 +19,20 @@ public class SessionBackendTests
     }
 
     [Fact]
-    public void Resolve_ServerFallsBackToInProcessAndSaysSo()
+    public void Resolve_PicksBackendByConfiguredValue()
     {
-        // "server" is reserved for the pty-host (#105). Until Phase 2 ships it must fall back —
-        // and report that it did, so the UI can tell the user instead of silently ignoring the key.
-        Assert.Same(InProcessSessionBackend.Instance, SessionBackends.Resolve("in-process", out bool fb1));
-        Assert.False(fb1);
-        Assert.Same(InProcessSessionBackend.Instance, SessionBackends.Resolve("server", out bool fb2));
-        Assert.True(fb2);
-        Assert.Same(InProcessSessionBackend.Instance, SessionBackends.Resolve(null, out bool fb3));
-        Assert.False(fb3);
+        Assert.Same(InProcessSessionBackend.Instance, SessionBackends.Resolve("in-process", "x", null));
+        Assert.Same(InProcessSessionBackend.Instance, SessionBackends.Resolve(null, "x", null));
+        Assert.IsType<ServerSessionBackend>(SessionBackends.Resolve("server", "x", null));
+        Assert.IsType<ServerSessionBackend>(SessionBackends.Resolve("SERVER", "x", null));
+    }
+
+    [Fact]
+    public void ServerBackend_WithNoHostAndNoExe_FailsAtCreate()
+    {
+        // Failure surfaces at Create — the one place the UI can catch it and fall back in-process.
+        using var backend = new ServerSessionBackend("agwinterm-test-nohost-" + Guid.NewGuid().ToString("N")[..8], exePath: null);
+        Assert.Throws<InvalidOperationException>(() => backend.Create(80, 24));
     }
 
     [Fact]


### PR DESCRIPTION
## What

Phase 2b of the pty-host plan (#105): the client half. `ServerSession` implements `ISession` over the Phase-2a protocol, so **`session-host = server` now actually works** — every pane''s terminal lives in the auto-spawned `--pty-host` process, and the UI renders from a client-side emulator replica fed by the host''s raw ConPTY stream. Experimental, config-key-only opt-in (the Settings toggle is Phase 2d); default stays `in-process`, untouched.

### How it fits the seam

Thanks to #108, no pane/render/control code changes at all — `ServerSession` slots in behind `ISessionBackend`:

- **Replica model:** read loop mirrors `TerminalSession`''s pump (lock → `Emulator.Feed` → `OutputReceived`); `Write` goes down the data pipe; `Resize` updates the replica and the host; `Inject`/`MutateLocked`/`SeedScrollback` are purely local, so the restore path (buffer seeding, banners) works before the shell starts.
- **Exit semantics:** data-pipe EOF triggers a `list` lookup that distinguishes child-exit (code), killed, and host-gone from a mere detach. `RunAsync` (overlays) rides the `Exited` event. Start failures are painted INTO the pane, same as the de-elevate precedent.
- **Agent status stays UI-local** — it''s a control-API concept; the host knows nothing about it.
- **Deliberate 2b semantics: `Dispose` = kill.** Closing a pane behaves byte-for-byte like in-process. The dispose-for-quit / dispose-for-close split — the actual survival feature — is Phase 2c, so this PR stays behaviorally conservative.

### Guard rails

- Default-terminal **handoff panes are pinned in-process** (their ConPTY handles only mean something in the UI process).
- **Unreachable host → the pane demotes to in-process with a toast**, never a dead surface.
- Startup toast announces server mode, so the second agwinterm process is never a mystery.
- Protocol hardening found by test: `create` now **awaits the spawn** — a bad exe/cwd comes back as the create error instead of a silently dead session. `create` also carries `deElevate`.

## Evidence

- **245/245 tests** — the full `ISession` contract exercised over real named pipes with real child processes: typed echo lands in the replica grid, exit codes via event and `RunAsync`, resize visible on both sides, dispose kills the hosted session, pre-start inject/seed, handoff refused, spawn failure painted into the pane.
- **E2E on the dev instance** with `session-host = server`: the host was auto-spawned (verified by command line), the host''s `list` showed both restored panes hosted and attached, a control-API echo round-tripped UI → wire → ConPTY → raw stream → replica → `session text`, split/unsplit created and killed hosted sessions, and rendering (split panes, omp prompt colors) is pixel-identical — screenshots in chat.

Next: **2c** — detach-on-quit + adoption-on-start (the payoff: sessions survive UI restarts), then **2d** — the Settings toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k