### PR TITLE
feat(render): draw SGR text styles — bold, italic, underline, strikethrough

### DIFF
--- a/src/Agwinterm.Core/CellAttributes.cs
+++ b/src/Agwinterm.Core/CellAttributes.cs
@@ -9,4 +9,5 @@ public enum CellAttributes
     Underline = 4,
     Inverse = 8,
     Dim = 16,
+    Strikethrough = 32,
 }

--- a/src/Agwinterm.Core/TerminalEmulator.cs
+++ b/src/Agwinterm.Core/TerminalEmulator.cs
@@ -612,10 +612,12 @@ public sealed class TerminalEmulator : IParserPerformer
                 case 3: _attrs |= CellAttributes.Italic; break;
                 case 4: _attrs |= CellAttributes.Underline; break;
                 case 7: _attrs |= CellAttributes.Inverse; break;
+                case 9: _attrs |= CellAttributes.Strikethrough; break;
                 case 22: _attrs &= ~(CellAttributes.Bold | CellAttributes.Dim); break;
                 case 23: _attrs &= ~CellAttributes.Italic; break;
                 case 24: _attrs &= ~CellAttributes.Underline; break;
                 case 27: _attrs &= ~CellAttributes.Inverse; break;
+                case 29: _attrs &= ~CellAttributes.Strikethrough; break;
                 case >= 30 and <= 37: _fg = Color.FromIndex(code - 30); _fgSpec = ColorSpec.Indexed(code - 30); break;
                 case 39: _fg = Color.DefaultForeground; _fgSpec = ColorSpec.Default; break;
                 case >= 40 and <= 47: _bg = Color.FromIndex(code - 40); _bgSpec = ColorSpec.Indexed(code - 40); break;

--- a/src/Agwinterm.Win32/Program.Render.cs
+++ b/src/Agwinterm.Win32/Program.Render.cs
@@ -312,10 +312,31 @@ internal partial class Program
     /// <summary>Draw one terminal surface (cells, images, cursor) at origin (ox,oy) with its font metrics.</summary>
     private Cell[] _cellSnap = Array.Empty<Cell>();   // reusable viewport snapshot; drawing reads it lock-free
 
+    /// <summary>The SGR attributes the renderer styles text with (colour attrs resolve in EffectiveFg/Bg).</summary>
+    private const CellAttributes StyleMask =
+        CellAttributes.Bold | CellAttributes.Italic | CellAttributes.Underline | CellAttributes.Strikethrough;
+    /// <summary>The subset drawn as decoration lines — the only styling visible on a blank cell.</summary>
+    private const CellAttributes LineMask = CellAttributes.Underline | CellAttributes.Strikethrough;
+
+    /// <summary>The format a run draws with: the pane's base format, or its bold/italic variant.</summary>
+    private static IDWriteTextFormat StyleFmt(IDWriteTextFormat baseFmt, CellAttributes style)
+        => (style & (CellAttributes.Bold | CellAttributes.Italic)) == 0
+            ? baseFmt
+            : StyledFormat(baseFmt.FontSize, (style & CellAttributes.Bold) != 0, (style & CellAttributes.Italic) != 0);
+
     private void RenderTerminal(ISession session, float ox, float oy, IDWriteTextFormat fmt, float cw, float ch, int scrollOffset, Pane? selPane = null)
     {
         var rt = _rt!;
         var brush = _brush!;
+        // Underline / strikethrough lines for a run (brush colour = the run's fg, set by the caller).
+        void DrawDecorations(float x, float w, float yy, CellAttributes a)
+        {
+            float th = MathF.Max(1f, MathF.Round(ch * 0.05f));
+            if ((a & CellAttributes.Underline) != 0)
+                rt.FillRectangle(new Rect(x, yy + ch - th - 0.5f, w, th), brush);
+            if ((a & CellAttributes.Strikethrough) != 0)
+                rt.FillRectangle(new Rect(x, yy + MathF.Round(ch * 0.52f), w, th), brush);
+        }
         // Snapshot the visible viewport under the session lock (sub-ms), then draw OUTSIDE it.
         // Holding the lock for the whole frame serializes rendering against the PTY pump's Feed,
         // capping sustained-output throughput (dotnet-stack showed the UI thread in Monitor.Enter
@@ -415,11 +436,15 @@ internal partial class Program
                                 new System.Numerics.Vector2(ox + (_linkC1 + 1) * cw, uy), brush, 1.4f);
                 }
                 c = 0;
-                while (c < cols)  // Pass 2: coalesced same-colour text runs
+                while (c < cols)  // Pass 2: coalesced same-colour, same-style text runs
                 {
                     Cell cell = CellAt(r, c);
-                    if (cell.Width == 0 || cell.Rune == ' ' || cell.Rune == '\0') { c++; continue; }
+                    bool startBlank = cell.Rune == ' ' || cell.Rune == '\0';
+                    // Blanks normally draw nothing — but an underlined/struck blank must still get
+                    // its decoration line, so those start a run like any glyph does.
+                    if (cell.Width == 0 || (startBlank && (cell.Attributes & LineMask) == 0)) { c++; continue; }
                     Color runFg = EffectiveFg(cell);
+                    CellAttributes runStyle = cell.Attributes & StyleMask;
                     // Builtin box-drawing / block elements: vector-draw for pixel-perfect borders
                     // (unhandled codepoints in the range fall back to the font glyph, drawn solo so
                     // the coalesced run never has to include them).
@@ -436,7 +461,8 @@ internal partial class Program
                         // column, and an astral codepoint is two UTF-16 units in one column.
                         brush.Color = C4(runFg);
                         float wx = ox + c * cw;
-                        rt.DrawText(RuneStr(cell.Rune), fmt, new Rect(wx, y, wx + cell.Width * cw, y + ch), brush);
+                        rt.DrawText(RuneStr(cell.Rune), StyleFmt(fmt, runStyle), new Rect(wx, y, wx + cell.Width * cw, y + ch), brush);
+                        DrawDecorations(wx, cell.Width * cw, y, runStyle);
                         c++;
                         continue;
                     }
@@ -449,7 +475,10 @@ internal partial class Program
                         if (cc.Width == 2 || cc.Width == 0 || cc.Rune > 0xFFFF) break;
                         if (_config.BuiltinGlyphs && cc.Rune is (>= 0x2500 and <= 0x259F) or 0x2571 or 0x2572) break; // vector-drawn separately
                         bool blank = cc.Rune == ' ' || cc.Rune == '\0';
-                        if (!blank && EffectiveFg(cc) != runFg) break;
+                        // Blanks only need matching decoration lines (bold/italic is invisible on a
+                        // space); glyphs must match colour AND full style to share the run's format.
+                        if (blank) { if ((cc.Attributes & LineMask) != (runStyle & LineMask)) break; }
+                        else if (EffectiveFg(cc) != runFg || (cc.Attributes & StyleMask) != runStyle) break;
                         _run.Append(blank ? ' ' : (char)cc.Rune);
                         c++;
                         if (!blank) lastNonBlank = _run.Length;
@@ -459,7 +488,14 @@ internal partial class Program
                         _run.Length = lastNonBlank;
                         brush.Color = C4(runFg);
                         float rx = ox + start * cw;
-                        DrawRun(rt, brush, _run.ToString(), fmt, rx, y, _run.Length * cw, ch);
+                        DrawRun(rt, brush, _run.ToString(), StyleFmt(fmt, runStyle), rx, y, _run.Length * cw, ch);
+                    }
+                    if ((runStyle & LineMask) != 0)
+                    {
+                        // Decoration lines span the whole run — including trailing blanks, which the
+                        // text draw trims but which joined precisely because their lines match.
+                        brush.Color = C4(runFg);
+                        DrawDecorations(ox + start * cw, (c - start) * cw, y, runStyle);
                     }
                 }
             }

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -590,12 +590,29 @@ internal partial class Program : ISessionHost, IWindowHost
         catch { return NewFormat("Consolas", px); }
     }
 
-    private static IDWriteTextFormat NewFormat(string family, float px)
+    private static IDWriteTextFormat NewFormat(string family, float px,
+        FontWeight weight = FontWeight.Normal, FontStyle style = FontStyle.Normal)
     {
-        var f = _dwrite.CreateTextFormat(family, null, FontWeight.Normal, FontStyle.Normal, FontStretch.Normal, px);
+        var f = _dwrite.CreateTextFormat(family, null, weight, style, FontStretch.Normal, px);
         f.WordWrapping = WordWrapping.NoWrap;
         f.TextAlignment = TextAlignment.Leading;
         f.ParagraphAlignment = ParagraphAlignment.Near;
+        return f;
+    }
+
+    // Bold/italic variants of the terminal format, per (size, style) — SGR 1/3 rendering. DWrite
+    // picks the nearest available face (and simulates oblique when the family has no italic), so
+    // this works for families without true bold/italic too. Family changes clear it (RebuildFont).
+    private static readonly Dictionary<(float Px, bool Bold, bool Italic), IDWriteTextFormat> _styledFmt = new();
+
+    private static IDWriteTextFormat StyledFormat(float px, bool bold, bool italic)
+    {
+        if (_styledFmt.TryGetValue((px, bold, italic), out var f)) return f;
+        var weight = bold ? FontWeight.Bold : FontWeight.Normal;
+        var style = italic ? FontStyle.Italic : FontStyle.Normal;
+        try { f = NewFormat(_config.FontFamily, px, weight, style); }
+        catch { f = NewFormat("Consolas", px, weight, style); }
+        _styledFmt[(px, bold, italic)] = f;
         return f;
     }
 
@@ -991,6 +1008,8 @@ internal partial class Program : ISessionHost, IWindowHost
         try { old?.Dispose(); } catch { }
         foreach (var m in _metrics.Values) { try { m.Fmt.Dispose(); } catch { } }   // COM formats — dispose before dropping
         _metrics.Clear();
+        foreach (var f in _styledFmt.Values) { try { f.Dispose(); } catch { } }     // bold/italic variants bake in the family too
+        _styledFmt.Clear();
         MeasureCell();
         foreach (var s in AllSessions()) RegridSession(s);
         if (_cover is not null) RegridCover();

--- a/tests/Agwinterm.Core.Tests/SgrTests.cs
+++ b/tests/Agwinterm.Core.Tests/SgrTests.cs
@@ -54,6 +54,32 @@ public class SgrTests
     }
 
     [Fact]
+    public void Strikethrough_9_Sets_29_Clears()
+    {
+        var t = Feed("\x1b[9mA\x1b[29mB");
+        Assert.True(t.Screen[0, 0].Attributes.HasFlag(CellAttributes.Strikethrough));
+        Assert.False(t.Screen[0, 1].Attributes.HasFlag(CellAttributes.Strikethrough));
+    }
+
+    [Fact]
+    public void Reset_ClearsStrikethrough()
+    {
+        var t = Feed("\x1b[9mA\x1b[0mB");
+        Assert.False(t.Screen[0, 1].Attributes.HasFlag(CellAttributes.Strikethrough));
+    }
+
+    [Fact]
+    public void StyleCombo_BoldItalicUnderlineStrike_AllStick()
+    {
+        var t = Feed("\x1b[1;3;4;9mX");
+        var a = t.Screen[0, 0].Attributes;
+        Assert.True(a.HasFlag(CellAttributes.Bold));
+        Assert.True(a.HasFlag(CellAttributes.Italic));
+        Assert.True(a.HasFlag(CellAttributes.Underline));
+        Assert.True(a.HasFlag(CellAttributes.Strikethrough));
+    }
+
+    [Fact]
     public void NormalIntensity_22_ClearsBoldAndDim()
     {
         var t = Feed("\x1b[1mA\x1b[2mB\x1b[22mC");


### PR DESCRIPTION
## Problem

docxy (and man pages, lazygit, every modern CLI UI) emits SGR 1/3/4/9 — agwinterm parsed most of it into cell attributes but the renderer drew everything with the one Normal-weight format, so styles were invisible. SGR 9 (strikethrough) was not parsed at all.

## Changes

**Emulator (Core):**
- `CellAttributes.Strikethrough` added; SGR `9` sets, `29` clears, `0` resets with the rest.

**Renderer (Win32 / DirectWrite):**
- Text runs coalesce on **(foreground, style)** instead of foreground alone.
- Bold/italic draw via per-`(size, bold, italic)` `IDWriteTextFormat` variants, cached beside the metrics cache and invalidated together with it on font-family change. DWrite picks the nearest available face and simulates oblique when the family has no true italic — so this degrades gracefully on any font.
- Underline/strikethrough draw as crisp fill-rects in the run''s foreground colour (so `\e[31;9m` gives a red line through red text), scaled to the cell height.
- Decoration lines span trailing blanks, and **all-blank underlined/struck runs draw their lines too** — previously blank cells were skipped outright, which would have eaten e.g. an underlined empty stretch of a docxy selection.
- Wide/astral solo-drawn glyphs get the same styling + decorations.

## Evidence

All 256 tests green (3 new SGR tests: 9/29 set/clear, reset-clears, 1;3;4;9 combo). Live on the dev instance:

```
BOLD  ITALIC  UNDERLINE  STRIKETHROUGH  bold-italic  all-four
underline spanning   spaces  red struck  bold yellow  dim  inverse
docxy-style: Bold normal Italic normal Under normal Strike normal
```

— renders with real weight/slant/lines, off-codes (22/23/24/29) drop back to plain mid-line, decorations carry the run colour. Screenshot verified (bold = heavier face, italic = slanted, underline spans the triple-space, strike through red text in red).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k