### PR TITLE
feat(lite): M1 phase 1 — sessions, sidebar, splits, styles, scrollback view

### DIFF
--- a/lite/src/main.cpp
+++ b/lite/src/main.cpp
@@ -1,18 +1,26 @@
-// agwinterm-lite M0 (issue #134): a thin Win32+GDI client over the Rust server.
+// agwinterm-lite M1 phase 1 (issue #134): layout core over the Rust server.
 //
-// Contains ZERO terminal logic and ZERO ConPTY code: it spawns/attaches to
-// agwinterm-ptyhost.exe (the protocol-proven Rust host), feeds the data-pipe
-// byte stream into a local agwinterm-core emulator (C ABI, the oracle-validated
-// crate) as its render replica, and paints the grid with classic-conhost
-// technology: ExtTextOutW + lpDx advances (grid-anchored by construction),
-// memory-DC double buffer, no Direct2D, no GPU requirements.
+// M0 gave one session on the full stack (Rust pty-host + agwinterm-core replica
+// + GDI ExtTextOutW/lpDx). M1p1 adds the layout skeleton with main-app parity:
+//   - multiple sessions + sidebar (click to select, status marker)
+//   - SPLITS from the start (Boris's #134 decision): vertical two-pane split,
+//     per-pane session + focus, per-pane host resize
+//   - text styles: bold/italic fonts, underline/strike lines, dim, inverse
+//   - scrollback view (mouse wheel / Shift+PgUp/PgDn) over the replica history
+// Keys: Ctrl+T new session · Ctrl+W close · Ctrl+Tab cycle · Ctrl+Shift+D
+// split toggle · Ctrl+Shift+Left/Right focus pane.
+// Still M1 phase 2: selection+clipboard, palette, astral glyphs, control API.
 //
-// M0 scope: one session, typing, scrolling, colors+inverse, resize, clean kill
-// on close. M1: layout parity (sidebar/splits), styles, selection, dirty rows.
+// Protocol v2 (protobuf; proto/ptyhost.proto). Zero terminal logic, zero ConPTY.
 
 #include <windows.h>
+#include <windowsx.h>
 #include <string>
 #include <vector>
+
+#include "proto/ptyhost.pb.h"
+#include "proto/pb_encode.h"
+#include "proto/pb_decode.h"
 
 // ---- agwinterm-core C ABI (ABI v7) ----
 struct FfiCell {
@@ -35,20 +43,35 @@ static bool (*emu_feed)(void*, const uint8_t*, uint32_t);
 static bool (*emu_resize)(void*, uint32_t, uint32_t);
 static bool (*emu_info)(void*, FfiEmuInfo*);
 static bool (*emu_copy_grid)(void*, FfiCell*, uint32_t);
+static bool (*emu_copy_history_row)(void*, uint32_t, FfiCell*, uint32_t);
 
 static constexpr uint32_t kRequiredAbi = 7;
-static constexpr uint32_t kAttrInverse = 8;
+static constexpr uint32_t kAttrBold = 1, kAttrItalic = 2, kAttrUnderline = 4,
+                          kAttrInverse = 8, kAttrDim = 16, kAttrStrike = 32;
+static constexpr uint32_t kProtocolVersion = 2;
+static constexpr int kSidebarW = 180;
 
-// ---- globals (M0 single-window simplicity) ----
+// ---- sessions & layout ----
+struct Session {
+    std::string id;
+    void* emu = nullptr;
+    HANDLE data = INVALID_HANDLE_VALUE;
+    HANDLE reader = nullptr;
+    int scrollOff = 0;          // rows scrolled up into history (0 = live)
+    bool exited = false;
+    std::vector<FfiCell> grid;  // paint snapshot buffer
+    std::vector<FfiCell> hrow;
+};
+
 static HWND g_hwnd;
-static HFONT g_font;
+static HFONT g_fonts[4];        // [bold][italic]
 static int g_cw = 8, g_ch = 16;
-static void* g_emu;
-static CRITICAL_SECTION g_lock;          // guards g_emu (reader thread vs paint/resize)
+static CRITICAL_SECTION g_lock; // guards every session's emu + the session list shape
 static HANDLE g_control = INVALID_HANDLE_VALUE;
-static HANDLE g_data = INVALID_HANDLE_VALUE;
-static std::string g_sessionId = "lite-session-1";
-static std::vector<FfiCell> g_grid;
+static std::vector<Session*> g_sessions;
+static int g_pane[2] = { 0, -1 };   // session index per pane; pane[1] = -1 → no split
+static int g_focus = 0;             // focused pane (0/1)
+static int g_seq = 1;
 static const wchar_t* kAppId = L"agwinterm-lite";
 
 static void fatal(const wchar_t* msg) {
@@ -56,28 +79,19 @@ static void fatal(const wchar_t* msg) {
     ExitProcess(1);
 }
 
-// ---- control pipe, protocol v2: 4-byte LE length prefix + nanopb-encoded frames.
-// Schema-generated handlers (proto/ptyhost.proto + ptyhost.options) — no JSON,
-// no hand parsing; the same schema drives the C#/Rust speakers.
-#include "proto/ptyhost.pb.h"
-#include "proto/pb_encode.h"
-#include "proto/pb_decode.h"
-
-static constexpr uint32_t kProtocolVersion = 2;
-
+// ---- control pipe: protobuf frames (4-byte LE length prefix) ----
 static bool request(const agwinterm_ptyhost_Request& req, agwinterm_ptyhost_Reply* reply) {
     uint8_t buf[4096];
     pb_ostream_t os = pb_ostream_from_buffer(buf + 4, sizeof buf - 4);
     if (!pb_encode(&os, agwinterm_ptyhost_Request_fields, &req)) return false;
     uint32_t len = (uint32_t)os.bytes_written;
-    memcpy(buf, &len, 4);                                 // LE on x64
+    memcpy(buf, &len, 4);
     DWORD n = 0;
     if (!WriteFile(g_control, buf, len + 4, &n, nullptr)) return false;
 
     uint32_t rlen = 0;
     DWORD got = 0, need = 4;
-    uint8_t* p = (uint8_t*)&rlen;
-    while (need && ReadFile(g_control, p + (4 - need), need, &got, nullptr) && got) need -= got;
+    while (need && ReadFile(g_control, (uint8_t*)&rlen + (4 - need), need, &got, nullptr) && got) need -= got;
     if (need || rlen > 1 << 20) return false;
     std::vector<uint8_t> payload(rlen);
     need = rlen;
@@ -89,10 +103,9 @@ static bool request(const agwinterm_ptyhost_Request& req, agwinterm_ptyhost_Repl
 }
 
 static HANDLE openPipe(const std::wstring& name, int timeoutMs, bool overlapped) {
-    // The DATA pipe must be overlapped: a non-overlapped duplex pipe SERIALIZES the
-    // handle, so the reader thread's pending ReadFile would block the UI thread's
-    // keystroke WriteFile forever (the same deadlock the Rust host hit and fixed).
-    // The CONTROL pipe stays sync — strict request/response on one thread.
+    // DATA pipes must be overlapped: a non-overlapped duplex pipe SERIALIZES the handle
+    // (pending reader ReadFile blocks the UI thread's keystroke write — both the Rust
+    // host and this client hit that identical deadlock). Control stays sync.
     std::wstring full = L"\\\\.\\pipe\\" + name;
     DWORD flags = overlapped ? FILE_FLAG_OVERLAPPED : 0;
     for (int waited = 0; waited <= timeoutMs; waited += 100) {
@@ -103,16 +116,13 @@ static HANDLE openPipe(const std::wstring& name, int timeoutMs, bool overlapped)
     return INVALID_HANDLE_VALUE;
 }
 
-// One overlapped op, blocking-style with its own event.
-static DWORD ovIo(bool write, const void* wbuf, void* rbuf, DWORD len) {
+static DWORD ovIo(HANDLE h, bool write, const void* wbuf, void* rbuf, DWORD len) {
     OVERLAPPED ov{};
     ov.hEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
-    BOOL issued = write
-        ? WriteFile(g_data, wbuf, len, nullptr, &ov)
-        : ReadFile(g_data, rbuf, len, nullptr, &ov);
+    BOOL issued = write ? WriteFile(h, wbuf, len, nullptr, &ov) : ReadFile(h, rbuf, len, nullptr, &ov);
     DWORD n = 0;
     if (issued || GetLastError() == ERROR_IO_PENDING) {
-        if (!GetOverlappedResult(g_data, &ov, &n, TRUE)) n = 0;
+        if (!GetOverlappedResult(h, &ov, &n, TRUE)) n = 0;
     }
     CloseHandle(ov.hEvent);
     return n;
@@ -126,8 +136,7 @@ static std::wstring exeDir() {
 }
 
 static void loadCore() {
-    std::wstring dll = exeDir() + L"\\agwinterm_core.dll";
-    HMODULE m = LoadLibraryW(dll.c_str());
+    HMODULE m = LoadLibraryW((exeDir() + L"\\agwinterm_core.dll").c_str());
     if (!m) fatal(L"agwinterm_core.dll not found next to the exe");
     core_abi = (decltype(core_abi))GetProcAddress(m, "agwcore_abi_version");
     emu_new = (decltype(emu_new))GetProcAddress(m, "agwcore_emu_new");
@@ -136,16 +145,16 @@ static void loadCore() {
     emu_resize = (decltype(emu_resize))GetProcAddress(m, "agwcore_emu_resize");
     emu_info = (decltype(emu_info))GetProcAddress(m, "agwcore_emu_info");
     emu_copy_grid = (decltype(emu_copy_grid))GetProcAddress(m, "agwcore_emu_copy_grid");
-    if (!core_abi || !emu_new || !emu_feed || !emu_info || !emu_copy_grid || !emu_resize || !emu_free)
+    emu_copy_history_row = (decltype(emu_copy_history_row))GetProcAddress(m, "agwcore_emu_copy_history_row");
+    if (!core_abi || !emu_new || !emu_feed || !emu_info || !emu_copy_grid || !emu_resize || !emu_free || !emu_copy_history_row)
         fatal(L"agwinterm_core.dll: exports missing");
     if (core_abi() != kRequiredAbi) fatal(L"agwinterm_core.dll: ABI mismatch (need v7)");
 }
 
-static void connectHost(int cols, int rows) {
+static void connectControl() {
     std::wstring control = std::wstring(kAppId) + L"-ptyhost";
     g_control = openPipe(control, 0, false);
     if (g_control == INVALID_HANDLE_VALUE) {
-        // Spawn the Rust host (lite's own instance id — the main app keeps its own).
         std::wstring cmd = L"\"" + exeDir() + L"\\agwinterm-ptyhost.exe\" --pipe " + kAppId;
         STARTUPINFOW si{ sizeof(si) };
         PROCESS_INFORMATION pi{};
@@ -164,128 +173,364 @@ static void connectHost(int cols, int rows) {
     req.cmd.hello.protocol = kProtocolVersion;
     if (!request(req, &rep) || rep.which_body != agwinterm_ptyhost_Reply_hello_tag)
         fatal(L"pty-host hello failed (protocol mismatch?)");
+}
 
-    req = agwinterm_ptyhost_Request_init_default;
+// ---- pane geometry ----
+static void paneRect(int pane, RECT client, RECT* out) {
+    int contentX = kSidebarW;
+    int contentW = client.right - kSidebarW;
+    if (g_pane[1] < 0) { *out = { contentX, 0, client.right, client.bottom }; return; }
+    int half = contentW / 2;
+    if (pane == 0) *out = { contentX, 0, contentX + half - 1, client.bottom };
+    else *out = { contentX + half + 1, 0, client.right, client.bottom };
+}
+
+static void paneGridSize(int pane, int* cols, int* rows) {
+    RECT rc;
+    GetClientRect(g_hwnd, &rc);
+    RECT pr;
+    paneRect(pane, rc, &pr);
+    *cols = max(2L, (pr.right - pr.left) / g_cw);
+    *rows = max(2L, (pr.bottom - pr.top) / g_ch);
+}
+
+static Session* focusedSession() {
+    int idx = g_pane[g_focus];
+    return (idx >= 0 && idx < (int)g_sessions.size()) ? g_sessions[idx] : nullptr;
+}
+
+static void hostResize(Session* s, int cols, int rows) {
+    agwinterm_ptyhost_Request req = agwinterm_ptyhost_Request_init_default;
+    agwinterm_ptyhost_Reply rep = agwinterm_ptyhost_Reply_init_default;
+    req.which_cmd = agwinterm_ptyhost_Request_resize_tag;
+    strcpy_s(req.cmd.resize.id, s->id.c_str());
+    req.cmd.resize.cols = (uint32_t)cols;
+    req.cmd.resize.rows = (uint32_t)rows;
+    request(req, &rep);
+    EnterCriticalSection(&g_lock);
+    emu_resize(s->emu, cols, rows);
+    LeaveCriticalSection(&g_lock);
+}
+
+static void syncPaneSizes() {
+    for (int p = 0; p < 2; p++) {
+        int idx = g_pane[p];
+        if (idx < 0 || idx >= (int)g_sessions.size()) continue;
+        int cols, rows;
+        paneGridSize(p, &cols, &rows);
+        hostResize(g_sessions[idx], cols, rows);
+    }
+}
+
+// ---- session lifecycle ----
+static DWORD WINAPI readerThread(void* param) {
+    Session* s = (Session*)param;
+    std::vector<uint8_t> buf(64 * 1024);
+    DWORD n;
+    while ((n = ovIo(s->data, false, nullptr, buf.data(), (DWORD)buf.size())) > 0) {
+        EnterCriticalSection(&g_lock);
+        emu_feed(s->emu, buf.data(), n);
+        LeaveCriticalSection(&g_lock);
+        InvalidateRect(g_hwnd, nullptr, FALSE);
+    }
+    s->exited = true;   // EOF: child exited, host shut down, or we were superseded
+    InvalidateRect(g_hwnd, nullptr, FALSE);
+    return 0;
+}
+
+static Session* newSession(int cols, int rows) {
+    char idbuf[64];
+    wsprintfA(idbuf, "lite-%d", g_seq++);
+    agwinterm_ptyhost_Request req = agwinterm_ptyhost_Request_init_default;
+    agwinterm_ptyhost_Reply rep = agwinterm_ptyhost_Reply_init_default;
     req.which_cmd = agwinterm_ptyhost_Request_create_tag;
-    strcpy_s(req.cmd.create.id, g_sessionId.c_str());
+    strcpy_s(req.cmd.create.id, idbuf);
     req.cmd.create.cols = (uint32_t)cols;
     req.cmd.create.rows = (uint32_t)rows;
     strcpy_s(req.cmd.create.app, "powershell.exe");
     req.cmd.create.args_count = 1;
     strcpy_s(req.cmd.create.args[0], "-NoLogo");
-    if (!request(req, &rep)) fatal(L"pty-host create failed");
+    if (!request(req, &rep)) return nullptr;
 
     req = agwinterm_ptyhost_Request_init_default;
     req.which_cmd = agwinterm_ptyhost_Request_attach_tag;
-    strcpy_s(req.cmd.attach.id, g_sessionId.c_str());
-    if (!request(req, &rep) || rep.which_body != agwinterm_ptyhost_Reply_attach_tag)
-        fatal(L"pty-host attach failed");
-    std::string dataName = rep.body.attach.pipe;
-    if (dataName.empty()) fatal(L"pty-host attach: no data pipe");
-    g_data = openPipe(std::wstring(dataName.begin(), dataName.end()), 5000, true);
-    if (g_data == INVALID_HANDLE_VALUE) fatal(L"data pipe connect failed");
+    strcpy_s(req.cmd.attach.id, idbuf);
+    if (!request(req, &rep) || rep.which_body != agwinterm_ptyhost_Reply_attach_tag) return nullptr;
+
+    Session* s = new Session();
+    s->id = idbuf;
+    s->emu = emu_new(cols, rows);
+    s->data = openPipe(std::wstring(rep.body.attach.pipe, rep.body.attach.pipe + strlen(rep.body.attach.pipe)), 5000, true);
+    if (s->data == INVALID_HANDLE_VALUE) { emu_free(s->emu); delete s; return nullptr; }
+    s->reader = CreateThread(nullptr, 0, readerThread, s, 0, nullptr);
+    EnterCriticalSection(&g_lock);
+    g_sessions.push_back(s);
+    LeaveCriticalSection(&g_lock);
+    return s;
 }
 
-// ---- data-pipe reader: bytes → replica emulator → repaint ----
-static DWORD WINAPI readerThread(void*) {
-    std::vector<uint8_t> buf(64 * 1024);
-    DWORD n;
-    while ((n = ovIo(false, nullptr, buf.data(), (DWORD)buf.size())) > 0) {
-        EnterCriticalSection(&g_lock);
-        emu_feed(g_emu, buf.data(), n);
-        LeaveCriticalSection(&g_lock);
-        InvalidateRect(g_hwnd, nullptr, FALSE);
+static void killSession(Session* s) {
+    agwinterm_ptyhost_Request req = agwinterm_ptyhost_Request_init_default;
+    agwinterm_ptyhost_Reply rep = agwinterm_ptyhost_Reply_init_default;
+    req.which_cmd = agwinterm_ptyhost_Request_kill_tag;
+    strcpy_s(req.cmd.kill.id, s->id.c_str());
+    request(req, &rep);
+}
+
+static void closeFocused() {
+    Session* s = focusedSession();
+    if (!s) return;
+    killSession(s);
+    EnterCriticalSection(&g_lock);
+    int idx = g_pane[g_focus];
+    g_sessions.erase(g_sessions.begin() + idx);
+    for (int p = 0; p < 2; p++) {
+        if (g_pane[p] == idx) g_pane[p] = g_sessions.empty() ? -1 : max(0, idx - 1);
+        else if (g_pane[p] > idx) g_pane[p]--;
     }
-    return 0;
+    if (g_sessions.empty()) g_pane[1] = -1;   // unsplit when the last pane dies
+    LeaveCriticalSection(&g_lock);
+    if (g_sessions.empty()) { DestroyWindow(g_hwnd); return; }
+    syncPaneSizes();
+    InvalidateRect(g_hwnd, nullptr, FALSE);
 }
 
-static void sendInput(const char* bytes, int len) {
-    if (g_data != INVALID_HANDLE_VALUE) ovIo(true, bytes, nullptr, (DWORD)len);
+// ---- GDI paint ----
+static COLORREF toColorRef(uint32_t packed, bool dim) {
+    uint32_t r = (packed >> 16) & 0xFF, g = (packed >> 8) & 0xFF, b = packed & 0xFF;
+    if (dim) { r = r * 6 / 10; g = g * 6 / 10; b = b * 6 / 10; }
+    return RGB(r, g, b);
 }
 
-// ---- GDI paint: color runs + ExtTextOutW with lpDx (grid-anchored by construction) ----
-static COLORREF toColorRef(uint32_t packed) {  // 0x00RRGGBB → COLORREF 0x00BBGGRR
-    return RGB((packed >> 16) & 0xFF, (packed >> 8) & 0xFF, packed & 0xFF);
+static HFONT styleFont(uint32_t attrs) {
+    return g_fonts[((attrs & kAttrBold) ? 1 : 0) | ((attrs & kAttrItalic) ? 2 : 0)];
 }
 
-static void paint(HDC dc, int width, int height) {
+static void paintPane(HDC mem, int pane, RECT pr) {
+    int idx = g_pane[pane];
+    if (idx < 0 || idx >= (int)g_sessions.size()) return;
+    Session* s = g_sessions[idx];
+
     FfiEmuInfo info{};
     EnterCriticalSection(&g_lock);
-    emu_info(g_emu, &info);
+    emu_info(s->emu, &info);
     size_t need = (size_t)info.cols * info.rows;
-    if (g_grid.size() < need) g_grid.resize(need);
-    emu_copy_grid(g_emu, g_grid.data(), (uint32_t)g_grid.size());
+    if (s->grid.size() < need) s->grid.resize(need);
+    if (s->hrow.size() < info.cols) s->hrow.resize(info.cols);
+    emu_copy_grid(s->emu, s->grid.data(), (uint32_t)s->grid.size());
+    int off = min(s->scrollOff, (int)info.historyCount);
+    s->scrollOff = off;
+    // Compose the viewport: history tail above, live grid below (main-app semantics).
+    std::vector<FfiCell> view((size_t)info.cols * info.rows);
+    for (uint32_t r = 0; r < info.rows; r++) {
+        int abs = (int)info.historyCount - off + (int)r;
+        if (abs < (int)info.historyCount) {
+            if (emu_copy_history_row(s->emu, (uint32_t)abs, s->hrow.data(), info.cols))
+                memcpy(&view[r * info.cols], s->hrow.data(), info.cols * sizeof(FfiCell));
+        } else {
+            int live = abs - (int)info.historyCount;
+            if (live < (int)info.rows)
+                memcpy(&view[r * info.cols], &s->grid[live * info.cols], info.cols * sizeof(FfiCell));
+        }
+    }
     LeaveCriticalSection(&g_lock);
-
-    HDC mem = CreateCompatibleDC(dc);
-    HBITMAP bmp = CreateCompatibleBitmap(dc, width, height);
-    HGDIOBJ oldBmp = SelectObject(mem, bmp);
-    HGDIOBJ oldFont = SelectObject(mem, g_font);
-    RECT all{ 0, 0, width, height };
-    HBRUSH bg = CreateSolidBrush(RGB(0, 0, 0));
-    FillRect(mem, &all, bg);
-    DeleteObject(bg);
 
     std::vector<wchar_t> text;
     std::vector<INT> dx;
     for (uint32_t r = 0; r < info.rows; r++) {
+        int y = pr.top + (int)r * g_ch;
+        if (y + g_ch > pr.bottom) break;
         uint32_t c = 0;
         while (c < info.cols) {
-            const FfiCell& cell = g_grid[r * info.cols + c];
+            const FfiCell& cell = view[r * info.cols + c];
             if (cell.width == 0) { c++; continue; }
+            uint32_t attrs = cell.attrs;
             uint32_t fg = cell.fg, bgc = cell.bg;
-            if (cell.attrs & kAttrInverse) { uint32_t t = fg; fg = bgc; bgc = t; }
-            // Coalesce a same-color run; every cell gets its own lpDx advance so
-            // fallback glyphs can NEVER derail the grid (the #120 lesson, solved
-            // in GDI by construction).
+            if (attrs & kAttrInverse) { uint32_t t = fg; fg = bgc; bgc = t; }
+            uint32_t styleKey = attrs & (kAttrBold | kAttrItalic | kAttrUnderline | kAttrStrike | kAttrDim);
             uint32_t start = c;
             text.clear();
             dx.clear();
             while (c < info.cols) {
-                const FfiCell& cc = g_grid[r * info.cols + c];
+                const FfiCell& cc = view[r * info.cols + c];
                 if (cc.width == 0) { c++; continue; }
-                uint32_t f2 = cc.fg, b2 = cc.bg;
-                if (cc.attrs & kAttrInverse) { uint32_t t = f2; f2 = b2; b2 = t; }
-                if (f2 != fg || b2 != bgc) break;
+                uint32_t f2 = cc.fg, b2 = cc.bg, a2 = cc.attrs;
+                if (a2 & kAttrInverse) { uint32_t t = f2; f2 = b2; b2 = t; }
+                if (f2 != fg || b2 != bgc ||
+                    (a2 & (kAttrBold | kAttrItalic | kAttrUnderline | kAttrStrike | kAttrDim)) != styleKey) break;
                 if (cc.rune > 0xFFFF) {
-                    text.push_back(0xFFFD);           // astral: placeholder in M0
+                    // Astral: surrogate pair with the advance on the FIRST unit (GDI draws the
+                    // pair as one glyph when the font covers it; U+FFFD look comes free otherwise).
+                    uint32_t v = cc.rune - 0x10000;
+                    text.push_back((wchar_t)(0xD800 + (v >> 10)));
                     dx.push_back(g_cw * (int)cc.width);
+                    text.push_back((wchar_t)(0xDC00 + (v & 0x3FF)));
+                    dx.push_back(0);
                 } else {
                     text.push_back((wchar_t)(cc.rune ? cc.rune : L' '));
                     dx.push_back(g_cw * (int)cc.width);
                 }
                 c += cc.width;
             }
-            SetTextColor(mem, toColorRef(fg));
-            SetBkColor(mem, toColorRef(bgc));
+            int x = pr.left + (int)start * g_cw;
+            if (x >= pr.right) break;
+            SelectObject(mem, styleFont(styleKey));
+            SetTextColor(mem, toColorRef(fg, (styleKey & kAttrDim) != 0));
+            SetBkColor(mem, toColorRef(bgc, false));
             SetBkMode(mem, OPAQUE);
-            RECT clip{ (LONG)(start * g_cw), (LONG)(r * g_ch), (LONG)(c * g_cw), (LONG)((r + 1) * g_ch) };
-            ExtTextOutW(mem, start * g_cw, r * g_ch, ETO_OPAQUE | ETO_CLIPPED, &clip,
-                        text.data(), (UINT)text.size(), dx.data());
+            RECT clip{ x, y, min((LONG)(pr.left + (LONG)c * g_cw), pr.right), y + g_ch };
+            ExtTextOutW(mem, x, y, ETO_OPAQUE | ETO_CLIPPED, &clip, text.data(), (UINT)text.size(), dx.data());
+            if (styleKey & (kAttrUnderline | kAttrStrike)) {
+                HBRUSH b = CreateSolidBrush(toColorRef(fg, (styleKey & kAttrDim) != 0));
+                if (styleKey & kAttrUnderline) { RECT u{ x, y + g_ch - 2, clip.right, y + g_ch - 1 }; FillRect(mem, &u, b); }
+                if (styleKey & kAttrStrike) { RECT k{ x, y + g_ch / 2, clip.right, y + g_ch / 2 + 1 }; FillRect(mem, &k, b); }
+                DeleteObject(b);
+            }
         }
     }
 
-    if (info.cursorVisible && info.cursorCol < info.cols) {
-        RECT cur{ (LONG)(info.cursorCol * g_cw), (LONG)(info.cursorRow * g_ch),
-                  (LONG)((info.cursorCol + 1) * g_cw), (LONG)((info.cursorRow + 1) * g_ch) };
-        InvertRect(mem, &cur);
+    // Cursor (only at live view, only in the focused pane).
+    if (off == 0 && info.cursorVisible && pane == g_focus && info.cursorCol < info.cols) {
+        RECT cur{ pr.left + (LONG)info.cursorCol * g_cw, pr.top + (LONG)info.cursorRow * g_ch,
+                  pr.left + (LONG)(info.cursorCol + 1) * g_cw, pr.top + (LONG)(info.cursorRow + 1) * g_ch };
+        if (cur.right <= pr.right) InvertRect(mem, &cur);
+    }
+    // Scrollback indicator: thin right-edge stripe while scrolled.
+    if (off > 0) {
+        RECT bar{ pr.right - 3, pr.top, pr.right, pr.bottom };
+        HBRUSH b = CreateSolidBrush(RGB(90, 140, 200));
+        FillRect(mem, &bar, b);
+        DeleteObject(b);
+    }
+}
+
+static void paintSidebar(HDC mem, RECT rc) {
+    RECT side{ 0, 0, kSidebarW, rc.bottom };
+    HBRUSH bg = CreateSolidBrush(RGB(18, 18, 22));
+    FillRect(mem, &side, bg);
+    DeleteObject(bg);
+    SelectObject(mem, g_fonts[0]);
+    SetBkMode(mem, TRANSPARENT);
+    SetTextColor(mem, RGB(140, 140, 150));
+    RECT title{ 10, 8, kSidebarW - 8, 8 + g_ch };
+    DrawTextW(mem, L"sessions  (Ctrl+T new)", -1, &title, DT_LEFT | DT_SINGLELINE);
+    for (int i = 0; i < (int)g_sessions.size(); i++) {
+        int y = 12 + (i + 1) * (g_ch + 8);
+        bool inPane = g_pane[0] == i || g_pane[1] == i;
+        bool focused = g_pane[g_focus] == i;
+        if (focused) {
+            RECT row{ 0, y - 4, kSidebarW, y + g_ch + 4 };
+            HBRUSH hb = CreateSolidBrush(RGB(38, 40, 48));
+            FillRect(mem, &row, hb);
+            DeleteObject(hb);
+        }
+        SetTextColor(mem, g_sessions[i]->exited ? RGB(120, 90, 90)
+                          : focused ? RGB(230, 230, 235)
+                          : inPane ? RGB(190, 190, 200) : RGB(150, 150, 160));
+        wchar_t name[64];
+        wsprintfW(name, L"%s%S", g_sessions[i]->exited ? L"× " : L"", g_sessions[i]->id.c_str());
+        RECT row{ 14, y, kSidebarW - 8, y + g_ch };
+        DrawTextW(mem, name, -1, &row, DT_LEFT | DT_SINGLELINE);
+    }
+}
+
+static void paint(HDC dc, RECT rc) {
+    HDC mem = CreateCompatibleDC(dc);
+    HBITMAP bmp = CreateCompatibleBitmap(dc, rc.right, rc.bottom);
+    HGDIOBJ oldBmp = SelectObject(mem, bmp);
+    HBRUSH bg = CreateSolidBrush(RGB(0, 0, 0));
+    FillRect(mem, &rc, bg);
+    DeleteObject(bg);
+
+    paintSidebar(mem, rc);
+    for (int p = 0; p < 2; p++) {
+        if (g_pane[p] < 0) continue;
+        RECT pr;
+        paneRect(p, rc, &pr);
+        paintPane(mem, p, pr);
+    }
+    if (g_pane[1] >= 0) {   // split divider
+        RECT pr0;
+        paneRect(0, rc, &pr0);
+        RECT div{ pr0.right, 0, pr0.right + 2, rc.bottom };
+        HBRUSH b = CreateSolidBrush(RGB(60, 62, 70));
+        FillRect(mem, &div, b);
+        DeleteObject(b);
     }
 
-    BitBlt(dc, 0, 0, width, height, mem, 0, 0, SRCCOPY);
-    SelectObject(mem, oldFont);
+    BitBlt(dc, 0, 0, rc.right, rc.bottom, mem, 0, 0, SRCCOPY);
     SelectObject(mem, oldBmp);
     DeleteObject(bmp);
     DeleteDC(mem);
 }
 
-// ---- input encoding ----
+// ---- input ----
+static void sendBytes(const char* bytes, int len) {
+    Session* s = focusedSession();
+    if (s && s->data != INVALID_HANDLE_VALUE) ovIo(s->data, true, bytes, nullptr, (DWORD)len);
+}
+
 static void sendUtf8(wchar_t wc) {
     char utf8[8];
     int n = WideCharToMultiByte(CP_UTF8, 0, &wc, 1, utf8, sizeof utf8, nullptr, nullptr);
-    if (n > 0) sendInput(utf8, n);
+    if (n > 0) sendBytes(utf8, n);
 }
 
-static bool sendSpecialKey(WPARAM vk) {
+static bool ctrlDown() { return (GetKeyState(VK_CONTROL) & 0x8000) != 0; }
+static bool shiftDown() { return (GetKeyState(VK_SHIFT) & 0x8000) != 0; }
+
+static void scrollFocused(int deltaRows) {
+    Session* s = focusedSession();
+    if (!s) return;
+    FfiEmuInfo info{};
+    EnterCriticalSection(&g_lock);
+    emu_info(s->emu, &info);
+    LeaveCriticalSection(&g_lock);
+    int off = s->scrollOff + deltaRows;
+    s->scrollOff = max(0, min(off, (int)info.historyCount));
+    InvalidateRect(g_hwnd, nullptr, FALSE);
+}
+
+static bool handleKeyDown(WPARAM vk) {
+    if (ctrlDown() && shiftDown()) {
+        switch (vk) {
+            case 'D': {   // split toggle
+                if (g_pane[1] < 0) {
+                    // Prefer a DIFFERENT session for the second pane (wraps); same-session
+                    // mirroring still works if there is only one.
+                    g_pane[1] = (int)g_sessions.size() > 1
+                                ? (g_pane[0] + 1) % (int)g_sessions.size() : g_pane[0];
+                } else { g_pane[1] = -1; g_focus = 0; }
+                syncPaneSizes();
+                InvalidateRect(g_hwnd, nullptr, FALSE);
+                return true;
+            }
+            case VK_LEFT: g_focus = 0; InvalidateRect(g_hwnd, nullptr, FALSE); return true;
+            case VK_RIGHT: if (g_pane[1] >= 0) g_focus = 1; InvalidateRect(g_hwnd, nullptr, FALSE); return true;
+        }
+    }
+    if (ctrlDown()) {
+        switch (vk) {
+            case 'T': {
+                int cols, rows;
+                paneGridSize(g_focus, &cols, &rows);
+                Session* s = newSession(cols, rows);
+                if (s) { g_pane[g_focus] = (int)g_sessions.size() - 1; InvalidateRect(g_hwnd, nullptr, FALSE); }
+                return true;
+            }
+            case 'W': closeFocused(); return true;
+            case VK_TAB: {
+                if (!g_sessions.empty()) {
+                    g_pane[g_focus] = (g_pane[g_focus] + 1) % (int)g_sessions.size();
+                    syncPaneSizes();
+                    InvalidateRect(g_hwnd, nullptr, FALSE);
+                }
+                return true;
+            }
+        }
+    }
+    if (shiftDown() && vk == VK_PRIOR) { scrollFocused(+10); return true; }
+    if (shiftDown() && vk == VK_NEXT) { scrollFocused(-10); return true; }
     const char* seq = nullptr;
     switch (vk) {
         case VK_UP: seq = "\x1b[A"; break;
@@ -299,23 +544,9 @@ static bool sendSpecialKey(WPARAM vk) {
         case VK_NEXT: seq = "\x1b[6~"; break;
         default: return false;
     }
-    sendInput(seq, (int)strlen(seq));
+    if (Session* s = focusedSession()) s->scrollOff = 0;   // typing snaps back to live
+    sendBytes(seq, (int)strlen(seq));
     return true;
-}
-
-static void resizeToClient(int width, int height) {
-    int cols = width / g_cw, rows = height / g_ch;
-    if (cols < 2 || rows < 2) return;
-    EnterCriticalSection(&g_lock);
-    emu_resize(g_emu, cols, rows);
-    LeaveCriticalSection(&g_lock);
-    agwinterm_ptyhost_Request req = agwinterm_ptyhost_Request_init_default;
-    agwinterm_ptyhost_Reply rep = agwinterm_ptyhost_Reply_init_default;
-    req.which_cmd = agwinterm_ptyhost_Request_resize_tag;
-    strcpy_s(req.cmd.resize.id, g_sessionId.c_str());
-    req.cmd.resize.cols = (uint32_t)cols;
-    req.cmd.resize.rows = (uint32_t)rows;
-    request(req, &rep);
 }
 
 static LRESULT CALLBACK wndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
@@ -325,32 +556,54 @@ static LRESULT CALLBACK wndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
             HDC dc = BeginPaint(hwnd, &ps);
             RECT rc;
             GetClientRect(hwnd, &rc);
-            paint(dc, rc.right, rc.bottom);
+            paint(dc, rc);
             EndPaint(hwnd, &ps);
             return 0;
         }
         case WM_ERASEBKGND:
-            return 1; // double-buffered
+            return 1;
         case WM_CHAR: {
             wchar_t wc = (wchar_t)wp;
-            if (wc == L'\r') { sendInput("\r", 1); return 0; }
+            if (ctrlDown() && (wc == 20 || wc == 23 || wc == 4)) return 0;   // eaten by shortcuts (T/W/D)
+            if (Session* s = focusedSession()) s->scrollOff = 0;
+            if (wc == L'\r') { sendBytes("\r", 1); return 0; }
             sendUtf8(wc);
             return 0;
         }
         case WM_KEYDOWN:
-            if (sendSpecialKey(wp)) return 0;
+            if (handleKeyDown(wp)) return 0;
             break;
+        case WM_MOUSEWHEEL:
+            scrollFocused(GET_WHEEL_DELTA_WPARAM(wp) > 0 ? 3 : -3);
+            return 0;
+        case WM_LBUTTONDOWN: {
+            int x = GET_X_LPARAM(lp), y = GET_Y_LPARAM(lp);
+            if (x < kSidebarW) {   // sidebar row hit-test
+                int i = (y - 12 - 8) / (g_ch + 8) - 0;   // rows start at 12 + (i+1)*(g_ch+8)
+                i = (y - 12) / (g_ch + 8) - 1;
+                if (i >= 0 && i < (int)g_sessions.size()) {
+                    g_pane[g_focus] = i;
+                    syncPaneSizes();
+                    InvalidateRect(hwnd, nullptr, FALSE);
+                }
+            } else if (g_pane[1] >= 0) {   // click focuses a pane
+                RECT rc;
+                GetClientRect(hwnd, &rc);
+                RECT p0;
+                paneRect(0, rc, &p0);
+                g_focus = (x <= p0.right) ? 0 : 1;
+                InvalidateRect(hwnd, nullptr, FALSE);
+            }
+            SetFocus(hwnd);
+            return 0;
+        }
         case WM_SIZE:
-            if (wp != SIZE_MINIMIZED && g_emu) resizeToClient(LOWORD(lp), HIWORD(lp));
+            if (wp != SIZE_MINIMIZED && !g_sessions.empty()) syncPaneSizes();
             return 0;
         case WM_DESTROY: {
-            // M0 hygiene: explicit close kills the session (adoption arrives in M1).
+            for (Session* s : g_sessions) killSession(s);
             agwinterm_ptyhost_Request req = agwinterm_ptyhost_Request_init_default;
             agwinterm_ptyhost_Reply rep = agwinterm_ptyhost_Reply_init_default;
-            req.which_cmd = agwinterm_ptyhost_Request_kill_tag;
-            strcpy_s(req.cmd.kill.id, g_sessionId.c_str());
-            request(req, &rep);
-            req = agwinterm_ptyhost_Request_init_default;
             req.which_cmd = agwinterm_ptyhost_Request_shutdown_tag;
             request(req, &rep);
             PostQuitMessage(0);
@@ -364,17 +617,17 @@ int WINAPI wWinMain(HINSTANCE inst, HINSTANCE, PWSTR, int show) {
     InitializeCriticalSection(&g_lock);
     loadCore();
 
-    // Bundled Meslo Nerd Font (Boris's favourite): loaded process-private, so lite
-    // looks right — prompt glyphs included — on machines with nothing installed.
+    // Bundled Meslo Nerd Font (process-private); Consolas fallback.
     std::wstring ttf = exeDir() + L"\\MesloLGLDZNerdFont-Regular.ttf";
     bool haveMeslo = AddFontResourceExW(ttf.c_str(), FR_PRIVATE, 0) > 0;
-    g_font = CreateFontW(-16, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE, DEFAULT_CHARSET,
-                         OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS, CLEARTYPE_QUALITY,
-                         FIXED_PITCH | FF_MODERN,
-                         haveMeslo ? L"MesloLGLDZ Nerd Font" : L"Consolas");
+    const wchar_t* face = haveMeslo ? L"MesloLGLDZ Nerd Font" : L"Consolas";
+    for (int i = 0; i < 4; i++)
+        g_fonts[i] = CreateFontW(-16, 0, 0, 0, (i & 1) ? FW_BOLD : FW_NORMAL, (i & 2) ? TRUE : FALSE,
+                                 FALSE, FALSE, DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS,
+                                 CLEARTYPE_QUALITY, FIXED_PITCH | FF_MODERN, face);
     {
         HDC dc = GetDC(nullptr);
-        HGDIOBJ old = SelectObject(dc, g_font);
+        HGDIOBJ old = SelectObject(dc, g_fonts[0]);
         TEXTMETRICW tm;
         GetTextMetricsW(dc, &tm);
         g_cw = tm.tmAveCharWidth;
@@ -383,9 +636,7 @@ int WINAPI wWinMain(HINSTANCE inst, HINSTANCE, PWSTR, int show) {
         ReleaseDC(nullptr, dc);
     }
 
-    int cols = 100, rows = 30;
-    g_emu = emu_new(cols, rows);
-    connectHost(cols, rows);
+    connectControl();
 
     WNDCLASSW wc{};
     wc.lpfnWndProc = wndProc;
@@ -393,14 +644,17 @@ int WINAPI wWinMain(HINSTANCE inst, HINSTANCE, PWSTR, int show) {
     wc.lpszClassName = L"AgwintermLite";
     wc.hCursor = LoadCursorW(nullptr, (LPCWSTR)IDC_IBEAM);
     RegisterClassW(&wc);
-    RECT want{ 0, 0, cols * g_cw, rows * g_ch };
+    RECT want{ 0, 0, kSidebarW + 100 * g_cw, 30 * g_ch };
     AdjustWindowRect(&want, WS_OVERLAPPEDWINDOW, FALSE);
     g_hwnd = CreateWindowW(L"AgwintermLite", L"agwinterm lite", WS_OVERLAPPEDWINDOW,
                            CW_USEDEFAULT, CW_USEDEFAULT, want.right - want.left, want.bottom - want.top,
                            nullptr, nullptr, inst, nullptr);
     ShowWindow(g_hwnd, show);
 
-    CreateThread(nullptr, 0, readerThread, nullptr, 0, nullptr);
+    int cols, rows;
+    paneGridSize(0, &cols, &rows);
+    if (!newSession(cols, rows)) fatal(L"could not create the first session");
+    InvalidateRect(g_hwnd, nullptr, FALSE);
 
     MSG msg;
     while (GetMessageW(&msg, nullptr, 0, 0)) {


### PR DESCRIPTION
The layout core per #134: multi-session + sidebar + **splits from the start** (different-session default, same-replica mirroring supported), GDI styles (bold/italic/underline/strike/dim/inverse), wheel/keyboard scrollback over replica history. Two-session split E2E verified with per-pane wrap + colors; clean shutdown chain. Phase 2 next: selection+clipboard, palette, control API, CI build, work-laptop perf run. Screenshot in session. — Generated with Claude Code — https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k