### PR TITLE
feat(reattach): full-fidelity attributed scrollback on pty-host reattach

### DIFF
--- a/native/agwinterm-ptyhost/src/main.rs
+++ b/native/agwinterm-ptyhost/src/main.rs
@@ -361,6 +361,9 @@ fn handle_attach(host: &Arc<Host>, a: proto::Attach) -> Reply {
         exit_code: hosted.exit_code.load(Ordering::SeqCst),
         modes,
         scrollback,
+        // Attributed history blob: not produced yet (would need persist encoding in this crate);
+        // the client falls back to the plain-text `scrollback` above. Follow-up.
+        scrollback_blob: Vec::new(),
     })))
 }
 

--- a/native/agwinterm-ptyhost/src/proto.rs
+++ b/native/agwinterm-ptyhost/src/proto.rs
@@ -140,9 +140,15 @@ pub struct AttachReply {
     /// synthesized VT reproducing mode state (DumpModes)
     #[prost(string, tag = "7")]
     pub modes: ::prost::alloc::string::String,
-    /// plain-text history rows, oldest first
+    /// plain-text history rows, oldest first (back-compat / lite)
     #[prost(string, repeated, tag = "8")]
     pub scrollback: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// Full-fidelity attributed scrollback: a serialized agwinterm.persist.PBuffer of the HISTORY
+    /// rows (colours + styles). When present the client seeds from this instead of the plain text,
+    /// so a reattached view is not dim-until-repaint. Empty when the host can't produce it (a Rust
+    /// host without persist support yet); the client falls back to `scrollback`.
+    #[prost(bytes = "vec", tag = "9")]
+    pub scrollback_blob: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SessionInfo {

--- a/proto/ptyhost.proto
+++ b/proto/ptyhost.proto
@@ -93,7 +93,12 @@ message AttachReply {
   bool has_exited = 5;
   int32 exit_code = 6;
   string modes = 7;               // synthesized VT reproducing mode state (DumpModes)
-  repeated string scrollback = 8; // plain-text history rows, oldest first
+  repeated string scrollback = 8; // plain-text history rows, oldest first (back-compat / lite)
+  // Full-fidelity attributed scrollback: a serialized agwinterm.persist.PBuffer of the HISTORY
+  // rows (colours + styles). When present the client seeds from this instead of the plain text,
+  // so a reattached view is not dim-until-repaint. Empty when the host can't produce it (a Rust
+  // host without persist support yet); the client falls back to `scrollback`.
+  bytes scrollback_blob = 9;
 }
 
 message SessionInfo {

--- a/src/Agwinterm.Core/BufferPersist.cs
+++ b/src/Agwinterm.Core/BufferPersist.cs
@@ -39,9 +39,11 @@ public static class BufferPersist
 
     private static bool RowNeeded(IReadOnlyList<PCell> _) => true;
 
-    /// <summary>Capture the last <paramref name="maxRows"/> buffer rows (scrollback + visible) as an
-    /// attributed blob. Trailing empty cells per row are dropped; the whole thing round-trips exactly.</summary>
-    public static byte[] Serialize(TerminalEmulator emu, int maxRows = 500)
+    /// <summary>Capture buffer rows as an attributed blob. <paramref name="includeVisible"/> controls
+    /// whether the live grid is appended after the scrollback (true for full save/restore; false for
+    /// pty-host reattach, where the live screen arrives separately via a ConPTY repaint and only the
+    /// history should be seeded). Trailing empty cells per row are dropped; it round-trips exactly.</summary>
+    public static byte[] Serialize(TerminalEmulator emu, int maxRows = 500, bool includeVisible = true)
     {
         var buf = new PBuffer { Version = Version, Cols = (uint)emu.Screen.Cols };
         int cols = emu.Screen.Cols;
@@ -61,11 +63,12 @@ public static class BufferPersist
             int hi = h;
             AddRow(c => emu.GetHistoryCell(hi, c));
         }
-        for (int r = 0; r < emu.Screen.Rows; r++)
-        {
-            int rr = r;
-            AddRow(c => emu.Screen[rr, c]);
-        }
+        if (includeVisible)
+            for (int r = 0; r < emu.Screen.Rows; r++)
+            {
+                int rr = r;
+                AddRow(c => emu.Screen[rr, c]);
+            }
         // Drop trailing all-empty rows, then cap to maxRows (keep the newest).
         while (rows.Count > 0 && rows[^1].Cells.Count == 0) rows.RemoveAt(rows.Count - 1);
         if (rows.Count > maxRows) rows.RemoveRange(0, rows.Count - maxRows);

--- a/src/Agwinterm.Pty/Proto/Ptyhost.cs
+++ b/src/Agwinterm.Pty/Proto/Ptyhost.cs
@@ -49,15 +49,16 @@ namespace Agwinterm.Pty.Proto {
             "eWhvc3QuQXR0YWNoUmVwbHlIABIsCgRsaXN0GAYgASgLMhwuYWd3aW50ZXJt",
             "LnB0eWhvc3QuTGlzdFJlcGx5SABCBgoEYm9keSIrCgpIZWxsb1JlcGx5EhAK",
             "CHByb3RvY29sGAEgASgNEgsKA3BpZBgCIAEoDSIZCgtDcmVhdGVSZXBseRIK",
-            "CgJpZBgBIAEoCSKUAQoLQXR0YWNoUmVwbHkSDAoEcGlwZRgBIAEoCRIMCgRj",
+            "CgJpZBgBIAEoCSKtAQoLQXR0YWNoUmVwbHkSDAoEcGlwZRgBIAEoCRIMCgRj",
             "b2xzGAIgASgNEgwKBHJvd3MYAyABKA0SEQoJY2hpbGRfcGlkGAQgASgNEhIK",
             "Cmhhc19leGl0ZWQYBSABKAgSEQoJZXhpdF9jb2RlGAYgASgFEg0KBW1vZGVz",
-            "GAcgASgJEhIKCnNjcm9sbGJhY2sYCCADKAkikAEKC1Nlc3Npb25JbmZvEgoK",
-            "AmlkGAEgASgJEgwKBGNvbHMYAiABKA0SDAoEcm93cxgDIAEoDRIRCgljaGls",
-            "ZF9waWQYBCABKA0SEgoKaGFzX2V4aXRlZBgFIAEoCBIRCglleGl0X2NvZGUY",
-            "BiABKAUSDQoFdGl0bGUYByABKAkSEAoIYXR0YWNoZWQYCCABKAgiPQoJTGlz",
-            "dFJlcGx5EjAKCHNlc3Npb25zGAEgAygLMh4uYWd3aW50ZXJtLnB0eWhvc3Qu",
-            "U2Vzc2lvbkluZm9CFqoCE0Fnd2ludGVybS5QdHkuUHJvdG9iBnByb3RvMw=="));
+            "GAcgASgJEhIKCnNjcm9sbGJhY2sYCCADKAkSFwoPc2Nyb2xsYmFja19ibG9i",
+            "GAkgASgMIpABCgtTZXNzaW9uSW5mbxIKCgJpZBgBIAEoCRIMCgRjb2xzGAIg",
+            "ASgNEgwKBHJvd3MYAyABKA0SEQoJY2hpbGRfcGlkGAQgASgNEhIKCmhhc19l",
+            "eGl0ZWQYBSABKAgSEQoJZXhpdF9jb2RlGAYgASgFEg0KBXRpdGxlGAcgASgJ",
+            "EhAKCGF0dGFjaGVkGAggASgIIj0KCUxpc3RSZXBseRIwCghzZXNzaW9ucxgB",
+            "IAMoCzIeLmFnd2ludGVybS5wdHlob3N0LlNlc3Npb25JbmZvQhaqAhNBZ3dp",
+            "bnRlcm0uUHR5LlByb3RvYgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(null, null, new pbr::GeneratedClrTypeInfo[] {
@@ -72,7 +73,7 @@ namespace Agwinterm.Pty.Proto {
             new pbr::GeneratedClrTypeInfo(typeof(global::Agwinterm.Pty.Proto.Reply), global::Agwinterm.Pty.Proto.Reply.Parser, new[]{ "Ok", "Error", "Hello", "Create", "Attach", "List" }, new[]{ "Body" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Agwinterm.Pty.Proto.HelloReply), global::Agwinterm.Pty.Proto.HelloReply.Parser, new[]{ "Protocol", "Pid" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Agwinterm.Pty.Proto.CreateReply), global::Agwinterm.Pty.Proto.CreateReply.Parser, new[]{ "Id" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Agwinterm.Pty.Proto.AttachReply), global::Agwinterm.Pty.Proto.AttachReply.Parser, new[]{ "Pipe", "Cols", "Rows", "ChildPid", "HasExited", "ExitCode", "Modes", "Scrollback" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Agwinterm.Pty.Proto.AttachReply), global::Agwinterm.Pty.Proto.AttachReply.Parser, new[]{ "Pipe", "Cols", "Rows", "ChildPid", "HasExited", "ExitCode", "Modes", "Scrollback", "ScrollbackBlob" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Agwinterm.Pty.Proto.SessionInfo), global::Agwinterm.Pty.Proto.SessionInfo.Parser, new[]{ "Id", "Cols", "Rows", "ChildPid", "HasExited", "ExitCode", "Title", "Attached" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Agwinterm.Pty.Proto.ListReply), global::Agwinterm.Pty.Proto.ListReply.Parser, new[]{ "Sessions" }, null, null, null, null)
           }));
@@ -3389,6 +3390,7 @@ namespace Agwinterm.Pty.Proto {
       exitCode_ = other.exitCode_;
       modes_ = other.modes_;
       scrollback_ = other.scrollback_.Clone();
+      scrollbackBlob_ = other.scrollbackBlob_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -3497,12 +3499,30 @@ namespace Agwinterm.Pty.Proto {
         = pb::FieldCodec.ForString(66);
     private readonly pbc::RepeatedField<string> scrollback_ = new pbc::RepeatedField<string>();
     /// <summary>
-    /// plain-text history rows, oldest first
+    /// plain-text history rows, oldest first (back-compat / lite)
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public pbc::RepeatedField<string> Scrollback {
       get { return scrollback_; }
+    }
+
+    /// <summary>Field number for the "scrollback_blob" field.</summary>
+    public const int ScrollbackBlobFieldNumber = 9;
+    private pb::ByteString scrollbackBlob_ = pb::ByteString.Empty;
+    /// <summary>
+    /// Full-fidelity attributed scrollback: a serialized agwinterm.persist.PBuffer of the HISTORY
+    /// rows (colours + styles). When present the client seeds from this instead of the plain text,
+    /// so a reattached view is not dim-until-repaint. Empty when the host can't produce it (a Rust
+    /// host without persist support yet); the client falls back to `scrollback`.
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public pb::ByteString ScrollbackBlob {
+      get { return scrollbackBlob_; }
+      set {
+        scrollbackBlob_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -3528,6 +3548,7 @@ namespace Agwinterm.Pty.Proto {
       if (ExitCode != other.ExitCode) return false;
       if (Modes != other.Modes) return false;
       if(!scrollback_.Equals(other.scrollback_)) return false;
+      if (ScrollbackBlob != other.ScrollbackBlob) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -3543,6 +3564,7 @@ namespace Agwinterm.Pty.Proto {
       if (ExitCode != 0) hash ^= ExitCode.GetHashCode();
       if (Modes.Length != 0) hash ^= Modes.GetHashCode();
       hash ^= scrollback_.GetHashCode();
+      if (ScrollbackBlob.Length != 0) hash ^= ScrollbackBlob.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -3590,6 +3612,10 @@ namespace Agwinterm.Pty.Proto {
         output.WriteString(Modes);
       }
       scrollback_.WriteTo(output, _repeated_scrollback_codec);
+      if (ScrollbackBlob.Length != 0) {
+        output.WriteRawTag(74);
+        output.WriteBytes(ScrollbackBlob);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -3629,6 +3655,10 @@ namespace Agwinterm.Pty.Proto {
         output.WriteString(Modes);
       }
       scrollback_.WriteTo(ref output, _repeated_scrollback_codec);
+      if (ScrollbackBlob.Length != 0) {
+        output.WriteRawTag(74);
+        output.WriteBytes(ScrollbackBlob);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -3661,6 +3691,9 @@ namespace Agwinterm.Pty.Proto {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Modes);
       }
       size += scrollback_.CalculateSize(_repeated_scrollback_codec);
+      if (ScrollbackBlob.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeBytesSize(ScrollbackBlob);
+      }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
       }
@@ -3695,6 +3728,9 @@ namespace Agwinterm.Pty.Proto {
         Modes = other.Modes;
       }
       scrollback_.Add(other.scrollback_);
+      if (other.ScrollbackBlob.Length != 0) {
+        ScrollbackBlob = other.ScrollbackBlob;
+      }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
@@ -3746,6 +3782,10 @@ namespace Agwinterm.Pty.Proto {
             scrollback_.AddEntriesFrom(input, _repeated_scrollback_codec);
             break;
           }
+          case 74: {
+            ScrollbackBlob = input.ReadBytes();
+            break;
+          }
         }
       }
     #endif
@@ -3795,6 +3835,10 @@ namespace Agwinterm.Pty.Proto {
           }
           case 66: {
             scrollback_.AddEntriesFrom(ref input, _repeated_scrollback_codec);
+            break;
+          }
+          case 74: {
+            ScrollbackBlob = input.ReadBytes();
             break;
           }
         }

--- a/src/Agwinterm.Pty/PtyHostClient.cs
+++ b/src/Agwinterm.Pty/PtyHostClient.cs
@@ -8,7 +8,7 @@ namespace Agwinterm.Pty;
 /// a fresh view needs to reconstruct the session (see PtyHostServer for the reattach model).</summary>
 public sealed record PtyHostAttachment(
     Stream Data, int Cols, int Rows, int? ChildPid, bool HasExited, int? ExitCode,
-    string Modes, IReadOnlyList<string> Scrollback) : IDisposable
+    string Modes, IReadOnlyList<string> Scrollback, byte[]? ScrollbackBlob = null) : IDisposable
 {
     public void Dispose() => Data.Dispose();
 }
@@ -101,7 +101,8 @@ public sealed class PtyHostClient : IDisposable
             reply.ChildPid != 0 ? (int)reply.ChildPid : null,
             reply.HasExited,
             reply.HasExited ? reply.ExitCode : null,
-            reply.Modes, reply.Scrollback);
+            reply.Modes, reply.Scrollback,
+            reply.ScrollbackBlob.IsEmpty ? null : reply.ScrollbackBlob.ToByteArray());
     }
 
     public void Resize(string id, int cols, int rows)

--- a/src/Agwinterm.Pty/PtyHostServer.cs
+++ b/src/Agwinterm.Pty/PtyHostServer.cs
@@ -1,4 +1,5 @@
 using System.IO.Pipes;
+using Agwinterm.Core;
 using Agwinterm.Pty.Proto;
 using Google.Protobuf;
 
@@ -205,6 +206,11 @@ public sealed class PtyHostServer : IDisposable
         {
             for (int i = 0; i < s.Emulator.HistoryCount; i++) reply.Scrollback.Add(s.Emulator.DumpHistoryRow(i));
             reply.Modes = s.Emulator.DumpModes();
+            // Full-fidelity attributed HISTORY (the live screen arrives via the repaint jiggle, so
+            // includeVisible=false). The client seeds from this instead of the plain text above.
+            if (s.Emulator is TerminalEmulator te)
+                reply.ScrollbackBlob = Google.Protobuf.ByteString.CopyFrom(
+                    BufferPersist.Serialize(te, includeVisible: false));
         }
         reply.Cols = (uint)s.Cols;
         reply.Rows = (uint)s.Rows;

--- a/src/Agwinterm.Pty/ServerSession.cs
+++ b/src/Agwinterm.Pty/ServerSession.cs
@@ -200,7 +200,13 @@ public sealed class ServerSession : ISession
         }
         lock (_sync)
         {
-            Emulator.SeedScrollback(att.Scrollback);
+            // Prefer the full-fidelity attributed history (colours survive the reattach) over the
+            // plain-text seed; the replica emulator is a concrete TerminalEmulator.
+            if (att.ScrollbackBlob is { Length: > 0 } blob && Emulator is TerminalEmulator te
+                && BufferPersist.TryParse(blob, out var pbuf))
+                BufferPersist.Restore(te, pbuf);
+            else
+                Emulator.SeedScrollback(att.Scrollback);
             Emulator.Feed(System.Text.Encoding.UTF8.GetBytes(att.Modes));
         }
         _data = att.Data;

--- a/tests/Agwinterm.Pty.Tests/ServerSessionTests.cs
+++ b/tests/Agwinterm.Pty.Tests/ServerSessionTests.cs
@@ -1,3 +1,4 @@
+using Agwinterm.Core;
 using Agwinterm.Pty;
 
 namespace Agwinterm.Pty.Tests;
@@ -147,6 +148,40 @@ public class ServerSessionTests : IDisposable
         // And it's live: same shell keeps taking input.
         gen2.Write("echo post+adopt\r"u8);
         Assert.True(WaitFor(() => GridText(gen2).Contains("post+adopt")));
+    }
+
+    [Fact]
+    public async Task Reattach_PreservesScrollbackColors()
+    {
+        string paneId = Guid.NewGuid().ToString();
+        var gen1 = _backend.Create(paneId, 60, 10);
+        await gen1.StartAsync("powershell.exe", new[] { "-NoLogo", "-NoProfile" });
+        // Emit a coloured line via ANSI, then scroll it into history.
+        TypeLine(gen1, "$e=[char]27; Write-Host \"$e[31mCOLORLINE$e[0m\"", "COLORLINE");
+        for (int i = 0; i < 14; i++) gen1.Write("echo .\r"u8);   // push COLORLINE into scrollback
+        Thread.Sleep(500);
+        gen1.Detach();
+
+        using var gen2 = (ServerSession)_backend.Create(paneId, 60, 10);
+        Assert.True(gen2.TryAdopt());
+        // Find COLORLINE in the replica's history and assert its 'C' cell has a NON-DEFAULT
+        // foreground — the attributed blob carried the colour; the old plain-text path would leave
+        // every cell at the default foreground (this is the whole point of attributed reattach).
+        bool colouredHistory = WaitFor(() =>
+        {
+            lock (gen2.SyncRoot)
+                for (int h = 0; h < gen2.Emulator.HistoryCount; h++)
+                {
+                    if (!gen2.Emulator.DumpHistoryRow(h).Contains("COLORLINE")) continue;
+                    for (int c = 0; c < gen2.Emulator.Screen.Cols; c++)
+                    {
+                        var cell = gen2.Emulator.GetHistoryCell(h, c);
+                        if (cell.Rune == 'C' && cell.FgSpec.Kind != ColorSpecKind.Default) return true;
+                    }
+                }
+            return false;
+        });
+        Assert.True(colouredHistory, "reattach did not preserve the scrollback colour (fell back to plain text?)");
     }
 
     [Fact]


### PR DESCRIPTION
Reattaching a session (`session-host = server` / `server-rust`, after a UI restart) seeded the scrollback as **plain text** — dim and colourless — until the live screen repainted. Now the C# host also puts an **attributed history blob** (serialized `persist.PBuffer`, colours + styles) in `AttachReply.scrollback_blob`, and the client prefers it: `BufferPersist.Restore` into the replica emulator instead of `SeedScrollback(text)`. A reattached view shows real colours in scrollback immediately.

Uses the `persist.proto` schema built in M2p3 — the natural payoff of that work.

- **proto**: `AttachReply` gains `bytes scrollback_blob` (field 9). Regenerated C#/Rust/nanopb; lite ignores it (plain-text seed unchanged).
- **`BufferPersist.Serialize`** gains `includeVisible` (false for reattach — the live grid arrives via the repaint jiggle, only history is seeded).
- The **Rust host** sets `scrollback_blob` empty for now (attributed encoding in that crate is a follow-up); the client falls back to plain text there, so nothing regresses. Compatibility oracle (same client drives both hosts) still green.

**Test**: `Reattach_PreservesScrollbackColors` — emit ANSI-red text, scroll to history, detach, adopt, assert the replica history cell has a **non-default** foreground (the plain-text path would be default). 287 tests green; lite + Rust host build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k