### PR TITLE
fix(pipes): never abandon an in-flight ack write (#118, dump-proven)

### DIFF
--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -77,7 +77,10 @@ public sealed class ControlServer : IDisposable
                 while ((line = await reader.ReadLineAsync(ct).ConfigureAwait(false)) != null)
                 {
                     if (line.Length == 0) continue;
-                    await writer.WriteLineAsync(Dispatch(line).AsMemory(), ct).ConfigureAwait(false);
+                    // No ct on the reply write — same #118 hazard as PtyHostServer's ack: a
+                    // cancelled WriteLineAsync abandons its overlapped write and the dispose
+                    // races the in-flight completion (native AV in the IOCP poller).
+                    await writer.WriteLineAsync(Dispatch(line).AsMemory(), CancellationToken.None).ConfigureAwait(false);
                 }
             }
             catch (OperationCanceledException) { }

--- a/src/Agwinterm.Pty/PtyHostServer.cs
+++ b/src/Agwinterm.Pty/PtyHostServer.cs
@@ -90,7 +90,13 @@ public sealed class PtyHostServer : IDisposable
                 while ((line = await reader.ReadLineAsync(ct).ConfigureAwait(false)) != null)
                 {
                     if (line.Length == 0) continue;
-                    await writer.WriteLineAsync(Dispatch(line).AsMemory(), ct).ConfigureAwait(false);
+                    // The ack write deliberately takes NO cancellation token (#118, dump-proven):
+                    // cancelling StreamWriter.WriteLineAsync mid-flush completes the TASK but
+                    // ABANDONS the overlapped write — the using-dispose then closes the pipe with
+                    // that op in flight, and its completion later faults the IOCP poller (native
+                    // AV). Acks are one short line; letting them finish closes the race window.
+                    // The read keeps ct: its cancel is one awaited op, consumed before dispose.
+                    await writer.WriteLineAsync(Dispatch(line).AsMemory(), CancellationToken.None).ConfigureAwait(false);
                 }
             }
             catch (OperationCanceledException) { }


### PR DESCRIPTION
First **dump-proven** #118 finding: the stress harness finally captured the AV with `DOTNET_DbgEnableMiniDump`, and the dump shows the crash firing while `Shutdown_KillsSessionsAndCompletes` runs — a test with **no data pipes**, which narrows the field to the control pipes. The only abandoned-overlapped-op site there: `StreamWriter.WriteLineAsync(reply, ct)`. Cancelling it mid-flush completes the *task* but leaves the overlapped write in flight; `using` then disposes the pipe underneath it, and the late completion faults the IOCP poller — a native AV with no managed trace.

Fix: replies write with `CancellationToken.None` in **both** `PtyHostServer` and `ControlServer` (identical code shape — and ControlServer runs in the production UI). An ack is one short line; letting it finish closes the window. Reads keep their token: a cancelled read is a single awaited op, consumed before dispose.

**Honest status:** a follow-up stress still aborted (~1/16) with the same signature during a different test — this closes *a* hole, not necessarily *the* hole. A poller-ablation experiment (`DOTNET_ThreadPool_UsePortableThreadPoolForIO=0`, 60 runs) is running to determine whether the remainder is a .NET 10 runtime bug; results go to #118 (which stays open). Related upstream: [dotnet/runtime#75828](https://github.com/dotnet/runtime/issues/75828), [dotnet/runtime#119795](https://github.com/dotnet/runtime/issues/119795).

All 258 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k