### PR TITLE
fix(profiles): survive Store PowerShell updates rotating the pwsh path

### DIFF
--- a/src/Agwinterm.Pty/ShellProfiles.cs
+++ b/src/Agwinterm.Pty/ShellProfiles.cs
@@ -94,6 +94,18 @@ public static class ShellProfiles
         // distros (e.g. "WSL: Press any key to install …") — distro names never contain spaces.
         c.Profiles.RemoveAll(p => p.Name.StartsWith("WSL: ", StringComparison.OrdinalIgnoreCase)
                                   && p.Name["WSL: ".Length..].Contains(' '));
+        // Repair STALE ABSOLUTE PATHS (real field failure: a Store PowerShell update rotates its
+        // versioned WindowsApps dir, and a profile that captured the resolved path dies with
+        // "spawn failed: file not found" on every pane). If the file is gone but the bare exe
+        // name resolves via PATH, fall back to the name — PATH re-resolves at every spawn, so
+        // version rotations can never strand it again. Only applies when the file is MISSING:
+        // deliberate absolute paths to existing exes are untouched.
+        foreach (var p in c.Profiles)
+        {
+            if (!Path.IsPathRooted(p.Command) || File.Exists(p.Command)) continue;
+            string bare = Path.GetFileName(p.Command);
+            if (bare.Length > 0 && Which(bare) is not null) p.Command = bare;
+        }
         if (c.Profiles.Count == 0) c.Profiles.Add(DefaultPowerShell());
         if (string.IsNullOrWhiteSpace(c.Default) ||
             !c.Profiles.Exists(p => p.Name.Equals(c.Default, StringComparison.OrdinalIgnoreCase)))
@@ -109,8 +121,12 @@ public static class ShellProfiles
     {
         var list = new List<ShellProfile> { DefaultPowerShell() }; // always present; the default
 
-        string? pwsh = Which("pwsh.exe")
-            ?? Exists(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "PowerShell", "7", "pwsh.exe"));
+        // Seed the COMMAND as the bare exe name when PATH can resolve it: PATH re-resolves at
+        // every spawn, so a Store PowerShell update rotating its versioned WindowsApps dir can't
+        // strand the profile (a captured resolved path dies on the next update — field failure).
+        // Only a non-PATH install (bare ProgramFiles copy) keeps an absolute path, which is stable.
+        string? pwsh = Which("pwsh.exe") is not null ? "pwsh.exe"
+            : Exists(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "PowerShell", "7", "pwsh.exe"));
         if (pwsh is not null) list.Add(new ShellProfile { Name = "PowerShell 7", Command = pwsh, Icon = Term });
 
         list.Add(new ShellProfile { Name = "Command Prompt", Command = "cmd.exe", Icon = Term });
@@ -133,8 +149,8 @@ public static class ShellProfiles
         }
         catch { /* WSL optional */ }
 
-        string? nu = Which("nu.exe");
-        if (nu is not null) list.Add(new ShellProfile { Name = "Nushell", Command = nu, Icon = Term });
+        if (Which("nu.exe") is not null)
+            list.Add(new ShellProfile { Name = "Nushell", Command = "nu.exe", Icon = Term });   // bare name: PATH re-resolves per spawn
 
         return list;
     }

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -224,6 +224,29 @@ internal partial class Program
         var prof = ResolveProfile(profileName);
         string cmd = prof?.Command is { Length: > 0 } c ? c : "powershell.exe";
         string[]? pargs = prof?.Args;
+        // Last line of defense against stale absolute paths (a Store PowerShell update rotating
+        // its versioned dir — real field failure): a missing exe degrades to the bare name (PATH
+        // re-resolves it) and ultimately to Windows PowerShell, with a visible notice — never a
+        // dead pane. ShellProfiles.Normalize heals the profile itself; this catches live races.
+        if (Path.IsPathRooted(cmd) && !File.Exists(cmd))
+        {
+            string bare = Path.GetFileName(cmd);
+            cmd = bare.Length > 0 ? bare : "powershell.exe";
+            if (cmd is not "powershell.exe" && FreshEnvironment.TryBuild() is { } fe
+                && (!fe.TryGetValue("Path", out var fp) || !fp.Split(';').Any(d => File.Exists(Path.Combine(d.Trim(), cmd)))))
+            {
+                cmd = "powershell.exe";   // not even a fresh PATH knows it — the shell is gone entirely
+                pargs = null;
+            }
+            // Scrollback (survives ConPTY's initial screen erase — an Inject would be wiped) +
+            // toast for immediate visibility.
+            session.MutateLocked(e => e.SeedScrollback(new[]
+            {
+                $"[agwinterm] profile exe not found: {prof?.Command}",
+                $"  fell back to {cmd} (fix the profile in profiles.json)",
+            }));
+            ShowToast($"profile '{prof?.Name}': exe missing — fell back to {cmd}", 6000);
+        }
         string? pcwd = string.IsNullOrEmpty(cwd) ? prof?.Cwd : cwd;
         // Per-profile env vars (WT parity). AGWINTERM_* set by CreatePane win, so profile env can't
         // clobber our identity vars; a custom-command's $AGW_* extraEnv still overrides last.

--- a/tests/Agwinterm.Pty.Tests/ShellProfilesTests.cs
+++ b/tests/Agwinterm.Pty.Tests/ShellProfilesTests.cs
@@ -1,0 +1,54 @@
+using Agwinterm.Pty;
+using System.Text.Json;
+
+namespace Agwinterm.Pty.Tests;
+
+/// <summary>Profile loading self-repair — born from a field failure: a Store PowerShell update
+/// rotated its versioned WindowsApps dir and every pane died with "spawn failed" because the
+/// profile had captured the resolved (version-baked) path.</summary>
+public class ShellProfilesTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), "agw-profiles-" + Guid.NewGuid().ToString("N")[..8]);
+
+    public ShellProfilesTests() => Directory.CreateDirectory(_dir);
+    public void Dispose() { try { Directory.Delete(_dir, true); } catch { } }
+
+    private void WriteProfiles(object cfg) =>
+        // camelCase to match Save()'s output — the loader's deserialization is case-SENSITIVE.
+        File.WriteAllText(Path.Combine(_dir, "profiles.json"),
+            JsonSerializer.Serialize(cfg, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }));
+
+    [Fact]
+    public void StaleAbsolutePath_HealsToBareName_WhenPathResolvesIt()
+    {
+        // The exact field shape: a version-baked WindowsApps path that no longer exists, whose
+        // bare name (cmd.exe here — guaranteed on PATH) still resolves.
+        WriteProfiles(new
+        {
+            Default = "P7",
+            Profiles = new[] { new { Name = "P7", Command = @"C:\Program Files\WindowsApps\Microsoft.PowerShell_7.6.3.0_x64__8wekyb3d8bbwe\cmd.exe" } }
+        });
+        var cfg = ShellProfiles.Load(_dir);
+        Assert.Equal("cmd.exe", Assert.Single(cfg.Profiles, p => p.Name == "P7").Command);
+    }
+
+    [Fact]
+    public void MissingExe_NotOnPath_IsLeftAlone()
+    {
+        // Unresolvable bare name → keep the absolute path (an honest error beats a silent swap
+        // to something unrelated; the LaunchShell fallback handles the pane-level degrade).
+        string stale = @"C:\definitely\not\here\no-such-shell-agw.exe";
+        WriteProfiles(new { Default = "X", Profiles = new[] { new { Name = "X", Command = stale } } });
+        var cfg = ShellProfiles.Load(_dir);
+        Assert.Equal(stale, Assert.Single(cfg.Profiles, p => p.Name == "X").Command);
+    }
+
+    [Fact]
+    public void ExistingAbsolutePath_IsUntouched()
+    {
+        string real = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "cmd.exe");
+        WriteProfiles(new { Default = "Real", Profiles = new[] { new { Name = "Real", Command = real } } });
+        var cfg = ShellProfiles.Load(_dir);
+        Assert.Equal(real, Assert.Single(cfg.Profiles, p => p.Name == "Real").Command);
+    }
+}


### PR DESCRIPTION
## Field failure

Work laptop, post-Windows-update reboot: every pane dead with `spawn failed: Could not start terminal process "C:\Program Files\WindowsApps\Microsoft.PowerShell_7.6.3.0_x64__8wekyb3d8bbwe\pwsh.exe" ... The system cannot find the file specified.` — profiles.json had captured the **resolved** pwsh path (version-baked WindowsApps package dir) and the PowerShell update rotated it away.

## Fix (three layers)

1. **Heal on load** (`ShellProfiles.Normalize`): an absolute `command` that no longer exists falls back to its bare exe name *when PATH still resolves it* — PATH re-resolves at every spawn, so version rotations can never strand a profile again. Missing *and* unresolvable is left alone (honest error over silent swap).
2. **Seed stable commands** (`Detect`): pwsh/nu seed as bare names when PATH finds them — fresh installs never bake a version into profiles.json. Non-PATH ProgramFiles installs keep their stable absolute path.
3. **Never a dead pane** (`LaunchShell`): live-race degrade — missing exe → bare name → (verified against a registry-fresh PATH) → Windows PowerShell, with a scrollback notice (an Inject would be wiped by ConPTY's initial erase) and a toast.

## Evidence

- 3 unit tests using the exact field path shape (heal / leave-alone / untouched).
- E2E: a ghost default profile produced a **live, typable PowerShell pane** (`echo fallback+alive` echoed) instead of the dead pane + error wall.
- Full suite green (261). One #118 runtime crash struck a local run mid-suite (99/99 passed before abort, rerun clean) — logged for the frequency record.

The broken work laptop heals automatically on first start of a release carrying this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k
