### PR TITLE
feat(pty-host): Settings toggle + live backend switch — Phase 2d completes #105 Phase 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ the real thing: **[github.com/umputun/agterm](https://github.com/umputun/agterm)
   right artifact for your install (installer or portable exe), **verifies its SHA-256** against the
   release digest, restarts, and your sessions restore. scoop/chocolatey installs are never touched —
   the hint points at your package manager instead.
+- **Shells that survive the UI** (EXPERIMENTAL): flip *Settings → General → Session host* to
+  **Pty-host server** (`session-host = server`) and your sessions live in a tiny headless process —
+  quit, self-update, or even crash the UI and every shell (including a running Claude conversation)
+  **keeps running**; the next start reattaches each pane to its live session, same process, same
+  state. Closing a pane still closes its shell. The tmux idea, native on Windows.
 - **A scriptable control API**: `agwintermctl` (or newline-JSON over a named pipe) — any language can
   drive it, including full **read-back** (tree with split ratios + pane ids, window state, session
   output). Opt-in installers for the **agent skill** and **Claude Code / Codex status hooks**.

--- a/src/Agwinterm.Core/TerminalConfig.cs
+++ b/src/Agwinterm.Core/TerminalConfig.cs
@@ -241,9 +241,10 @@ public sealed class TerminalConfig
         update-check = true
 
         # Where terminal sessions live. "in-process" (default): the window process owns them.
-        # "server" (EXPERIMENTAL - see github issue #105): a separate pty-host process owns them -
-        # the groundwork for shells surviving UI updates and crashes. In this phase closing a pane
-        # or the app still closes its sessions (survival + adoption land next).
+        # "server" (EXPERIMENTAL - see github issue #105): a separate pty-host process owns them,
+        # so shells KEEP RUNNING when the UI quits, updates, or crashes - the next start reconnects
+        # every pane to its live session (closing a pane still closes its shell). Changing this
+        # applies to new sessions immediately; restart agwinterm to migrate existing ones.
         session-host = in-process
 
         # Blocked sound: play a sound whenever a session enters the "blocked" agent status (needs

--- a/src/Agwinterm.Pty/ServerSession.cs
+++ b/src/Agwinterm.Pty/ServerSession.cs
@@ -65,9 +65,9 @@ public sealed class ServerSessionBackend : ISessionBackend, IDisposable
 /// <see cref="Emulator"/> is a REPLICA fed by the host's raw ConPTY stream (the host keeps the
 /// authoritative one); input, resize, and lifecycle travel over the host protocol.
 ///
-/// Phase 2b semantics: <see cref="Dispose"/> KILLS the hosted session — closing a pane behaves
-/// exactly like the in-process backend. Detach-and-survive (app quit leaves sessions running,
-/// next start adopts them) is Phase 2c, where dispose-for-quit and dispose-for-close diverge.
+/// Lifecycle: <see cref="Dispose"/> KILLS the hosted session (explicit pane close);
+/// <see cref="Detach"/> releases it alive (app quit) for a later <see cref="TryAdopt"/> — that
+/// split is what lets shells survive UI restarts, updates, and crashes (#105, Phase 2c).
 /// </summary>
 public sealed class ServerSession : ISession
 {

--- a/src/Agwinterm.Win32/Program.Services.cs
+++ b/src/Agwinterm.Win32/Program.Services.cs
@@ -906,6 +906,15 @@ internal partial class Program
         _config = TerminalConfig.Load(ConfigPath);       // reparse so clamping/validation is centralized
         if (key == "theme") _theme = FindTheme(_config.Theme);
         if (key is "theme" or "theme-follow-system" or "theme-dark" or "theme-light") ApplySystemTheme();
+        if (key == "session-host")
+        {
+            // Live switch (#105 2d): NEW sessions use the chosen backend immediately; existing panes
+            // keep the one they were born with (both kinds coexist fine) and converge on restart.
+            _sessionBackend = SessionBackends.Resolve(_config.SessionHost, _argPipe ?? _appId, AppExePath);
+            ShowToast(_config.SessionHost == "server"
+                ? "server mode ON (experimental) — new sessions survive UI restarts; restart agwinterm to move existing ones"
+                : "in-process mode — new sessions run in the window process; restart agwinterm to convert existing ones", 6000);
+        }
         if (key == "cursor-blink-ms" && _hwnd != IntPtr.Zero) SetTimer(_hwnd, (IntPtr)1, (uint)_config.CursorBlinkMs, IntPtr.Zero);
         RecomputeChrome();
         ApplyWindowOpacity();

--- a/src/Agwinterm.Win32/Settings.cs
+++ b/src/Agwinterm.Win32/Settings.cs
@@ -108,6 +108,9 @@ internal partial class Program
         _setRows.Add(new SetRow { Kind = SW.Path, Tab = 0, Key = "new-session-dir", Label = "Custom directory" });
         Tog(0, "restore-commands", "Restore running commands");
         Tog(0, "confirm-close-session", "Confirm before closing");
+        // pty-host opt-in (#105): server mode keeps shells alive across UI restarts/updates/crashes.
+        Drop(0, "session-host", "Session host (shells survive restarts)",
+            new[] { "In-process (default)", "Pty-host server (experimental)" }, new[] { "in-process", "server" });
         Sec(0, "Shell");
         Tog(0, "shell-integration", "Shell integration (live cwd)");
         Tog(0, "omp-integration", "oh-my-posh integration");


### PR DESCRIPTION
## What

The last piece of the pty-host plan: opting in no longer requires editing a config file.

- **Settings → General → Sessions → "Session host (shells survive restarts)"**: *In-process (default)* | *Pty-host server (experimental)*. Drives the exact same `config.set` path as `agwintermctl config set session-host …`.
- **Live switch:** changing the key re-resolves the backend, so **new sessions use it immediately**; existing panes keep the backend they were born with (the two kinds coexist fine) and converge on restart. A toast states exactly that — the switch is never a silent no-op and never a surprise restart.
- Docs told the truth again: the config template and `ServerSession` summary no longer describe the pre-2c "dispose = kill only" world; README gains the feature bullet.

## Evidence

- 248/248 tests.
- E2E on a live instance: `config set session-host server` → toast; a **new** session appears in the pty-host''s `list` while the pre-switch session stays in-process; the key persists; the Settings row renders with the server option selected (screenshots in chat).

## Series recap (#105 Phase 2, as agreed)

| PR | Phase |
|---|---|
| #108 | 1 — `ISession`/`ISessionBackend` seam, zero behavior change |
| #109 | 2a — `--pty-host` role: host process + protocol |
| #110 | 2b — `ServerSessionBackend`: `session-host = server` live |
| #111 | 2c — detach-on-quit + adoption: **shells survive UI crash/quit/update** (same PID proven) |
| this | 2d — Settings toggle + live switch |

Two release artifacts throughout, one binary playing both roles, defaults untouched — existing users see nothing until they flip the toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k