### PR TITLE
fix(render): stop repainting for output in panes that are not on screen

### DIFF
--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -73,11 +73,15 @@ internal partial class Program
         // ACTUALLY scrolled (a line pushed into history) — not on every repaint. TUIs like Claude Code
         // redraw in place without scrolling, so a mouse selection now survives those frames and Ctrl+C can
         // copy it (previously any repaint wiped the selection microseconds after you made it). #copy-selection
+        // Repaints are requested ONLY when this pane is on screen: a background tab's output flood
+        // used to repaint the (unchanged!) foreground at the full frame cap, starving typing on slow
+        // machines. The emulator still consumes everything; switching to the pane shows current
+        // content, and the sidebar title catches up on the next paint (cursor blink at the latest).
         session.OutputReceived += () =>
         {
             long gen = session.Emulator.ScrollGeneration;
             if (gen != pane.LastScrollGen) { pane.LastScrollGen = gen; pane.ScrollOffset = 0; pane.ClearSel(); }
-            RequestRedraw();
+            if (IsSurfaceVisible(pane)) RequestRedraw();
         };
         // On a transition INTO blocked, play the configured blocked-sound (best-effort, off the UI thread).
         AgentStatus lastStatus = session.Status;
@@ -551,6 +555,20 @@ internal partial class Program
 
     /// <summary>The surface that receives input/render focus: a shown cover, else the active pane.</summary>
     private Pane? ActiveSurface() => _cover ?? _active?.ActivePane;
+
+    /// <summary>Whether a pane is currently on screen — i.e. whether its output warrants a repaint.
+    /// Called on session pump threads: field reads are benignly racy (a stale answer costs one
+    /// skipped-or-extra frame), but the pane-list read locks like every other cross-thread reader
+    /// (#85). Dashboard open = every session shows a live preview; a shown cover renders ABOVE the
+    /// active session's panes, which stay partially visible behind floating overlays — so both count.</summary>
+    private bool IsSurfaceVisible(Pane p)
+    {
+        if (_dashboardOpen) return true;
+        if (_cover is { } c && ReferenceEquals(c, p)) return true;
+        var act = _active;
+        if (act is null) return false;
+        lock (_workspaces) return act.Panes.Contains(p);
+    }
 
     private void SyncSession() => _session = ActiveSurface()?.S;
 


### PR DESCRIPTION
## The bug (Boris''s slow-laptop report: heavy process in one tab → typing lags in other tabs)

Every output chunk from **any** pane — including tabs you aren''t looking at — requested a full-window repaint. Measured on an idle-looking window with a ~325 KB/s flood running in a **background** tab: **600 full renders / 10s** (the 66fps frame cap), all painting unchanged foreground content. On a fast GPU that''s invisible waste (~1.5ms/frame); on a slow machine each frame costs 15–50ms, the UI thread saturates, and keystrokes for the tab you ARE using queue behind paint after paint. ConPTY itself was never the bottleneck — each session has its own pump thread.

(For the record: the pty-host work doesn''t and couldn''t fix this — the repaint requests happen in the UI process either way. This fix helps both backends equally.)

## The fix

One gate: the `OutputReceived` handler requests a repaint **only when the pane is on screen** — dashboard open (live previews), the shown cover, or any pane of the active session (panes stay partially visible behind floating overlays, so a cover doesn''t exclude them). Everything else is unchanged:

- the emulator consumes all output regardless — switching to the pane shows fully current content
- scroll-generation / selection bookkeeping stays unconditional
- `StatusChanged` repaints stay ungated (sidebar dots are always visible); sidebar titles catch up on the next paint (cursor blink at the latest)
- visibility fields are benignly-racy reads on pump threads; the pane list is read under the same lock as every other cross-thread reader (#85)

## Evidence (dev instance, `AGWINTERM_PERF` frame counts)

| Scenario | Renders |
|---|---|
| Idle | ~19 / 10s (cursor blink) |
| Background flood, **before** | **600 / 10s** |
| Background flood, **after** | **19 / 10s** — zero paint cost, same ~325 KB/s consumed |
| Switch TO the flooding tab | 301 / 5s (~60fps cap) with fully current content |

Typing echo in the focused quiet tab round-trips during the flood. Full suite 245/245.

Honest test-harness note: the first "before" measurements were garbage — the flood command itself was failing quietly (PowerShell arg-quoting ate the cmd loop''s quotes). Verified byte throughput (`AGWINTERM_DUMP`) alongside frame counts before trusting any numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k