### PR TITLE
feat(rust): wire the Rust core into real panes — emulator-core = rust

### DIFF
--- a/native/agwinterm-core/src/lib.rs
+++ b/native/agwinterm-core/src/lib.rs
@@ -26,7 +26,7 @@ use screen::ScreenBuffer;
 /// Bumped whenever the exported C surface changes shape. The C# loader
 /// refuses a mismatch loudly (same hard-handshake philosophy as the
 /// pty-host protocol).
-pub const ABI_VERSION: u32 = 6;
+pub const ABI_VERSION: u32 = 7;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn agwcore_abi_version() -> u32 {
@@ -429,6 +429,9 @@ pub struct FfiEmuInfo {
     pub mouse_sgr: u32,
     pub bracketed_paste: u32,
     pub keyboard_flags: i32,
+    pub scroll_top: u32,
+    pub scroll_bottom: u32,
+    pub mark_count: u32,
 }
 
 /// # Safety
@@ -457,8 +460,63 @@ pub unsafe extern "C" fn agwcore_emu_info(p: *mut Terminal, out: *mut FfiEmuInfo
             mouse_sgr: ms as u32,
             bracketed_paste: e.bracketed_paste as u32,
             keyboard_flags: e.keyboard_flags(),
+            scroll_top: e.scroll_top() as u32,
+            scroll_bottom: e.scroll_bottom() as u32,
+            mark_count: e.marks().len() as u32,
         };
     }
+    true
+}
+
+/// One FTCS shell mark over the ABI (buffer-absolute lines; -1 = unset).
+#[repr(C)]
+pub struct FfiMark {
+    pub prompt_line: i64,
+    pub command_line: i64,
+    pub output_line: i64,
+    pub end_line: i64,
+    pub has_exit: u32,
+    pub exit_code: i32,
+}
+
+/// Copy all FTCS marks (oldest first) into `out`; returns how many were written.
+/// # Safety
+/// `p` from `agwcore_emu_new`; `out` points to `cap` writable FfiMarks.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn agwcore_emu_marks(p: *mut Terminal, out: *mut FfiMark, cap: u32) -> u32 {
+    let Some(t) = (unsafe { p.as_mut() }) else { return 0 };
+    if out.is_null() {
+        return 0;
+    }
+    let marks = t.emu.marks();
+    let n = marks.len().min(cap as usize);
+    let out = unsafe { core::slice::from_raw_parts_mut(out, n) };
+    for (i, m) in marks.iter().take(n).enumerate() {
+        out[i] = FfiMark {
+            prompt_line: m.prompt_line,
+            command_line: m.command_line,
+            output_line: m.output_line,
+            end_line: m.end_line,
+            has_exit: m.exit_code.is_some() as u32,
+            exit_code: m.exit_code.unwrap_or(0),
+        };
+    }
+    n as u32
+}
+
+/// Seed the scrollback with plain-text lines ('\n'-separated UTF-8) — the restore path.
+/// # Safety
+/// `p` from `agwcore_emu_new`; `text` points to `len` readable bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn agwcore_emu_seed_scrollback(p: *mut Terminal, text: *const u8, len: u32) -> bool {
+    let Some(t) = (unsafe { p.as_mut() }) else { return false };
+    if text.is_null() {
+        return len == 0;
+    }
+    let bytes = unsafe { core::slice::from_raw_parts(text, len as usize) };
+    let s = String::from_utf8_lossy(bytes);
+    let lines: Vec<&str> = s.split('\n').collect();
+    t.emu.seed_scrollback(&lines);
     true
 }
 

--- a/src/Agwinterm.Core/ITerminalCore.cs
+++ b/src/Agwinterm.Core/ITerminalCore.cs
@@ -1,0 +1,69 @@
+namespace Agwinterm.Core;
+
+/// <summary>
+/// The emulator surface a pane consumes — extracted so the managed
+/// <see cref="TerminalEmulator"/> and the Rust-backed <see cref="RustTerminalCore"/>
+/// are interchangeable behind <c>emulator-core = managed | rust</c>. Member names
+/// deliberately mirror TerminalEmulator exactly, so existing consumers compile
+/// unchanged against the interface.
+/// </summary>
+public interface ITerminalCore
+{
+    // ---- content ----
+    ScreenBuffer Screen { get; }
+    void Feed(ReadOnlySpan<byte> bytes);
+    void Resize(int cols, int rows);
+
+    // ---- cursor / screens ----
+    int CursorRow { get; }
+    int CursorCol { get; }
+    bool CursorVisible { get; }
+    bool IsAltScreen { get; }
+    int ScrollTop { get; }
+    int ScrollBottom { get; }
+
+    // ---- modes ----
+    bool MouseReporting { get; }
+    bool MouseReportsMotion { get; }
+    bool MouseSgr { get; }
+    bool MouseClick { get; }
+    bool MouseDrag { get; }
+    bool MouseMotion { get; }
+    bool BracketedPaste { get; }
+    int KeyboardFlags { get; }
+
+    // ---- scrollback ----
+    int ScrollbackMax { get; set; }
+    int HistoryCount { get; }
+    long ScrollGeneration { get; }
+    Cell GetHistoryCell(int historyRow, int col);
+    void SeedScrollback(IReadOnlyList<string> lines);
+
+    // ---- marks / identity ----
+    IReadOnlyList<TerminalEmulator.ShellMark> Marks { get; }
+    string Title { get; }
+    string Cwd { get; }
+
+    // ---- host actions (notifications, clipboard, PTY responses). The Rust core
+    // does not invoke these yet (phase-2 gap; documented in the config text). ----
+    IHostActions? Host { get; set; }
+
+    // ---- images. The Rust core reports none and ignores placement calls in the
+    // experimental phase (phase-2 gap; kitty/sixel panes need the managed core). ----
+    IReadOnlyDictionary<int, KittyImage> Images { get; }
+    IReadOnlyList<ImagePlacement> Placements { get; }
+    void ClearPlacements();
+    bool HasImage(int id);
+    void SetImageData(int id, KittyFormat format, int width, int height, byte[] data);
+    void PlaceImage(int id, int row, int col, int cols, int rows,
+        int srcX = 0, int srcY = 0, int srcW = 0, int srcH = 0);
+    bool PlaceSixel(byte[] data);
+    int CellPixelWidth { get; set; }
+    int CellPixelHeight { get; set; }
+
+    // ---- dumps (persistence / reattach) ----
+    string DumpRow(int row);
+    string DumpHistoryRow(int index);
+    IReadOnlyList<string> DumpBuffer();
+    string DumpModes();
+}

--- a/src/Agwinterm.Core/RustEmulatorCore.cs
+++ b/src/Agwinterm.Core/RustEmulatorCore.cs
@@ -16,7 +16,7 @@ namespace Agwinterm.Core;
 /// </summary>
 public sealed unsafe class RustEmulatorCore : IDisposable
 {
-    public const uint RequiredAbi = 6;
+    public const uint RequiredAbi = 7;
 
     [StructLayout(LayoutKind.Sequential)]
     public struct Info
@@ -25,6 +25,7 @@ public sealed unsafe class RustEmulatorCore : IDisposable
         public long ScrollGeneration;
         public uint MouseClick, MouseDrag, MouseMotion, MouseSgr, BracketedPaste;
         public int KeyboardFlags;
+        public uint ScrollTop, ScrollBottom, MarkCount;
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -94,6 +95,8 @@ public sealed unsafe class RustEmulatorCore : IDisposable
             _copyHistory = Get<EmuCopyHistoryRowFn>("agwcore_emu_copy_history_row");
             _getText = Get<EmuGetTextFn>("agwcore_emu_get_text");
             _freeBuf = Get<FreeBufFn>("agwcore_free_buf");
+            _marks = Get<EmuMarksFn>("agwcore_emu_marks");
+            _seed = Get<EmuSeedFn>("agwcore_emu_seed_scrollback");
             _lib = lib;
             return true;
         }
@@ -149,6 +152,46 @@ public sealed unsafe class RustEmulatorCore : IDisposable
     public string Title => GetText(0);
     public string Cwd => GetText(1);
     public string DumpModes() => GetText(2);
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct NativeMark
+    {
+        public long PromptLine, CommandLine, OutputLine, EndLine;
+        public uint HasExit;
+        public int ExitCode;
+    }
+
+    private delegate uint EmuMarksFn(nint p, NativeMark* marks, uint cap);
+    private delegate bool EmuSeedFn(nint p, byte* text, uint len);
+    private static EmuMarksFn _marks = null!;
+    private static EmuSeedFn _seed = null!;
+
+    /// <summary>All FTCS marks, converted to the managed mark type.</summary>
+    public TerminalEmulator.ShellMark[] GetMarks()
+    {
+        uint count = GetInfo().MarkCount;
+        if (count == 0) return Array.Empty<TerminalEmulator.ShellMark>();
+        var native = new NativeMark[count];
+        uint n;
+        fixed (NativeMark* p = native) n = _marks(_handle, p, count);
+        var result = new TerminalEmulator.ShellMark[n];
+        for (int i = 0; i < n; i++)
+            result[i] = new TerminalEmulator.ShellMark
+            {
+                PromptLine = (int)native[i].PromptLine,
+                CommandLine = (int)native[i].CommandLine,
+                OutputLine = (int)native[i].OutputLine,
+                EndLine = (int)native[i].EndLine,
+                ExitCode = native[i].HasExit != 0 ? native[i].ExitCode : null,
+            };
+        return result;
+    }
+
+    public void SeedScrollback(string joinedLines)
+    {
+        byte[] bytes = System.Text.Encoding.UTF8.GetBytes(joinedLines);
+        fixed (byte* p = bytes.Length == 0 ? new byte[1] : bytes) _seed(_handle, p, (uint)bytes.Length);
+    }
 
     private string GetText(uint which)
     {

--- a/src/Agwinterm.Core/RustTerminalCore.cs
+++ b/src/Agwinterm.Core/RustTerminalCore.cs
@@ -1,0 +1,180 @@
+using System.Text;
+
+namespace Agwinterm.Core;
+
+/// <summary>
+/// The Rust emulator behind the <see cref="ITerminalCore"/> seam (`emulator-core = rust`,
+/// EXPERIMENTAL). The Rust core is authoritative; a managed mirror (grid + history +
+/// scalars) is refreshed after every Feed/Resize with ONE bulk interop copy, so all
+/// reads (renderer snapshots, selection, dumps) stay lock-cheap managed accesses with
+/// unchanged semantics. All calls run under the session lock per the ISession contract.
+///
+/// Phase-2 gaps (documented in the config text): host actions are not invoked
+/// (no OSC 52 clipboard / notifications / kitty-query responses), and images
+/// (kitty/sixel) are not surfaced — panes that need those want the managed core.
+/// </summary>
+public sealed class RustTerminalCore : ITerminalCore, IDisposable
+{
+    private readonly RustEmulatorCore _rust;
+    private readonly ScreenBuffer _mirror;
+    private readonly List<Cell[]> _histMirror = new();
+    private RustEmulatorCore.NativeCell[] _gridBuf;
+    private RustEmulatorCore.NativeCell[] _rowBuf;
+    private RustEmulatorCore.Info _info;
+    private TerminalEmulator.ShellMark[] _marks = Array.Empty<TerminalEmulator.ShellMark>();
+    private string _title = "", _cwd = "";
+
+    public RustTerminalCore(int cols, int rows)
+    {
+        _rust = new RustEmulatorCore(cols, rows);
+        _mirror = new ScreenBuffer(cols, rows);
+        _gridBuf = new RustEmulatorCore.NativeCell[cols * rows];
+        _rowBuf = new RustEmulatorCore.NativeCell[cols];
+        Sync();
+    }
+
+    private void Sync()
+    {
+        _info = _rust.GetInfo();
+        int cols = (int)_info.Cols, rows = (int)_info.Rows;
+        if (_mirror.Cols != cols || _mirror.Rows != rows)
+        {
+            _mirror.Resize(cols, rows);
+            _gridBuf = new RustEmulatorCore.NativeCell[cols * rows];
+            _rowBuf = new RustEmulatorCore.NativeCell[cols];
+        }
+        if (_rust.CopyGrid(_gridBuf))
+            for (int r = 0; r < rows; r++)
+                for (int c = 0; c < cols; c++)
+                    _mirror[r, c] = _gridBuf[r * cols + c].ToCell();
+
+        int target = (int)_info.HistoryCount;
+        if (target < _histMirror.Count) _histMirror.Clear();   // trimmed — refetch all
+        for (int h = _histMirror.Count; h < target; h++)
+        {
+            if (!_rust.CopyHistoryRow(h, _rowBuf)) break;
+            var row = new Cell[cols];
+            for (int c = 0; c < cols; c++) row[c] = _rowBuf[c].ToCell();
+            _histMirror.Add(row);
+        }
+
+        _title = _rust.Title;
+        _cwd = _rust.Cwd;
+        _marks = _rust.GetMarks();
+    }
+
+    // ---- content ----
+    public ScreenBuffer Screen => _mirror;
+    public void Feed(ReadOnlySpan<byte> bytes) { _rust.Feed(bytes); Sync(); }
+    public void Resize(int cols, int rows) { _rust.Resize(cols, rows); Sync(); }
+
+    // ---- cursor / screens ----
+    public int CursorRow => (int)_info.CursorRow;
+    public int CursorCol => (int)_info.CursorCol;
+    public bool CursorVisible => _info.CursorVisible != 0;
+    public bool IsAltScreen => _info.IsAltScreen != 0;
+    public int ScrollTop => (int)_info.ScrollTop;
+    public int ScrollBottom => (int)_info.ScrollBottom;
+
+    // ---- modes ----
+    public bool MouseClick => _info.MouseClick != 0;
+    public bool MouseDrag => _info.MouseDrag != 0;
+    public bool MouseMotion => _info.MouseMotion != 0;
+    public bool MouseSgr => _info.MouseSgr != 0;
+    public bool MouseReporting => MouseClick || MouseDrag || MouseMotion;
+    public bool MouseReportsMotion => MouseDrag || MouseMotion;
+    public bool BracketedPaste => _info.BracketedPaste != 0;
+    public int KeyboardFlags => _info.KeyboardFlags;
+
+    // ---- scrollback ----
+    public int ScrollbackMax { get; set; } = 5000;   // native side owns the real cap (same default)
+    public int HistoryCount => _histMirror.Count;
+    public long ScrollGeneration => _info.ScrollGeneration;
+
+    public Cell GetHistoryCell(int historyRow, int col)
+    {
+        if ((uint)historyRow >= (uint)_histMirror.Count) return Cell.Empty;
+        var row = _histMirror[historyRow];
+        return (uint)col < (uint)row.Length ? row[col] : Cell.Empty;
+    }
+
+    public void SeedScrollback(IReadOnlyList<string> lines)
+    {
+        if (lines.Count == 0) return;
+        _rust.SeedScrollback(string.Join('\n', lines));
+        _histMirror.Clear();   // counts jumped — refetch from scratch
+        Sync();
+    }
+
+    // ---- marks / identity ----
+    public IReadOnlyList<TerminalEmulator.ShellMark> Marks => _marks;
+    public string Title => _title;
+    public string Cwd => _cwd;
+
+    // ---- host actions: stored but never invoked by the Rust core (phase 2) ----
+    public IHostActions? Host { get; set; }
+
+    // ---- images: not surfaced in the experimental phase ----
+    private static readonly Dictionary<int, KittyImage> NoImages = new();
+    private static readonly List<ImagePlacement> NoPlacements = new();
+    public IReadOnlyDictionary<int, KittyImage> Images => NoImages;
+    public IReadOnlyList<ImagePlacement> Placements => NoPlacements;
+    public void ClearPlacements() { }
+    public bool HasImage(int id) => false;
+    public void SetImageData(int id, KittyFormat format, int width, int height, byte[] data) { }
+    public void PlaceImage(int id, int row, int col, int cols, int rows,
+        int srcX = 0, int srcY = 0, int srcW = 0, int srcH = 0) { }
+    public bool PlaceSixel(byte[] data) => false;
+    public int CellPixelWidth { get; set; } = 8;
+    public int CellPixelHeight { get; set; } = 18;
+
+    // ---- dumps (same conventions as TerminalEmulator) ----
+    public string DumpRow(int row)
+    {
+        var sb = new StringBuilder();
+        for (int c = 0; c < _mirror.Cols; c++)
+        {
+            Cell cell = _mirror[row, c];
+            if (cell.Width == 0) continue;
+            if (cell.Rune > 0xFFFF) sb.Append(char.ConvertFromUtf32(cell.Rune));
+            else sb.Append((char)cell.Rune);
+        }
+        return sb.ToString().TrimEnd();
+    }
+
+    public string DumpHistoryRow(int index)
+    {
+        var sb = new StringBuilder();
+        for (int c = 0; c < _mirror.Cols; c++)
+        {
+            Cell cell = GetHistoryCell(index, c);
+            if (cell.Width == 0) continue;
+            if (cell.Rune > 0xFFFF) sb.Append(char.ConvertFromUtf32(cell.Rune));
+            else sb.Append((char)cell.Rune);
+        }
+        return sb.ToString().TrimEnd();
+    }
+
+    public IReadOnlyList<string> DumpBuffer()
+    {
+        var lines = new List<string>();
+        for (int h = 0; h < _histMirror.Count; h++)
+        {
+            var sb = new StringBuilder();
+            foreach (var cell in _histMirror[h])
+            {
+                if (cell.Width == 0) continue;
+                if (cell.Rune > 0xFFFF) sb.Append(char.ConvertFromUtf32(cell.Rune));
+                else sb.Append(cell.Rune == 0 ? ' ' : (char)cell.Rune);
+            }
+            lines.Add(sb.ToString().TrimEnd());
+        }
+        for (int r = 0; r < _mirror.Rows; r++) lines.Add(DumpRow(r));
+        while (lines.Count > 0 && lines[^1].Length == 0) lines.RemoveAt(lines.Count - 1);
+        return lines;
+    }
+
+    public string DumpModes() => _rust.DumpModes();
+
+    public void Dispose() => _rust.Dispose();
+}

--- a/src/Agwinterm.Core/TerminalConfig.cs
+++ b/src/Agwinterm.Core/TerminalConfig.cs
@@ -85,6 +85,13 @@ public sealed class TerminalConfig
     /// long-term basis for sessions surviving UI updates/crashes).</summary>
     public string SessionHost { get; set; } = "in-process";
 
+    /// <summary>Which terminal core new sessions run on: "managed" (default — the C#
+    /// TerminalEmulator) or "rust" (EXPERIMENTAL — the oracle-validated agwinterm-core crate
+    /// behind the ITerminalCore seam; falls back to managed with a toast when the native dll
+    /// is missing). Known gaps in rust mode: kitty/sixel images and OSC host actions
+    /// (clipboard writes, notifications, kitty-keyboard query replies).</summary>
+    public string EmulatorCore { get; set; } = "managed";
+
     /// <summary>Rebuild each new session's environment from the registry at spawn (WT's
     /// reloadEnvironmentVariables analog): software installed while agwinterm runs — a JDK, a new
     /// PATH entry — is visible in the next tab without restarting anything. Off = tabs inherit
@@ -260,6 +267,13 @@ public sealed class TerminalConfig
         # LAUNCHED agwinterm do not reach tabs (same trade-off as Windows Terminal's default).
         fresh-env = true
 
+        # Terminal core for NEW sessions: "managed" (default) or "rust" (EXPERIMENTAL - the
+        # Rust agwinterm-core crate, differentially validated against the managed emulator).
+        # Applies to sessions created after the change; falls back to managed with a toast if
+        # the native dll is missing. Known gaps in rust mode: kitty/sixel images and OSC host
+        # actions (clipboard writes, desktop notifications, kitty-keyboard query replies).
+        emulator-core = managed
+
         # Blocked sound: play a sound whenever a session enters the "blocked" agent status (needs
         # your attention). Empty / off / none = silent. Accepts a system-sound name (beep, asterisk,
         # exclamation, hand, question), a Windows sound-event alias, or a path to a .wav file.
@@ -381,6 +395,9 @@ public sealed class TerminalConfig
                     if (val is "in-process" or "server") cfg.SessionHost = val;
                     break;
                 case "fresh-env": cfg.FreshEnv = ParseBool(val, cfg.FreshEnv); break;
+                case "emulator-core":
+                    if (val is "managed" or "rust") cfg.EmulatorCore = val;
+                    break;
                 case "word-delimiters": cfg.WordDelimiters = val; break;
                 case "desktop-notifications": cfg.DesktopNotifications = ParseBool(val, cfg.DesktopNotifications); break;
                 case "blocked-sound": cfg.BlockedSound = val; break;

--- a/src/Agwinterm.Core/TerminalEmulator.cs
+++ b/src/Agwinterm.Core/TerminalEmulator.cs
@@ -2,7 +2,7 @@ using System.Text;
 
 namespace Agwinterm.Core;
 
-public sealed class TerminalEmulator : IParserPerformer
+public sealed class TerminalEmulator : IParserPerformer, ITerminalCore
 {
     private readonly VtParser _parser;
     private readonly ScreenBuffer _main;

--- a/src/Agwinterm.Pty/ISession.cs
+++ b/src/Agwinterm.Pty/ISession.cs
@@ -18,7 +18,7 @@ public interface ISession : IDisposable
 {
     /// <summary>The screen model this session renders from. In-process: the live emulator; a
     /// server backend supplies a client-side replica with the same contract.</summary>
-    TerminalEmulator Emulator { get; }
+    ITerminalCore Emulator { get; }
     int Cols { get; }
     int Rows { get; }
 
@@ -63,7 +63,7 @@ public interface ISession : IDisposable
     /// <summary>Feed bytes into the EMULATOR only (display injection; never reaches the shell).</summary>
     void Inject(ReadOnlySpan<byte> bytes);
     /// <summary>Run a mutation against the emulator under <see cref="SyncRoot"/>.</summary>
-    void MutateLocked(Action<TerminalEmulator> mutate);
+    void MutateLocked(Action<ITerminalCore> mutate);
     /// <summary>Send bytes to the shell's stdin (real keystrokes).</summary>
     void Write(ReadOnlySpan<byte> bytes);
     void Resize(int cols, int rows);

--- a/src/Agwinterm.Pty/ServerSession.cs
+++ b/src/Agwinterm.Pty/ServerSession.cs
@@ -80,7 +80,7 @@ public sealed class ServerSession : ISession
     private volatile bool _started;
     private volatile bool _disposed;
 
-    public TerminalEmulator Emulator { get; }
+    public ITerminalCore Emulator { get; }
     public int Cols { get; private set; }
     public int Rows { get; private set; }
     public int? ChildProcessId => _childPid;
@@ -265,7 +265,7 @@ public sealed class ServerSession : ISession
         OutputReceived?.Invoke();
     }
 
-    public void MutateLocked(Action<TerminalEmulator> mutate)
+    public void MutateLocked(Action<ITerminalCore> mutate)
     {
         lock (_sync) mutate(Emulator);
         OutputReceived?.Invoke();

--- a/src/Agwinterm.Pty/TerminalSession.cs
+++ b/src/Agwinterm.Pty/TerminalSession.cs
@@ -14,7 +14,7 @@ public sealed class TerminalSession : ISession
     private readonly object _sync = new();
     private IPtyConnection? _connection;
 
-    public TerminalEmulator Emulator { get; }
+    public ITerminalCore Emulator { get; }
     public int Cols { get; private set; }
     public int Rows { get; private set; }
 
@@ -69,11 +69,17 @@ public sealed class TerminalSession : ISession
     /// <summary>Lock held while the emulator is mutated; renderers should lock this while reading the grid.</summary>
     public object SyncRoot => _sync;
 
+    /// <summary>When set (UI process, `emulator-core = rust`), new sessions build their
+    /// terminal core through this instead of the managed <see cref="TerminalEmulator"/>.</summary>
+    public static Func<int, int, ITerminalCore>? CoreFactory;
+
     public TerminalSession(int cols, int rows)
     {
         Cols = cols;
         Rows = rows;
-        Emulator = new TerminalEmulator(cols, rows);
+        // The emulator-core seam (`emulator-core = rust`): the UI process installs a factory;
+        // headless contexts (tests, the pty-host process) stay on the managed core.
+        Emulator = CoreFactory?.Invoke(cols, rows) ?? new TerminalEmulator(cols, rows);
     }
 
     /// <summary>Spawn <paramref name="app"/> and pump its output until it exits. Returns the exit code.</summary>
@@ -297,7 +303,7 @@ public sealed class TerminalSession : ISession
     /// Mutate the emulator directly under the render lock, then signal a repaint. Used to place
     /// images without pushing a large base64 payload through the parser under the lock.
     /// </summary>
-    public void MutateLocked(Action<TerminalEmulator> mutate)
+    public void MutateLocked(Action<ITerminalCore> mutate)
     {
         lock (_sync) mutate(Emulator);
         OutputReceived?.Invoke();

--- a/src/Agwinterm.Win32/Program.Input.cs
+++ b/src/Agwinterm.Win32/Program.Input.cs
@@ -576,7 +576,7 @@ internal partial class Program
         return (line, col);
     }
 
-    private static Cell CellAbs(TerminalEmulator em, int hist, int rows, int cols, int line, int col)
+    private static Cell CellAbs(ITerminalCore em, int hist, int rows, int cols, int line, int col)
     {
         col = Math.Clamp(col, 0, cols - 1);
         if (line < hist) return em.GetHistoryCell(line, col);

--- a/src/Agwinterm.Win32/Program.Render.cs
+++ b/src/Agwinterm.Win32/Program.Render.cs
@@ -32,7 +32,7 @@ internal partial class Program
     /// thread so the UI never blocks; only the cheap GPU upload runs here. An image simply
     /// appears on the next redraw once its pixels are ready. Called under the session lock.
     /// </summary>
-    private void DrawImages(TerminalEmulator em, float ox, float oy, float cw, float ch)
+    private void DrawImages(ITerminalCore em, float ox, float oy, float cw, float ch)
     {
         if (_rt is null) return;
 

--- a/src/Agwinterm.Win32/Program.Services.cs
+++ b/src/Agwinterm.Win32/Program.Services.cs
@@ -823,7 +823,7 @@ internal partial class Program
         "new-session-dir-mode", "confirm-close-session", "compact-toolbar", "toolbar-mode", "notification-badges",
         "attention-button", "status-color-active", "status-color-blocked", "status-color-completed",
         "paste-protection", "clipboard-write", "notification-flash", "claude-update-check", "update-check",
-        "session-host", "fresh-env",
+        "session-host", "fresh-env", "emulator-core",
     };
 
     /// <summary>Rewrite (or append) a single `key = value` line in agwinterm.conf, preserving the rest.</summary>
@@ -889,6 +889,7 @@ internal partial class Program
         "update-check" => _config.UpdateCheck ? "true" : "false",
         "session-host" => _config.SessionHost,
         "fresh-env" => _config.FreshEnv ? "true" : "false",
+        "emulator-core" => _config.EmulatorCore,
         "paste-protection" => _config.PasteProtection ? "true" : "false",
         "clipboard-write" => _config.ClipboardWrite ? "true" : "false",
         "attention-button" => _config.AttentionButton ? "true" : "false",
@@ -915,6 +916,14 @@ internal partial class Program
             ShowToast(_config.SessionHost == "server"
                 ? "server mode ON (experimental) — new sessions survive UI restarts; restart agwinterm to move existing ones"
                 : "in-process mode — new sessions run in the window process; restart agwinterm to convert existing ones", 6000);
+        }
+        if (key == "emulator-core")
+        {
+            // Live switch, same semantics as session-host: NEW sessions get the chosen core;
+            // existing panes keep the one they were born with and converge on restart.
+            ResolveEmulatorCore();
+            ShowToast(_emulatorCoreNote ?? "emulator-core = managed — new sessions use the C# emulator", 6000);
+            _emulatorCoreNote = null;   // startup path only announces once
         }
         if (key == "cursor-blink-ms" && _hwnd != IntPtr.Zero) SetTimer(_hwnd, (IntPtr)1, (uint)_config.CursorBlinkMs, IntPtr.Zero);
         RecomputeChrome();

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -424,6 +424,7 @@ internal partial class Program : ISessionHost, IWindowHost
         // Process-global setup (config/themes/keymap + window class + shared D2D/DWrite objects).
         _config = LoadOrCreateConfig();
         _sessionBackend = SessionBackends.Resolve(_config.SessionHost, _argPipe ?? _appId, AppExePath);
+        ResolveEmulatorCore();
         _allThemes = LoadThemes();
         _theme = FindTheme(_config.Theme);
         LoadKeymap();
@@ -478,6 +479,9 @@ internal partial class Program : ISessionHost, IWindowHost
             front ??= w;
         }
         Frontmost = front!;
+        // Experimental knobs announce themselves once at startup — never a silent mystery.
+        if (_emulatorCoreNote is { } note)
+            front!.Post(() => front.ShowToast(note, 6000));
         // Server mode is experimental (#105) — say so once at startup, so a flipped knob is never
         // a silent mystery ("why is there a second agwinterm process?").
         if (_sessionBackend is ServerSessionBackend)
@@ -608,6 +612,35 @@ internal partial class Program : ISessionHost, IWindowHost
     // (the "overlapping text / shifted colored text" bug, issue #120).
     private static IDWriteFont? _familyFont;
     private static readonly Dictionary<int, bool> _glyphInFont = new();
+
+    // Deferred startup toast when `emulator-core = rust` couldn't load (shown once a window exists).
+    private static string? _emulatorCoreNote;
+
+    /// <summary>Wire `emulator-core = rust`: probe the native dll (next to the exe, then the
+    /// dev-tree cargo output), verify the ABI handshake, and install the session core factory.
+    /// Any failure falls back to the managed emulator — visibly, never silently.</summary>
+    private static void ResolveEmulatorCore()
+    {
+        if (_config.EmulatorCore != "rust") { Agwinterm.Pty.TerminalSession.CoreFactory = null; return; }
+        string? err = null;
+        foreach (var dll in new[]
+        {
+            Path.Combine(AppContext.BaseDirectory, "agwinterm_core.dll"),
+            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "..", "..",
+                "native", "agwinterm-core", "target", "release", "agwinterm_core.dll"),
+        })
+        {
+            if (RustEmulatorCore.TryLoad(Path.GetFullPath(dll), out err))
+            {
+                Agwinterm.Pty.TerminalSession.CoreFactory = (c, r) => new RustTerminalCore(c, r);
+                _emulatorCoreNote = "emulator-core = rust (EXPERIMENTAL) — new sessions run the native core";
+                return;
+            }
+            if (err is not null && !err.StartsWith("native core not found")) break;   // found but bad → stop probing
+        }
+        Agwinterm.Pty.TerminalSession.CoreFactory = null;
+        _emulatorCoreNote = "emulator-core = rust unavailable (" + (err ?? "unknown") + ") — using managed";
+    }
 
     private static void ResolveFamilyFont()
     {

--- a/src/Agwinterm.Win32/Settings.cs
+++ b/src/Agwinterm.Win32/Settings.cs
@@ -111,6 +111,9 @@ internal partial class Program
         // pty-host opt-in (#105): server mode keeps shells alive across UI restarts/updates/crashes.
         Drop(0, "session-host", "Session host (shells survive restarts)",
             new[] { "In-process (default)", "Pty-host server (experimental)" }, new[] { "in-process", "server" });
+        // Rust core opt-in: new sessions parse/render state in native/agwinterm-core.
+        Drop(0, "emulator-core", "Terminal core (new sessions)",
+            new[] { "Managed (default)", "Rust (experimental)" }, new[] { "managed", "rust" });
         Sec(0, "Shell");
         Tog(0, "shell-integration", "Shell integration (live cwd)");
         // fresh-env: rebuild each new tab's env from the registry (new installs visible, no restart).


### PR DESCRIPTION
feat(rust): wire the Rust core into real panes - `emulator-core = rust`

The integration seam: ITerminalCore, extracted with member names IDENTICAL to
TerminalEmulator, so the renderer, control API, selection, and session stack
compile unchanged (zero call-site edits - the build was green on the first
try after retyping ISession.Emulator). TerminalEmulator implements it as-is.

RustTerminalCore implements it over the native core: Rust is authoritative;
a managed mirror (grid + history + scalars + marks + title/cwd) refreshes
after every Feed/Resize with one bulk interop copy, so all reads stay
lock-cheap managed accesses with unchanged semantics. ABI v7 adds marks,
scrollback seeding, and scroll-region/mark-count in the info snapshot.

Wiring: `emulator-core = managed | rust` (validated, default managed, live-
switchable like session-host: NEW sessions get the chosen core), Settings
dropdown, startup + switch toasts, fail-loud dll probe (exe dir, then the
dev cargo tree) with visible fallback to managed. The factory is installed
only in the UI process - the pty-host process and tests stay managed.

Known gaps in rust mode, announced in config docs: kitty/sixel images and
OSC host actions (clipboard, notifications, kitty-query replies) - phase 2.

E2E: dev instance, config set emulator-core rust, new session -> live pane
with starship prompt glyphs, PSReadLine syntax colors, scrolling, and
control-API reads (session text) all served from the Rust core's mirror.
Screenshot in PR. 272 tests green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k
