### PR TITLE
fix(render): anchor fallback-font glyphs to the grid — no more overlapping/shifted text

### DIFF
--- a/src/Agwinterm.Win32/Program.Render.cs
+++ b/src/Agwinterm.Win32/Program.Render.cs
@@ -318,6 +318,11 @@ internal partial class Program
     /// <summary>The subset drawn as decoration lines — the only styling visible on a blank cell.</summary>
     private const CellAttributes LineMask = CellAttributes.Underline | CellAttributes.Strikethrough;
 
+    /// <summary>Whether a BMP width-1 glyph is safe to coalesce into a text run: ASCII always is
+    /// (any monospace font is grid-exact there); anything else only if the configured family
+    /// itself covers it — a FALLBACK glyph's advance is arbitrary and would derail the run.</summary>
+    private static bool GridTrue(int rune) => rune < 0x7F || FontHasGlyph(rune);
+
     /// <summary>The format a run draws with: the pane's base format, or its bold/italic variant.</summary>
     private static IDWriteTextFormat StyleFmt(IDWriteTextFormat baseFmt, CellAttributes style)
         => (style & (CellAttributes.Bold | CellAttributes.Italic)) == 0
@@ -455,13 +460,26 @@ internal partial class Program
                         { brush.Color = C4(runFg); rt.DrawText(RuneStr(cell.Rune), fmt, new Rect(bx, y, bx + cw, y + ch), brush); }
                         c++; continue;
                     }
-                    if (cell.Width == 2 || cell.Rune > 0xFFFF)
+                    if (cell.Width == 2 || cell.Rune > 0xFFFF || !GridTrue(cell.Rune))
                     {
-                        // Wide and astral glyphs draw individually: runs assume string index ==
-                        // column, and an astral codepoint is two UTF-16 units in one column.
+                        // Solo draws, anchored to their own grid column: wide glyphs, astral
+                        // codepoints (two UTF-16 units in one column — runs assume string index ==
+                        // column), and any glyph NOT in the configured family. Fallback glyphs have
+                        // arbitrary advances/line metrics, so inside a coalesced run they make the
+                        // whole run drift off the grid and overpaint neighbouring runs (issue #120:
+                        // "overlapping text, shifted colored text"). Clip contains a fallback
+                        // glyph's overflow to its own cell(s) instead of bleeding into the next.
                         brush.Color = C4(runFg);
                         float wx = ox + c * cw;
-                        rt.DrawText(RuneStr(cell.Rune), StyleFmt(fmt, runStyle), new Rect(wx, y, wx + cell.Width * cw, y + ch), brush);
+                        // A width-1 fallback glyph often RENDERS wide (⏺, emoji-adjacent symbols).
+                        // If the next cell is blank, let the glyph finish there instead of clipping
+                        // it to half — alignment is preserved because the neighbour holds no ink.
+                        int clipCells = cell.Width;
+                        if (cell.Width == 1 && c + 1 < cols && CellAt(r, c + 1) is { Width: not 0 } nxt
+                            && (nxt.Rune == ' ' || nxt.Rune == '\0'))
+                            clipCells = 2;
+                        rt.DrawText(RuneStr(cell.Rune), StyleFmt(fmt, runStyle), new Rect(wx, y, clipCells * cw, ch),
+                            brush, DrawTextOptions.Clip);
                         DrawDecorations(wx, cell.Width * cw, y, runStyle);
                         c++;
                         continue;
@@ -475,6 +493,7 @@ internal partial class Program
                         if (cc.Width == 2 || cc.Width == 0 || cc.Rune > 0xFFFF) break;
                         if (_config.BuiltinGlyphs && cc.Rune is (>= 0x2500 and <= 0x259F) or 0x2571 or 0x2572) break; // vector-drawn separately
                         bool blank = cc.Rune == ' ' || cc.Rune == '\0';
+                        if (!blank && !GridTrue(cc.Rune)) break;   // fallback glyph → its own solo draw
                         // Blanks only need matching decoration lines (bold/italic is invisible on a
                         // space); glyphs must match colour AND full style to share the run's format.
                         if (blank) { if ((cc.Attributes & LineMask) != (runStyle & LineMask)) break; }

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -447,6 +447,7 @@ internal partial class Program : ISessionHost, IWindowHost
         _d2d = D2D1.D2D1CreateFactory<ID2D1Factory>(Vortice.Direct2D1.FactoryType.SingleThreaded);
         _dwrite = DWrite.DWriteCreateFactory<IDWriteFactory>();
         _format = CreateTextFormat(_config);
+        ResolveFamilyFont();
         _uiFont = NewChromeFormat("Segoe UI", 13f, center: false);
         _uiSmall = NewChromeFormat("Segoe UI", 11.5f, center: false);
         RebuildSidebarFonts();
@@ -598,6 +599,41 @@ internal partial class Program : ISessionHost, IWindowHost
         f.TextAlignment = TextAlignment.Leading;
         f.ParagraphAlignment = ParagraphAlignment.Near;
         return f;
+    }
+
+    // The configured family's font object, for per-codepoint coverage checks. A glyph that IS in
+    // the (monospace) family advances exactly one cell — safe to coalesce into text runs. A glyph
+    // that falls back to another font (emoji, ⏺/✻ symbols, …) has arbitrary advance and MUST be
+    // drawn solo, anchored to its own grid column, or runs drift and overpaint their neighbours
+    // (the "overlapping text / shifted colored text" bug, issue #120).
+    private static IDWriteFont? _familyFont;
+    private static readonly Dictionary<int, bool> _glyphInFont = new();
+
+    private static void ResolveFamilyFont()
+    {
+        _glyphInFont.Clear();
+        try { _familyFont?.Dispose(); } catch { }
+        _familyFont = null;
+        try
+        {
+            using var coll = _dwrite.GetSystemFontCollection(false);
+            if (coll.FindFamilyName(_config.FontFamily, out uint idx))
+            {
+                using var fam = coll.GetFontFamily(idx);
+                _familyFont = fam.GetFirstMatchingFont(FontWeight.Normal, FontStretch.Normal, FontStyle.Normal);
+            }
+        }
+        catch { }   // no family match → every non-ASCII glyph draws solo (safe, just slower)
+    }
+
+    /// <summary>Whether the configured family itself covers this codepoint (cached).</summary>
+    private static bool FontHasGlyph(int cp)
+    {
+        if (_glyphInFont.TryGetValue(cp, out bool has)) return has;
+        bool h = false;
+        try { h = _familyFont?.HasCharacter((uint)cp) ?? false; } catch { }
+        _glyphInFont[cp] = h;
+        return h;
     }
 
     // Bold/italic variants of the terminal format, per (size, style) — SGR 1/3 rendering. DWrite
@@ -1005,6 +1041,7 @@ internal partial class Program : ISessionHost, IWindowHost
     {
         var old = _format;
         _format = CreateTextFormat(_config);
+        ResolveFamilyFont();
         try { old?.Dispose(); } catch { }
         foreach (var m in _metrics.Values) { try { m.Fmt.Dispose(); } catch { } }   // COM formats — dispose before dropping
         _metrics.Clear();


### PR DESCRIPTION
## The bug (Boris''s "makes me crazy" screenshot)

Text overlapping and colored/linked text shifted left over its neighbours. Grid text was always CORRECT (`session text` dumps clean) — this was purely paint-layer.

## Root cause

Coalesced text runs are laid out by DirectWrite with **natural advances**. ASCII in a monospace font advances exactly one cell — fine. But glyphs the configured family doesn''t cover (Claude Code''s ⏺ U+23FA / ✻ U+273B status marks, arrows, dingbats) resolve via **font fallback** with arbitrary advances and line metrics. The run containing them drifts off the column grid and overpaints the next run — which anchors at its true grid column, hence "shifted colored text".

Reproduced deterministically at MesloLGSDZ 16px: `⏺ done ✻ thinking ↑3 ↓1 → next` + a cyan segment → the space before the colored text is painted over (`nextVITE_FEATURE_FLAGS`).

## Fix

- Per-codepoint **family-coverage cache** (`IDWriteFont.HasCharacter`, reset on font change). ASCII always coalesces; other BMP glyphs only if the family itself covers them (in-family glyphs in a mono font are grid-exact by definition).
- Every fallback glyph draws **solo, anchored at its own grid column, clipped** to its cell(s) — drift can''t accumulate, oversized fallback ink can''t bleed into neighbouring cells or rows.
- If the next cell is blank, the clip extends one cell so wide-rendering width-1 glyphs (the Claude ⏺) show whole instead of halved — the blank holds no ink, alignment unaffected.

## Evidence

Before/after screenshots on the dev instance with the production font config: broken line `nextVITE_FEATURE_FLAGS=on` → fixed `next VITE_FEATURE_FLAGS=on`, all rulers column-exact, ⏺ rendered whole. All 258 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k