### PR TITLE
feat(lite): M2 phase 2 — FTCS prompt pips + shell-integration wrap

### DIFF
--- a/lite/src/main.cpp
+++ b/lite/src/main.cpp
@@ -37,6 +37,11 @@ struct FfiEmuInfo {
     int32_t keyboardFlags;
     uint32_t scrollTop, scrollBottom, markCount;
 };
+struct FfiMark {   // FTCS / OSC 133 boundary; lines are buffer-absolute, -1 = unset
+    int64_t promptLine, commandLine, outputLine, endLine;
+    uint32_t hasExit;
+    int32_t exitCode;
+};
 static uint32_t (*core_abi)();
 static void* (*emu_new)(uint32_t, uint32_t);
 static void (*emu_free)(void*);
@@ -45,6 +50,7 @@ static bool (*emu_resize)(void*, uint32_t, uint32_t);
 static bool (*emu_info)(void*, FfiEmuInfo*);
 static bool (*emu_copy_grid)(void*, FfiCell*, uint32_t);
 static bool (*emu_copy_history_row)(void*, uint32_t, FfiCell*, uint32_t);
+static uint32_t (*emu_marks)(void*, FfiMark*, uint32_t);
 
 static constexpr uint32_t kRequiredAbi = 7;
 static constexpr uint32_t kAttrBold = 1, kAttrItalic = 2, kAttrUnderline = 4,
@@ -178,7 +184,8 @@ static void loadCore() {
     emu_info = (decltype(emu_info))GetProcAddress(m, "agwcore_emu_info");
     emu_copy_grid = (decltype(emu_copy_grid))GetProcAddress(m, "agwcore_emu_copy_grid");
     emu_copy_history_row = (decltype(emu_copy_history_row))GetProcAddress(m, "agwcore_emu_copy_history_row");
-    if (!core_abi || !emu_new || !emu_feed || !emu_info || !emu_copy_grid || !emu_resize || !emu_free || !emu_copy_history_row)
+    emu_marks = (decltype(emu_marks))GetProcAddress(m, "agwcore_emu_marks");
+    if (!core_abi || !emu_new || !emu_feed || !emu_info || !emu_copy_grid || !emu_resize || !emu_free || !emu_copy_history_row || !emu_marks)
         fatal(L"agwinterm_core.dll: exports missing");
     if (core_abi() != kRequiredAbi) fatal(L"agwinterm_core.dll: ABI mismatch (need v7)");
 }
@@ -254,6 +261,30 @@ static void syncPaneSizes() {
     }
 }
 
+// ---- FTCS prompt wrap: chain the user's prompt so it emits OSC 133 D;<exit> + A each turn,
+// giving lite the prompt pips out of the box while preserving oh-my-posh/starship. Passed as
+// -EncodedCommand (base64 of UTF-16LE) so there is zero quoting to mangle. ----
+static std::string base64(const std::wstring& s) {
+    static const char* T = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    const uint8_t* p = (const uint8_t*)s.data();
+    size_t n = s.size() * sizeof(wchar_t);
+    std::string out;
+    for (size_t i = 0; i < n; i += 3) {
+        uint32_t v = p[i] << 16 | (i + 1 < n ? p[i + 1] << 8 : 0) | (i + 2 < n ? p[i + 2] : 0);
+        out += T[(v >> 18) & 63];
+        out += T[(v >> 12) & 63];
+        out += (i + 1 < n) ? T[(v >> 6) & 63] : '=';
+        out += (i + 2 < n) ? T[v & 63] : '=';
+    }
+    return out;
+}
+
+static const wchar_t* kPromptWrap =
+    L"if(-not $global:__agwLiteWrap){$global:__agwLiteWrap=$true;$global:__agwLiteP=$function:prompt;"
+    L"function global:prompt{$ec=if($?){0}else{1};$e=[char]27;$b=[char]7;"
+    L"[Console]::Write(\"$e]133;D;$ec$b$e]133;A$b\");"
+    L"if($global:__agwLiteP){& $global:__agwLiteP}else{\"PS $($executionContext.SessionState.Path.CurrentLocation)> \"}}}";
+
 // ---- session lifecycle ----
 static DWORD WINAPI readerThread(void* param) {
     Session* s = (Session*)param;
@@ -280,8 +311,14 @@ static Session* newSession(int cols, int rows) {
     req.cmd.create.cols = (uint32_t)cols;
     req.cmd.create.rows = (uint32_t)rows;
     strcpy_s(req.cmd.create.app, "powershell.exe");
-    req.cmd.create.args_count = 1;
+    // -NoExit keeps the shell interactive after the wrap runs; -EncodedCommand runs AFTER the
+    // profile so it chains (not replaces) the user's prompt.
+    std::string enc = base64(kPromptWrap);
+    req.cmd.create.args_count = 4;
     strcpy_s(req.cmd.create.args[0], "-NoLogo");
+    strcpy_s(req.cmd.create.args[1], "-NoExit");
+    strcpy_s(req.cmd.create.args[2], "-EncodedCommand");
+    strcpy_s(req.cmd.create.args[3], enc.c_str());
     // AGWINTERM_* identity env, so the Claude skill / hooks / agwintermctl inside the
     // session auto-target LITE's control pipe (all non-UI features are protocol).
     auto setEnv = [&](int i, const char* k, const char* v) {
@@ -459,6 +496,28 @@ static void paintPane(HDC mem, int pane, RECT pr) {
                   pr.left + (LONG)(info.cursorCol + 1) * g_cw, pr.top + (LONG)(info.cursorRow + 1) * g_ch };
         if (cur.right <= pr.right) InvertRect(mem, &cur);
     }
+    // FTCS prompt pips (OSC 133): a small right-edge marker at each prompt line — green ok,
+    // red failed, accent for a still-running command. The agent-status cue for Claude sessions.
+    if (info.markCount > 0) {
+        std::vector<FfiMark> marks(info.markCount);
+        EnterCriticalSection(&g_lock);
+        uint32_t nm = emu_marks(s->emu, marks.data(), info.markCount);
+        LeaveCriticalSection(&g_lock);
+        int base = (int)info.historyCount - off;   // buffer-absolute row of the top visible line
+        for (uint32_t mi = 0; mi < nm; mi++) {
+            int vr = (int)marks[mi].promptLine - base;
+            if (vr < 0 || vr >= (int)info.rows) continue;
+            COLORREF col = RGB(120, 130, 200);   // running (no end yet)
+            if (marks[mi].endLine >= 0)
+                col = (marks[mi].hasExit && marks[mi].exitCode == 0) ? RGB(60, 180, 90)
+                    : marks[mi].hasExit ? RGB(210, 70, 70) : RGB(120, 130, 200);
+            RECT pip{ pr.right - 3, pr.top + vr * g_ch + 2, pr.right, pr.top + vr * g_ch + g_ch - 2 };
+            HBRUSH b = CreateSolidBrush(col);
+            FillRect(mem, &pip, b);
+            DeleteObject(b);
+        }
+    }
+
     // Scrollback indicator: thin right-edge stripe while scrolled.
     if (off > 0) {
         RECT bar{ pr.right - 3, pr.top, pr.right, pr.bottom };

--- a/lite/src/proto/ptyhost.pb.h
+++ b/lite/src/proto/ptyhost.pb.h
@@ -25,7 +25,7 @@ typedef struct _agwinterm_ptyhost_Create {
     uint32_t rows;
     char app[260];
     pb_size_t args_count;
-    char args[16][260];
+    char args[16][2048];
     char cwd[260]; /* empty = inherit */
     bool verbatim;
     bool de_elevate;
@@ -382,11 +382,11 @@ extern const pb_msgdesc_t agwinterm_ptyhost_ListReply_msg;
 #define agwinterm_ptyhost_Attach_size            132
 #define agwinterm_ptyhost_CreateReply_size       130
 #define agwinterm_ptyhost_Create_EnvEntry_size   259
-#define agwinterm_ptyhost_Create_size            6960
+#define agwinterm_ptyhost_Create_size            35568
 #define agwinterm_ptyhost_HelloReply_size        12
 #define agwinterm_ptyhost_Hello_size             6
 #define agwinterm_ptyhost_List_size              0
-#define agwinterm_ptyhost_Request_size           6963
+#define agwinterm_ptyhost_Request_size           35572
 #define agwinterm_ptyhost_Resize_size            142
 #define agwinterm_ptyhost_SessionRef_size        130
 #define agwinterm_ptyhost_Shutdown_size          0

--- a/proto/ptyhost.options
+++ b/proto/ptyhost.options
@@ -4,7 +4,7 @@ agwinterm.ptyhost.Create.id            max_size:128
 agwinterm.ptyhost.Create.app           max_size:260
 agwinterm.ptyhost.Create.cwd           max_size:260
 agwinterm.ptyhost.Create.args          max_count:16
-agwinterm.ptyhost.Create.args          max_size:260
+agwinterm.ptyhost.Create.args          max_size:2048
 agwinterm.ptyhost.Attach.id            max_size:128
 agwinterm.ptyhost.SessionRef.id        max_size:128
 agwinterm.ptyhost.Resize.id            max_size:128


### PR DESCRIPTION
Lite now shows **OSC 133 prompt pips** on each pane''s right edge — green (exit 0), red (non-zero), accent (still running) — the command-boundary / agent-status cue that makes Claude sessions legible. It reads marks via `agwcore_emu_marks` (ABI v7) and maps buffer-absolute prompt lines into the viewport.

To make them work **out of the box**, lite injects a minimal FTCS prompt wrap (`-NoExit -EncodedCommand`, base64 UTF-16LE — zero quoting risk) that **chains** the user''s existing prompt after the profile loads, so oh-my-posh/starship are preserved (verified: starship prompt intact, pips layered on top). The protobuf `args` field grew to 2048 to carry the encoded command.

**E2E** (screenshot in session): `echo` → green, `cmd /c exit 3` → red, `echo` → green, live prompt → accent, all rendered correctly on the right edge. Host compatibility oracle still green.

M2 status: p1 scrollback-trim ✅ (#140), p2 FTCS marks ✅ (this). Planned p3: protobuf persistence (full-fidelity buffer restore) — Boris''s idea. Still gating lite-as-artifact: the work-laptop perf run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k