### PR TITLE
feat(pty-host): detach-on-quit + adoption-on-start — sessions survive UI restarts (Phase 2c, #105)

### DIFF
--- a/src/Agwinterm.App/MainWindow.xaml.cs
+++ b/src/Agwinterm.App/MainWindow.xaml.cs
@@ -207,7 +207,7 @@ public sealed partial class MainWindow : Window, ISessionHost
     {
         StartControlServerOnce();
         var (cols, rows) = ComputeGridSize();
-        var session = InProcessSessionBackend.Instance.Create(cols, rows);
+        var session = InProcessSessionBackend.Instance.Create(Guid.NewGuid().ToString(), cols, rows);
         int ordinal;
         lock (_workspaces) ordinal = ws.Sessions.Count + 1;
         var ses = new Ses { Id = id, Name = name ?? $"session {ordinal}", S = session, Ws = ws };

--- a/src/Agwinterm.Pty/ISession.cs
+++ b/src/Agwinterm.Pty/ISession.cs
@@ -65,4 +65,10 @@ public interface ISession : IDisposable
     void Resize(int cols, int rows);
     /// <summary>Thread-safe text snapshot of one visible row.</summary>
     string SnapshotRow(int row);
+
+    /// <summary>Release the UI's hold WITHOUT necessarily killing (#105, Phase 2c): a server-backed
+    /// session detaches — the child keeps running in the pty-host for a later adoption. An
+    /// in-process session cannot outlive its process, so there this equals <see cref="IDisposable.Dispose"/>.
+    /// App-quit paths call this; explicit pane close still calls Dispose.</summary>
+    void Detach();
 }

--- a/src/Agwinterm.Pty/ServerSession.cs
+++ b/src/Agwinterm.Pty/ServerSession.cs
@@ -28,10 +28,10 @@ public sealed class ServerSessionBackend : ISessionBackend, IDisposable
 
     public string Name => "server";
 
-    public ISession Create(int cols, int rows)
+    public ISession Create(string id, int cols, int rows)
     {
         EnsureClient();   // connect/spawn NOW so an unreachable host fails here, where callers can fall back
-        return new ServerSession(this, cols, rows);
+        return new ServerSession(this, id, cols, rows);
     }
 
     internal PtyHostClient Client => EnsureClient();
@@ -73,7 +73,7 @@ public sealed class ServerSession : ISession
 {
     private readonly object _sync = new();
     private readonly ServerSessionBackend _backend;
-    private readonly string _id = Guid.NewGuid().ToString();
+    private readonly string _id;   // = the pane id; names the hosted session (the adoption key)
     private Stream? _data;
     private int? _childPid;
     private volatile bool _started;
@@ -90,13 +90,19 @@ public sealed class ServerSession : ISession
     public bool HasExited { get; private set; }
     public event Action<int>? Exited;
 
-    internal ServerSession(ServerSessionBackend backend, int cols, int rows)
+    internal ServerSession(ServerSessionBackend backend, string id, int cols, int rows)
     {
         _backend = backend;
+        _id = id;
         Cols = cols;
         Rows = rows;
         Emulator = new TerminalEmulator(cols, rows);
     }
+
+    /// <summary>True when this handle reconnected to a SURVIVING hosted session instead of spawning
+    /// a fresh shell — restore must then skip buffer seeding, agent-resume typing, and
+    /// restore-commands (the real thing is still running; typing a resume into it would be chaos).</summary>
+    public bool Adopted { get; private set; }
 
     // ---- Agent status: a UI-process concept (set via the control API), tracked locally exactly
     // like TerminalSession — the host knows nothing about it. Kept duplicated (25 lines) rather
@@ -167,6 +173,36 @@ public sealed class ServerSession : ISession
         await StartAsync(app, commandLine, verbatimCommandLine, ct: ct).ConfigureAwait(false);
         if (HasExited) return ExitCode ?? 0;                         // failed to start / exited during attach
         return await tcs.Task.ConfigureAwait(false);
+    }
+
+    /// <summary>Adopt a surviving hosted session with this pane's id (after a UI restart or crash):
+    /// attach with a repaint, seed the replica from the host's snapshot (scrollback text + modes),
+    /// and go live — the child process keeps running untouched. False = nothing to adopt, launch
+    /// fresh; an exited leftover is reaped here so the fresh launch starts clean.</summary>
+    public bool TryAdopt()
+    {
+        PtyHostAttachment att;
+        try { att = _backend.Client.Attach(_id, repaint: true); }
+        catch { return false; }                       // no such session (or host unreachable)
+        if (att.HasExited)
+        {
+            att.Dispose();
+            try { _backend.Client.Kill(_id); } catch { }
+            return false;
+        }
+        lock (_sync)
+        {
+            Emulator.SeedScrollback(att.Scrollback);
+            Emulator.Feed(System.Text.Encoding.UTF8.GetBytes(att.Modes));
+        }
+        _data = att.Data;
+        _childPid = att.ChildPid;
+        Adopted = true;
+        _started = true;
+        _ = Task.Factory.StartNew(ReadLoop, CancellationToken.None,
+            TaskCreationOptions.LongRunning, TaskScheduler.Default);
+        OutputReceived?.Invoke();
+        return true;
     }
 
     /// <summary>Default-terminal handoff hands us raw HANDLES — they only mean something in this
@@ -249,11 +285,19 @@ public sealed class ServerSession : ISession
         lock (_sync) return Emulator.DumpRow(row);
     }
 
+    /// <summary>Stop viewing WITHOUT killing: close the data pipe (the host sees a detach) and
+    /// leave the child running for a later <see cref="TryAdopt"/>. The app-quit path.</summary>
+    public void Detach()
+    {
+        _disposed = true;                                            // EOF now means "we left", not "it died"
+        try { _data?.Dispose(); } catch { }
+    }
+
     public void Dispose()
     {
         _disposed = true;
         if (_started)
-            try { _backend.Client.Kill(_id); } catch { }             // Phase 2b: dispose = close = kill
+            try { _backend.Client.Kill(_id); } catch { }             // explicit close = kill (pane closed)
         try { _data?.Dispose(); } catch { }
     }
 }

--- a/src/Agwinterm.Pty/SessionBackend.cs
+++ b/src/Agwinterm.Pty/SessionBackend.cs
@@ -7,11 +7,13 @@ namespace Agwinterm.Pty;
 /// </summary>
 public interface ISessionBackend
 {
-    /// <summary>Stable name for diagnostics/toasts ("in-process", later "server").</summary>
+    /// <summary>Stable name for diagnostics/toasts ("in-process", "server").</summary>
     string Name { get; }
 
-    /// <summary>Create a session sized <paramref name="cols"/>×<paramref name="rows"/> (not yet started).</summary>
-    ISession Create(int cols, int rows);
+    /// <summary>Create a session sized <paramref name="cols"/>×<paramref name="rows"/> (not yet
+    /// started). <paramref name="id"/> is the PANE id — for the server backend it names the hosted
+    /// session, which is the adoption key after a UI restart (in-process ignores it).</summary>
+    ISession Create(string id, int cols, int rows);
 }
 
 /// <summary>Today's model: the UI process owns the ConPTY (a plain <see cref="TerminalSession"/>).</summary>
@@ -19,7 +21,7 @@ public sealed class InProcessSessionBackend : ISessionBackend
 {
     public static readonly InProcessSessionBackend Instance = new();
     public string Name => "in-process";
-    public ISession Create(int cols, int rows) => new TerminalSession(cols, rows);
+    public ISession Create(string id, int cols, int rows) => new TerminalSession(cols, rows);
 }
 
 public static class SessionBackends

--- a/src/Agwinterm.Pty/TerminalSession.cs
+++ b/src/Agwinterm.Pty/TerminalSession.cs
@@ -318,6 +318,9 @@ public sealed class TerminalSession : ISession
         lock (_sync) return Emulator.DumpRow(row);
     }
 
+    /// <summary>In-process sessions cannot outlive the process — detach IS dispose here.</summary>
+    public void Detach() => Dispose();
+
     public void Dispose()
     {
         var c = _connection;

--- a/src/Agwinterm.Win32/Program.Services.cs
+++ b/src/Agwinterm.Win32/Program.Services.cs
@@ -1161,6 +1161,10 @@ internal partial class Program
 
     private List<Pane> PanesOf(Ses s) { lock (_workspaces) return s.Panes.ToList(); }
 
+    /// <summary>Whether a pane reconnected to a surviving pty-host session on this restore
+    /// (see <see cref="ServerSession.Adopted"/>) — such panes' shells are LIVE, not fresh.</summary>
+    private static bool IsAdopted(Pane p) => p.S is ServerSession { Adopted: true };
+
     private static string DenylistPath => Path.Combine(AppDir, "restore-denylist.conf");
 
     /// <summary>Exe/process names (no extension) that restore-commands never re-runs. Seeds a starter file.</summary>
@@ -1428,10 +1432,12 @@ internal partial class Program
                         ses.Active = Math.Clamp(s.Active, 0, ses.Panes.Count - 1);
                     }
                     // Buffer-content restore: seed each pane's scrollback (dimmed) above the fresh shell.
+                    // ADOPTED panes skip it — they reconnected to the live session, whose real (and
+                    // fresher) scrollback came with the attach; seeding would duplicate it.
                     if (_config.RestoreBuffer)
                         lock (_workspaces)
                             for (int i = 0; i < pl.Count && i < ses.Panes.Count; i++)
-                                if (pl[i].Buffer is { Count: > 0 } b)
+                                if (pl[i].Buffer is { Count: > 0 } b && !IsAdopted(ses.Panes[i]))
                                 {
                                     var seed = new List<string>(b) { "──── restored ────" };
                                     var pane = ses.Panes[i];
@@ -1455,6 +1461,10 @@ internal partial class Program
                         string agent = pl[i].AgentResume ?? "";
                         if (agent.Length == 0) continue;
                         var apane = ses.Panes[i];
+                        // An ADOPTED pane's agent is STILL RUNNING — typing `claude --resume ...`
+                        // into it would land in the live agent's prompt. The binding stays for
+                        // future (non-adopted) restarts; nothing to relaunch now.
+                        if (IsAdopted(apane)) continue;
                         _ = Task.Run(async () =>
                         {
                             await Task.Delay(2500); // let the shell/profile settle so the wrapper function is defined
@@ -1469,6 +1479,7 @@ internal partial class Program
                         for (int i = 0; i < pl.Count && i < ses.Panes.Count; i++)
                         {
                             if (!string.IsNullOrWhiteSpace(pl[i].AgentResume)) continue; // agent panes handled above
+                            if (IsAdopted(ses.Panes[i])) continue;   // the captured command is still running
                             string cmd = pl[i].Command ?? "";
                             if (cmd.Length == 0) continue;
                             string lead = StripExe(cmd.TrimStart('"').Split(' ', 2)[0]);

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -56,15 +56,22 @@ internal partial class Program
         var (cols, rows) = GridSizeFor(fontSize);
         // The ONLY session creation site (see ISessionBackend). Handoff panes are pinned in-process
         // (their ConPTY handles only mean something here); an unreachable pty-host demotes the pane
-        // to in-process with a visible note rather than a dead surface.
+        // to in-process with a visible note rather than a dead surface. During restore, a server
+        // pane first tries to ADOPT a surviving hosted session with its id (UI restart/crash/update)
+        // — the still-running shell reconnects instead of a fresh one spawning.
         ISession session;
-        if (handoff is not null) session = InProcessSessionBackend.Instance.Create(cols, rows);
-        else if (ReferenceEquals(_sessionBackend, InProcessSessionBackend.Instance)) session = _sessionBackend.Create(cols, rows);
+        bool adopted = false;
+        if (handoff is not null) session = InProcessSessionBackend.Instance.Create(paneId, cols, rows);
+        else if (ReferenceEquals(_sessionBackend, InProcessSessionBackend.Instance)) session = _sessionBackend.Create(paneId, cols, rows);
         else
-            try { session = _sessionBackend.Create(cols, rows); }
+            try
+            {
+                session = _sessionBackend.Create(paneId, cols, rows);
+                adopted = _restoring && session is ServerSession ss && ss.TryAdopt();
+            }
             catch (Exception ex)
             {
-                session = InProcessSessionBackend.Instance.Create(cols, rows);
+                session = InProcessSessionBackend.Instance.Create(paneId, cols, rows);
                 ShowToast("pty-host unavailable (" + ex.Message + ") — session created in-process", 5000);
             }
         session.Emulator.ScrollbackMax = _config.Scrollback;
@@ -112,6 +119,7 @@ internal partial class Program
             session.Attach(new Microsoft.Win32.SafeHandles.SafeFileHandle(h.ConOut, true),
                            new Microsoft.Win32.SafeHandles.SafeFileHandle(h.ConIn, true),
                            new Microsoft.Win32.SafeHandles.SafeFileHandle(h.Signal, true), h.Client, h.ClientPid);
+        else if (adopted) { /* reattached to the surviving shell — nothing to launch */ }
         else if (!string.IsNullOrWhiteSpace(command) && interactive)
             // Run the command in a fresh shell that STAYS OPEN afterwards (custom-command "new" mode):
             // the user's profile loads (oh-my-posh etc.), the command runs, then it's an interactive shell.
@@ -738,6 +746,36 @@ internal partial class Program
             ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".claude", "projects")
             : Path.Combine(cfg, "projects");
         return Path.Combine(projects, EncodeClaudeProject(cwd));
+    }
+
+    /// <summary>Kill hosted sessions no live pane claims (server mode): pane ids ARE hosted-session
+    /// ids, so anything unclaimed belongs to a closed pane (its kill lost to a crash) or already
+    /// exited. Every surface counts as a claim — panes, scratch, overlay, quick — across all
+    /// windows. Best-effort; runs once, well after restore/adoption has claimed everything.</summary>
+    private static void ReapOrphanedHostedSessions(string appId)
+    {
+        try
+        {
+            var claimed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            List<Program> wins;
+            lock (_windowIndex) wins = _byId.Values.ToList();
+            foreach (var w in wins)
+            {
+                lock (w._workspaces)
+                    foreach (var s in w._workspaces.SelectMany(x => x.Sessions))
+                    {
+                        foreach (var p in s.Panes) claimed.Add(p.Id);
+                        if (s.Scratch is { } sc) claimed.Add(sc.Id);
+                        if (s.Overlay is { } ov) claimed.Add(ov.Id);
+                    }
+                if (w._quick is { } q) claimed.Add(q.Id);
+            }
+            using var probe = Agwinterm.Pty.PtyHostClient.Connect(appId);
+            foreach (var info in probe.List())
+                if (!claimed.Contains(info.Id) || info.HasExited)
+                    try { probe.Kill(info.Id); } catch { }
+        }
+        catch { }   // host not running / racing shutdown — nothing to reap
     }
 
     /// <summary>Whether a Claude conversation transcript with this exact id exists for the folder.

--- a/src/Agwinterm.Win32/Program.WndProc.cs
+++ b/src/Agwinterm.Win32/Program.WndProc.cs
@@ -540,7 +540,18 @@ internal partial class Program
             case WM_DESTROY:
                 RemoveTrayIcon();                 // drop the shell tray balloon icon
                 SaveState(captureCommands: true); // persist this window's tree before tearing down its sessions
-                foreach (var s in AllSessions()) { foreach (var p in s.Panes) { try { p.S.Dispose(); } catch { } } try { s.Scratch?.S.Dispose(); } catch { } try { s.Overlay?.S.Dispose(); } catch { } }
+                // App-quit (last window, or an update-quit closing all of them) DETACHES panes —
+                // server-hosted sessions keep running and the next start adopts them (#105 2c).
+                // An explicit window close (others remain) still disposes = kills, like a pane
+                // close. Scratch/overlay/quick are never restored, so they always dispose.
+                bool quitting;
+                lock (_windowIndex) quitting = _updateQuitting || _byId.Count <= 1;
+                foreach (var s in AllSessions())
+                {
+                    foreach (var p in s.Panes) { try { if (quitting) p.S.Detach(); else p.S.Dispose(); } catch { } }
+                    try { s.Scratch?.S.Dispose(); } catch { }
+                    try { s.Overlay?.S.Dispose(); } catch { }
+                }
                 try { _quick?.S.Dispose(); } catch { }
                 bool lastWindow;
                 lock (_windowIndex)

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -480,7 +480,17 @@ internal partial class Program : ISessionHost, IWindowHost
         // Server mode is experimental (#105) — say so once at startup, so a flipped knob is never
         // a silent mystery ("why is there a second agwinterm process?").
         if (_sessionBackend is ServerSessionBackend)
+        {
             front!.Post(() => front.ShowToast("session-host = server (experimental) — sessions live in the pty-host process", 6000));
+            // Reap hosted sessions no pane claims — leftovers of closed panes whose kill raced a
+            // crash, or exited corpses. WELL after boot: restore/adoption must claim everything
+            // (incl. slow multi-window restores) before anything is judged an orphan.
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(TimeSpan.FromSeconds(30));
+                ReapOrphanedHostedSessions(_argPipe ?? _appId);
+            });
+        }
 
         while (GetMessageW(out MSG msg, IntPtr.Zero, 0, 0) > 0)
         {

--- a/tests/Agwinterm.Pty.Tests/ServerSessionTests.cs
+++ b/tests/Agwinterm.Pty.Tests/ServerSessionTests.cs
@@ -34,7 +34,7 @@ public class ServerSessionTests : IDisposable
     [Fact]
     public async Task TypeEcho_LandsInTheReplicaEmulator()
     {
-        using var s = _backend.Create(100, 24);
+        using var s = _backend.Create(Guid.NewGuid().ToString(), 100, 24);
         Assert.Null(s.ChildProcessId);                                 // not started yet — mirrors TerminalSession
         int outputEvents = 0;
         s.OutputReceived += () => Interlocked.Increment(ref outputEvents);
@@ -52,7 +52,7 @@ public class ServerSessionTests : IDisposable
     [Fact]
     public async Task ExitCode_TravelsViaExitedEvent_AndRunAsync()
     {
-        using var s = _backend.Create(80, 24);
+        using var s = _backend.Create(Guid.NewGuid().ToString(), 80, 24);
         var exited = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
         s.Exited += code => exited.TrySetResult(code);
         await s.StartAsync("cmd.exe", new[] { "/q", "/c", "exit", "5" }, verbatimCommandLine: true);
@@ -60,7 +60,7 @@ public class ServerSessionTests : IDisposable
         Assert.True(s.HasExited);
         Assert.Equal(5, s.ExitCode);
 
-        using var r = _backend.Create(80, 24);
+        using var r = _backend.Create(Guid.NewGuid().ToString(), 80, 24);
         Assert.Equal(7, await r.RunAsync("cmd.exe", new[] { "/q", "/c", "exit", "7" }, verbatimCommandLine: true)
             .WaitAsync(TimeSpan.FromSeconds(15)));
     }
@@ -68,7 +68,7 @@ public class ServerSessionTests : IDisposable
     [Fact]
     public async Task Resize_UpdatesReplicaAndHost()
     {
-        using var s = _backend.Create(80, 24);
+        using var s = _backend.Create(Guid.NewGuid().ToString(), 80, 24);
         await s.StartAsync("cmd.exe", new[] { "/q" }, verbatimCommandLine: true);
         s.Resize(132, 40);
         Assert.Equal((132, 40), (s.Cols, s.Rows));
@@ -81,7 +81,7 @@ public class ServerSessionTests : IDisposable
     [Fact]
     public async Task Dispose_KillsTheHostedSession_Phase2bSemantics()
     {
-        var s = _backend.Create(80, 24);
+        var s = _backend.Create(Guid.NewGuid().ToString(), 80, 24);
         await s.StartAsync("cmd.exe", new[] { "/q" }, verbatimCommandLine: true);
         s.Dispose();
         using var probe = PtyHostClient.Connect(_appId);
@@ -92,7 +92,7 @@ public class ServerSessionTests : IDisposable
     [Fact]
     public void PreStart_InjectAndSeedWork_ForTheRestorePath()
     {
-        using var s = _backend.Create(80, 24);
+        using var s = _backend.Create(Guid.NewGuid().ToString(), 80, 24);
         // Restore seeds buffers and paints banners BEFORE the shell starts — must work replica-side.
         lock (s.SyncRoot) s.Emulator.SeedScrollback(new[] { "restored line" });
         s.Inject("hello"u8);
@@ -102,16 +102,76 @@ public class ServerSessionTests : IDisposable
     }
 
     [Fact]
+    public async Task DetachAdopt_SameShellSurvivesAUiGeneration()
+    {
+        string paneId = Guid.NewGuid().ToString();
+
+        // "UI generation 1": start a shell, set modes + produce output, then DETACH (app quit).
+        var gen1 = _backend.Create(paneId, 100, 24);
+        await gen1.StartAsync("cmd.exe", new[] { "/q" }, verbatimCommandLine: true);
+        int? pid = gen1.ChildProcessId;
+        gen1.Write("echo pre+restart\r"u8);
+        Assert.True(WaitFor(() => GridText(gen1).Contains("pre+restart")));
+        Thread.Sleep(300);   // let the echo reach the HOST emulator too (its snapshot feeds adoption)
+        gen1.Detach();
+
+        // The host still runs the child, unattached.
+        using (var probe = PtyHostClient.Connect(_appId))
+        {
+            var info = Assert.Single(probe.List());
+            Assert.False(info.HasExited);
+            Assert.False(info.Attached);
+        }
+
+        // "UI generation 2": a fresh handle with the SAME pane id adopts it.
+        using var gen2 = (ServerSession)_backend.Create(paneId, 100, 24);
+        Assert.True(gen2.TryAdopt(), "adoption must find the surviving session");
+        Assert.True(gen2.Adopted);
+        Assert.Equal(pid, gen2.ChildProcessId);                      // SAME child process — the whole point
+        Assert.True(WaitFor(() => GridText(gen2).Contains("pre+restart")),
+            "pre-restart output missing after adoption; grid:\n" + GridText(gen2));
+
+        // And it's live: same shell keeps taking input.
+        gen2.Write("echo post+adopt\r"u8);
+        Assert.True(WaitFor(() => GridText(gen2).Contains("post+adopt")));
+    }
+
+    [Fact]
+    public void TryAdopt_NothingToAdopt_ReturnsFalse()
+    {
+        using var s = (ServerSession)_backend.Create(Guid.NewGuid().ToString(), 80, 24);
+        Assert.False(s.TryAdopt());
+        Assert.False(s.Adopted);
+    }
+
+    [Fact]
+    public async Task TryAdopt_ExitedLeftover_ReapsAndReturnsFalse()
+    {
+        string paneId = Guid.NewGuid().ToString();
+        var dead = _backend.Create(paneId, 80, 24);
+        var exited = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        dead.Exited += c => exited.TrySetResult(c);
+        await dead.StartAsync("cmd.exe", new[] { "/q", "/c", "exit", "0" }, verbatimCommandLine: true);
+        await exited.Task.WaitAsync(TimeSpan.FromSeconds(15));
+        dead.Detach();                                               // leave the corpse on the host
+
+        using var fresh = (ServerSession)_backend.Create(paneId, 80, 24);
+        Assert.False(fresh.TryAdopt(), "an exited leftover is not adoptable");
+        using var probe = PtyHostClient.Connect(_appId);
+        Assert.Empty(probe.List());                                  // ...and it got reaped
+    }
+
+    [Fact]
     public void HandoffAttach_IsNotSupported()
     {
-        using var s = _backend.Create(80, 24);
+        using var s = _backend.Create(Guid.NewGuid().ToString(), 80, 24);
         Assert.Throws<NotSupportedException>(() => s.Attach(null!, null!, null!, IntPtr.Zero, 0));
     }
 
     [Fact]
     public async Task StartFailure_PaintsTheErrorIntoThePane()
     {
-        using var s = _backend.Create(80, 24);
+        using var s = _backend.Create(Guid.NewGuid().ToString(), 80, 24);
         await s.StartAsync("definitely-not-a-real-exe-agw.exe", Array.Empty<string>());
         Assert.True(WaitFor(() => s.HasExited, 10000));
         Assert.Equal(1, s.ExitCode);

--- a/tests/Agwinterm.Pty.Tests/SessionBackendTests.cs
+++ b/tests/Agwinterm.Pty.Tests/SessionBackendTests.cs
@@ -7,7 +7,7 @@ public class SessionBackendTests
     [Fact]
     public void InProcessBackend_CreatesWorkingSessions()
     {
-        using ISession s = InProcessSessionBackend.Instance.Create(20, 5);
+        using ISession s = InProcessSessionBackend.Instance.Create("t", 20, 5);
         Assert.Equal(20, s.Cols);
         Assert.Equal(5, s.Rows);
         // The handle drives the emulator through the interface alone (what a Phase-2 replica must honor).
@@ -32,14 +32,14 @@ public class SessionBackendTests
     {
         // Failure surfaces at Create — the one place the UI can catch it and fall back in-process.
         using var backend = new ServerSessionBackend("agwinterm-test-nohost-" + Guid.NewGuid().ToString("N")[..8], exePath: null);
-        Assert.Throws<InvalidOperationException>(() => backend.Create(80, 24));
+        Assert.Throws<InvalidOperationException>(() => backend.Create("t3", 80, 24));
     }
 
     [Fact]
     public void ControlServer_AcceptsAnyISession()
     {
         // The single-session ControlServer ctor is part of the seam: it must take the interface.
-        using ISession s = InProcessSessionBackend.Instance.Create(80, 24);
+        using ISession s = InProcessSessionBackend.Instance.Create("t2", 80, 24);
         using var server = new ControlServer(s, "agwinterm-test-" + Guid.NewGuid().ToString("N")[..8]);
         Assert.NotNull(server);
     }


### PR DESCRIPTION
## What

The payoff phase of #105: with `session-host = server`, **quitting or crashing the UI no longer kills your shells**. The pty-host keeps them running; the next start reconnects every restored pane to its surviving session — same process, same state, full-color content.

### Mechanics

- **`ISession.Detach()`** — release without killing. Server sessions close the data pipe (the host records a detach; the child runs on); in-process sessions can''t outlive their process, so there `Detach == Dispose` and the quit path stays a uniform call.
- **Quit vs close is now a real distinction:** `WM_DESTROY` *detaches* panes when the app is quitting (last window, or an update-quit), *disposes* on an explicit window close; closing a pane still kills its session. Scratch/overlay/quick are never restored, so they always dispose — no orphans by design.
- **Adoption:** `ISessionBackend.Create` now takes the **pane id**, which names the hosted session — the adoption key. On restore, a server pane calls `TryAdopt()`: attach → seed the replica (scrollback + modes) → ConPTY repaint → live, with `Adopted = true` and the original `childPid`. Exited leftovers are reaped and the pane launches fresh.
- **Restore honors adoption:** buffer seeding, **agent-resume typing**, and restore-commands are all skipped for adopted panes — the real thing is still running; typing `claude --resume …` into a live Claude would land in its prompt. (The binding survives for future non-adopted restarts.)
- **Orphan reaper:** 30s after boot, hosted sessions claimed by no surface (panes/scratch/overlay/quick across all windows) or already exited are killed — covers pane-close kills lost to a crash.

## Evidence

- **248/248 tests.** New: detach → host still runs the child → a fresh handle with the same pane id adopts it — asserting the **same child PID** and pre-detach output present in the replica; nothing-to-adopt → fresh launch; exited leftover → reaped + fresh launch.
- **E2E on the dev instance** (screenshot in chat): shell **PID 28632 survived three UI generations** — generation 1 typed a marker, the UI was then **killed with `-Force`** (no WM_DESTROY, no goodbye), generation 2 adopted: same pane id, same shell PID, pre-crash output rendered in full color (the repaint, not a dim seed); a **graceful last-window quit** followed, generation 3 adopted again — still PID 28632. Explicit session close still removed its hosted session from the host.

With this, `session-host = server` delivers the actual promise: **UI updates and crashes cost zero running shells.** Remaining: Phase 2d — the experimental Settings toggle (plus README wording) so opting in doesn''t require hand-editing the config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k