### PR TITLE
fix(pty-host): never close a pipe with async IO in flight (#118 hardening)

### DIFF
--- a/src/Agwinterm.Pty/PtyHostClient.cs
+++ b/src/Agwinterm.Pty/PtyHostClient.cs
@@ -52,7 +52,12 @@ public sealed class PtyHostClient : IDisposable
     /// must fail loudly at the seam, never surface as garbled sessions later.</summary>
     public static PtyHostClient Connect(string appId, int timeoutMs = 3000)
     {
-        var pipe = new NamedPipeClientStream(".", PtyHostServer.ControlPipeName(appId), PipeDirection.InOut, PipeOptions.Asynchronous);
+        // Deliberately a SYNCHRONOUS pipe handle (no PipeOptions.Asynchronous): every control
+        // request is sync request/response under a lock, and a sync operation on an async handle
+        // secretly runs overlapped IO — closing the pipe with such an op in flight is the crash
+        // class behind issue #118 (AV in the IOCP poller). A sync handle keeps this path on plain
+        // blocking syscalls, where a close during a read is a clean error, not a race.
+        var pipe = new NamedPipeClientStream(".", PtyHostServer.ControlPipeName(appId), PipeDirection.InOut);
         pipe.Connect(timeoutMs);
         var client = new PtyHostClient(pipe);
         try
@@ -106,6 +111,10 @@ public sealed class PtyHostClient : IDisposable
         string pipeName = root.GetProperty("pipe").GetString()!;
         var scrollback = new List<string>();
         foreach (var e in root.GetProperty("scrollback").EnumerateArray()) scrollback.Add(e.GetString() ?? "");
+        // Async handle: the reader (ServerSession.ReadLoop, or a test) must be able to bail out
+        // mid-read via cancellation — a SYNC handle can't be unblocked by closing our own end
+        // (SafeHandle ref-counting keeps the OS handle open under a blocked read). The #118 rule
+        // still applies: cancel the pending read FIRST, and only the reader disposes the pipe.
         var data = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
         data.Connect(timeoutMs);
         return new PtyHostAttachment(

--- a/src/Agwinterm.Pty/PtyHostServer.cs
+++ b/src/Agwinterm.Pty/PtyHostServer.cs
@@ -41,7 +41,17 @@ public sealed class PtyHostServer : IDisposable
         public required string Id;
         public required TerminalSession S;
         public readonly object DataLock = new();                 // guards Data + writes to it
-        public NamedPipeServerStream? Data;                      // the currently-attached client
+        public DataChannel? Data;                                // the currently-attached client
+    }
+
+    /// <summary>A data pipe plus its read-cancellation source. Ownership rule (issue #118): the
+    /// input pump is the ONLY code that disposes a connected pipe, and only after its pending
+    /// ReadAsync has completed — everyone else just cancels. Disposing a pipe with overlapped IO
+    /// in flight lets the completion fire against freed IOCP state (native AV, no managed trace).</summary>
+    private sealed class DataChannel
+    {
+        public required NamedPipeServerStream Pipe;
+        public readonly CancellationTokenSource Cancel = new();
     }
 
     public PtyHostServer(string appId)
@@ -158,7 +168,7 @@ public sealed class PtyHostServer : IDisposable
             {
                 var d = hosted.Data;
                 if (d is null) return;
-                try { d.Write(chunk); d.Flush(); }
+                try { d.Pipe.Write(chunk); d.Pipe.Flush(); }
                 catch { CloseDataLocked(hosted); }   // client vanished mid-write → plain detach
             }
         };
@@ -204,11 +214,23 @@ public sealed class PtyHostServer : IDisposable
                 using var connectTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
                 await data.WaitForConnectionAsync(connectTimeout.Token).ConfigureAwait(false);
             }
-            catch { data.Dispose(); return; }              // client never came — abandon this attach
-            lock (hosted.DataLock) { CloseDataLocked(hosted); hosted.Data = data; }
-            if (hosted.S.HasExited) { CloseData(hosted); return; }   // exited while attaching → immediate EOF
+            catch { data.Dispose(); return; }              // client never came (no reads yet) — safe to close here
+            var ch = new DataChannel { Pipe = data };
+            lock (hosted.DataLock) { CloseDataLocked(hosted); hosted.Data = ch; }
+            if (hosted.S.HasExited)
+            {
+                // Exited while attaching → the client's EOF signal. No read is pending yet, so
+                // closing directly here is safe — the pump never starts for this channel.
+                lock (hosted.DataLock)
+                {
+                    if (ReferenceEquals(hosted.Data, ch)) hosted.Data = null;
+                    try { ch.Pipe.Dispose(); } catch { }
+                    ch.Cancel.Dispose();
+                }
+                return;
+            }
             if (repaint) JiggleRepaint(hosted.S);
-            await PumpInputAsync(hosted, data).ConfigureAwait(false);
+            await PumpInputAsync(hosted, ch).ConfigureAwait(false);
         });
 
         return Ok(w =>
@@ -226,22 +248,32 @@ public sealed class PtyHostServer : IDisposable
     });
 
     /// <summary>Client→host side of a data pipe: bytes are the child's stdin. EOF/error = detach;
-    /// the session keeps running unattached.</summary>
-    private static async Task PumpInputAsync(Hosted hosted, NamedPipeServerStream data)
+    /// the session keeps running unattached. This pump OWNS the pipe: it is the only code that
+    /// disposes it, and only here — after its ReadAsync has completed (EOF, error, or the
+    /// cancellation that CloseData signals) — so no overlapped read is ever in flight at close
+    /// (issue #118).</summary>
+    private static async Task PumpInputAsync(Hosted hosted, DataChannel ch)
     {
         var buf = new byte[16 * 1024];
         try
         {
             while (true)
             {
-                int n = await data.ReadAsync(buf).ConfigureAwait(false);
+                int n = await ch.Pipe.ReadAsync(buf, ch.Cancel.Token).ConfigureAwait(false);
                 if (n <= 0) break;
                 try { hosted.S.Write(buf.AsSpan(0, n)); } catch { break; }   // child gone
             }
         }
+        catch (OperationCanceledException) { }
         catch (IOException) { }
         catch (ObjectDisposedException) { }
-        lock (hosted.DataLock) if (ReferenceEquals(hosted.Data, data)) CloseDataLocked(hosted);
+        // Under DataLock so a RawOutput forward can't be mid-write on the pipe we're closing.
+        lock (hosted.DataLock)
+        {
+            if (ReferenceEquals(hosted.Data, ch)) hosted.Data = null;
+            try { ch.Pipe.Dispose(); } catch { }
+            ch.Cancel.Dispose();
+        }
     }
 
     /// <summary>The classic ConPTY repaint trick: a real row-count change makes conhost re-emit the
@@ -316,11 +348,15 @@ public sealed class PtyHostServer : IDisposable
         return h is null ? Err($"no session '{id}'") : act(h);
     }
 
+    /// <summary>Signal the attached client (if any) to go away. Cancels the pump's pending read —
+    /// the pump then disposes the pipe (which is the client's EOF). Never disposes here: closing
+    /// a pipe with its overlapped read still in flight is the #118 crash.</summary>
     private void CloseData(Hosted h) { lock (h.DataLock) CloseDataLocked(h); }
     private static void CloseDataLocked(Hosted h)
     {
-        try { h.Data?.Dispose(); } catch { }
-        h.Data = null;
+        var ch = h.Data;
+        h.Data = null;                                   // writers stop immediately
+        if (ch is not null) try { ch.Cancel.Cancel(); } catch (ObjectDisposedException) { }
     }
 
     public void Dispose()

--- a/src/Agwinterm.Pty/ServerSession.cs
+++ b/src/Agwinterm.Pty/ServerSession.cs
@@ -75,6 +75,7 @@ public sealed class ServerSession : ISession
     private readonly ServerSessionBackend _backend;
     private readonly string _id;   // = the pane id; names the hosted session (the adoption key)
     private Stream? _data;
+    private readonly CancellationTokenSource _readCancel = new();   // unblocks ReadLoop's pending read (#118)
     private int? _childPid;
     private volatile bool _started;
     private volatile bool _disposed;
@@ -210,7 +211,10 @@ public sealed class ServerSession : ISession
     public void Attach(SafeFileHandle conOut, SafeFileHandle conIn, SafeFileHandle signal, IntPtr clientProcess, int pid)
         => throw new NotSupportedException("default-terminal handoff sessions run in-process");
 
-    /// <summary>Mirror of TerminalSession's pump, fed by the host's data pipe instead of ConPTY.</summary>
+    /// <summary>Mirror of TerminalSession's pump, fed by the host's data pipe instead of ConPTY.
+    /// OWNS the pipe (issue #118): Detach/Dispose only CANCEL the pending read — this loop is the
+    /// one place the pipe is disposed, strictly after that read has completed, so no overlapped
+    /// operation is ever in flight at close (that race is a native AV in the IOCP poller).</summary>
     private void ReadLoop()
     {
         var data = _data!;
@@ -219,14 +223,18 @@ public sealed class ServerSession : ISession
         {
             while (true)
             {
-                int n = data.Read(buffer, 0, buffer.Length);
+                // Sync-over-async on a dedicated thread (the pipe handle is async so cancellation
+                // can unblock us); same read cadence as before, now with a cancel seam.
+                int n = data.ReadAsync(buffer, 0, buffer.Length, _readCancel.Token).GetAwaiter().GetResult();
                 if (n <= 0) break;
                 lock (_sync) Emulator.Feed(buffer.AsSpan(0, n));
                 OutputReceived?.Invoke();
             }
         }
+        catch (OperationCanceledException) { }
         catch (IOException) { }
         catch (ObjectDisposedException) { }
+        try { data.Dispose(); } catch { }                            // safe now: our read is done
         OnStreamEnded();
     }
 
@@ -285,12 +293,13 @@ public sealed class ServerSession : ISession
         lock (_sync) return Emulator.DumpRow(row);
     }
 
-    /// <summary>Stop viewing WITHOUT killing: close the data pipe (the host sees a detach) and
-    /// leave the child running for a later <see cref="TryAdopt"/>. The app-quit path.</summary>
+    /// <summary>Stop viewing WITHOUT killing: cancel the read loop, which closes the data pipe (the
+    /// host sees a detach) and leaves the child running for a later <see cref="TryAdopt"/>. The
+    /// app-quit path. Never disposes the pipe directly — see ReadLoop's ownership rule (#118).</summary>
     public void Detach()
     {
         _disposed = true;                                            // EOF now means "we left", not "it died"
-        try { _data?.Dispose(); } catch { }
+        CancelRead();
     }
 
     public void Dispose()
@@ -298,6 +307,14 @@ public sealed class ServerSession : ISession
         _disposed = true;
         if (_started)
             try { _backend.Client.Kill(_id); } catch { }             // explicit close = kill (pane closed)
-        try { _data?.Dispose(); } catch { }
+        CancelRead();
+    }
+
+    private void CancelRead()
+    {
+        try { _readCancel.Cancel(); } catch (ObjectDisposedException) { }
+        // If the loop never started (start failed / never started), there is no pending read and
+        // no owner to close the pipe — do it here, where it is safe for the same reason.
+        if (!_started && _data is { } d) { try { d.Dispose(); } catch { } }
     }
 }

--- a/tests/Agwinterm.Pty.Tests/PtyHostTests.cs
+++ b/tests/Agwinterm.Pty.Tests/PtyHostTests.cs
@@ -23,21 +23,26 @@ public class PtyHostTests : IDisposable
         var buf = new byte[16 * 1024];
         var sw = System.Diagnostics.Stopwatch.StartNew();
         long nextTypeAt = 0;
+        using var cts = new CancellationTokenSource();
         Task<int>? pending = null;
-        while (sw.ElapsedMilliseconds < timeoutMs)
+        try
         {
-            if (sw.ElapsedMilliseconds >= nextTypeAt)
+            while (sw.ElapsedMilliseconds < timeoutMs)
             {
-                data.Write(bytes); data.Flush();
-                nextTypeAt = sw.ElapsedMilliseconds + 2500;
+                if (sw.ElapsedMilliseconds >= nextTypeAt)
+                {
+                    data.Write(bytes); data.Flush();
+                    nextTypeAt = sw.ElapsedMilliseconds + 2500;
+                }
+                pending ??= data.ReadAsync(buf, 0, buf.Length, cts.Token);
+                if (!pending.Wait(250)) continue;             // keep ONE read in flight across retries
+                int n = pending.Result; pending = null;
+                if (n <= 0) break;
+                all.Append(System.Text.Encoding.UTF8.GetString(buf, 0, n));
+                if (all.ToString().Contains(marker, StringComparison.Ordinal)) break;
             }
-            pending ??= data.ReadAsync(buf, 0, buf.Length);
-            if (!pending.Wait(250)) continue;             // keep ONE read in flight across retries
-            int n = pending.Result; pending = null;
-            if (n <= 0) break;
-            all.Append(System.Text.Encoding.UTF8.GetString(buf, 0, n));
-            if (all.ToString().Contains(marker, StringComparison.Ordinal)) break;
         }
+        finally { DrainPending(ref pending, cts); }           // never dispose the pipe with a read in flight (#118)
         return all.ToString();
     }
 
@@ -46,15 +51,32 @@ public class PtyHostTests : IDisposable
         var all = new System.Text.StringBuilder();
         var buf = new byte[16 * 1024];
         var sw = System.Diagnostics.Stopwatch.StartNew();
-        while (sw.ElapsedMilliseconds < timeoutMs)
+        using var cts = new CancellationTokenSource();
+        Task<int>? read = null;
+        try
         {
-            var read = data.ReadAsync(buf, 0, buf.Length);
-            if (!read.Wait(Math.Max(1, timeoutMs - (int)sw.ElapsedMilliseconds))) break;
-            if (read.Result <= 0) break;
-            all.Append(System.Text.Encoding.UTF8.GetString(buf, 0, read.Result));
-            if (done(all.ToString())) return all.ToString();
+            while (sw.ElapsedMilliseconds < timeoutMs)
+            {
+                read = data.ReadAsync(buf, 0, buf.Length, cts.Token);
+                if (!read.Wait(Math.Max(1, timeoutMs - (int)sw.ElapsedMilliseconds))) break;
+                int n = read.Result; read = null;
+                if (n <= 0) break;
+                all.Append(System.Text.Encoding.UTF8.GetString(buf, 0, n));
+                if (done(all.ToString())) return all.ToString();
+            }
         }
+        finally { DrainPending(ref read, cts); }              // never dispose the pipe with a read in flight (#118)
         return all.ToString();
+    }
+
+    /// <summary>Cancel an in-flight read and WAIT for it to finish, so the caller's `using` can
+    /// dispose the pipe without an overlapped op outstanding (the #118 crash class).</summary>
+    private static void DrainPending(ref Task<int>? pending, CancellationTokenSource cts)
+    {
+        if (pending is null) return;
+        cts.Cancel();
+        try { pending.Wait(5000); } catch (AggregateException) { }    // canceled/IO-error = drained
+        pending = null;
     }
 
     [Fact]


### PR DESCRIPTION
Hardens every pty-host pipe teardown path against the #118 crash class (native AV in the IOCP poller — an overlapped op completing against freed state after its pipe was disposed underneath it):

- **PtyHostServer**: data pipes wrapped in a `DataChannel` (pipe + CTS). All closers (detach/kill/supersede/exit/shutdown) now only **cancel**; the input pump is the single owner that disposes, strictly after its pending `ReadAsync` completes, under `DataLock` so `RawOutput` forwards can''t be mid-write.
- **ServerSession.ReadLoop**: same ownership client-side — `Detach`/`Dispose` cancel, the loop disposes after its read completes. (Sync pipe handle considered and rejected: closing your own end can''t unblock a blocked sync read — SafeHandle ref-counting keeps the OS handle open.)
- **PtyHostClient control pipe**: now a sync handle — requests are sync request/response under a lock, and sync ops on an async handle secretly run overlapped IO with the same teardown hazard.
- **Test helpers**: cancel + drain in-flight reads before `using` disposes the pipe.

All 258 tests green, including detach/adopt semantics (cancel-based detach still delivers the host-side EOF).

**Honest status: this does NOT close #118.** Local stress still aborted ~1-in-15 post-fix (baseline 1-in-12; the post-run was also contaminated by concurrent rebuilds, so the numbers are noisy). It shrinks the racy surface and is correct on its own merits. Next step tracked in #118: stress with `DOTNET_DbgEnableMiniDump` and read the actual native faulting stack — remaining suspect is Porta.Pty''s ConPTY stream internals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k