### PR TITLE
ci: retry once on the known .NET 10 test-host native crash (#118)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,14 @@ jobs:
         run: dotnet build Agwinterm.slnx -c Release --no-restore
 
       - name: Test (Core + Pty)
-        run: dotnet test Agwinterm.slnx -c Release --no-build
+        # One retry, but ONLY for the known .NET 10 test-host native crash (issue #118:
+        # AccessViolation in the IOCP poller under named-pipe churn — "Test Run Aborted" with
+        # zero failed tests). Real test failures never retry — they fail the job immediately.
+        shell: pwsh
+        run: |
+          $out = dotnet test Agwinterm.slnx -c Release --no-build 2>&1 | Tee-Object -Variable lines | Out-String
+          if ($LASTEXITCODE -eq 0) { exit 0 }
+          if ($out -notmatch 'Test Run Aborted|host process crashed') { exit 1 }
+          Write-Host '::warning::test host crashed natively (issue #118) - retrying once'
+          dotnet test Agwinterm.slnx -c Release --no-build
+          exit $LASTEXITCODE


### PR DESCRIPTION
The #118 native AV survives all app-level hardening (#121 teardown ownership, #124 ack-write fix — both real bugs, both fixed, neither was the whole story). Evidence now points at the .NET 10 runtime itself:

- 3 captured dumps, all faulting in `PortableThreadPool+IOCompletionPoller+Event.Invoke` under named-pipe churn, each during a *different* test (shutdown / reattach / child-exit) — no app-level common denominator remains.
- The classic ablation (`DOTNET_ThreadPool_UsePortableThreadPoolForIO=0`) is **void on .NET 10**: dumps confirm poller threads still run — the switch is ignored, the unmanaged fallback no longer exists.
- Crash rate is a few percent per suite run, unchanged (within noise) across all three fixes.

This adds a **surgical CI retry**: exactly the native-crash signature ("Test Run Aborted"/"host process crashed") retries once with a workflow warning; genuine test failures still fail immediately, and the warning keeps every occurrence visible in run logs for #118 frequency tracking.

Upstream report proposal is on #118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k