### PR TITLE
feat(env): fresh-env — new tabs get a registry-fresh environment (no restart needed)

### DIFF
--- a/src/Agwinterm.Core/TerminalConfig.cs
+++ b/src/Agwinterm.Core/TerminalConfig.cs
@@ -85,6 +85,12 @@ public sealed class TerminalConfig
     /// long-term basis for sessions surviving UI updates/crashes).</summary>
     public string SessionHost { get; set; } = "in-process";
 
+    /// <summary>Rebuild each new session's environment from the registry at spawn (WT's
+    /// reloadEnvironmentVariables analog): software installed while agwinterm runs — a JDK, a new
+    /// PATH entry — is visible in the next tab without restarting anything. Off = tabs inherit
+    /// the env snapshot the spawning process started with (the old behavior).</summary>
+    public bool FreshEnv { get; set; } = true;
+
     /// <summary>Characters that DELIMIT words for double-click selection (in addition to whitespace).
     /// Empty = whitespace only (double-click grabs a whole path/URL). WT's wordDelimiters analog.</summary>
     public string WordDelimiters { get; set; } = "";
@@ -247,6 +253,13 @@ public sealed class TerminalConfig
         # applies to new sessions immediately; restart agwinterm to migrate existing ones.
         session-host = in-process
 
+        # Build each new tab's environment FRESH from the registry (what a brand-new process tree
+        # would get): software installed while agwinterm is running - a JDK, a new PATH entry - is
+        # visible in the next tab, no restart needed. Off = tabs inherit the environment agwinterm
+        # itself started with. Note: with fresh-env on, variables set only in the shell that
+        # LAUNCHED agwinterm do not reach tabs (same trade-off as Windows Terminal's default).
+        fresh-env = true
+
         # Blocked sound: play a sound whenever a session enters the "blocked" agent status (needs
         # your attention). Empty / off / none = silent. Accepts a system-sound name (beep, asterisk,
         # exclamation, hand, question), a Windows sound-event alias, or a path to a .wav file.
@@ -367,6 +380,7 @@ public sealed class TerminalConfig
                 case "session-host":
                     if (val is "in-process" or "server") cfg.SessionHost = val;
                     break;
+                case "fresh-env": cfg.FreshEnv = ParseBool(val, cfg.FreshEnv); break;
                 case "word-delimiters": cfg.WordDelimiters = val; break;
                 case "desktop-notifications": cfg.DesktopNotifications = ParseBool(val, cfg.DesktopNotifications); break;
                 case "blocked-sound": cfg.BlockedSound = val; break;

--- a/src/Agwinterm.Pty/FreshEnvironment.cs
+++ b/src/Agwinterm.Pty/FreshEnvironment.cs
@@ -1,0 +1,48 @@
+using System.Runtime.InteropServices;
+
+namespace Agwinterm.Pty;
+
+/// <summary>
+/// Builds the environment a GENUINELY FRESH process tree would receive right now: Windows
+/// (userenv) re-reads machine + user variables from the registry, composes PATH as
+/// machine-then-user, and expands REG_EXPAND_SZ values — instead of the snapshot this process
+/// inherited when IT started. This is how a new tab sees a JDK installed five minutes ago
+/// without restarting agwinterm (or the pty-host, which can be even longer-lived). Same
+/// semantics as Windows Terminal's <c>compatibility.reloadEnvironmentVariables</c> (also
+/// default-on there); the <c>fresh-env</c> config key is the escape hatch.
+/// </summary>
+public static class FreshEnvironment
+{
+    /// <summary>The freshly generated environment for the current user, or null if Windows
+    /// refused — callers fall back to the inherited process env (the pre-feature behavior).</summary>
+    public static Dictionary<string, string>? TryBuild()
+    {
+        IntPtr block = IntPtr.Zero;
+        try
+        {
+            using var identity = System.Security.Principal.WindowsIdentity.GetCurrent();
+            if (!CreateEnvironmentBlock(out block, identity.Token, inherit: false) || block == IntPtr.Zero)
+                return null;
+
+            // The block is a run of NUL-terminated "NAME=value" UTF-16 strings, double-NUL at the end.
+            var env = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            IntPtr p = block;
+            while (Marshal.PtrToStringUni(p) is { Length: > 0 } entry)
+            {
+                p += (entry.Length + 1) * 2;
+                int eq = entry.IndexOf('=');
+                if (eq <= 0) continue;   // skip malformed entries and "=C:=..." drive-cwd pseudo-vars
+                env[entry[..eq]] = entry[(eq + 1)..];
+            }
+            return env.Count > 0 ? env : null;
+        }
+        catch { return null; }
+        finally { if (block != IntPtr.Zero) DestroyEnvironmentBlock(block); }
+    }
+
+    [DllImport("userenv.dll", SetLastError = true)]
+    private static extern bool CreateEnvironmentBlock(out IntPtr lpEnvironment, IntPtr hToken, bool inherit);
+
+    [DllImport("userenv.dll", SetLastError = true)]
+    private static extern bool DestroyEnvironmentBlock(IntPtr lpEnvironment);
+}

--- a/src/Agwinterm.Pty/ISession.cs
+++ b/src/Agwinterm.Pty/ISession.cs
@@ -44,9 +44,13 @@ public interface ISession : IDisposable
     // ---- Lifecycle ----
     /// <summary>Spawn <paramref name="app"/> and pump until it exits; returns the exit code.</summary>
     Task<int> RunAsync(string app, string[] commandLine, bool verbatimCommandLine = false, CancellationToken ct = default);
-    /// <summary>Spawn an interactive shell and pump in the background until exit or dispose.</summary>
+    /// <summary>Spawn an interactive shell and pump in the background until exit or dispose.
+    /// <paramref name="freshEnv"/> (default): the child's base environment is rebuilt from the
+    /// registry at spawn (new installs visible without an app restart — see
+    /// <see cref="FreshEnvironment"/>); false = inherit the spawning process's env snapshot.</summary>
     Task StartAsync(string app, string[] commandLine, bool verbatimCommandLine = false,
-        IReadOnlyDictionary<string, string>? extraEnv = null, string? cwd = null, bool deElevate = false, CancellationToken ct = default);
+        IReadOnlyDictionary<string, string>? extraEnv = null, string? cwd = null, bool deElevate = false,
+        bool freshEnv = true, CancellationToken ct = default);
     /// <summary>Adopt an externally-created pseudoconsole (default-terminal handoff). Inherently
     /// handle-based: a server backend must duplicate the handles into the host process (Phase 2).</summary>
     void Attach(SafeFileHandle conOut, SafeFileHandle conIn, SafeFileHandle signal, IntPtr clientProcess, int pid);

--- a/src/Agwinterm.Pty/PtyHostClient.cs
+++ b/src/Agwinterm.Pty/PtyHostClient.cs
@@ -65,7 +65,8 @@ public sealed class PtyHostClient : IDisposable
 
     /// <summary>Create a session on the host (not attached yet — call <see cref="Attach"/>).</summary>
     public string Create(string id, int cols, int rows, string app, string[] args,
-        string? cwd = null, IReadOnlyDictionary<string, string>? env = null, bool verbatim = false, bool deElevate = false)
+        string? cwd = null, IReadOnlyDictionary<string, string>? env = null, bool verbatim = false, bool deElevate = false,
+        bool freshEnv = true)
     {
         using var ms = new MemoryStream();
         using (var w = new Utf8JsonWriter(ms))
@@ -77,6 +78,7 @@ public sealed class PtyHostClient : IDisposable
             w.WriteString("app", app);
             if (verbatim) w.WriteBoolean("verbatim", true);
             if (deElevate) w.WriteBoolean("deElevate", true);
+            if (!freshEnv) w.WriteBoolean("freshEnv", false);   // absent = true (the default)
             w.WriteStartArray("args");
             foreach (var a in args) w.WriteStringValue(a);
             w.WriteEndArray();

--- a/src/Agwinterm.Pty/PtyHostServer.cs
+++ b/src/Agwinterm.Pty/PtyHostServer.cs
@@ -135,6 +135,7 @@ public sealed class PtyHostServer : IDisposable
         string? cwd = GetString(root, "cwd");
         bool verbatim = root.TryGetProperty("verbatim", out var vb) && vb.ValueKind == JsonValueKind.True;
         bool deElevate = root.TryGetProperty("deElevate", out var de) && de.ValueKind == JsonValueKind.True;
+        bool freshEnv = !(root.TryGetProperty("freshEnv", out var fe) && fe.ValueKind == JsonValueKind.False);
         Dictionary<string, string>? env = null;
         if (root.TryGetProperty("env", out var ev) && ev.ValueKind == JsonValueKind.Object)
         {
@@ -166,7 +167,8 @@ public sealed class PtyHostServer : IDisposable
         // fire-and-forget here would leave the client attached to a session that never lived.
         try
         {
-            session.StartAsync(app, args, verbatimCommandLine: verbatim, extraEnv: env, cwd: cwd, deElevate: deElevate)
+            session.StartAsync(app, args, verbatimCommandLine: verbatim, extraEnv: env, cwd: cwd, deElevate: deElevate,
+                    freshEnv: freshEnv)
                 .GetAwaiter().GetResult();
         }
         catch (Exception ex)

--- a/src/Agwinterm.Pty/ServerSession.cs
+++ b/src/Agwinterm.Pty/ServerSession.cs
@@ -137,7 +137,7 @@ public sealed class ServerSession : ISession
 
     public async Task StartAsync(string app, string[] commandLine, bool verbatimCommandLine = false,
         IReadOnlyDictionary<string, string>? extraEnv = null, string? cwd = null, bool deElevate = false,
-        CancellationToken ct = default)
+        bool freshEnv = true, CancellationToken ct = default)
     {
         try
         {
@@ -145,7 +145,7 @@ public sealed class ServerSession : ISession
             {
                 var client = _backend.Client;
                 client.Create(_id, Cols, Rows, app, commandLine, cwd, extraEnv,
-                    verbatim: verbatimCommandLine, deElevate: deElevate);
+                    verbatim: verbatimCommandLine, deElevate: deElevate, freshEnv: freshEnv);
                 var att = client.Attach(_id);
                 _data = att.Data;
                 _childPid = att.ChildPid;

--- a/src/Agwinterm.Pty/TerminalSession.cs
+++ b/src/Agwinterm.Pty/TerminalSession.cs
@@ -149,7 +149,8 @@ public sealed class TerminalSession : ISession
     /// When <paramref name="deElevate"/> is set, the shell runs at the interactive user's Medium integrity
     /// (only valid from an elevated agwinterm) so an elevated window can host a normal session.</summary>
     public async Task StartAsync(string app, string[] commandLine, bool verbatimCommandLine = false,
-        IReadOnlyDictionary<string, string>? extraEnv = null, string? cwd = null, bool deElevate = false, CancellationToken ct = default)
+        IReadOnlyDictionary<string, string>? extraEnv = null, string? cwd = null, bool deElevate = false,
+        bool freshEnv = true, CancellationToken ct = default)
     {
         if (deElevate)
         {
@@ -191,13 +192,20 @@ public sealed class TerminalSession : ISession
             VerbatimCommandLine = verbatimCommandLine,
         };
 
-        if (extraEnv is not null)
+        if (extraEnv is not null || freshEnv)
         {
-            // Copy the parent environment (so PATH etc. survive) then layer our additions.
-            var env = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            foreach (System.Collections.DictionaryEntry e in Environment.GetEnvironmentVariables())
-                env[(string)e.Key] = e.Value as string ?? "";
-            foreach (var kv in extraEnv) env[kv.Key] = kv.Value;
+            // Base environment: rebuilt fresh from the registry (so software installed while this
+            // process runs — a JDK, a PATH entry — is visible in the child without a restart;
+            // matters double for the long-lived pty-host). Fallback, and the freshEnv=false path:
+            // copy this process's inherited env, the pre-fresh-env behavior. Then our additions.
+            var env = freshEnv ? FreshEnvironment.TryBuild() : null;
+            if (env is null)
+            {
+                env = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                foreach (System.Collections.DictionaryEntry e in Environment.GetEnvironmentVariables())
+                    env[(string)e.Key] = e.Value as string ?? "";
+            }
+            if (extraEnv is not null) foreach (var kv in extraEnv) env[kv.Key] = kv.Value;
             options.Environment = env;
         }
 

--- a/src/Agwinterm.Win32/Program.Services.cs
+++ b/src/Agwinterm.Win32/Program.Services.cs
@@ -823,7 +823,7 @@ internal partial class Program
         "new-session-dir-mode", "confirm-close-session", "compact-toolbar", "toolbar-mode", "notification-badges",
         "attention-button", "status-color-active", "status-color-blocked", "status-color-completed",
         "paste-protection", "clipboard-write", "notification-flash", "claude-update-check", "update-check",
-        "session-host",
+        "session-host", "fresh-env",
     };
 
     /// <summary>Rewrite (or append) a single `key = value` line in agwinterm.conf, preserving the rest.</summary>
@@ -888,6 +888,7 @@ internal partial class Program
         "claude-update-check" => _config.ClaudeUpdateCheck ? "true" : "false",
         "update-check" => _config.UpdateCheck ? "true" : "false",
         "session-host" => _config.SessionHost,
+        "fresh-env" => _config.FreshEnv ? "true" : "false",
         "paste-protection" => _config.PasteProtection ? "true" : "false",
         "clipboard-write" => _config.ClipboardWrite ? "true" : "false",
         "attention-button" => _config.AttentionButton ? "true" : "false",

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -127,17 +127,17 @@ internal partial class Program
         else if (!string.IsNullOrWhiteSpace(command) && interactive)
             // Run the command in a fresh shell that STAYS OPEN afterwards (custom-command "new" mode):
             // the user's profile loads (oh-my-posh etc.), the command runs, then it's an interactive shell.
-            _ = session.StartAsync("powershell.exe", new[] { "-NoLogo", "-NoExit", "-Command", command! }, extraEnv: env, cwd: cwd);
+            _ = session.StartAsync("powershell.exe", new[] { "-NoLogo", "-NoExit", "-Command", command! }, extraEnv: env, cwd: cwd, freshEnv: _config.FreshEnv);
         else if (!string.IsNullOrWhiteSpace(command) && shellWrap)
             // Run the whole command line through cmd so shell syntax works AND the child's exit code
             // propagates. Verbatim so it becomes exactly `cmd.exe /c <command>` (no extra quoting,
             // which cmd's /c quote-stripping rules would otherwise mangle).
-            _ = session.StartAsync("cmd.exe", new[] { "/c", command! }, verbatimCommandLine: true, extraEnv: env, cwd: cwd);
+            _ = session.StartAsync("cmd.exe", new[] { "/c", command! }, verbatimCommandLine: true, extraEnv: env, cwd: cwd, freshEnv: _config.FreshEnv);
         else if (!string.IsNullOrWhiteSpace(command))
         {
             var argv = ParseArgv(command);
             if (argv.Length > 0)
-                _ = session.StartAsync(argv[0], argv[1..], extraEnv: env, cwd: cwd);
+                _ = session.StartAsync(argv[0], argv[1..], extraEnv: env, cwd: cwd, freshEnv: _config.FreshEnv);
             else
                 LaunchShell(session, profileName, env, cwd, deElevate);
         }
@@ -232,9 +232,9 @@ internal partial class Program
         string exe = Path.GetFileName(cmd).ToLowerInvariant();
         bool isPwsh = exe is "powershell.exe" or "pwsh.exe" or "pwsh";
         if (isPwsh && (pargs is null || pargs.Length == 0))
-            _ = session.StartAsync(cmd, ShellArgs(), extraEnv: env, cwd: pcwd, deElevate: deElevate);        // wrap + omp (cwd-in-title)
+            _ = session.StartAsync(cmd, ShellArgs(), extraEnv: env, cwd: pcwd, deElevate: deElevate, freshEnv: _config.FreshEnv);        // wrap + omp (cwd-in-title)
         else
-            _ = session.StartAsync(cmd, pargs ?? Array.Empty<string>(), extraEnv: env, cwd: pcwd, deElevate: deElevate); // raw shell
+            _ = session.StartAsync(cmd, pargs ?? Array.Empty<string>(), extraEnv: env, cwd: pcwd, deElevate: deElevate, freshEnv: _config.FreshEnv); // raw shell
     }
 
     /// <summary>Per-pane implementation of the emulator's host-action seam. Emulator calls arrive on

--- a/src/Agwinterm.Win32/Settings.cs
+++ b/src/Agwinterm.Win32/Settings.cs
@@ -113,6 +113,8 @@ internal partial class Program
             new[] { "In-process (default)", "Pty-host server (experimental)" }, new[] { "in-process", "server" });
         Sec(0, "Shell");
         Tog(0, "shell-integration", "Shell integration (live cwd)");
+        // fresh-env: rebuild each new tab's env from the registry (new installs visible, no restart).
+        Tog(0, "fresh-env", "Fresh environment for new tabs");
         Tog(0, "omp-integration", "oh-my-posh integration");
         Sec(0, "Default Terminal");
         _setRows.Add(new SetRow

--- a/tests/Agwinterm.Pty.Tests/FreshEnvironmentTests.cs
+++ b/tests/Agwinterm.Pty.Tests/FreshEnvironmentTests.cs
@@ -1,0 +1,120 @@
+using Agwinterm.Pty;
+using Microsoft.Win32;
+
+namespace Agwinterm.Pty.Tests;
+
+/// <summary>fresh-env: new sessions get an environment rebuilt from the registry at spawn, so
+/// software installed while the app (or the pty-host) runs is visible without a restart.</summary>
+public class FreshEnvironmentTests
+{
+    [Fact]
+    public void TryBuild_ProducesACredibleUserEnvironment()
+    {
+        var env = FreshEnvironment.TryBuild();
+        Assert.NotNull(env);
+        Assert.True(env!.ContainsKey("SystemRoot"));
+        Assert.True(env.ContainsKey("USERPROFILE"));
+        Assert.False(string.IsNullOrEmpty(env["Path"]));
+        Assert.True(env.ContainsKey("PATH"));                        // case-insensitive lookups
+        Assert.DoesNotContain(env.Keys, k => k.StartsWith('='));     // no "=C:=..." pseudo-vars
+    }
+
+    /// <summary>The core claim: a registry env change (== an installer's work) is visible in the
+    /// NEXT build without this process restarting — and gone again after the uninstall.</summary>
+    [Fact]
+    public void TryBuild_SeesRegistryChangesImmediately()
+    {
+        string name = "AGWTEST_FRESH_" + Guid.NewGuid().ToString("N")[..8];
+        using var hkcu = Registry.CurrentUser.OpenSubKey("Environment", writable: true)!;
+        try
+        {
+            Assert.False(FreshEnvironment.TryBuild()!.ContainsKey(name));
+            hkcu.SetValue(name, "installed-just-now", RegistryValueKind.String);
+            Assert.Equal("installed-just-now", FreshEnvironment.TryBuild()![name]);
+            // NOTE: the var is deliberately NOT in this process's env — registry only.
+            Assert.Null(Environment.GetEnvironmentVariable(name));
+        }
+        finally { try { hkcu.DeleteValue(name); } catch { } }
+        Assert.False(FreshEnvironment.TryBuild()!.ContainsKey(name));
+    }
+}
+
+/// <summary>End-to-end: the child shell actually SEES the fresh environment — in-process, over
+/// the pty-host wire, and NOT when fresh-env is off.</summary>
+public class FreshEnvironmentE2ETests : IDisposable
+{
+    private readonly string _name = "AGWTEST_FRESH_" + Guid.NewGuid().ToString("N")[..8];
+    private readonly string _value = "fresh-proof-" + Guid.NewGuid().ToString("N")[..8];
+    private readonly RegistryKey _hkcu;
+
+    public FreshEnvironmentE2ETests()
+    {
+        _hkcu = Registry.CurrentUser.OpenSubKey("Environment", writable: true)!;
+        _hkcu.SetValue(_name, _value, RegistryValueKind.String);     // "the installer ran"
+    }
+
+    public void Dispose()
+    {
+        try { _hkcu.DeleteValue(_name); } catch { }
+        _hkcu.Dispose();
+    }
+
+    private static bool WaitFor(Func<bool> cond, int timeoutMs = 15000)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (sw.ElapsedMilliseconds < timeoutMs) { if (cond()) return true; Thread.Sleep(50); }
+        return cond();
+    }
+
+    private static string GridText(ISession s)
+    {
+        lock (s.SyncRoot) return string.Join("\n", s.Emulator.DumpBuffer());
+    }
+
+    /// <summary>Type-until-echoed (see ServerSessionTests.TypeLine): input during conhost init can
+    /// be silently discarded, so retype until the marker shows; duplicates are harmless.</summary>
+    private static void TypeLine(ISession s, string line, string marker)
+    {
+        var bytes = System.Text.Encoding.UTF8.GetBytes(line + "\r");
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (sw.ElapsedMilliseconds < 20000)
+        {
+            s.Write(bytes);
+            if (WaitFor(() => GridText(s).Contains(marker), 2500)) return;
+        }
+        Assert.Fail($"typed line never echoed: {line}\ngrid:\n" + GridText(s));
+    }
+
+    [Fact]
+    public async Task InProcess_ChildSeesTheRegistryVar_WithoutAppRestart()
+    {
+        using var s = new TerminalSession(100, 24);
+        // extraEnv mirrors what CreatePane always passes; the var itself comes from the registry.
+        await s.StartAsync("cmd.exe", new[] { "/q" }, verbatimCommandLine: true,
+            extraEnv: new Dictionary<string, string> { ["AGWINTERM"] = "1" });
+        // cmd expands %name% in its OUTPUT only if the var is in the child's env — the input echo
+        // shows the literal %name%, so seeing _value proves expansion (and thus the fresh env).
+        TypeLine(s, $"echo %{_name}%", _value);
+    }
+
+    [Fact]
+    public async Task InProcess_FreshEnvOff_ChildInheritsTheStaleSnapshot()
+    {
+        using var s = new TerminalSession(100, 24);
+        await s.StartAsync("cmd.exe", new[] { "/q" }, verbatimCommandLine: true, freshEnv: false);
+        TypeLine(s, $"echo %{_name}%", $"%{_name}%");                // at least the input echo
+        TypeLine(s, "echo sentinel+done", "sentinel+done");          // ...and the shell is responsive
+        Assert.DoesNotContain(_value, GridText(s));                  // the var was NOT expanded
+    }
+
+    [Fact]
+    public async Task PtyHost_FreshEnvCrossesTheWire()
+    {
+        string appId = "agwinterm-test-" + Guid.NewGuid().ToString("N")[..8];
+        using var server = new PtyHostServer(appId);
+        using var backend = new ServerSessionBackend(appId, exePath: null);
+        using var s = backend.Create(Guid.NewGuid().ToString(), 100, 24);
+        await s.StartAsync("cmd.exe", new[] { "/q" }, verbatimCommandLine: true);
+        TypeLine(s, $"echo %{_name}%", _value);                      // host-side spawn rebuilt the env
+    }
+}


### PR DESCRIPTION
## Problem

Install a JDK (or anything that edits `PATH`/env vars) while agwinterm is running → new tabs can't see it. Tabs inherited the environment snapshot the spawning process started with, because that's what a child process gets by default. Pty-host server mode makes it worse: the host can outlive UI restarts, so its snapshot can be days old.

## Fix

`TerminalSession.StartAsync` now rebuilds the child's **base** environment at every spawn via `userenv!CreateEnvironmentBlock` — Windows re-reads machine + user vars from the registry, composes `PATH` machine-then-user, and expands `REG_EXPAND_SZ`. The usual `AGWINTERM_*` / profile / custom-command additions layer on top, unchanged.

Same semantics as Windows Terminal's `compatibility.reloadEnvironmentVariables` (default-on there too).

- **`fresh-env` config key** (default `true`) + Settings toggle ("Fresh environment for new tabs") as the escape hatch. Trade-off documented in the config text: with it on, vars set only in the shell that *launched* agwinterm don't reach tabs (same as WT).
- The flag travels the pty-host `create` protocol (absent = true), so **server-mode spawns rebuild host-side** — the long-lived host's stale snapshot no longer matters.
- Fail-open: if the userenv call fails, we fall back to the inherited process env (the old behavior).
- De-elevated spawns and `RunAsync` overlays unchanged.

## Tests (5 new, all 253 green)

- `TryBuild` produces a credible env (SystemRoot/USERPROFILE/PATH, case-insensitive, no `=C:=` pseudo-vars)
- `TryBuild` sees an HKCU `Environment` write **immediately** — and its removal too (the var is deliberately never in the test process's own env)
- E2E in-process: child `cmd` expands `%VAR%` to the registry-only value (input echo shows the literal, so expansion is proof)
- E2E negative: `freshEnv:false` → child does **not** see it
- E2E over the pty-host wire: host-side spawn rebuilds

## Live E2E (dev instance, isolated `agwinterm-dev`)

1. Launched dev instance → wrote `AGW_DEMO_JDK` into `HKCU:\Environment` (the "installer ran" moment) → `session new` → typed `echo $env:AGW_DEMO_JDK`:

```
# echo $env:AGW_DEMO_JDK
jdk-25-installed-while-agwinterm-was-running
```

2. `config set fresh-env false` (live, via control API) → another `session new` → same probe:

```
# echo [$env:AGW_DEMO_JDK]
[]
```

New tab sees the mid-run install; escape hatch verifiably returns to the old inherit behavior. Registry var cleaned up after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k