### PR TITLE
feat(lite): M1 phase 2 — control API server, AGWINTERM env, status dots, CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,12 @@ jobs:
         # hard merge gate.
         run: cargo build --release --manifest-path native/Cargo.toml
 
+      - name: Build agwinterm-lite (C++/GDI client)
+        # Compiles the lite client against the Rust core dll + committed nanopb sources, so a
+        # protocol/schema drift or C++ break fails the merge. cl.exe is on windows-latest.
+        shell: pwsh
+        run: ./lite/build.ps1
+
       - name: Test (Core + Pty)
         # One retry, but ONLY for the known .NET 10 test-host native crash (issue #118:
         # AccessViolation in the IOCP poller under named-pipe churn — "Test Run Aborted" with

--- a/lite/src/control.h
+++ b/lite/src/control.h
@@ -1,0 +1,137 @@
+// agwinterm-lite control-API server (M1 phase 2): the same newline-JSON protocol
+// the main app serves, so agwintermctl, the Claude skill, and hooks work against
+// lite UNCHANGED (the control API deliberately stays JSON — it is the human/
+// scripting surface; the pty-host protocol is the protobuf one).
+//
+// Serves a subset: ping, tree, session.new, session.select, session.close,
+// session.type, session.text, session.status. Thread-per-client, sync pipes,
+// strict request/response.
+#pragma once
+
+#include <windows.h>
+#include <string>
+#include <map>
+
+// ---- tiny JSON: parse one request object into the fields the API subset uses.
+// Full escapes on strings; nested "args" is flattened as "args.<key>". ----
+struct JsonReq {
+    std::map<std::string, std::string> fields;
+    const std::string& get(const std::string& k) const {
+        static const std::string empty;
+        auto it = fields.find(k);
+        return it == fields.end() ? empty : it->second;
+    }
+};
+
+inline bool jsonParseString(const std::string& s, size_t& i, std::string& out) {
+    if (s[i] != '"') return false;
+    i++;
+    out.clear();
+    while (i < s.size() && s[i] != '"') {
+        char c = s[i++];
+        if (c == '\\' && i < s.size()) {
+            char e = s[i++];
+            switch (e) {
+                case 'n': out += '\n'; break;
+                case 'r': out += '\r'; break;
+                case 't': out += '\t'; break;
+                case 'b': out += '\b'; break;
+                case 'f': out += '\f'; break;
+                case 'u': {
+                    if (i + 4 > s.size()) return false;
+                    unsigned code = strtoul(s.substr(i, 4).c_str(), nullptr, 16);
+                    i += 4;
+                    // UTF-8 encode (BMP; surrogate pairs re-combine)
+                    if (code >= 0xD800 && code <= 0xDBFF && i + 6 <= s.size() && s[i] == '\\' && s[i + 1] == 'u') {
+                        unsigned lo = strtoul(s.substr(i + 2, 4).c_str(), nullptr, 16);
+                        i += 6;
+                        unsigned cp = 0x10000 + ((code - 0xD800) << 10) + (lo - 0xDC00);
+                        out += (char)(0xF0 | (cp >> 18));
+                        out += (char)(0x80 | ((cp >> 12) & 0x3F));
+                        out += (char)(0x80 | ((cp >> 6) & 0x3F));
+                        out += (char)(0x80 | (cp & 0x3F));
+                    } else if (code < 0x80) out += (char)code;
+                    else if (code < 0x800) {
+                        out += (char)(0xC0 | (code >> 6));
+                        out += (char)(0x80 | (code & 0x3F));
+                    } else {
+                        out += (char)(0xE0 | (code >> 12));
+                        out += (char)(0x80 | ((code >> 6) & 0x3F));
+                        out += (char)(0x80 | (code & 0x3F));
+                    }
+                    break;
+                }
+                default: out += e; break;
+            }
+        } else out += c;
+    }
+    if (i >= s.size()) return false;
+    i++; // closing quote
+    return true;
+}
+
+inline void jsonSkipWs(const std::string& s, size_t& i) {
+    while (i < s.size() && (s[i] == ' ' || s[i] == '\t')) i++;
+}
+
+// Parses {"k":"v"|number|true|false|{...}} one level deep (args flattened).
+inline bool jsonParseObject(const std::string& s, size_t& i, const std::string& prefix, JsonReq& out) {
+    jsonSkipWs(s, i);
+    if (i >= s.size() || s[i] != '{') return false;
+    i++;
+    for (;;) {
+        jsonSkipWs(s, i);
+        if (i < s.size() && s[i] == '}') { i++; return true; }
+        std::string key;
+        if (!jsonParseString(s, i, key)) return false;
+        jsonSkipWs(s, i);
+        if (i >= s.size() || s[i] != ':') return false;
+        i++;
+        jsonSkipWs(s, i);
+        if (i >= s.size()) return false;
+        if (s[i] == '"') {
+            std::string val;
+            if (!jsonParseString(s, i, val)) return false;
+            out.fields[prefix + key] = val;
+        } else if (s[i] == '{') {
+            if (!jsonParseObject(s, i, prefix + key + ".", out)) return false;
+        } else if (s[i] == '[') {   // arrays: skip balanced (unused by the subset)
+            int depth = 0;
+            do {
+                if (s[i] == '[') depth++;
+                else if (s[i] == ']') depth--;
+                else if (s[i] == '"') { std::string sk; if (!jsonParseString(s, i, sk)) return false; continue; }
+                i++;
+            } while (i < s.size() && depth > 0);
+        } else {   // number / true / false / null
+            size_t start = i;
+            while (i < s.size() && s[i] != ',' && s[i] != '}') i++;
+            std::string raw = s.substr(start, i - start);
+            while (!raw.empty() && (raw.back() == ' ' || raw.back() == '\t')) raw.pop_back();
+            out.fields[prefix + key] = raw;
+        }
+        jsonSkipWs(s, i);
+        if (i < s.size() && s[i] == ',') { i++; continue; }
+    }
+}
+
+inline std::string jsonEscape(const std::string& s) {
+    std::string out;
+    for (char c : s) {
+        switch (c) {
+            case '"': out += "\\\""; break;
+            case '\\': out += "\\\\"; break;
+            case '\n': out += "\\n"; break;
+            case '\r': out += "\\r"; break;
+            case '\t': out += "\\t"; break;
+            default:
+                if ((unsigned char)c < 0x20) { char b[8]; sprintf_s(b, "\\u%04x", c); out += b; }
+                else out += c;
+        }
+    }
+    return out;
+}
+
+inline std::string ctlOk(const std::string& resultJson) { return "{\"ok\":true,\"result\":" + resultJson + "}"; }
+inline std::string ctlOkStr(const std::string& s) { return ctlOk("\"" + jsonEscape(s) + "\""); }
+inline std::string ctlErr(const std::string& msg) { return "{\"ok\":false,\"error\":\"" + jsonEscape(msg) + "\"}"; }

--- a/lite/src/main.cpp
+++ b/lite/src/main.cpp
@@ -21,6 +21,7 @@
 #include "proto/ptyhost.pb.h"
 #include "proto/pb_encode.h"
 #include "proto/pb_decode.h"
+#include "control.h"
 
 // ---- agwinterm-core C ABI (ABI v7) ----
 struct FfiCell {
@@ -54,6 +55,7 @@ static constexpr int kSidebarW = 180;
 // ---- sessions & layout ----
 struct Session {
     std::string id;
+    std::string status = "idle";   // control-API agent status (sidebar dot)
     void* emu = nullptr;
     HANDLE data = INVALID_HANDLE_VALUE;
     HANDLE reader = nullptr;
@@ -80,7 +82,10 @@ static void fatal(const wchar_t* msg) {
 }
 
 // ---- control pipe: protobuf frames (4-byte LE length prefix) ----
+static CRITICAL_SECTION g_reqLock;   // the control pipe is shared by the UI thread and the ctl server thread
 static bool request(const agwinterm_ptyhost_Request& req, agwinterm_ptyhost_Reply* reply) {
+    EnterCriticalSection(&g_reqLock);
+    struct Unlock { ~Unlock() { LeaveCriticalSection(&g_reqLock); } } unlock;
     uint8_t buf[4096];
     pb_ostream_t os = pb_ostream_from_buffer(buf + 4, sizeof buf - 4);
     if (!pb_encode(&os, agwinterm_ptyhost_Request_fields, &req)) return false;
@@ -250,6 +255,19 @@ static Session* newSession(int cols, int rows) {
     strcpy_s(req.cmd.create.app, "powershell.exe");
     req.cmd.create.args_count = 1;
     strcpy_s(req.cmd.create.args[0], "-NoLogo");
+    // AGWINTERM_* identity env, so the Claude skill / hooks / agwintermctl inside the
+    // session auto-target LITE's control pipe (all non-UI features are protocol).
+    auto setEnv = [&](int i, const char* k, const char* v) {
+        strcpy_s(req.cmd.create.env[i].key, k);
+        strcpy_s(req.cmd.create.env[i].value, v);
+    };
+    req.cmd.create.env_count = 6;
+    setEnv(0, "AGWINTERM", "1");
+    setEnv(1, "AGWINTERM_ENABLED", "1");
+    setEnv(2, "AGWINTERM_PIPE", "agwinterm-lite");
+    setEnv(3, "AGWINTERM_SESSION_ID", idbuf);
+    setEnv(4, "AGWINTERM_PANE_ID", idbuf);
+    setEnv(5, "TERM_PROGRAM", "agwinterm-lite");
     if (!request(req, &rep)) return nullptr;
 
     req = agwinterm_ptyhost_Request_init_default;
@@ -427,6 +445,17 @@ static void paintSidebar(HDC mem, RECT rc) {
         SetTextColor(mem, g_sessions[i]->exited ? RGB(120, 90, 90)
                           : focused ? RGB(230, 230, 235)
                           : inPane ? RGB(190, 190, 200) : RGB(150, 150, 160));
+        // Status dot (control-API agent status): idle gray, active blue, blocked red, completed green.
+        COLORREF dot = RGB(110, 110, 120);
+        const std::string& st = g_sessions[i]->status;
+        if (g_sessions[i]->exited) dot = RGB(140, 80, 80);
+        else if (st == "active") dot = RGB(80, 140, 230);
+        else if (st == "blocked") dot = RGB(220, 80, 80);
+        else if (st == "completed") dot = RGB(70, 190, 100);
+        RECT d{ 4, y + g_ch / 2 - 3, 10, y + g_ch / 2 + 3 };
+        HBRUSH db = CreateSolidBrush(dot);
+        FillRect(mem, &d, db);
+        DeleteObject(db);
         wchar_t name[64];
         wsprintfW(name, L"%s%S", g_sessions[i]->exited ? L"× " : L"", g_sessions[i]->id.c_str());
         RECT row{ 14, y, kSidebarW - 8, y + g_ch };
@@ -613,8 +642,150 @@ static LRESULT CALLBACK wndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
     return DefWindowProcW(hwnd, msg, wp, lp);
 }
 
+
+// ---- control-API server (newline JSON, agwintermctl/skill-compatible subset) ----
+static Session* resolveTarget(const std::string& target) {
+    if (target.empty() || target == "active") return focusedSession();
+    for (Session* s : g_sessions)
+        if (s->id == target || (target.size() >= 4 && s->id.compare(0, target.size(), target) == 0))
+            return s;
+    return nullptr;
+}
+
+static std::string dumpBufferText(Session* s) {
+    FfiEmuInfo info{};
+    std::string out;
+    EnterCriticalSection(&g_lock);
+    emu_info(s->emu, &info);
+    std::vector<FfiCell> row(info.cols);
+    auto appendRow = [&](const FfiCell* cells) {
+        std::string line;
+        for (uint32_t c = 0; c < info.cols; c++) {
+            const FfiCell& cell = cells[c];
+            if (cell.width == 0) continue;
+            int cp = cell.rune ? cell.rune : ' ';
+            wchar_t wbuf[2];
+            int wn = 0;
+            if (cp > 0xFFFF) {
+                wbuf[wn++] = (wchar_t)(0xD800 + ((cp - 0x10000) >> 10));
+                wbuf[wn++] = (wchar_t)(0xDC00 + ((cp - 0x10000) & 0x3FF));
+            } else wbuf[wn++] = (wchar_t)cp;
+            char u8[8];
+            int n8 = WideCharToMultiByte(CP_UTF8, 0, wbuf, wn, u8, sizeof u8, nullptr, nullptr);
+            line.append(u8, n8);
+        }
+        while (!line.empty() && line.back() == ' ') line.pop_back();
+        out += line;
+        out += '\n';
+    };
+    for (uint32_t h = 0; h < info.historyCount; h++)
+        if (emu_copy_history_row(s->emu, h, row.data(), info.cols)) appendRow(row.data());
+    if (s->grid.size() >= (size_t)info.cols * info.rows)
+        for (uint32_t r = 0; r < info.rows; r++) appendRow(&s->grid[r * info.cols]);
+    LeaveCriticalSection(&g_lock);
+    while (out.size() >= 2 && out[out.size() - 1] == '\n' && out[out.size() - 2] == '\n') out.pop_back();
+    return out;
+}
+
+static std::string ctlDispatch(const std::string& line) {
+    JsonReq req;
+    size_t i = 0;
+    if (!jsonParseObject(line, i, "", req)) return ctlErr("invalid JSON");
+    const std::string& cmd = req.get("cmd");
+
+    if (cmd == "ping") return ctlOkStr("agwinterm-lite 0.1");
+    if (cmd == "tree") {
+        std::string sess;
+        for (int i2 = 0; i2 < (int)g_sessions.size(); i2++) {
+            if (i2) sess += ",";
+            Session* s = g_sessions[i2];
+            sess += "{\"id\":\"" + jsonEscape(s->id) + "\",\"name\":\"" + jsonEscape(s->id) +
+                    "\",\"active\":" + (g_pane[g_focus] == i2 ? "true" : "false") +
+                    ",\"status\":\"" + jsonEscape(s->status) + "\"}";
+        }
+        return ctlOk("{\"workspaces\":[{\"id\":\"lite\",\"name\":\"workspace 1\",\"active\":true,\"sessions\":[" + sess + "]}]}");
+    }
+    if (cmd == "session.new") {
+        int cols, rows;
+        paneGridSize(g_focus, &cols, &rows);
+        Session* s = newSession(cols, rows);
+        if (!s) return ctlErr("create failed");
+        g_pane[g_focus] = (int)g_sessions.size() - 1;
+        InvalidateRect(g_hwnd, nullptr, FALSE);
+        return ctlOkStr(s->id);
+    }
+    Session* target = resolveTarget(req.get("target"));
+    if (cmd == "session.select") {
+        if (!target) return ctlErr("session not found");
+        for (int i2 = 0; i2 < (int)g_sessions.size(); i2++)
+            if (g_sessions[i2] == target) g_pane[g_focus] = i2;
+        InvalidateRect(g_hwnd, nullptr, FALSE);
+        return ctlOkStr("selected");
+    }
+    if (cmd == "session.type") {
+        if (!target) return ctlErr("session not found");
+        std::string text = req.get("args.text");
+        // \n → \r (keystroke semantics, like the main app's session.type)
+        for (char& ch : text) if (ch == '\n') ch = '\r';
+        if (target->data != INVALID_HANDLE_VALUE)
+            ovIo(target->data, true, text.data(), nullptr, (DWORD)text.size());
+        return ctlOkStr("typed");
+    }
+    if (cmd == "session.text") {
+        if (!target) return ctlErr("session not found");
+        return ctlOkStr(dumpBufferText(target));
+    }
+    if (cmd == "session.status") {
+        if (!target) return ctlErr("session not found");
+        std::string st = req.get("args.status");
+        if (st.empty()) return ctlErr("session status needs a state");
+        target->status = st;
+        InvalidateRect(g_hwnd, nullptr, FALSE);
+        return ctlOkStr("status set");
+    }
+    if (cmd == "session.close") {
+        if (!target) return ctlErr("session not found");
+        for (int i2 = 0; i2 < (int)g_sessions.size(); i2++)
+            if (g_sessions[i2] == target) { g_pane[g_focus] = i2; closeFocused(); break; }
+        return ctlOkStr("closed");
+    }
+    return ctlErr("unknown command '" + cmd + "' (lite subset)");
+}
+
+static DWORD WINAPI ctlClientThread(void* param) {
+    HANDLE pipe = (HANDLE)param;
+    std::string line;
+    char ch;
+    DWORD n;
+    while (ReadFile(pipe, &ch, 1, &n, nullptr) && n == 1) {
+        if (ch == '\n') {
+            if (!line.empty() && line.back() == '\r') line.pop_back();
+            if (!line.empty()) {
+                std::string reply = ctlDispatch(line) + "\n";
+                DWORD w;
+                if (!WriteFile(pipe, reply.data(), (DWORD)reply.size(), &w, nullptr)) break;
+            }
+            line.clear();
+        } else line += ch;
+    }
+    CloseHandle(pipe);
+    return 0;
+}
+
+static DWORD WINAPI ctlServerThread(void*) {
+    for (;;) {
+        HANDLE pipe = CreateNamedPipeW(L"\\\\.\\pipe\\agwinterm-lite", PIPE_ACCESS_DUPLEX,
+                                       PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
+                                       PIPE_UNLIMITED_INSTANCES, 64 * 1024, 64 * 1024, 0, nullptr);
+        if (pipe == INVALID_HANDLE_VALUE) return 1;
+        BOOL ok = ConnectNamedPipe(pipe, nullptr);
+        if (!ok && GetLastError() != ERROR_PIPE_CONNECTED) { CloseHandle(pipe); continue; }
+        CreateThread(nullptr, 0, ctlClientThread, pipe, 0, nullptr);
+    }
+}
 int WINAPI wWinMain(HINSTANCE inst, HINSTANCE, PWSTR, int show) {
     InitializeCriticalSection(&g_lock);
+    InitializeCriticalSection(&g_reqLock);
     loadCore();
 
     // Bundled Meslo Nerd Font (process-private); Consolas fallback.
@@ -654,6 +825,7 @@ int WINAPI wWinMain(HINSTANCE inst, HINSTANCE, PWSTR, int show) {
     int cols, rows;
     paneGridSize(0, &cols, &rows);
     if (!newSession(cols, rows)) fatal(L"could not create the first session");
+    CreateThread(nullptr, 0, ctlServerThread, nullptr, 0, nullptr);   // agwintermctl --pipe agwinterm-lite
     InvalidateRect(g_hwnd, nullptr, FALSE);
 
     MSG msg;

--- a/lite/src/proto/ptyhost.pb.c
+++ b/lite/src/proto/ptyhost.pb.c
@@ -15,7 +15,7 @@ PB_BIND(agwinterm_ptyhost_Hello, agwinterm_ptyhost_Hello, AUTO)
 PB_BIND(agwinterm_ptyhost_Create, agwinterm_ptyhost_Create, 4)
 
 
-PB_BIND(agwinterm_ptyhost_Create_EnvEntry, agwinterm_ptyhost_Create_EnvEntry, AUTO)
+PB_BIND(agwinterm_ptyhost_Create_EnvEntry, agwinterm_ptyhost_Create_EnvEntry, 2)
 
 
 PB_BIND(agwinterm_ptyhost_Attach, agwinterm_ptyhost_Attach, AUTO)

--- a/lite/src/proto/ptyhost.pb.h
+++ b/lite/src/proto/ptyhost.pb.h
@@ -14,6 +14,11 @@ typedef struct _agwinterm_ptyhost_Hello {
     uint32_t protocol; /* must equal the host's version (2 = protobuf wire) */
 } agwinterm_ptyhost_Hello;
 
+typedef struct _agwinterm_ptyhost_Create_EnvEntry {
+    char key[64];
+    char value[192];
+} agwinterm_ptyhost_Create_EnvEntry;
+
 typedef struct _agwinterm_ptyhost_Create {
     char id[128];
     uint32_t cols;
@@ -25,13 +30,9 @@ typedef struct _agwinterm_ptyhost_Create {
     bool verbatim;
     bool de_elevate;
     bool fresh_env_off; /* proto3 default false = freshEnv ON (matches v1 semantics) */
-    pb_callback_t env;
+    pb_size_t env_count;
+    agwinterm_ptyhost_Create_EnvEntry env[8];
 } agwinterm_ptyhost_Create;
-
-typedef struct _agwinterm_ptyhost_Create_EnvEntry {
-    pb_callback_t key;
-    pb_callback_t value;
-} agwinterm_ptyhost_Create_EnvEntry;
 
 typedef struct _agwinterm_ptyhost_Attach {
     char id[128];
@@ -125,8 +126,8 @@ extern "C" {
 /* Initializer values for message structs */
 #define agwinterm_ptyhost_Request_init_default   {0, {agwinterm_ptyhost_Hello_init_default}}
 #define agwinterm_ptyhost_Hello_init_default     {0}
-#define agwinterm_ptyhost_Create_init_default    {"", 0, 0, "", 0, {"", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""}, "", 0, 0, 0, {{NULL}, NULL}}
-#define agwinterm_ptyhost_Create_EnvEntry_init_default {{{NULL}, NULL}, {{NULL}, NULL}}
+#define agwinterm_ptyhost_Create_init_default    {"", 0, 0, "", 0, {"", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""}, "", 0, 0, 0, 0, {agwinterm_ptyhost_Create_EnvEntry_init_default, agwinterm_ptyhost_Create_EnvEntry_init_default, agwinterm_ptyhost_Create_EnvEntry_init_default, agwinterm_ptyhost_Create_EnvEntry_init_default, agwinterm_ptyhost_Create_EnvEntry_init_default, agwinterm_ptyhost_Create_EnvEntry_init_default, agwinterm_ptyhost_Create_EnvEntry_init_default, agwinterm_ptyhost_Create_EnvEntry_init_default}}
+#define agwinterm_ptyhost_Create_EnvEntry_init_default {"", ""}
 #define agwinterm_ptyhost_Attach_init_default    {"", 0}
 #define agwinterm_ptyhost_SessionRef_init_default {""}
 #define agwinterm_ptyhost_Resize_init_default    {"", 0, 0}
@@ -140,8 +141,8 @@ extern "C" {
 #define agwinterm_ptyhost_ListReply_init_default {{{NULL}, NULL}}
 #define agwinterm_ptyhost_Request_init_zero      {0, {agwinterm_ptyhost_Hello_init_zero}}
 #define agwinterm_ptyhost_Hello_init_zero        {0}
-#define agwinterm_ptyhost_Create_init_zero       {"", 0, 0, "", 0, {"", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""}, "", 0, 0, 0, {{NULL}, NULL}}
-#define agwinterm_ptyhost_Create_EnvEntry_init_zero {{{NULL}, NULL}, {{NULL}, NULL}}
+#define agwinterm_ptyhost_Create_init_zero       {"", 0, 0, "", 0, {"", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""}, "", 0, 0, 0, 0, {agwinterm_ptyhost_Create_EnvEntry_init_zero, agwinterm_ptyhost_Create_EnvEntry_init_zero, agwinterm_ptyhost_Create_EnvEntry_init_zero, agwinterm_ptyhost_Create_EnvEntry_init_zero, agwinterm_ptyhost_Create_EnvEntry_init_zero, agwinterm_ptyhost_Create_EnvEntry_init_zero, agwinterm_ptyhost_Create_EnvEntry_init_zero, agwinterm_ptyhost_Create_EnvEntry_init_zero}}
+#define agwinterm_ptyhost_Create_EnvEntry_init_zero {"", ""}
 #define agwinterm_ptyhost_Attach_init_zero       {"", 0}
 #define agwinterm_ptyhost_SessionRef_init_zero   {""}
 #define agwinterm_ptyhost_Resize_init_zero       {"", 0, 0}
@@ -156,6 +157,8 @@ extern "C" {
 
 /* Field tags (for use in manual encoding/decoding) */
 #define agwinterm_ptyhost_Hello_protocol_tag     1
+#define agwinterm_ptyhost_Create_EnvEntry_key_tag 1
+#define agwinterm_ptyhost_Create_EnvEntry_value_tag 2
 #define agwinterm_ptyhost_Create_id_tag          1
 #define agwinterm_ptyhost_Create_cols_tag        2
 #define agwinterm_ptyhost_Create_rows_tag        3
@@ -166,8 +169,6 @@ extern "C" {
 #define agwinterm_ptyhost_Create_de_elevate_tag  8
 #define agwinterm_ptyhost_Create_fresh_env_off_tag 9
 #define agwinterm_ptyhost_Create_env_tag         10
-#define agwinterm_ptyhost_Create_EnvEntry_key_tag 1
-#define agwinterm_ptyhost_Create_EnvEntry_value_tag 2
 #define agwinterm_ptyhost_Attach_id_tag          1
 #define agwinterm_ptyhost_Attach_repaint_tag     2
 #define agwinterm_ptyhost_SessionRef_id_tag      1
@@ -245,15 +246,15 @@ X(a, STATIC,   SINGULAR, STRING,   cwd,               6) \
 X(a, STATIC,   SINGULAR, BOOL,     verbatim,          7) \
 X(a, STATIC,   SINGULAR, BOOL,     de_elevate,        8) \
 X(a, STATIC,   SINGULAR, BOOL,     fresh_env_off,     9) \
-X(a, CALLBACK, REPEATED, MESSAGE,  env,              10)
-#define agwinterm_ptyhost_Create_CALLBACK pb_default_field_callback
+X(a, STATIC,   REPEATED, MESSAGE,  env,              10)
+#define agwinterm_ptyhost_Create_CALLBACK NULL
 #define agwinterm_ptyhost_Create_DEFAULT NULL
 #define agwinterm_ptyhost_Create_env_MSGTYPE agwinterm_ptyhost_Create_EnvEntry
 
 #define agwinterm_ptyhost_Create_EnvEntry_FIELDLIST(X, a) \
-X(a, CALLBACK, SINGULAR, STRING,   key,               1) \
-X(a, CALLBACK, SINGULAR, STRING,   value,             2)
-#define agwinterm_ptyhost_Create_EnvEntry_CALLBACK pb_default_field_callback
+X(a, STATIC,   SINGULAR, STRING,   key,               1) \
+X(a, STATIC,   SINGULAR, STRING,   value,             2)
+#define agwinterm_ptyhost_Create_EnvEntry_CALLBACK NULL
 #define agwinterm_ptyhost_Create_EnvEntry_DEFAULT NULL
 
 #define agwinterm_ptyhost_Attach_FIELDLIST(X, a) \
@@ -373,19 +374,19 @@ extern const pb_msgdesc_t agwinterm_ptyhost_ListReply_msg;
 #define agwinterm_ptyhost_ListReply_fields &agwinterm_ptyhost_ListReply_msg
 
 /* Maximum encoded size of messages (where known) */
-/* agwinterm_ptyhost_Request_size depends on runtime parameters */
-/* agwinterm_ptyhost_Create_size depends on runtime parameters */
-/* agwinterm_ptyhost_Create_EnvEntry_size depends on runtime parameters */
 /* agwinterm_ptyhost_Reply_size depends on runtime parameters */
 /* agwinterm_ptyhost_AttachReply_size depends on runtime parameters */
 /* agwinterm_ptyhost_SessionInfo_size depends on runtime parameters */
 /* agwinterm_ptyhost_ListReply_size depends on runtime parameters */
-#define AGWINTERM_PTYHOST_PTYHOST_PB_H_MAX_SIZE  agwinterm_ptyhost_Resize_size
+#define AGWINTERM_PTYHOST_PTYHOST_PB_H_MAX_SIZE  agwinterm_ptyhost_Request_size
 #define agwinterm_ptyhost_Attach_size            132
 #define agwinterm_ptyhost_CreateReply_size       130
+#define agwinterm_ptyhost_Create_EnvEntry_size   259
+#define agwinterm_ptyhost_Create_size            6960
 #define agwinterm_ptyhost_HelloReply_size        12
 #define agwinterm_ptyhost_Hello_size             6
 #define agwinterm_ptyhost_List_size              0
+#define agwinterm_ptyhost_Request_size           6963
 #define agwinterm_ptyhost_Resize_size            142
 #define agwinterm_ptyhost_SessionRef_size        130
 #define agwinterm_ptyhost_Shutdown_size          0

--- a/proto/ptyhost.options
+++ b/proto/ptyhost.options
@@ -13,3 +13,6 @@ agwinterm.ptyhost.HelloReply.protocol  int_size:IS_32
 agwinterm.ptyhost.CreateReply.id       max_size:128
 agwinterm.ptyhost.AttachReply.pipe     max_size:128
 agwinterm.ptyhost.AttachReply.modes    max_size:1024
+agwinterm.ptyhost.Create.env           max_count:8
+agwinterm.ptyhost.Create.EnvEntry.key    max_size:64
+agwinterm.ptyhost.Create.EnvEntry.value  max_size:192


### PR DESCRIPTION
Lite becomes fully agent-drivable: it serves the **same newline-JSON control API** as the main app (a thread-per-client server on `\\.\pipe\agwinterm-lite`), so `agwintermctl`, the Claude skill, and hooks work against it **unchanged**. Subset: ping, tree, session.new/select/close/type/text/status. (The control API stays JSON on purpose — it''s the human/scripting surface; the pty-host wire is the protobuf one.)

- **AGWINTERM_* env injection**: every lite session gets `AGWINTERM_PIPE=agwinterm-lite`, `AGWINTERM_SESSION_ID`, `TERM_PROGRAM=agwinterm-lite` etc. via the pty-host env map, so tools *inside* a session auto-target lite''s pipe.
- **Sidebar status dots** (idle/active/blocked/completed/exited) driven by `session.status`.
- **CI builds lite** (cl.exe on windows-latest) against the committed nanopb sources — protocol/schema drift now fails the merge.

**E2E**: `agwintermctl --pipe agwinterm-lite` drove ping → tree → session.new → type → status → text against a live client; the blocked-status dot rendered (screenshot in session). 277 tests green.

Remaining M1: selection+clipboard, palette; then the work-laptop perf gate run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k