### PR TITLE
fix(tests): un-flake the pty-host type-echo tests (main CI red after 0.14.3)

### DIFF
--- a/tests/Agwinterm.Pty.Tests/PtyHostTests.cs
+++ b/tests/Agwinterm.Pty.Tests/PtyHostTests.cs
@@ -13,6 +13,34 @@ public class PtyHostTests : IDisposable
     public PtyHostTests() => _server = new PtyHostServer(_appId);
     public void Dispose() => _server.Dispose();
 
+    /// <summary>Type a line and make sure it took (raw-stream twin of ServerSessionTests.TypeLine):
+    /// input during cmd/conhost console init can be silently discarded, and `cmd /q` prints no
+    /// prompt on newer Windows — so retype every ~2.5s until the echo shows up in the stream.</summary>
+    private static string TypeUntilEcho(Stream data, string line, string marker, int timeoutMs = 20000)
+    {
+        var bytes = System.Text.Encoding.UTF8.GetBytes(line + "\r");
+        var all = new System.Text.StringBuilder();
+        var buf = new byte[16 * 1024];
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        long nextTypeAt = 0;
+        Task<int>? pending = null;
+        while (sw.ElapsedMilliseconds < timeoutMs)
+        {
+            if (sw.ElapsedMilliseconds >= nextTypeAt)
+            {
+                data.Write(bytes); data.Flush();
+                nextTypeAt = sw.ElapsedMilliseconds + 2500;
+            }
+            pending ??= data.ReadAsync(buf, 0, buf.Length);
+            if (!pending.Wait(250)) continue;             // keep ONE read in flight across retries
+            int n = pending.Result; pending = null;
+            if (n <= 0) break;
+            all.Append(System.Text.Encoding.UTF8.GetString(buf, 0, n));
+            if (all.ToString().Contains(marker, StringComparison.Ordinal)) break;
+        }
+        return all.ToString();
+    }
+
     private static string ReadUntil(Stream data, Func<string, bool> done, int timeoutMs = 15000)
     {
         var all = new System.Text.StringBuilder();
@@ -47,9 +75,7 @@ public class PtyHostTests : IDisposable
         Assert.True(att.ChildPid > 0);
 
         // Type through the data pipe; the echo must come back as raw ConPTY output.
-        byte[] line = System.Text.Encoding.UTF8.GetBytes("echo host+work\r");
-        att.Data.Write(line); att.Data.Flush();
-        string seen = ReadUntil(att.Data, s => s.Contains("host+work", StringComparison.Ordinal));
+        string seen = TypeUntilEcho(att.Data, "echo host+work", "host+work");
         Assert.Contains("host+work", seen);
 
         client.Kill(id);
@@ -64,8 +90,7 @@ public class PtyHostTests : IDisposable
 
         using (var first = client.Attach(id))
         {
-            first.Data.Write("echo before-detach\r"u8.ToArray()); first.Data.Flush();
-            ReadUntil(first.Data, s => s.Contains("before-detach"));
+            Assert.Contains("before-detach", TypeUntilEcho(first.Data, "echo before-detach", "before-detach"));
         }   // disposing the data pipe = detach; the shell must keep running
 
         var info = Assert.Single(client.List());

--- a/tests/Agwinterm.Pty.Tests/ServerSessionTests.cs
+++ b/tests/Agwinterm.Pty.Tests/ServerSessionTests.cs
@@ -31,6 +31,22 @@ public class ServerSessionTests : IDisposable
         lock (s.SyncRoot) return string.Join("\n", s.Emulator.DumpBuffer());
     }
 
+    /// <summary>Type a line and make sure it took: input written while cmd/conhost is still
+    /// initializing can be silently DISCARDED (bit main's CI on 0.14.3), and there is no portable
+    /// readiness signal (`cmd /q` prints no prompt on newer Windows). So: type, and if the marker
+    /// hasn't echoed shortly, type again — a duplicate echo is harmless for Contains asserts.</summary>
+    private static void TypeLine(ISession s, string line, string marker)
+    {
+        var bytes = System.Text.Encoding.UTF8.GetBytes(line + "\r");
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (sw.ElapsedMilliseconds < 20000)
+        {
+            s.Write(bytes);
+            if (WaitFor(() => GridText(s).Contains(marker), 2500)) return;
+        }
+        Assert.Fail($"typed line never echoed: {line}\ngrid:\n" + GridText(s));
+    }
+
     [Fact]
     public async Task TypeEcho_LandsInTheReplicaEmulator()
     {
@@ -43,9 +59,7 @@ public class ServerSessionTests : IDisposable
         Assert.True(s.ChildProcessId > 0);
         Assert.False(s.HasExited);
 
-        s.Write("echo replica+works\r"u8);
-        Assert.True(WaitFor(() => GridText(s).Contains("replica+works")),
-            "typed echo never reached the replica emulator; grid:\n" + GridText(s));
+        TypeLine(s, "echo replica+works", "replica+works");   // asserts the echo reached the replica
         Assert.True(outputEvents > 0);
     }
 
@@ -110,8 +124,7 @@ public class ServerSessionTests : IDisposable
         var gen1 = _backend.Create(paneId, 100, 24);
         await gen1.StartAsync("cmd.exe", new[] { "/q" }, verbatimCommandLine: true);
         int? pid = gen1.ChildProcessId;
-        gen1.Write("echo pre+restart\r"u8);
-        Assert.True(WaitFor(() => GridText(gen1).Contains("pre+restart")));
+        TypeLine(gen1, "echo pre+restart", "pre+restart");
         Thread.Sleep(300);   // let the echo reach the HOST emulator too (its snapshot feeds adoption)
         gen1.Detach();
 


### PR DESCRIPTION
## What broke

Main''s post-merge CI run for the 0.14.3 bump failed in `ServerSessionTests.TypeEcho_LandsInTheReplicaEmulator` — the same commit was green on the PR branch and the Release workflow succeeded, so **the product and the release are fine**; this is a flaky integration test.

Root cause: the tests type into cmd **immediately** after `StartAsync`, and input that arrives while cmd/conhost is still initializing its console can be **silently discarded**. Slow CI runners lose that race; the failure dump shows the banner and prompt painted but the echo missing.

## Why not "wait for the prompt"

Tried first, failed honestly: `cmd /q` prints **no prompt at all** on newer Windows builds (locally deterministic 15s timeout), and the CI dump proves input can be dropped even after the prompt is visible — prompt presence is not a readiness signal.

## The fix

**Retry-until-echoed**: type the line; if the marker hasn''t echoed within ~2.5s, type it again (a duplicate echo is harmless for `Contains` asserts). Applied to every first-write-after-start site in `ServerSessionTests` and `PtyHostTests`; the raw-stream variant keeps a single read in flight across retries so the pipe never sees a second concurrent `ReadAsync`.

Test-only change. 3 consecutive local full-suite runs green (echo lands on the first try here — the retry is pure CI insurance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k