### PR TITLE
chore(release): bump version to 0.14.5

### DIFF
--- a/installer/agwinterm.iss
+++ b/installer/agwinterm.iss
@@ -2,7 +2,7 @@
 ; Build via installer\build.ps1 (publishes to stage\ then runs ISCC on this file).
 
 #define AppName    "agwinterm"
-#define AppVersion "0.14.4"
+#define AppVersion "0.14.5"
 #define AppExe     "Agwinterm.Win32.exe"
 #define AppPublisher "Boris Kudriashov"
 


### PR DESCRIPTION
0.14.5 — the render-quality release:

- **#120** fallback-font glyphs anchored to the grid — fixes the overlapping / shifted-colored-text bug (Claude Code status symbols, emoji, dingbats)
- **#119** SGR text styles: bold, italic, underline, strikethrough (docxy formatting preview lights up)
- **#121** pty-host pipe-teardown hardening (#118)
- **#122** Rust core scaffold (no runtime impact; crate is opt-in)

Tag `v0.14.5` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k