### PR TITLE
chore(release): bump version to 0.14.4

### DIFF
--- a/installer/agwinterm.iss
+++ b/installer/agwinterm.iss
@@ -2,7 +2,7 @@
 ; Build via installer\build.ps1 (publishes to stage\ then runs ISCC on this file).
 
 #define AppName    "agwinterm"
-#define AppVersion "0.14.3"
+#define AppVersion "0.14.4"
 #define AppExe     "Agwinterm.Win32.exe"
 #define AppPublisher "Boris Kudriashov"
 


### PR DESCRIPTION
0.14.4 ships **fresh-env** (#116): new tabs get their environment rebuilt from the registry at spawn — software installed while agwinterm is running (JDK, PATH entries) is visible in the next tab, no restart needed. Works through both session backends (in-process and pty-host); `fresh-env` config key + Settings toggle as the escape hatch.

Tag `v0.14.4` after merge to trigger the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k