### PR TITLE
feat(rust): module 4 — the emulator, with a full-state differential oracle

### DIFF
--- a/native/agwinterm-core/src/emulator.rs
+++ b/native/agwinterm-core/src/emulator.rs
@@ -1,0 +1,900 @@
+//! Faithful port of Agwinterm.Core/TerminalEmulator.cs (module 4).
+//!
+//! Scope: everything EXCEPT images (kitty APC / sixel DCS / placements — module 5)
+//! and host actions (notifications, clipboard, responses — the C# oracle runs with
+//! Host = null, where those are dropped, so parity holds with them absent here).
+//!
+//! Quirks deliberately preserved (the full-state differential oracle enforces them):
+//!  - Deferred-ish wrap: CursorCol may sit == Cols after printing the last column;
+//!    the NEXT print wraps. Dumps expose the raw value.
+//!  - TAB clamps to Cols-1 (and can move the cursor LEFT from the post-print
+//!    overflow position).
+//!  - EraseLine treats any mode != 0 as "from column 0" and any mode != 1 as
+//!    "to the last column" (so mode 3 == mode 2). EraseDisplay ignores modes > 2.
+//!  - SGR 38/48;2 casts channel params with wrapping byte conversion; ;5 with an
+//!    out-of-range index consumes params and changes nothing (C# guarded the same
+//!    way after the port review found the unguarded throw).
+//!  - Invalid DECSTBM resets to full screen; any DECSTBM homes the cursor.
+//!  - Zero-width codepoints are dropped (v1 semantics).
+
+use crate::cell::{attrs, Cell, Color, ColorSpec};
+use crate::screen::ScreenBuffer;
+use crate::vtparser::{Performer, VtParser};
+use crate::wcwidth;
+
+const TRIM_SLACK: usize = 512;
+
+#[derive(Clone, Copy, Default)]
+pub struct ShellMark {
+    pub prompt_line: i64,
+    pub command_line: i64, // -1 = unset
+    pub output_line: i64,
+    pub end_line: i64,
+    pub exit_code: Option<i32>,
+}
+
+pub struct Emulator {
+    main: ScreenBuffer,
+    alt: ScreenBuffer,
+    on_alt: bool,
+
+    pub cursor_row: usize,
+    pub cursor_col: usize, // may equal cols (post-print overflow) — see module docs
+    pub cursor_visible: bool,
+    saved_row: usize,
+    saved_col: usize,
+
+    mouse_click: bool,
+    mouse_drag: bool,
+    mouse_motion: bool,
+    mouse_sgr: bool,
+    pub bracketed_paste: bool,
+
+    scroll_top: usize,
+    scroll_bottom: usize,
+
+    history: Vec<Vec<Cell>>,
+    pub scrollback_max: usize,
+    pub scroll_generation: i64,
+
+    marks: Vec<ShellMark>,
+
+    fg: Color,
+    bg: Color,
+    fg_spec: ColorSpec,
+    bg_spec: ColorSpec,
+    attrs: u32,
+
+    pub title: String,
+    pub cwd: String,
+
+    kbd_stack: Vec<i32>,
+    pending_high_surrogate: u16,
+}
+
+impl Emulator {
+    pub fn new(cols: usize, rows: usize) -> Emulator {
+        Emulator {
+            main: ScreenBuffer::new(cols, rows),
+            alt: ScreenBuffer::new(cols, rows),
+            on_alt: false,
+            cursor_row: 0,
+            cursor_col: 0,
+            cursor_visible: true,
+            saved_row: 0,
+            saved_col: 0,
+            mouse_click: false,
+            mouse_drag: false,
+            mouse_motion: false,
+            mouse_sgr: false,
+            bracketed_paste: false,
+            scroll_top: 0,
+            scroll_bottom: rows - 1,
+            history: Vec::new(),
+            scrollback_max: 5000,
+            scroll_generation: 0,
+            marks: Vec::new(),
+            fg: Color::DEFAULT_FOREGROUND,
+            bg: Color::DEFAULT_BACKGROUND,
+            fg_spec: ColorSpec::DEFAULT,
+            bg_spec: ColorSpec::DEFAULT,
+            attrs: attrs::NONE,
+            title: String::new(),
+            cwd: String::new(),
+            kbd_stack: Vec::new(),
+            pending_high_surrogate: 0,
+        }
+    }
+
+    pub fn screen(&self) -> &ScreenBuffer {
+        if self.on_alt { &self.alt } else { &self.main }
+    }
+    fn scr(&mut self) -> &mut ScreenBuffer {
+        if self.on_alt { &mut self.alt } else { &mut self.main }
+    }
+    pub fn is_alt_screen(&self) -> bool {
+        self.on_alt
+    }
+    pub fn history_count(&self) -> usize {
+        self.history.len()
+    }
+    pub fn marks(&self) -> &[ShellMark] {
+        &self.marks
+    }
+    pub fn keyboard_flags(&self) -> i32 {
+        *self.kbd_stack.last().unwrap_or(&0)
+    }
+    pub fn mouse_flags(&self) -> (bool, bool, bool, bool) {
+        (self.mouse_click, self.mouse_drag, self.mouse_motion, self.mouse_sgr)
+    }
+    pub fn scroll_top(&self) -> usize {
+        self.scroll_top
+    }
+    pub fn scroll_bottom(&self) -> usize {
+        self.scroll_bottom
+    }
+
+    pub fn get_history_cell(&self, history_row: usize, col: usize) -> Cell {
+        match self.history.get(history_row) {
+            Some(row) => *row.get(col).unwrap_or(&Cell::EMPTY),
+            None => Cell::EMPTY,
+        }
+    }
+
+    pub fn resize(&mut self, cols: usize, rows: usize) {
+        if cols == 0 || rows == 0 {
+            return;
+        }
+        self.main.resize(cols, rows);
+        self.alt.resize(cols, rows);
+        self.scroll_top = 0;
+        self.scroll_bottom = rows - 1;
+        if self.cursor_row >= rows {
+            self.cursor_row = rows - 1;
+        }
+        if self.cursor_col >= cols {
+            self.cursor_col = cols - 1;
+        }
+    }
+
+    // ---- content ----
+
+    fn print_scalar(&mut self, cp: i32) {
+        let w = wcwidth::of(cp as u32) as usize;
+        if w == 0 {
+            return; // combining/zero-width: dropped in v1
+        }
+        let cols = self.screen().cols();
+        if self.cursor_col >= cols {
+            self.cursor_col = 0;
+            self.index();
+        }
+        if w == 2 && self.cursor_col == self.screen().cols() - 1 {
+            let b = self.blank();
+            let (r, c) = (self.cursor_row, self.cursor_col);
+            self.scr().set(r, c, b);
+            self.cursor_col = 0;
+            self.index();
+        }
+        let cell = Cell {
+            rune: cp,
+            foreground: self.fg,
+            background: self.bg,
+            attributes: self.attrs,
+            width: w as u8,
+            fg_spec: self.fg_spec,
+            bg_spec: self.bg_spec,
+        };
+        let (r, c) = (self.cursor_row, self.cursor_col);
+        self.scr().set(r, c, cell);
+        if w == 2 {
+            let spacer = Cell { rune: 0, width: 0, ..cell };
+            self.scr().set(r, c + 1, spacer);
+        }
+        self.cursor_col += w;
+    }
+
+    fn blank(&self) -> Cell {
+        Cell {
+            rune: ' ' as i32,
+            foreground: Color::DEFAULT_FOREGROUND,
+            background: self.bg,
+            attributes: attrs::NONE,
+            width: 1,
+            fg_spec: ColorSpec::DEFAULT,
+            bg_spec: self.bg_spec,
+        }
+    }
+
+    // ---- scrolling / regions ----
+
+    fn push_history(&mut self) {
+        let cols = self.screen().cols();
+        let mut row = vec![Cell::EMPTY; cols];
+        self.screen().copy_row_to(0, &mut row);
+        self.history.push(row);
+        self.scroll_generation += 1;
+        if self.history.len() > self.scrollback_max + TRIM_SLACK {
+            let trim = (self.history.len() - self.scrollback_max) as i64;
+            self.history.drain(0..trim as usize);
+            self.marks.retain_mut(|m| {
+                m.prompt_line -= trim;
+                if m.command_line >= 0 { m.command_line -= trim; }
+                if m.output_line >= 0 { m.output_line -= trim; }
+                if m.end_line >= 0 { m.end_line -= trim; }
+                m.prompt_line >= 0
+            });
+        }
+    }
+
+    fn index(&mut self) {
+        if self.cursor_row == self.scroll_bottom {
+            self.scroll_region_up();
+        } else if self.cursor_row < self.screen().rows() - 1 {
+            self.cursor_row += 1;
+        }
+    }
+
+    fn reverse_index(&mut self) {
+        if self.cursor_row == self.scroll_top {
+            self.scroll_region_down();
+        } else if self.cursor_row > 0 {
+            self.cursor_row -= 1;
+        }
+    }
+
+    fn scroll_region_up(&mut self) {
+        if !self.on_alt
+            && self.scrollback_max > 0
+            && self.scroll_top == 0
+            && self.scroll_bottom == self.screen().rows() - 1
+        {
+            self.push_history();
+        }
+        let (top, bottom) = (self.scroll_top, self.scroll_bottom);
+        let b = self.blank();
+        self.scr().move_rows(top + 1, top, bottom - top);
+        self.scr().fill_row(bottom, b);
+    }
+
+    fn scroll_region_down(&mut self) {
+        let (top, bottom) = (self.scroll_top, self.scroll_bottom);
+        let b = self.blank();
+        self.scr().move_rows(top, top + 1, bottom - top);
+        self.scr().fill_row(top, b);
+    }
+
+    fn set_scroll_region(&mut self, top: i64, bottom: i64) {
+        let rows = self.screen().rows() as i64;
+        let mut top = top.clamp(0, rows - 1);
+        let mut bottom = bottom.clamp(0, rows - 1);
+        if top >= bottom {
+            top = 0;
+            bottom = rows - 1;
+        }
+        self.scroll_top = top as usize;
+        self.scroll_bottom = bottom as usize;
+        self.cursor_row = 0;
+        self.cursor_col = 0;
+    }
+
+    fn insert_lines(&mut self, n: i64) {
+        if self.cursor_row < self.scroll_top || self.cursor_row > self.scroll_bottom {
+            return;
+        }
+        let n = n.min((self.scroll_bottom - self.cursor_row + 1) as i64).max(0) as usize;
+        let shift = self.scroll_bottom - self.cursor_row + 1 - n;
+        let row = self.cursor_row;
+        let b = self.blank();
+        if shift > 0 {
+            self.scr().move_rows(row, row + n, shift);
+        }
+        for r in row..row + n {
+            self.scr().fill_row(r, b);
+        }
+    }
+
+    fn delete_lines(&mut self, n: i64) {
+        if self.cursor_row < self.scroll_top || self.cursor_row > self.scroll_bottom {
+            return;
+        }
+        let n = n.min((self.scroll_bottom - self.cursor_row + 1) as i64).max(0) as usize;
+        let shift = self.scroll_bottom - self.cursor_row + 1 - n;
+        let row = self.cursor_row;
+        let bottom = self.scroll_bottom;
+        let b = self.blank();
+        if shift > 0 {
+            self.scr().move_rows(row + n, row, shift);
+        }
+        for r in (bottom + 1 - n)..=bottom {
+            self.scr().fill_row(r, b);
+        }
+    }
+
+    fn insert_chars(&mut self, n: i64) {
+        let cols = self.screen().cols() as i64;
+        let n = n.max(0);
+        let b = self.blank();
+        let (row, cur) = (self.cursor_row, self.cursor_col as i64);
+        let mut c = cols - 1;
+        while c >= cur + n {
+            let src = self.screen().get(row, (c - n) as usize);
+            self.scr().set(row, c as usize, src);
+            c -= 1;
+        }
+        let to = (cur + n).min(cols);
+        for c in cur..to {
+            self.scr().set(row, c as usize, b);
+        }
+    }
+
+    fn delete_chars(&mut self, n: i64) {
+        let cols = self.screen().cols() as i64;
+        let n = n.max(0);
+        let b = self.blank();
+        let (row, cur) = (self.cursor_row, self.cursor_col as i64);
+        for c in cur..cols {
+            let cell = if c + n < cols { self.screen().get(row, (c + n) as usize) } else { b };
+            self.scr().set(row, c as usize, cell);
+        }
+    }
+
+    // ---- erase ----
+
+    fn erase_chars(&mut self, count: i64) {
+        let cols = self.screen().cols() as i64;
+        let to = (self.cursor_col as i64 + count.max(0)).min(cols);
+        let b = self.blank();
+        let row = self.cursor_row;
+        for c in self.cursor_col as i64..to {
+            self.scr().set(row, c as usize, b);
+        }
+    }
+
+    fn erase_line(&mut self, mode: i32) {
+        let from = if mode == 0 { self.cursor_col } else { 0 };
+        let to = if mode == 1 { self.cursor_col } else { self.screen().cols() - 1 };
+        let b = self.blank();
+        let row = self.cursor_row;
+        let mut c = from;
+        while c <= to {
+            self.scr().set(row, c, b);
+            c += 1;
+        }
+    }
+
+    fn erase_display(&mut self, mode: i32) {
+        let (rows, cols) = (self.screen().rows(), self.screen().cols());
+        let b = self.blank();
+        match mode {
+            2 => {
+                for r in 0..rows {
+                    for c in 0..cols {
+                        self.scr().set(r, c, b);
+                    }
+                }
+            }
+            0 => {
+                self.erase_line(0);
+                for r in self.cursor_row + 1..rows {
+                    for c in 0..cols {
+                        self.scr().set(r, c, b);
+                    }
+                }
+            }
+            1 => {
+                self.erase_line(1);
+                for r in 0..self.cursor_row {
+                    for c in 0..cols {
+                        self.scr().set(r, c, b);
+                    }
+                }
+            }
+            _ => {} // modes > 2 (e.g. 3): no-op, like the original
+        }
+    }
+
+    // ---- modes / screens / cursor save ----
+
+    fn set_private_mode(&mut self, params: &[i32], set: bool) {
+        for &mode in params {
+            match mode {
+                1049 => {
+                    if set {
+                        self.save_cursor();
+                        self.enter_alt_screen();
+                    } else {
+                        self.leave_alt_screen();
+                        self.restore_cursor();
+                    }
+                }
+                47 | 1047 => {
+                    if set {
+                        self.enter_alt_screen();
+                    } else {
+                        self.leave_alt_screen();
+                    }
+                }
+                25 => self.cursor_visible = set,
+                1000 => self.mouse_click = set,
+                1002 => self.mouse_drag = set,
+                1003 => self.mouse_motion = set,
+                1006 => self.mouse_sgr = set,
+                2004 => self.bracketed_paste = set,
+                _ => {} // Host.Unhandled — headless drop
+            }
+        }
+    }
+
+    fn enter_alt_screen(&mut self) {
+        if self.on_alt {
+            return;
+        }
+        self.on_alt = true;
+        self.alt.clear();
+        self.cursor_row = 0;
+        self.cursor_col = 0;
+    }
+
+    fn leave_alt_screen(&mut self) {
+        self.on_alt = false;
+    }
+
+    fn save_cursor(&mut self) {
+        self.saved_row = self.cursor_row;
+        self.saved_col = self.cursor_col;
+    }
+
+    fn restore_cursor(&mut self) {
+        self.cursor_row = self.saved_row.min(self.screen().rows() - 1);
+        self.cursor_col = self.saved_col.min(self.screen().cols() - 1);
+    }
+
+    // ---- SGR ----
+
+    fn apply_sgr(&mut self, p: &[i32]) {
+        if p.is_empty() {
+            self.reset_pen();
+            return;
+        }
+        let mut i = 0usize;
+        while i < p.len() {
+            let code = p[i];
+            match code {
+                0 => self.reset_pen(),
+                1 => self.attrs |= attrs::BOLD,
+                2 => self.attrs |= attrs::DIM,
+                3 => self.attrs |= attrs::ITALIC,
+                4 => self.attrs |= attrs::UNDERLINE,
+                7 => self.attrs |= attrs::INVERSE,
+                9 => self.attrs |= attrs::STRIKETHROUGH,
+                22 => self.attrs &= !(attrs::BOLD | attrs::DIM),
+                23 => self.attrs &= !attrs::ITALIC,
+                24 => self.attrs &= !attrs::UNDERLINE,
+                27 => self.attrs &= !attrs::INVERSE,
+                29 => self.attrs &= !attrs::STRIKETHROUGH,
+                30..=37 => {
+                    self.fg = Color::from_index((code - 30) as u8);
+                    self.fg_spec = ColorSpec::indexed((code - 30) as u8);
+                }
+                39 => {
+                    self.fg = Color::DEFAULT_FOREGROUND;
+                    self.fg_spec = ColorSpec::DEFAULT;
+                }
+                40..=47 => {
+                    self.bg = Color::from_index((code - 40) as u8);
+                    self.bg_spec = ColorSpec::indexed((code - 40) as u8);
+                }
+                49 => {
+                    self.bg = Color::DEFAULT_BACKGROUND;
+                    self.bg_spec = ColorSpec::DEFAULT;
+                }
+                90..=97 => {
+                    self.fg = Color::from_index((code - 90 + 8) as u8);
+                    self.fg_spec = ColorSpec::indexed((code - 90 + 8) as u8);
+                }
+                100..=107 => {
+                    self.bg = Color::from_index((code - 100 + 8) as u8);
+                    self.bg_spec = ColorSpec::indexed((code - 100 + 8) as u8);
+                }
+                38 => i = self.extended_color(p, i, true),
+                48 => i = self.extended_color(p, i, false),
+                _ => {}
+            }
+            i += 1;
+        }
+    }
+
+    fn extended_color(&mut self, p: &[i32], i: usize, is_fg: bool) -> usize {
+        if i + 1 >= p.len() {
+            return i;
+        }
+        let mode = p[i + 1];
+        if mode == 5 && i + 2 < p.len() {
+            let idx = p[i + 2];
+            // Out-of-range index: consume params, change nothing (matches the guarded C#).
+            if (0..=255).contains(&idx) {
+                let (c, s) = (Color::from_index(idx as u8), ColorSpec::indexed(idx as u8));
+                if is_fg { self.fg = c; self.fg_spec = s; } else { self.bg = c; self.bg_spec = s; }
+            }
+            return i + 2;
+        }
+        if mode == 2 && i + 4 < p.len() {
+            // Wrapping byte casts, matching C#'s unchecked (byte) conversion.
+            let c = Color { r: p[i + 2] as u8, g: p[i + 3] as u8, b: p[i + 4] as u8 };
+            let s = ColorSpec::from_rgb(c);
+            if is_fg { self.fg = c; self.fg_spec = s; } else { self.bg = c; self.bg_spec = s; }
+            return i + 4;
+        }
+        i + 1
+    }
+
+    fn reset_pen(&mut self) {
+        self.fg = Color::DEFAULT_FOREGROUND;
+        self.bg = Color::DEFAULT_BACKGROUND;
+        self.fg_spec = ColorSpec::DEFAULT;
+        self.bg_spec = ColorSpec::DEFAULT;
+        self.attrs = attrs::NONE;
+    }
+
+    // ---- OSC ----
+
+    fn strip_controls(s: &str) -> String {
+        s.chars()
+            .filter(|&c| c >= '\u{20}' && c != '\u{7f}' && !('\u{80}'..='\u{9f}').contains(&c))
+            .collect()
+    }
+
+    fn ftcs_dispatch(&mut self, text: &str) {
+        if self.on_alt || text.is_empty() {
+            return;
+        }
+        let abs = self.history.len() as i64 + self.cursor_row as i64;
+        match text.chars().next().unwrap().to_ascii_uppercase() {
+            'A' => {
+                if self.marks.last().map(|m| m.prompt_line) != Some(abs) {
+                    self.marks.push(ShellMark {
+                        prompt_line: abs,
+                        command_line: -1,
+                        output_line: -1,
+                        end_line: -1,
+                        exit_code: None,
+                    });
+                }
+            }
+            'B' => {
+                if let Some(m) = self.marks.last_mut() {
+                    if m.command_line < 0 { m.command_line = abs; }
+                }
+            }
+            'C' => {
+                if let Some(m) = self.marks.last_mut() {
+                    if m.output_line < 0 { m.output_line = abs; }
+                }
+            }
+            'D' => {
+                if let Some(m) = self.marks.last_mut() {
+                    if m.end_line < 0 {
+                        m.end_line = abs;
+                        if let Some(semi) = text.find(';') {
+                            if let Ok(ec) = text[semi + 1..].parse::<i32>() {
+                                m.exit_code = Some(ec);
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+        if self.marks.len() > 512 {
+            let excess = self.marks.len() - 512;
+            self.marks.drain(0..excess);
+        }
+    }
+
+    // ---- kitty keyboard ----
+
+    fn kitty_keyboard(&mut self, prefix: u8, params: &[i32]) {
+        match prefix {
+            b'?' => {} // query — Host.Respond, headless drop
+            b'>' => self.kbd_stack.push(*params.first().unwrap_or(&0)),
+            b'=' => {
+                let flags = *params.first().unwrap_or(&0);
+                let mode = *params.get(1).unwrap_or(&1);
+                let cur = self.keyboard_flags();
+                let next = match mode {
+                    2 => cur | flags,
+                    3 => cur & !flags,
+                    _ => flags,
+                };
+                self.kbd_stack.pop();
+                self.kbd_stack.push(next);
+            }
+            b'<' => {
+                let mut n = (*params.first().unwrap_or(&1)).max(1);
+                while n > 0 && !self.kbd_stack.is_empty() {
+                    self.kbd_stack.pop();
+                    n -= 1;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // ---- mode dump / scrollback seed (integration surface, matches C#) ----
+
+    pub fn dump_modes(&self) -> String {
+        let mut s = String::new();
+        if self.on_alt { s.push_str("\u{1b}[?1049h"); }
+        if !self.cursor_visible { s.push_str("\u{1b}[?25l"); }
+        if self.mouse_click { s.push_str("\u{1b}[?1000h"); }
+        if self.mouse_drag { s.push_str("\u{1b}[?1002h"); }
+        if self.mouse_motion { s.push_str("\u{1b}[?1003h"); }
+        if self.mouse_sgr { s.push_str("\u{1b}[?1006h"); }
+        if self.bracketed_paste { s.push_str("\u{1b}[?2004h"); }
+        if !self.title.is_empty() { s.push_str("\u{1b}]0;"); s.push_str(&self.title); s.push('\u{7}'); }
+        if !self.cwd.is_empty() { s.push_str("\u{1b}]7;"); s.push_str(&self.cwd); s.push('\u{7}'); }
+        s
+    }
+
+    pub fn seed_scrollback(&mut self, lines: &[&str]) {
+        let cols = self.screen().cols();
+        for line in lines {
+            // Per-UTF-16-unit like the C# char indexing (BMP-only content expected here).
+            let units: Vec<u16> = line.encode_utf16().collect();
+            let mut row = Vec::with_capacity(cols);
+            for c in 0..cols {
+                let ch = *units.get(c).unwrap_or(&(' ' as u16));
+                row.push(Cell {
+                    rune: ch as i32,
+                    foreground: Color::DEFAULT_FOREGROUND,
+                    background: Color::DEFAULT_BACKGROUND,
+                    attributes: attrs::DIM,
+                    width: 1,
+                    fg_spec: ColorSpec::DEFAULT,
+                    bg_spec: ColorSpec::DEFAULT,
+                });
+            }
+            self.history.push(row);
+        }
+        if self.history.len() > self.scrollback_max + TRIM_SLACK {
+            let trim = self.history.len() - self.scrollback_max;
+            self.history.drain(0..trim);
+        }
+    }
+}
+
+/// The emulator + its parser, fed together (mirrors the C# object graph where
+/// TerminalEmulator owns the VtParser and implements IParserPerformer itself).
+pub struct Terminal {
+    pub emu: Emulator,
+    parser: VtParser,
+}
+
+impl Terminal {
+    pub fn new(cols: usize, rows: usize) -> Terminal {
+        Terminal { emu: Emulator::new(cols, rows), parser: VtParser::new() }
+    }
+
+    pub fn feed(&mut self, bytes: &[u8]) {
+        self.parser.feed(bytes, &mut self.emu);
+    }
+}
+
+impl Performer for Emulator {
+    fn print(&mut self, ch: u16) {
+        // Surrogate re-pairing, mirroring TerminalEmulator.Print(char).
+        if (0xD800..=0xDBFF).contains(&ch) {
+            self.pending_high_surrogate = ch;
+            return;
+        }
+        if (0xDC00..=0xDFFF).contains(&ch) {
+            if self.pending_high_surrogate != 0 {
+                let hs = self.pending_high_surrogate as i32;
+                let cp = 0x10000 + ((hs - 0xD800) << 10) + (ch as i32 - 0xDC00);
+                self.print_scalar(cp);
+            }
+            self.pending_high_surrogate = 0;
+            return;
+        }
+        self.pending_high_surrogate = 0;
+        self.print_scalar(ch as i32);
+    }
+
+    fn execute(&mut self, control: u8) {
+        match control {
+            13 => self.cursor_col = 0,
+            10 => self.index(),
+            8 => {
+                if self.cursor_col > 0 {
+                    self.cursor_col -= 1;
+                }
+            }
+            9 => {
+                let cols = self.screen().cols();
+                self.cursor_col = (cols - 1).min((self.cursor_col / 8 + 1) * 8);
+            }
+            _ => {} // NUL ignored; others → Host.Unhandled (headless drop)
+        }
+    }
+
+    fn esc_dispatch(&mut self, ch: u8) {
+        match ch {
+            b'7' => self.save_cursor(),
+            b'8' => self.restore_cursor(),
+            b'D' => self.index(),
+            b'M' => self.reverse_index(),
+            b'E' => {
+                self.cursor_col = 0;
+                self.index();
+            }
+            _ => {}
+        }
+    }
+
+    fn csi_dispatch(&mut self, ch: u8, params: &[i32], prefix: u8) {
+        let p = |index: usize, def: i64| -> i64 {
+            match params.get(index) {
+                Some(&v) if v != 0 => v as i64,
+                _ => def,
+            }
+        };
+
+        if ch == b'u' && matches!(prefix, b'?' | b'>' | b'=' | b'<') {
+            self.kitty_keyboard(prefix, params);
+            return;
+        }
+
+        if prefix == b'?' {
+            if ch == b'h' || ch == b'l' {
+                self.set_private_mode(params, ch == b'h');
+            }
+            return;
+        }
+
+        let rows = self.screen().rows() as i64;
+        let cols = self.screen().cols() as i64;
+        match ch {
+            b'H' | b'f' => {
+                self.cursor_row = (p(0, 1) - 1).clamp(0, rows - 1) as usize;
+                self.cursor_col = (p(1, 1) - 1).clamp(0, cols - 1) as usize;
+            }
+            b'A' => self.cursor_row = (self.cursor_row as i64 - p(0, 1)).max(0) as usize,
+            b'B' => self.cursor_row = (self.cursor_row as i64 + p(0, 1)).min(rows - 1) as usize,
+            b'C' => self.cursor_col = (self.cursor_col as i64 + p(0, 1)).min(cols - 1) as usize,
+            b'D' => self.cursor_col = (self.cursor_col as i64 - p(0, 1)).max(0) as usize,
+            b'G' => self.cursor_col = (p(0, 1) - 1).clamp(0, cols - 1) as usize,
+            b'd' => self.cursor_row = (p(0, 1) - 1).clamp(0, rows - 1) as usize,
+            b'J' => self.erase_display(*params.first().unwrap_or(&0)),
+            b'K' => self.erase_line(*params.first().unwrap_or(&0)),
+            b'X' => self.erase_chars(p(0, 1)),
+            b'm' => self.apply_sgr(params),
+            b'r' => {
+                let bottom = match params.get(1) {
+                    Some(&v) if v != 0 => v as i64 - 1,
+                    _ => rows - 1,
+                };
+                self.set_scroll_region(p(0, 1) - 1, bottom);
+            }
+            b'L' => self.insert_lines(p(0, 1)),
+            b'M' => self.delete_lines(p(0, 1)),
+            b'@' => self.insert_chars(p(0, 1)),
+            b'P' => self.delete_chars(p(0, 1)),
+            b'S' => {
+                for _ in 0..p(0, 1) {
+                    self.scroll_region_up();
+                }
+            }
+            b'T' => {
+                for _ in 0..p(0, 1) {
+                    self.scroll_region_down();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn osc_dispatch(&mut self, command: i32, text: &str) {
+        let text = Self::strip_controls(text);
+        match command {
+            0 | 2 => self.title = text,
+            7 => self.cwd = text,
+            133 => self.ftcs_dispatch(&text),
+            _ => {} // 9/777/52: Host-only side effects; others → Unhandled (headless drop)
+        }
+    }
+
+    fn apc_dispatch(&mut self, _data: &str) {
+        // Kitty graphics — module 5. No grid/cursor state is touched by the C# path either.
+    }
+
+    fn dcs_dispatch(&mut self, _payload: &[u8]) {
+        // Sixel — module 5. (Oracle inputs exclude valid sixel payloads: the C# path
+        // advances the cursor below a decoded image, which this stub does not.)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn term(cols: usize, rows: usize, input: &[u8]) -> Terminal {
+        let mut t = Terminal::new(cols, rows);
+        t.feed(input);
+        t
+    }
+
+    fn row_text(t: &Terminal, r: usize) -> String {
+        let mut s = String::new();
+        for c in 0..t.emu.screen().cols() {
+            let cell = t.emu.screen().get(r, c);
+            if cell.width == 0 {
+                continue;
+            }
+            if let Some(ch) = char::from_u32(cell.rune as u32) {
+                s.push(ch);
+            }
+        }
+        s.trim_end().to_string()
+    }
+
+    #[test]
+    fn print_wrap_and_scroll() {
+        let t = term(5, 3, b"abcdefgh\r\nxyz");
+        assert_eq!(row_text(&t, 0), "abcde");
+        assert_eq!(row_text(&t, 1), "fgh");
+        assert_eq!(row_text(&t, 2), "xyz");
+    }
+
+    #[test]
+    fn wide_glyph_wraps_before_edge() {
+        let t = term(4, 2, "ab\u{4E2D}".as_bytes()); // CJK at col 2-3 fits
+        assert_eq!(t.emu.screen().get(0, 2).width, 2);
+        assert_eq!(t.emu.screen().get(0, 3).width, 0);
+        let t = term(4, 2, "abc\u{4E2D}".as_bytes()); // would straddle → wraps
+        assert_eq!(t.emu.screen().get(1, 0).rune, 0x4E2D);
+    }
+
+    #[test]
+    fn scroll_region_and_history() {
+        let mut t = Terminal::new(4, 3);
+        t.feed(b"1\r\n2\r\n3\r\n4\r\n5"); // full-height scrolling pushes history
+        assert_eq!(t.emu.history_count(), 2);
+        assert_eq!(t.emu.scroll_generation, 2);
+        t.feed(b"\x1b[1;2r"); // region rows 0-1; homes cursor
+        t.feed(b"\x1b[2;1Ha\nb\nc"); // scroll inside region only
+        assert_eq!(t.emu.history_count(), 2); // partial region: no history
+    }
+
+    #[test]
+    fn alt_screen_round_trip() {
+        let mut t = Terminal::new(6, 2);
+        t.feed(b"main\x1b[?1049h");
+        assert!(t.emu.is_alt_screen());
+        t.feed(b"ALT");
+        t.feed(b"\x1b[?1049l");
+        assert!(!t.emu.is_alt_screen());
+        assert_eq!(row_text(&t, 0), "main");
+    }
+
+    #[test]
+    fn sgr_pen_and_bce() {
+        let mut t = Terminal::new(4, 2);
+        t.feed(b"\x1b[41mX\x1b[K");
+        let x = t.emu.screen().get(0, 0);
+        assert_eq!(x.background, Color::from_index(1));
+        let erased = t.emu.screen().get(0, 2);
+        assert_eq!(erased.background, Color::from_index(1)); // BCE carries the pen bg
+        assert_eq!(erased.rune, ' ' as i32);
+    }
+
+    #[test]
+    fn osc_title_cwd_marks() {
+        let mut t = Terminal::new(10, 3);
+        t.feed(b"\x1b]2;my\x07\x1b]7;file://h/c\x07\x1b]133;A\x07ok\r\n\x1b]133;D;3\x07");
+        assert_eq!(t.emu.title, "my");
+        assert_eq!(t.emu.cwd, "file://h/c");
+        assert_eq!(t.emu.marks().len(), 1);
+        assert_eq!(t.emu.marks()[0].exit_code, Some(3));
+    }
+}

--- a/native/agwinterm-core/src/lib.rs
+++ b/native/agwinterm-core/src/lib.rs
@@ -6,6 +6,7 @@
 //!   1. wcwidth              — DONE
 //!   2. cell + screen buffer — DONE
 //!   3. VT parser            — DONE (event-stream oracle)
+//!   4. emulator             — DONE (full-state oracle; images excluded → module 5)
 //!   4. emulator (cursor, modes, SGR, scroll regions, alt screen, marks)
 //!   5. sixel/kitty image decode
 //!
@@ -13,6 +14,7 @@
 //! stage by stage; nothing is exported until its differential tests pass.
 
 pub mod cell;
+pub mod emulator;
 pub mod screen;
 pub mod vtparser;
 pub mod wcwidth;
@@ -23,7 +25,7 @@ use screen::ScreenBuffer;
 /// Bumped whenever the exported C surface changes shape. The C# loader
 /// refuses a mismatch loudly (same hard-handshake philosophy as the
 /// pty-host protocol).
-pub const ABI_VERSION: u32 = 3;
+pub const ABI_VERSION: u32 = 4;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn agwcore_abi_version() -> u32 {
@@ -274,6 +276,118 @@ pub unsafe extern "C" fn agwcore_vtparse_events(bytes: *const u8, len: u32, out_
     let mut rec = RecordingPerformer(String::new());
     parser.feed(input, &mut rec);
     let mut buf = rec.0.into_bytes().into_boxed_slice();
+    unsafe { *out_len = buf.len() as u32 };
+    let ptr = buf.as_mut_ptr();
+    core::mem::forget(buf);
+    ptr
+}
+
+// ---- Emulator (module 4): opaque Terminal handle + canonical full-state dump ----
+
+use emulator::Terminal;
+
+#[unsafe(no_mangle)]
+pub extern "C" fn agwcore_emu_new(cols: u32, rows: u32) -> *mut Terminal {
+    if cols == 0 || rows == 0 || cols > 10_000 || rows > 10_000 {
+        return core::ptr::null_mut();
+    }
+    Box::into_raw(Box::new(Terminal::new(cols as usize, rows as usize)))
+}
+
+/// # Safety
+/// `p` from `agwcore_emu_new`, freed exactly once.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn agwcore_emu_free(p: *mut Terminal) {
+    if !p.is_null() {
+        drop(unsafe { Box::from_raw(p) });
+    }
+}
+
+/// # Safety
+/// `p` from `agwcore_emu_new`; `bytes` points to `len` readable bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn agwcore_emu_feed(p: *mut Terminal, bytes: *const u8, len: u32) -> bool {
+    let Some(t) = (unsafe { p.as_mut() }) else { return false };
+    if bytes.is_null() {
+        return false;
+    }
+    t.feed(unsafe { core::slice::from_raw_parts(bytes, len as usize) });
+    true
+}
+
+/// # Safety
+/// `p` from `agwcore_emu_new`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn agwcore_emu_resize(p: *mut Terminal, cols: u32, rows: u32) -> bool {
+    let Some(t) = (unsafe { p.as_mut() }) else { return false };
+    if cols == 0 || rows == 0 || cols > 10_000 || rows > 10_000 {
+        return false;
+    }
+    t.emu.resize(cols as usize, rows as usize);
+    true
+}
+
+fn dump_cell(s: &mut String, c: Cell) {
+    use core::fmt::Write;
+    let pc = |c: Color| ((c.r as u32) << 16) | ((c.g as u32) << 8) | c.b as u32;
+    let _ = write!(
+        s,
+        "{:X}.{:06X}.{:06X}.{:X}.{}.{}{:02X}.{:06X}.{}{:02X}.{:06X}",
+        c.rune, pc(c.foreground), pc(c.background), c.attributes, c.width,
+        c.fg_spec.kind as u8, c.fg_spec.index, pc(c.fg_spec.rgb),
+        c.bg_spec.kind as u8, c.bg_spec.index, pc(c.bg_spec.rgb)
+    );
+}
+
+/// Canonical full-state dump (the C# oracle builds the identical text from the
+/// public TerminalEmulator surface): cursor, region, modes, kbd, title/cwd,
+/// generation, marks, every history row, every grid row. Free with agwcore_free_buf.
+/// # Safety
+/// `p` from `agwcore_emu_new`; `out_len` writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn agwcore_emu_state_dump(p: *mut Terminal, out_len: *mut u32) -> *mut u8 {
+    use core::fmt::Write;
+    let Some(t) = (unsafe { p.as_mut() }) else { return core::ptr::null_mut() };
+    if out_len.is_null() {
+        return core::ptr::null_mut();
+    }
+    let e = &t.emu;
+    let mut s = String::new();
+    let (mc, md, mm, ms) = e.mouse_flags();
+    let _ = writeln!(s, "cursor:{},{},{}", e.cursor_row, e.cursor_col, e.cursor_visible as u8);
+    let _ = writeln!(s, "region:{},{}", e.scroll_top(), e.scroll_bottom());
+    let _ = writeln!(s, "alt:{}", e.is_alt_screen() as u8);
+    let _ = writeln!(s, "mouse:{}{}{}{}", mc as u8, md as u8, mm as u8, ms as u8);
+    let _ = writeln!(s, "paste:{}", e.bracketed_paste as u8);
+    let _ = writeln!(s, "kbd:{}", e.keyboard_flags());
+    let _ = writeln!(s, "title:{}", e.title);
+    let _ = writeln!(s, "cwd:{}", e.cwd);
+    let _ = writeln!(s, "gen:{}", e.scroll_generation);
+    for m in e.marks() {
+        let _ = writeln!(
+            s, "mark:{},{},{},{},{}",
+            m.prompt_line, m.command_line, m.output_line, m.end_line,
+            m.exit_code.map_or("none".to_string(), |v| v.to_string())
+        );
+    }
+    let (cols, rows) = (e.screen().cols(), e.screen().rows());
+    for h in 0..e.history_count() {
+        let _ = write!(s, "h{h}:");
+        for c in 0..cols {
+            if c > 0 { s.push(' '); }
+            dump_cell(&mut s, e.get_history_cell(h, c));
+        }
+        s.push('\n');
+    }
+    for r in 0..rows {
+        let _ = write!(s, "g{r}:");
+        for c in 0..cols {
+            if c > 0 { s.push(' '); }
+            dump_cell(&mut s, e.screen().get(r, c));
+        }
+        s.push('\n');
+    }
+    let mut buf = s.into_bytes().into_boxed_slice();
     unsafe { *out_len = buf.len() as u32 };
     let ptr = buf.as_mut_ptr();
     core::mem::forget(buf);

--- a/src/Agwinterm.Core/TerminalEmulator.cs
+++ b/src/Agwinterm.Core/TerminalEmulator.cs
@@ -38,11 +38,20 @@ public sealed class TerminalEmulator : IParserPerformer
     /// <summary>True if the app requested SGR (?1006) mouse encoding.</summary>
     public bool MouseSgr => _mouseSgr;
 
+    /// <summary>Individual mouse-mode flags (?1000/?1002/?1003) — for state diffing/tests.</summary>
+    public bool MouseClick => _mouseClick;
+    public bool MouseDrag => _mouseDrag;
+    public bool MouseMotion => _mouseMotion;
+
     /// <summary>Bracketed paste mode (DECSET 2004): wrap pasted text in ESC[200~ … ESC[201~.</summary>
     public bool BracketedPaste { get; private set; }
 
     private int _scrollTop;
     private int _scrollBottom;
+
+    /// <summary>DECSTBM scroll region (0-based, inclusive) — exposed for state diffing/tests.</summary>
+    public int ScrollTop => _scrollTop;
+    public int ScrollBottom => _scrollBottom;
 
     // Scrollback: rows scrolled off the TOP of the MAIN screen (oldest first). Trimmed in batches
     // to amortise the cost, so the count can float up to ScrollbackMax + a small slack.
@@ -634,7 +643,15 @@ public sealed class TerminalEmulator : IParserPerformer
     {
         if (i + 1 >= p.Count) return i;
         int mode = p[i + 1];
-        if (mode == 5 && i + 2 < p.Count) { target = Color.FromIndex(p[i + 2]); spec = ColorSpec.Indexed(p[i + 2]); return i + 2; }
+        if (mode == 5 && i + 2 < p.Count)
+        {
+            // Guard the palette index: FromIndex throws outside 0..255, and parser params are
+            // arbitrary ints (e.g. "38;5;999" from a garbled stream) — a throw here escapes Feed
+            // and kills the output pump (frozen pane). Out of range = consume params, change nothing.
+            int idx = p[i + 2];
+            if (idx is >= 0 and <= 255) { target = Color.FromIndex(idx); spec = ColorSpec.Indexed(idx); }
+            return i + 2;
+        }
         if (mode == 2 && i + 4 < p.Count) { var c = new Color((byte)p[i + 2], (byte)p[i + 3], (byte)p[i + 4]); target = c; spec = ColorSpec.FromRgb(c); return i + 4; }
         return i + 1;
     }

--- a/tests/Agwinterm.Core.Tests/RustParityTests.cs
+++ b/tests/Agwinterm.Core.Tests/RustParityTests.cs
@@ -33,7 +33,7 @@ public class RustParityTests
     public void AbiVersion_Matches()
     {
         if (Lib == 0) return;   // crate not built — differential run is opt-in
-        Assert.Equal(3u, Fn<AbiVersion>("agwcore_abi_version")());
+        Assert.Equal(4u, Fn<AbiVersion>("agwcore_abi_version")());
     }
 
     [Fact]
@@ -288,6 +288,186 @@ public class RustParityTests
                 for (int i = 0; i < buf.Length; i += 3 + rng.Next(5))
                     buf[i] = (byte)"\x1b[]_P;m0123456789?<=>:\x07\\"[rng.Next(24)];
             AssertParserParity(buf, $"soup#{stream}");
+        }
+    }
+
+    // ---- Module 4: emulator full-state oracle ----
+
+    private delegate nint EmuNew(uint cols, uint rows);
+    private delegate void EmuFree(nint p);
+    private unsafe delegate bool EmuFeed(nint p, byte* bytes, uint len);
+    private delegate bool EmuResize(nint p, uint cols, uint rows);
+    private unsafe delegate byte* EmuStateDump(nint p, uint* outLen);
+
+    /// <summary>The canonical state dump, built from the C# emulator's public surface — must match
+    /// agwcore_emu_state_dump byte-for-byte.</summary>
+    private static string CsStateDump(TerminalEmulator e)
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.Append($"cursor:{e.CursorRow},{e.CursorCol},{(e.CursorVisible ? 1 : 0)}\n");
+        sb.Append($"region:{e.ScrollTop},{e.ScrollBottom}\n");
+        sb.Append($"alt:{(e.IsAltScreen ? 1 : 0)}\n");
+        sb.Append($"mouse:{(e.MouseClick ? 1 : 0)}{(e.MouseDrag ? 1 : 0)}{(e.MouseMotion ? 1 : 0)}{(e.MouseSgr ? 1 : 0)}\n");
+        sb.Append($"paste:{(e.BracketedPaste ? 1 : 0)}\n");
+        sb.Append($"kbd:{e.KeyboardFlags}\n");
+        sb.Append($"title:{e.Title}\n");
+        sb.Append($"cwd:{e.Cwd}\n");
+        sb.Append($"gen:{e.ScrollGeneration}\n");
+        foreach (var m in e.Marks)
+            sb.Append($"mark:{m.PromptLine},{m.CommandLine},{m.OutputLine},{m.EndLine},{(m.ExitCode?.ToString() ?? "none")}\n");
+        int cols = e.Screen.Cols, rows = e.Screen.Rows;
+        for (int h = 0; h < e.HistoryCount; h++)
+        {
+            sb.Append($"h{h}:");
+            for (int c = 0; c < cols; c++) { if (c > 0) sb.Append(' '); DumpCell(sb, e.GetHistoryCell(h, c)); }
+            sb.Append('\n');
+        }
+        for (int r = 0; r < rows; r++)
+        {
+            sb.Append($"g{r}:");
+            for (int c = 0; c < cols; c++) { if (c > 0) sb.Append(' '); DumpCell(sb, e.Screen[r, c]); }
+            sb.Append('\n');
+        }
+        return sb.ToString();
+    }
+
+    private static void DumpCell(System.Text.StringBuilder sb, Cell c)
+    {
+        static uint Pk(Color x) => ((uint)x.R << 16) | ((uint)x.G << 8) | x.B;
+        sb.Append($"{c.Rune:X}.{Pk(c.Foreground):X6}.{Pk(c.Background):X6}.{(uint)c.Attributes:X}.{c.Width}");
+        sb.Append($".{(byte)c.FgSpec.Kind}{c.FgSpec.Index:X2}.{Pk(c.FgSpec.Rgb):X6}");
+        sb.Append($".{(byte)c.BgSpec.Kind}{c.BgSpec.Index:X2}.{Pk(c.BgSpec.Rgb):X6}");
+    }
+
+    private unsafe void AssertEmulatorParity(int cols, int rows, IEnumerable<byte[]> feeds, string label,
+        (int Cols, int Rows)? resizeMidway = null)
+    {
+        var emuNew = Fn<EmuNew>("agwcore_emu_new");
+        var emuFree = Fn<EmuFree>("agwcore_emu_free");
+        var emuFeed = Fn<EmuFeed>("agwcore_emu_feed");
+        var emuResize = Fn<EmuResize>("agwcore_emu_resize");
+        var emuDump = Fn<EmuStateDump>("agwcore_emu_state_dump");
+        var freeBuf = Fn<FreeBuf>("agwcore_free_buf");
+
+        var cs = new TerminalEmulator(cols, rows);
+        nint rs = emuNew((uint)cols, (uint)rows);
+        Assert.NotEqual(0, rs);
+        try
+        {
+            int step = 0; var list = feeds.ToList();
+            foreach (var chunk in list)
+            {
+                cs.Feed(chunk);
+                fixed (byte* bp = chunk.Length == 0 ? new byte[1] : chunk)
+                    Assert.True(emuFeed(rs, bp, (uint)chunk.Length));
+                if (resizeMidway is { } rm && step == list.Count / 2)
+                {
+                    cs.Resize(rm.Cols, rm.Rows);
+                    Assert.True(emuResize(rs, (uint)rm.Cols, (uint)rm.Rows));
+                }
+                // Compare the FULL state after every chunk — first divergence names the chunk.
+                string want = CsStateDump(cs);
+                uint outLen;
+                byte* buf = emuDump(rs, &outLen);
+                string got = buf == null ? "" : System.Text.Encoding.UTF8.GetString(buf, (int)outLen);
+                if (buf != null) freeBuf(buf, outLen);
+                if (want != got)
+                {
+                    var a = want.Split('\n'); var b = got.Split('\n');
+                    int i = 0; while (i < a.Length && i < b.Length && a[i] == b[i]) i++;
+                    string al = i < a.Length ? a[i] : "<end>", bl = i < b.Length ? b[i] : "<end>";
+                    Assert.Fail($"emulator divergence [{label}] chunk {step}, line {i}:\n  C#:   {Trunc(al)}\n  rust: {Trunc(bl)}");
+                }
+                step++;
+            }
+        }
+        finally { emuFree(rs); }
+
+        static string Trunc(string s) => s.Length > 220 ? s[..220] + "…" : s;
+    }
+
+    private static byte[] B(string s) =>
+        s.Any(c => c > 0xFF) ? System.Text.Encoding.UTF8.GetBytes(s) : s.Select(c => (byte)c).ToArray();
+
+    [Fact]
+    public void Emulator_CuratedScenarios_FullStateAgrees()
+    {
+        if (Lib == 0) return;
+        var scenarios = new (string Label, string[] Feeds)[]
+        {
+            ("wrap+scroll", new[] { "aaaaabbbbbcccccddddd", "eee\r\nfff\r\n", "ggg\r\nhhh\r\niii\r\n" }),
+            ("wide-edge", new[] { "abc中", "中中中", "x中\r\n", "🚀🚀" }),
+            ("controls", new[] { "ab\bX\tY\rZ", "\t\t\t\t\t\t\t\t\t\t\t\t" }),
+            ("sgr", new[] { "\x1b[1;3;4;9;31;44mX", "\x1b[38;5;104;48;2;10;20;30mY", "\x1b[38;5;999mZ",
+                            "\x1b[22;23;24;27;29;39;49mW", "\x1b[mV", "\x1b[38;2;300;256;257mQ" }),
+            ("cursor", new[] { "\x1b[5;10H*", "\x1b[2A\x1b[3B\x1b[4C\x1b[5D*", "\x1b[99;99H*", "\x1b[0;0H*",
+                               "\x1b[G\x1b[15d*", "\x1b[3G*" }),
+            ("erase-bce", new[] { "\x1b[41m", "fill\x1b[2J", "\x1b[3;3Habcdef\x1b[3;5H\x1b[K", "\x1b[1K",
+                                  "\x1b[3X", "\x1b[J", "\x1b[1J", "\x1b[3J", "\x1b[9K" }),
+            ("region", new[] { "\x1b[3;8r", "\x1b[5;1Hone\ntwo\n", "\x1b[8;1Hbottom\n\n\n", "\x1b[1;1H\x1bM\x1bM",
+                               "\x1b[2S\x1b[3T", "\x1b[0;0r", "\x1b[100;1r" }),
+            ("il-dl-ich-dch", new[] { "\x1b[4;10r\x1b[5;1HAAAA\r\nBBBB\r\nCCCC", "\x1b[5;1H\x1b[2L", "\x1b[2M",
+                                      "\x1b[99L", "\x1b[6;2H\x1b[3@", "\x1b[2P", "\x1b[99@", "\x1b[99P" }),
+            ("alt-screen", new[] { "main1\r\nmain2", "\x1b[?1049h", "ALT", "\x1b[?1049l", "\x1b[?47h", "x",
+                                   "\x1b[?47l", "\x1b[?1047h", "\x1b[?1047l" }),
+            ("save-restore", new[] { "\x1b[5;5H\x1b7", "\x1b[1;1Hmoved", "\x1b8*", "\x1bE!" }),
+            ("modes", new[] { "\x1b[?25l", "\x1b[?1000;1002;1006h", "\x1b[?1003h", "\x1b[?2004h",
+                              "\x1b[?1002l", "\x1b[?12;7727h", "\x1b[?25h" }),
+            ("osc", new[] { "\x1b]0;my title 🚀\x07", "\x1b]2;other\x1b\\", "\x1b]7;file://h/c/x\x07",
+                            "\x1b]0;ctrlchars!\x07", "\x1b]777;notify;t;b\x07", "\x1b]52;c;aGk=\x07" }),
+            ("ftcs", new[] { "\x1b]133;A\x07prompt$ ", "\x1b]133;B\x07cmd\r\n", "\x1b]133;C\x07out\r\n",
+                             "\x1b]133;D;0\x07", "\x1b]133;A\x07", "\x1b]133;A\x07", "\x1b]133;D;bad\x07" }),
+            ("kitty-kbd", new[] { "\x1b[>1u", "\x1b[=5;2u", "\x1b[=1;3u", "\x1b[<1u", "\x1b[<99u", "\x1b[=7u", "\x1b[>31u\x1b[<u" }),
+            ("scroll-history", new[] { "1\r\n2\r\n3\r\n4\r\n5\r\n6\r\n7\r\n8\r\n9\r\n10\r\n11\r\n12\r\n",
+                                       "\x1b[2;5r\r\n\r\n\r\n\r\n\r\n", "\x1b[r\r\n\r\n" }),
+            ("unknown-seqs", new[] { "\x1b[13;37z", "\x1b[>1;2c", "\x1bZ", "\x1b[?1234h", "\x1b[?9999l", "\x07" }),
+        };
+        foreach (var (label, feeds) in scenarios)
+        {
+            AssertEmulatorParity(80, 24, feeds.Select(B), label);
+            AssertEmulatorParity(20, 6, feeds.Select(B), label + "@20x6");
+        }
+    }
+
+    [Fact]
+    public void Emulator_ResizeMidStream_FullStateAgrees()
+    {
+        if (Lib == 0) return;
+        var feeds = new[] { "one\r\ntwo\r\nthree\r\n\x1b[2;4r\x1b[31mfour", "\x1b[5;5Hafter", "more\r\ntext\r\n" };
+        AssertEmulatorParity(40, 12, feeds.Select(B), "resize-shrink", resizeMidway: (25, 8));
+        AssertEmulatorParity(20, 6, feeds.Select(B), "resize-grow", resizeMidway: (60, 20));
+    }
+
+    [Fact]
+    public void Emulator_RandomSoup_FullStateAgrees()
+    {
+        if (Lib == 0) return;
+        var rng = new Random(20260725);
+        for (int stream = 0; stream < 60; stream++)
+        {
+            var chunks = new List<byte[]>();
+            for (int k = 0; k < 4; k++)
+            {
+                var buf = new byte[512];
+                rng.NextBytes(buf);
+                if (stream % 2 == 1)
+                    for (int i = 0; i < buf.Length; i += 2 + rng.Next(4))
+                        buf[i] = (byte)"\x1b[]m0123456789;?hlHJKrSTLMPX@ABCD"[rng.Next(33)];
+                // Guards (identical transform both sides, so parity still holds):
+                for (int i = 0; i + 1 < buf.Length; i++)
+                {
+                    if (buf[i] == 0x1b && buf[i + 1] == (byte)'P') buf[i + 1] = (byte)'Q';  // no DCS/sixel (module 5)
+                    if (buf[i] == 0x1b && buf[i + 1] == (byte)'_') buf[i + 1] = (byte)'^';  // no APC/kitty (module 5)
+                }
+                int digits = 0;   // cap runs of digits: CSI 999999999 S would loop-scroll for minutes
+                for (int i = 0; i < buf.Length; i++)
+                {
+                    if (buf[i] >= (byte)'0' && buf[i] <= (byte)'9') { if (++digits > 4) buf[i] = (byte)';'; }
+                    else digits = 0;
+                }
+                chunks.Add(buf);
+            }
+            AssertEmulatorParity(stream % 3 == 0 ? 132 : 80, stream % 3 == 0 ? 50 : 24, chunks, $"soup#{stream}");
         }
     }
 


### PR DESCRIPTION
## Module 4 of 5: the emulator

`TerminalEmulator` fully ported to `emulator.rs`, quirk-for-quirk: post-print `col == Cols` overflow, wide-glyph wrap-before-edge, scroll regions with history push + `ScrollGeneration`, IL/DL/ICH/DCH/ECH, BCE erase semantics (including EraseLine's mode-3 == mode-2 behavior), alt screen (1049 with cursor save vs 47/1047 without), SGR with wrapping truecolor byte casts, private modes, the kitty keyboard stack, OSC title/cwd/FTCS marks with control stripping, plus `DumpModes` + `SeedScrollback` for the eventual pty-host integration. Images (kitty APC / sixel DCS) are module 5 and excluded from oracle inputs.

## Port review found a real C# bug (fixed here)

`ExtendedColor` fed arbitrary parser params straight into `Color.FromIndex`, which **throws** outside 0–255 — a garbled `ESC[38;5;999m` escaped `Feed` and killed the output pump: a silently frozen pane in production. Now guarded (consume params, change nothing); Rust mirrors the guarded behavior. Also exposed `ScrollTop`/`ScrollBottom` + individual mouse flags (needed for state diffing, useful generally).

## The oracle (ABI v4)

`agwcore_emu_state_dump` produces a canonical dump of the **entire** state — cursor, scroll region, all modes, keyboard stack, title/cwd, scroll generation, every FTCS mark, every history row, and every grid cell with full attributes/colors/specs — and the C# test builds the identical dump from the public surface. Compared **after every feed chunk**, so the first divergence names the chunk and line.

Coverage: 16 curated scenario families × 2 grid sizes, mid-stream shrink/grow resizes, and 60 seeded random byte-soup streams (digit-run caps prevent minutes-long `CSI 999999999 S` scroll loops; DCS/APC introducers redirected until module 5).

**First full oracle run: zero divergences.** 268 tests green.

Remaining after this: module 5 (sixel/kitty), CI cargo wiring, then the config-keyed integration adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k
