### PR TITLE
feat(rust): the integration adapter — RustEmulatorCore over ABI v6

### DIFF
--- a/native/agwinterm-core/src/lib.rs
+++ b/native/agwinterm-core/src/lib.rs
@@ -26,7 +26,7 @@ use screen::ScreenBuffer;
 /// Bumped whenever the exported C surface changes shape. The C# loader
 /// refuses a mismatch loudly (same hard-handshake philosophy as the
 /// pty-host protocol).
-pub const ABI_VERSION: u32 = 5;
+pub const ABI_VERSION: u32 = 6;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn agwcore_abi_version() -> u32 {
@@ -403,6 +403,120 @@ pub unsafe extern "C" fn agwcore_emu_state_dump(p: *mut Terminal, out_len: *mut 
         }
         s.push('\n');
     }
+    let mut buf = s.into_bytes().into_boxed_slice();
+    unsafe { *out_len = buf.len() as u32 };
+    let ptr = buf.as_mut_ptr();
+    core::mem::forget(buf);
+    ptr
+}
+
+// ---- Integration surface (the RustEmulatorCore adapter, beyond the oracle) ----
+
+/// Fixed-size scalar snapshot for per-frame reads — one call instead of a dozen.
+#[repr(C)]
+pub struct FfiEmuInfo {
+    pub cols: u32,
+    pub rows: u32,
+    pub cursor_row: u32,
+    pub cursor_col: u32,      // may equal cols (post-print overflow)
+    pub cursor_visible: u32,
+    pub is_alt_screen: u32,
+    pub history_count: u32,
+    pub scroll_generation: i64,
+    pub mouse_click: u32,
+    pub mouse_drag: u32,
+    pub mouse_motion: u32,
+    pub mouse_sgr: u32,
+    pub bracketed_paste: u32,
+    pub keyboard_flags: i32,
+}
+
+/// # Safety
+/// `p` from `agwcore_emu_new`; `out` a valid FfiEmuInfo pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn agwcore_emu_info(p: *mut Terminal, out: *mut FfiEmuInfo) -> bool {
+    let Some(t) = (unsafe { p.as_mut() }) else { return false };
+    if out.is_null() {
+        return false;
+    }
+    let e = &t.emu;
+    let (mc, md, mm, ms) = e.mouse_flags();
+    unsafe {
+        *out = FfiEmuInfo {
+            cols: e.screen().cols() as u32,
+            rows: e.screen().rows() as u32,
+            cursor_row: e.cursor_row as u32,
+            cursor_col: e.cursor_col as u32,
+            cursor_visible: e.cursor_visible as u32,
+            is_alt_screen: e.is_alt_screen() as u32,
+            history_count: e.history_count() as u32,
+            scroll_generation: e.scroll_generation,
+            mouse_click: mc as u32,
+            mouse_drag: md as u32,
+            mouse_motion: mm as u32,
+            mouse_sgr: ms as u32,
+            bracketed_paste: e.bracketed_paste as u32,
+            keyboard_flags: e.keyboard_flags(),
+        };
+    }
+    true
+}
+
+/// Copy the whole visible grid, row-major, into `out` (must hold cols*rows cells).
+/// This is the renderer's per-frame snapshot path: one bulk copy under the session
+/// lock instead of cols×rows interop calls.
+/// # Safety
+/// `p` from `agwcore_emu_new`; `out` points to `cap` writable FfiCells.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn agwcore_emu_copy_grid(p: *mut Terminal, out: *mut FfiCell, cap: u32) -> bool {
+    let Some(t) = (unsafe { p.as_mut() }) else { return false };
+    let e = &t.emu;
+    let (cols, rows) = (e.screen().cols(), e.screen().rows());
+    if out.is_null() || (cap as usize) < cols * rows {
+        return false;
+    }
+    let out = unsafe { core::slice::from_raw_parts_mut(out, cols * rows) };
+    for r in 0..rows {
+        for c in 0..cols {
+            out[r * cols + c] = e.screen().get(r, c).into();
+        }
+    }
+    true
+}
+
+/// Copy one scrollback row (padded to the current width). Row 0 = oldest.
+/// # Safety
+/// `p` from `agwcore_emu_new`; `out` points to `cap` writable FfiCells.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn agwcore_emu_copy_history_row(p: *mut Terminal, row: u32, out: *mut FfiCell, cap: u32) -> bool {
+    let Some(t) = (unsafe { p.as_mut() }) else { return false };
+    let e = &t.emu;
+    let cols = e.screen().cols();
+    if out.is_null() || (cap as usize) < cols || (row as usize) >= e.history_count() {
+        return false;
+    }
+    let out = unsafe { core::slice::from_raw_parts_mut(out, cols) };
+    for c in 0..cols {
+        out[c] = e.get_history_cell(row as usize, c).into();
+    }
+    true
+}
+
+/// UTF-8 string properties: 0 = title, 1 = cwd, 2 = DumpModes. Free with agwcore_free_buf.
+/// # Safety
+/// `p` from `agwcore_emu_new`; `out_len` writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn agwcore_emu_get_text(p: *mut Terminal, which: u32, out_len: *mut u32) -> *mut u8 {
+    let Some(t) = (unsafe { p.as_mut() }) else { return core::ptr::null_mut() };
+    if out_len.is_null() {
+        return core::ptr::null_mut();
+    }
+    let s = match which {
+        0 => t.emu.title.clone(),
+        1 => t.emu.cwd.clone(),
+        2 => t.emu.dump_modes(),
+        _ => return core::ptr::null_mut(),
+    };
     let mut buf = s.into_bytes().into_boxed_slice();
     unsafe { *out_len = buf.len() as u32 };
     let ptr = buf.as_mut_ptr();

--- a/src/Agwinterm.Core/Agwinterm.Core.csproj
+++ b/src/Agwinterm.Core/Agwinterm.Core.csproj
@@ -5,5 +5,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>Agwinterm.Core</RootNamespace>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- RustEmulatorCore passes pinned cell buffers across the C ABI. -->
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 </Project>

--- a/src/Agwinterm.Core/RustEmulatorCore.cs
+++ b/src/Agwinterm.Core/RustEmulatorCore.cs
@@ -1,0 +1,169 @@
+using System.Runtime.InteropServices;
+
+namespace Agwinterm.Core;
+
+/// <summary>
+/// Adapter over the Rust emulator core (native/agwinterm-core). Wraps the opaque
+/// Terminal handle and exposes the surface a pane needs: Feed, Resize, bulk grid
+/// snapshots (one interop copy per frame, mirroring the renderer's existing
+/// snapshot-under-lock pattern), history rows, and the scalar/mode state.
+///
+/// Loading is explicit and fail-loud: <see cref="TryLoad"/> probes the dll and
+/// verifies the ABI handshake (same philosophy as the pty-host protocol) —
+/// a mismatch refuses to load rather than half-working. The eventual
+/// `emulator-core = rust` config path calls this and falls back to the managed
+/// emulator when unavailable.
+/// </summary>
+public sealed unsafe class RustEmulatorCore : IDisposable
+{
+    public const uint RequiredAbi = 6;
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Info
+    {
+        public uint Cols, Rows, CursorRow, CursorCol, CursorVisible, IsAltScreen, HistoryCount;
+        public long ScrollGeneration;
+        public uint MouseClick, MouseDrag, MouseMotion, MouseSgr, BracketedPaste;
+        public int KeyboardFlags;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct NativeCell
+    {
+        public int Rune;
+        public uint Fg, Bg, Attrs, Width;
+        public uint FgKind, FgIndex, FgRgb;
+        public uint BgKind, BgIndex, BgRgb;
+
+        /// <summary>Convert to the managed Cell (colors unpacked from 0x00RRGGBB).</summary>
+        public Cell ToCell() => new(
+            Rune, Unpack(Fg), Unpack(Bg), (CellAttributes)Attrs, (byte)Width,
+            new ColorSpec((ColorSpecKind)FgKind, (byte)FgIndex, Unpack(FgRgb)),
+            new ColorSpec((ColorSpecKind)BgKind, (byte)BgIndex, Unpack(BgRgb)));
+
+        private static Color Unpack(uint v) => new((byte)(v >> 16), (byte)(v >> 8), (byte)v);
+    }
+
+    private delegate uint AbiVersionFn();
+    private delegate nint EmuNewFn(uint cols, uint rows);
+    private delegate void EmuFreeFn(nint p);
+    private delegate bool EmuFeedFn(nint p, byte* bytes, uint len);
+    private delegate bool EmuResizeFn(nint p, uint cols, uint rows);
+    private delegate bool EmuInfoFn(nint p, Info* info);
+    private delegate bool EmuCopyGridFn(nint p, NativeCell* cells, uint cap);
+    private delegate bool EmuCopyHistoryRowFn(nint p, uint row, NativeCell* cells, uint cap);
+    private delegate byte* EmuGetTextFn(nint p, uint which, uint* outLen);
+    private delegate void FreeBufFn(byte* ptr, uint len);
+
+    private static nint _lib;
+    private static EmuNewFn _new = null!;
+    private static EmuFreeFn _free = null!;
+    private static EmuFeedFn _feed = null!;
+    private static EmuResizeFn _resize = null!;
+    private static EmuInfoFn _info = null!;
+    private static EmuCopyGridFn _copyGrid = null!;
+    private static EmuCopyHistoryRowFn _copyHistory = null!;
+    private static EmuGetTextFn _getText = null!;
+    private static FreeBufFn _freeBuf = null!;
+
+    /// <summary>Load the native core from <paramref name="dllPath"/> and verify the ABI.
+    /// Idempotent; returns false (with a reason) when missing or mismatched.</summary>
+    public static bool TryLoad(string dllPath, out string? error)
+    {
+        error = null;
+        if (_lib != 0) return true;
+        if (!File.Exists(dllPath)) { error = "native core not found: " + dllPath; return false; }
+        if (!NativeLibrary.TryLoad(dllPath, out nint lib)) { error = "failed to load " + dllPath; return false; }
+        try
+        {
+            T Get<T>(string name) where T : Delegate
+                => Marshal.GetDelegateForFunctionPointer<T>(NativeLibrary.GetExport(lib, name));
+            uint abi = Get<AbiVersionFn>("agwcore_abi_version")();
+            if (abi != RequiredAbi)
+            {
+                error = $"native core ABI {abi} != required {RequiredAbi}";
+                NativeLibrary.Free(lib);
+                return false;
+            }
+            _new = Get<EmuNewFn>("agwcore_emu_new");
+            _free = Get<EmuFreeFn>("agwcore_emu_free");
+            _feed = Get<EmuFeedFn>("agwcore_emu_feed");
+            _resize = Get<EmuResizeFn>("agwcore_emu_resize");
+            _info = Get<EmuInfoFn>("agwcore_emu_info");
+            _copyGrid = Get<EmuCopyGridFn>("agwcore_emu_copy_grid");
+            _copyHistory = Get<EmuCopyHistoryRowFn>("agwcore_emu_copy_history_row");
+            _getText = Get<EmuGetTextFn>("agwcore_emu_get_text");
+            _freeBuf = Get<FreeBufFn>("agwcore_free_buf");
+            _lib = lib;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            error = "native core export missing: " + ex.Message;
+            NativeLibrary.Free(lib);
+            return false;
+        }
+    }
+
+    public static bool Loaded => _lib != 0;
+
+    private nint _handle;
+
+    public RustEmulatorCore(int cols, int rows)
+    {
+        if (!Loaded) throw new InvalidOperationException("RustEmulatorCore.TryLoad first");
+        _handle = _new((uint)cols, (uint)rows);
+        if (_handle == 0) throw new ArgumentOutOfRangeException(nameof(cols));
+    }
+
+    public void Feed(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.IsEmpty) return;
+        fixed (byte* p = bytes) _feed(_handle, p, (uint)bytes.Length);
+    }
+
+    public void Resize(int cols, int rows)
+    {
+        if (cols > 0 && rows > 0) _resize(_handle, (uint)cols, (uint)rows);
+    }
+
+    public Info GetInfo()
+    {
+        Info i;
+        _info(_handle, &i);
+        return i;
+    }
+
+    /// <summary>Bulk-copy the visible grid into <paramref name="cells"/> (row-major,
+    /// cols*rows). The renderer's one-interop-per-frame snapshot.</summary>
+    public bool CopyGrid(NativeCell[] cells)
+    {
+        fixed (NativeCell* p = cells) return _copyGrid(_handle, p, (uint)cells.Length);
+    }
+
+    public bool CopyHistoryRow(int row, NativeCell[] cells)
+    {
+        fixed (NativeCell* p = cells) return _copyHistory(_handle, (uint)row, p, (uint)cells.Length);
+    }
+
+    public string Title => GetText(0);
+    public string Cwd => GetText(1);
+    public string DumpModes() => GetText(2);
+
+    private string GetText(uint which)
+    {
+        uint len;
+        byte* buf = _getText(_handle, which, &len);
+        if (buf == null) return "";
+        try { return System.Text.Encoding.UTF8.GetString(buf, (int)len); }
+        finally { _freeBuf(buf, len); }
+    }
+
+    public void Dispose()
+    {
+        if (_handle != 0) { _free(_handle); _handle = 0; }
+        GC.SuppressFinalize(this);
+    }
+
+    ~RustEmulatorCore() { if (_handle != 0) _free(_handle); }
+}

--- a/tests/Agwinterm.Core.Tests/RustEmulatorCoreTests.cs
+++ b/tests/Agwinterm.Core.Tests/RustEmulatorCoreTests.cs
@@ -1,0 +1,115 @@
+using Agwinterm.Core;
+
+namespace Agwinterm.Core.Tests;
+
+/// <summary>
+/// The integration adapter, validated headless: RustEmulatorCore (the class the UI will
+/// consume behind `emulator-core = rust`) driven side-by-side with the managed
+/// TerminalEmulator — grid snapshots, info scalars, history rows, and text properties
+/// must agree through the ADAPTER's own code path (bulk copies, string marshaling),
+/// not just the oracle's dump. Skips when the crate isn't built locally; CI builds it.
+/// </summary>
+public class RustEmulatorCoreTests
+{
+    private static readonly bool Available = Probe();
+
+    private static bool Probe()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Agwinterm.slnx"))) dir = dir.Parent;
+        if (dir is null) return false;
+        string dll = Path.Combine(dir.FullName, "native", "agwinterm-core", "target", "release", "agwinterm_core.dll");
+        return RustEmulatorCore.TryLoad(dll, out _);
+    }
+
+    private static void AssertAdapterParity(int cols, int rows, params string[] feeds)
+    {
+        var cs = new TerminalEmulator(cols, rows);
+        using var rust = new RustEmulatorCore(cols, rows);
+        foreach (var feed in feeds)
+        {
+            byte[] bytes = feed.Any(c => c > 0xFF)
+                ? System.Text.Encoding.UTF8.GetBytes(feed)
+                : feed.Select(c => (byte)c).ToArray();
+            cs.Feed(bytes);
+            rust.Feed(bytes);
+        }
+
+        var info = rust.GetInfo();
+        Assert.Equal((uint)cs.Screen.Cols, info.Cols);
+        Assert.Equal((uint)cs.Screen.Rows, info.Rows);
+        Assert.Equal((uint)cs.CursorRow, info.CursorRow);
+        Assert.Equal((uint)cs.CursorCol, info.CursorCol);
+        Assert.Equal(cs.CursorVisible, info.CursorVisible != 0);
+        Assert.Equal(cs.IsAltScreen, info.IsAltScreen != 0);
+        Assert.Equal((uint)cs.HistoryCount, info.HistoryCount);
+        Assert.Equal(cs.ScrollGeneration, info.ScrollGeneration);
+        Assert.Equal(cs.BracketedPaste, info.BracketedPaste != 0);
+        Assert.Equal(cs.MouseSgr, info.MouseSgr != 0);
+        Assert.Equal(cs.KeyboardFlags, info.KeyboardFlags);
+        Assert.Equal(cs.Title, rust.Title);
+        Assert.Equal(cs.Cwd, rust.Cwd);
+        Assert.Equal(cs.DumpModes(), rust.DumpModes());
+
+        var grid = new RustEmulatorCore.NativeCell[cs.Screen.Cols * cs.Screen.Rows];
+        Assert.True(rust.CopyGrid(grid));
+        for (int r = 0; r < cs.Screen.Rows; r++)
+            for (int c = 0; c < cs.Screen.Cols; c++)
+            {
+                Cell want = cs.Screen[r, c], got = grid[r * cs.Screen.Cols + c].ToCell();
+                if (want != got)
+                    Assert.Fail($"grid cell ({r},{c}): C# rune={want.Rune} rust rune={got.Rune}");
+            }
+
+        var hrow = new RustEmulatorCore.NativeCell[cs.Screen.Cols];
+        for (int h = 0; h < cs.HistoryCount; h++)
+        {
+            Assert.True(rust.CopyHistoryRow(h, hrow));
+            for (int c = 0; c < cs.Screen.Cols; c++)
+                Assert.Equal(cs.GetHistoryCell(h, c), hrow[c].ToCell());
+        }
+    }
+
+    [Fact]
+    public void Adapter_ScreenAndScrollback_Agree()
+    {
+        if (!Available) return;
+        AssertAdapterParity(40, 10,
+            "\x1b[1;31mhello 🚀 中文\x1b[0m\r\n",
+            "line2\r\nline3\r\nline4\r\nline5\r\nline6\r\nline7\r\nline8\r\nline9\r\nline10\r\nline11\r\nline12\r\n",
+            "\x1b]0;adapter test\x07\x1b]7;file://x/y\x07",
+            "\x1b[?25l\x1b[?2004h\x1b[?1006h\x1b[>3u");
+    }
+
+    [Fact]
+    public void Adapter_ResizeAndAltScreen_Agree()
+    {
+        if (!Available) return;
+        var cs = new TerminalEmulator(30, 8);
+        using var rust = new RustEmulatorCore(30, 8);
+        foreach (var f in new[] { "before resize\r\n", "\x1b[?1049h", "alt content", "\x1b[?1049l" })
+        {
+            var b = f.Select(c => (byte)c).ToArray();
+            cs.Feed(b); rust.Feed(b);
+        }
+        cs.Resize(50, 15);
+        rust.Resize(50, 15);
+        var b2 = "after resize"u8.ToArray();
+        cs.Feed(b2); rust.Feed(b2);
+
+        var info = rust.GetInfo();
+        Assert.Equal((50u, 15u), (info.Cols, info.Rows));
+        var grid = new RustEmulatorCore.NativeCell[50 * 15];
+        Assert.True(rust.CopyGrid(grid));
+        for (int r = 0; r < 15; r++)
+            for (int c = 0; c < 50; c++)
+                Assert.Equal(cs.Screen[r, c], grid[r * 50 + c].ToCell());
+    }
+
+    [Fact]
+    public void TryLoad_WrongPath_FailsLoudly()
+    {
+        Assert.False(RustEmulatorCore.TryLoad(@"C:\nope\missing.dll", out var err) && !RustEmulatorCore.Loaded);
+        if (!RustEmulatorCore.Loaded) Assert.NotNull(err);
+    }
+}

--- a/tests/Agwinterm.Core.Tests/RustParityTests.cs
+++ b/tests/Agwinterm.Core.Tests/RustParityTests.cs
@@ -33,7 +33,7 @@ public class RustParityTests
     public void AbiVersion_Matches()
     {
         if (Lib == 0) return;   // crate not built — differential run is opt-in
-        Assert.Equal(5u, Fn<AbiVersion>("agwcore_abi_version")());
+        Assert.Equal(RustEmulatorCore.RequiredAbi, Fn<AbiVersion>("agwcore_abi_version")());
     }
 
     [Fact]


### PR DESCRIPTION
feat(rust): the integration adapter - RustEmulatorCore over ABI v6

The class the UI will consume behind a future `emulator-core = rust` config
key. ABI v6 adds the per-frame integration surface: agwcore_emu_info (one
scalar snapshot call), agwcore_emu_copy_grid (bulk row-major viewport copy -
one interop call per frame, mirroring the renderer's existing snapshot-under-
lock pattern), agwcore_emu_copy_history_row, and agwcore_emu_get_text
(title/cwd/DumpModes).

C# side: RustEmulatorCore (Agwinterm.Core) - explicit fail-loud TryLoad with
an ABI handshake (pty-host philosophy: refuse to half-work), Feed/Resize,
pinned bulk copies, NativeCell -> Cell conversion, IDisposable handle.

Validated headless through the ADAPTER's own code path (not just the oracle
dump): side-by-side runs against TerminalEmulator comparing every grid cell,
history rows, info scalars, title/cwd/DumpModes, and resize + alt-screen
round-trips. 272 tests green.

Next (separate PR): wire it behind the config key so a real pane can run on
the Rust core, opt-in, pty-host-style rollout.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k
