### PR TITLE
feat(session-host): make the Rust pty-host a selectable backend (server-rust)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,14 +41,32 @@ jobs:
         run: ./lite/build.ps1
 
       - name: Test (Core + Pty)
-        # One retry, but ONLY for the known .NET 10 test-host native crash (issue #118:
-        # AccessViolation in the IOCP poller under named-pipe churn — "Test Run Aborted" with
-        # zero failed tests). Real test failures never retry — they fail the job immediately.
+        # One retry for the known .NET 10 test-host #118 pathology under named-pipe churn, which
+        # manifests two ways: a native CRASH ("Test Run Aborted") OR a DEADLOCK that hangs the run
+        # forever (a pipe teardown that never completes — no crash, no output). The crash-only retry
+        # missed the hang and stalled the job for hours, so this runs the suite under a hard timeout
+        # and retries once on EITHER symptom. Genuine test failures fail immediately (no retry).
         shell: pwsh
+        timeout-minutes: 25
         run: |
-          $out = dotnet test Agwinterm.slnx -c Release --no-build 2>&1 | Tee-Object -Variable lines | Out-String
-          if ($LASTEXITCODE -eq 0) { exit 0 }
-          if ($out -notmatch 'Test Run Aborted|host process crashed') { exit 1 }
-          Write-Host '::warning::test host crashed natively (issue #118) - retrying once'
-          dotnet test Agwinterm.slnx -c Release --no-build
-          exit $LASTEXITCODE
+          function Invoke-Tests {
+            if (Test-Path out.txt) { Remove-Item out.txt, err.txt -ErrorAction SilentlyContinue }
+            $p = Start-Process dotnet -ArgumentList 'test','Agwinterm.slnx','-c','Release','--no-build' `
+                 -NoNewWindow -PassThru -RedirectStandardOutput out.txt -RedirectStandardError err.txt
+            if (-not $p.WaitForExit(360000)) {   # 6 min: the suite is ~30s, so this only trips on a deadlock
+              try { $p.Kill($true) } catch {}
+              Write-Host '::warning::test run HUNG (issue #118 deadlock variant) - killed'
+              return 'retry'
+            }
+            $out = (Get-Content out.txt, err.txt -Raw -ErrorAction SilentlyContinue) -join "`n"
+            if ($p.ExitCode -eq 0) { Write-Host $out; return 'ok' }
+            if ($out -match 'Test Run Aborted|host process crashed') {
+              Write-Host '::warning::test host crashed natively (issue #118)'; return 'retry'
+            }
+            Write-Host $out; return 'fail'   # a genuine failure
+          }
+          $r = Invoke-Tests
+          if ($r -eq 'ok') { exit 0 }
+          if ($r -eq 'fail') { exit 1 }
+          Write-Host '::warning::retrying the test suite once (issue #118)'
+          if ((Invoke-Tests) -eq 'ok') { exit 0 } else { exit 1 }

--- a/installer/build.ps1
+++ b/installer/build.ps1
@@ -39,13 +39,15 @@ if ($LASTEXITCODE -ne 0) { throw "ctl publish failed" }
 # Rust emulator core: build it and drop the dll next to the exe, so an INSTALLED copy can run
 # `emulator-core = rust` (ResolveEmulatorCore probes exeDir\agwinterm_core.dll; without this it
 # silently falls back to managed for real users). The oracle-gated crate is deterministic.
-Write-Host "== build agwinterm-core (Rust) ==" -ForegroundColor Cyan
+Write-Host "== build agwinterm-core + pty-host (Rust) ==" -ForegroundColor Cyan
 & cargo build --release --manifest-path (Join-Path $root "native\Cargo.toml")
-if ($LASTEXITCODE -ne 0) { throw "cargo build (core) failed" }
+if ($LASTEXITCODE -ne 0) { throw "cargo build (native) failed" }
+# core dll -> `emulator-core = rust`; pty-host exe -> `session-host = server-rust`
 Copy-Item (Join-Path $root "native\target\release\agwinterm_core.dll") $stage -Force
+Copy-Item (Join-Path $root "native\target\release\agwinterm-ptyhost.exe") $stage -Force
 
 # sanity: required payload present
-foreach ($f in @("Agwinterm.Win32.exe","agwintermctl.exe","agwinterm_core.dll","assets\agwinterm.ico")) {
+foreach ($f in @("Agwinterm.Win32.exe","agwintermctl.exe","agwinterm_core.dll","agwinterm-ptyhost.exe","assets\agwinterm.ico")) {
   if (-not (Test-Path (Join-Path $stage $f))) { throw "stage missing $f" }
 }
 if (-not (Get-ChildItem (Join-Path $stage "themes") -Filter *.conf -ErrorAction SilentlyContinue)) { throw "stage missing themes\*.conf" }

--- a/src/Agwinterm.Core/TerminalConfig.cs
+++ b/src/Agwinterm.Core/TerminalConfig.cs
@@ -81,8 +81,10 @@ public sealed class TerminalConfig
     public bool UpdateCheck { get; set; } = true;
 
     /// <summary>Where terminal sessions live: "in-process" (default — the UI process owns the
-    /// ConPTYs) or "server" (EXPERIMENTAL, #105 — a separate pty-host process owns them; the
-    /// long-term basis for sessions surviving UI updates/crashes).</summary>
+    /// ConPTYs), "server" (EXPERIMENTAL, #105 — a separate C# pty-host process owns them), or
+    /// "server-rust" (EXPERIMENTAL — the standalone Rust pty-host binary; same protocol, but
+    /// blocking-threaded so the .NET 10 IOCP crash class is absent). Both server modes let sessions
+    /// survive UI updates/crashes; server-rust falls back to in-process if the binary is missing.</summary>
     public string SessionHost { get; set; } = "in-process";
 
     /// <summary>Which terminal core new sessions run on: "managed" (default — the C#
@@ -254,10 +256,13 @@ public sealed class TerminalConfig
         update-check = true
 
         # Where terminal sessions live. "in-process" (default): the window process owns them.
-        # "server" (EXPERIMENTAL - see github issue #105): a separate pty-host process owns them,
-        # so shells KEEP RUNNING when the UI quits, updates, or crashes - the next start reconnects
-        # every pane to its live session (closing a pane still closes its shell). Changing this
-        # applies to new sessions immediately; restart agwinterm to migrate existing ones.
+        # "server" (EXPERIMENTAL, github #105): a separate C# pty-host process owns them, so shells
+        # KEEP RUNNING when the UI quits, updates, or crashes - the next start reconnects every pane
+        # to its live session (closing a pane still closes its shell). "server-rust" (EXPERIMENTAL):
+        # same, but the host is the standalone Rust binary (agwinterm-ptyhost.exe) - identical
+        # protocol, blocking-threaded so a .NET runtime IOCP crash class can't occur; falls back to
+        # in-process if the binary isn't present. Changing this applies to NEW sessions immediately;
+        # restart agwinterm to migrate existing ones.
         session-host = in-process
 
         # Build each new tab's environment FRESH from the registry (what a brand-new process tree
@@ -392,7 +397,7 @@ public sealed class TerminalConfig
                 case "claude-update-check": cfg.ClaudeUpdateCheck = ParseBool(val, cfg.ClaudeUpdateCheck); break;
                 case "update-check": cfg.UpdateCheck = ParseBool(val, cfg.UpdateCheck); break;
                 case "session-host":
-                    if (val is "in-process" or "server") cfg.SessionHost = val;
+                    if (val is "in-process" or "server" or "server-rust") cfg.SessionHost = val;
                     break;
                 case "fresh-env": cfg.FreshEnv = ParseBool(val, cfg.FreshEnv); break;
                 case "emulator-core":

--- a/src/Agwinterm.Pty/ServerSession.cs
+++ b/src/Agwinterm.Pty/ServerSession.cs
@@ -14,19 +14,26 @@ public sealed class ServerSessionBackend : ISessionBackend, IDisposable
 {
     private readonly string _appId;
     private readonly string? _exePath;
+    private readonly string _spawnArgs;
+    private readonly string _name;
     private readonly object _lock = new();
     private PtyHostClient? _client;
 
     /// <param name="appId">Instance id — names the host's control pipe.</param>
-    /// <param name="exePath">The agwinterm exe to spawn with <c>--pty-host</c> when no host is
-    /// running; null = require an already-running host (tests).</param>
-    public ServerSessionBackend(string appId, string? exePath)
+    /// <param name="exePath">The host exe to spawn when none is running; null = require an
+    /// already-running host (tests).</param>
+    /// <param name="spawnArgs">Argument string for the host exe. The C# host is the app itself
+    /// (<c>--pty-host --pipe ...</c>); the Rust host is a standalone binary (<c>--pipe ...</c>).</param>
+    /// <param name="name">Diagnostics name ("server" or "server-rust").</param>
+    public ServerSessionBackend(string appId, string? exePath, string? spawnArgs = null, string name = "server")
     {
         _appId = appId;
         _exePath = exePath;
+        _spawnArgs = spawnArgs ?? $"--pty-host --pipe \"{appId}\"";
+        _name = name;
     }
 
-    public string Name => "server";
+    public string Name => _name;
 
     public ISession Create(string id, int cols, int rows)
     {
@@ -45,7 +52,7 @@ public sealed class ServerSessionBackend : ISessionBackend, IDisposable
             {
                 if (_exePath is null || !File.Exists(_exePath))
                     throw new InvalidOperationException("no pty-host is running and no exe to spawn one");
-                var psi = new ProcessStartInfo(_exePath, $"--pty-host --pipe \"{_appId}\"")
+                var psi = new ProcessStartInfo(_exePath, _spawnArgs)
                 { UseShellExecute = false, CreateNoWindow = true };
                 Process.Start(psi);
                 for (int i = 0; i < 50 && !PtyHostClient.IsRunning(_appId); i++) Thread.Sleep(100);

--- a/src/Agwinterm.Pty/SessionBackend.cs
+++ b/src/Agwinterm.Pty/SessionBackend.cs
@@ -26,12 +26,37 @@ public sealed class InProcessSessionBackend : ISessionBackend
 
 public static class SessionBackends
 {
-    /// <summary>Resolve the configured <c>session-host</c> value to a backend. "server" (#105,
-    /// experimental) hosts sessions in the pty-host process — spawned on demand from
-    /// <paramref name="exePath"/> (the same exe, <c>--pty-host</c> role) under
-    /// <paramref name="appId"/>'s pipe namespace. Anything else = in-process.</summary>
+    /// <summary>Resolve the configured <c>session-host</c> value to a backend:
+    ///  - "server": the C# pty-host (the same exe, <c>--pty-host</c> role).
+    ///  - "server-rust": the standalone Rust pty-host binary (agwinterm-ptyhost.exe next to the
+    ///    exe) — same protocol (protobuf v2, oracle-proven), but blocking-threaded so the .NET 10
+    ///    IOCP crash class (#118) is structurally absent. Uses a distinct pipe namespace
+    ///    (<c>&lt;appId&gt;-rust</c>) so it never collides with a C# host on the same instance.
+    ///  - anything else: in-process.
+    /// A missing Rust binary falls through to a null exe, so Create throws and the UI falls back to
+    /// in-process (same graceful path as an unreachable C# host).</summary>
     public static ISessionBackend Resolve(string? configured, string appId, string? exePath)
-        => string.Equals(configured, "server", StringComparison.OrdinalIgnoreCase)
-            ? new ServerSessionBackend(appId, exePath)
-            : InProcessSessionBackend.Instance;
+    {
+        if (string.Equals(configured, "server", StringComparison.OrdinalIgnoreCase))
+            return new ServerSessionBackend(appId, exePath);
+        if (string.Equals(configured, "server-rust", StringComparison.OrdinalIgnoreCase))
+        {
+            string rustAppId = appId + "-rust";
+            string? rustHost = FindRustHost(exePath);
+            return new ServerSessionBackend(rustAppId, rustHost, $"--pipe \"{rustAppId}\"", name: "server-rust");
+        }
+        return InProcessSessionBackend.Instance;
+    }
+
+    /// <summary>Locate agwinterm-ptyhost.exe next to the app exe (the installer ships it there).</summary>
+    private static string? FindRustHost(string? exePath)
+    {
+        try
+        {
+            string dir = exePath is not null ? Path.GetDirectoryName(exePath)! : AppContext.BaseDirectory;
+            string p = Path.Combine(dir, "agwinterm-ptyhost.exe");
+            return File.Exists(p) ? p : null;
+        }
+        catch { return null; }
+    }
 }

--- a/src/Agwinterm.Win32/Program.Services.cs
+++ b/src/Agwinterm.Win32/Program.Services.cs
@@ -913,9 +913,12 @@ internal partial class Program
             // Live switch (#105 2d): NEW sessions use the chosen backend immediately; existing panes
             // keep the one they were born with (both kinds coexist fine) and converge on restart.
             _sessionBackend = SessionBackends.Resolve(_config.SessionHost, _argPipe ?? _appId, AppExePath);
-            ShowToast(_config.SessionHost == "server"
-                ? "server mode ON (experimental) — new sessions survive UI restarts; restart agwinterm to move existing ones"
-                : "in-process mode — new sessions run in the window process; restart agwinterm to convert existing ones", 6000);
+            ShowToast(_config.SessionHost switch
+            {
+                "server" => "server mode ON (experimental) — new sessions survive UI restarts; restart agwinterm to move existing ones",
+                "server-rust" => "Rust server mode ON (experimental) — new sessions live in the Rust pty-host; restart agwinterm to move existing ones",
+                _ => "in-process mode — new sessions run in the window process; restart agwinterm to convert existing ones",
+            }, 6000);
         }
         if (key == "emulator-core")
         {

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -484,16 +484,18 @@ internal partial class Program : ISessionHost, IWindowHost
             front!.Post(() => front.ShowToast(note, 6000));
         // Server mode is experimental (#105) — say so once at startup, so a flipped knob is never
         // a silent mystery ("why is there a second agwinterm process?").
-        if (_sessionBackend is ServerSessionBackend)
+        if (_sessionBackend is ServerSessionBackend sb)
         {
-            front!.Post(() => front.ShowToast("session-host = server (experimental) — sessions live in the pty-host process", 6000));
+            string host = sb.Name == "server-rust" ? "the Rust pty-host binary" : "the pty-host process";
+            front!.Post(() => front.ShowToast($"session-host = {sb.Name} (experimental) — sessions live in {host}", 6000));
             // Reap hosted sessions no pane claims — leftovers of closed panes whose kill raced a
             // crash, or exited corpses. WELL after boot: restore/adoption must claim everything
             // (incl. slow multi-window restores) before anything is judged an orphan.
+            string reapPipe = (_argPipe ?? _appId) + (sb.Name == "server-rust" ? "-rust" : "");
             _ = Task.Run(async () =>
             {
                 await Task.Delay(TimeSpan.FromSeconds(30));
-                ReapOrphanedHostedSessions(_argPipe ?? _appId);
+                ReapOrphanedHostedSessions(reapPipe);
             });
         }
 

--- a/src/Agwinterm.Win32/Settings.cs
+++ b/src/Agwinterm.Win32/Settings.cs
@@ -110,7 +110,8 @@ internal partial class Program
         Tog(0, "confirm-close-session", "Confirm before closing");
         // pty-host opt-in (#105): server mode keeps shells alive across UI restarts/updates/crashes.
         Drop(0, "session-host", "Session host (shells survive restarts)",
-            new[] { "In-process (default)", "Pty-host server (experimental)" }, new[] { "in-process", "server" });
+            new[] { "In-process (default)", "Pty-host server (experimental)", "Pty-host server: Rust (experimental)" },
+            new[] { "in-process", "server", "server-rust" });
         // Rust core opt-in: new sessions parse/render state in native/agwinterm-core.
         Drop(0, "emulator-core", "Terminal core (new sessions)",
             new[] { "Managed (default)", "Rust (experimental)" }, new[] { "managed", "rust" });

--- a/tests/Agwinterm.Pty.Tests/SessionBackendTests.cs
+++ b/tests/Agwinterm.Pty.Tests/SessionBackendTests.cs
@@ -28,6 +28,16 @@ public class SessionBackendTests
     }
 
     [Fact]
+    public void Resolve_ServerRust_PicksServerRustBackend()
+    {
+        var b = SessionBackends.Resolve("server-rust", "x", null);
+        Assert.IsType<ServerSessionBackend>(b);
+        Assert.Equal("server-rust", b.Name);   // distinct name drives the toast + reap pipe
+        // Case-insensitive, like the other values.
+        Assert.Equal("server-rust", SessionBackends.Resolve("SERVER-RUST", "x", null).Name);
+    }
+
+    [Fact]
     public void ServerBackend_WithNoHostAndNoExe_FailsAtCreate()
     {
         // Failure surfaces at Create — the one place the UI can catch it and fall back in-process.


### PR DESCRIPTION
The Rust pty-host was built and oracle-proven but nothing used it. Now `session-host = server-rust` runs real sessions on the standalone Rust binary — same protobuf v2 protocol as the C# host (the same `PtyHostClient` drives both), but **blocking-threaded so the .NET 10 IOCP crash class (#118) is structurally absent**. This is the reliability payoff of the whole Rust journey, now flippable in your daily driver.

- `ServerSessionBackend` takes a spawn-args string + name, so one class serves both the C# in-exe host (`--pty-host --pipe`) and the Rust binary (`--pipe`).
- `SessionBackends.Resolve` adds the server-rust branch: locates `agwinterm-ptyhost.exe` next to the exe, uses a **distinct pipe namespace** (`<appId>-rust`) so it never collides with a C# host, and falls back to in-process (existing Create-throws path) if the binary is absent.
- Config validation + docs, Settings dropdown, startup + live-switch toasts, and the orphan-reaper all handle the new value/pipe.
- `installer/build.ps1` now stages `agwinterm-ptyhost.exe` too, so installed copies can use server-rust (like the core dll enables `emulator-core = rust`).

**E2E** (screenshot in session): switched the running app to server-rust → it spawned the Rust host (7 MB) → a colored session ran through it end to end. 285 tests green (+ a `Resolve(server-rust)` unit test).

Now you can dogfood the crash-free Rust host in the real app; if it holds up, the eventual default flip is evidence-driven from there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k