### PR TITLE
chore(release): bump version to 0.14.6

### DIFF
--- a/installer/agwinterm.iss
+++ b/installer/agwinterm.iss
@@ -2,7 +2,7 @@
 ; Build via installer\build.ps1 (publishes to stage\ then runs ISCC on this file).
 
 #define AppName    "agwinterm"
-#define AppVersion "0.14.5"
+#define AppVersion "0.14.6"
 #define AppExe     "Agwinterm.Win32.exe"
 #define AppPublisher "Boris Kudriashov"
 


### PR DESCRIPTION
0.14.6 — field-failure fixes:

- **#127** profiles survive Store PowerShell updates: stale absolute paths heal on load, seeds store bare exe names, and a missing exe degrades to a working shell instead of a dead pane.
- **#124** control-pipe ack writes are never abandoned mid-flight (#118 crash class; hardens the production control API too).

Tag v0.14.6 after merge.

Generated with Claude Code - https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k