### PR TITLE
feat(rust-core): surface kitty/sixel images over ABI v8 (close emulator-core=rust image gap)

### DIFF
--- a/lite/src/main.cpp
+++ b/lite/src/main.cpp
@@ -23,7 +23,7 @@
 #include "proto/pb_decode.h"
 #include "control.h"
 
-// ---- agwinterm-core C ABI (ABI v7) ----
+// ---- agwinterm-core C ABI (ABI v8) ----
 struct FfiCell {
     int32_t rune;
     uint32_t fg, bg, attrs, width;
@@ -52,7 +52,7 @@ static bool (*emu_copy_grid)(void*, FfiCell*, uint32_t);
 static bool (*emu_copy_history_row)(void*, uint32_t, FfiCell*, uint32_t);
 static uint32_t (*emu_marks)(void*, FfiMark*, uint32_t);
 
-static constexpr uint32_t kRequiredAbi = 7;
+static constexpr uint32_t kRequiredAbi = 8;
 static constexpr uint32_t kAttrBold = 1, kAttrItalic = 2, kAttrUnderline = 4,
                           kAttrInverse = 8, kAttrDim = 16, kAttrStrike = 32;
 static constexpr uint32_t kProtocolVersion = 2;
@@ -187,7 +187,7 @@ static void loadCore() {
     emu_marks = (decltype(emu_marks))GetProcAddress(m, "agwcore_emu_marks");
     if (!core_abi || !emu_new || !emu_feed || !emu_info || !emu_copy_grid || !emu_resize || !emu_free || !emu_copy_history_row || !emu_marks)
         fatal(L"agwinterm_core.dll: exports missing");
-    if (core_abi() != kRequiredAbi) fatal(L"agwinterm_core.dll: ABI mismatch (need v7)");
+    if (core_abi() != kRequiredAbi) fatal(L"agwinterm_core.dll: ABI mismatch (need v8)");
 }
 
 static void connectControl() {

--- a/native/agwinterm-core/src/emulator.rs
+++ b/native/agwinterm-core/src/emulator.rs
@@ -208,6 +208,28 @@ impl Emulator {
         &self.placements
     }
 
+    // ---- direct image API (mirrors TerminalEmulator: host-delivered images without the
+    // APC/base64 text path — used by the control pipe). ----
+    pub fn clear_placements(&mut self) {
+        self.placements.clear();
+    }
+    pub fn has_image(&self, id: i32) -> bool {
+        self.images.contains_key(&id)
+    }
+    pub fn set_image_data(&mut self, id: i32, format: i32, width: i32, height: i32, data: Vec<u8>) {
+        self.images.insert(id, KittyImage { id, format, width, height, data });
+    }
+    #[allow(clippy::too_many_arguments)]
+    pub fn place_image(&mut self, id: i32, row: i64, col: i64, cols: i32, rows: i32,
+                       src_x: i32, src_y: i32, src_w: i32, src_h: i32) {
+        self.placements.retain(|p| p.image_id != id);
+        self.placements.push(ImagePlacement { image_id: id, row, col, cols, rows, src_x, src_y, src_w, src_h });
+    }
+    /// Decode a sixel payload and place it at the cursor (advancing below). Public wrapper.
+    pub fn place_sixel_public(&mut self, data: &[u8]) -> bool {
+        self.place_sixel(data)
+    }
+
     pub fn screen(&self) -> &ScreenBuffer {
         if self.on_alt { &self.alt } else { &self.main }
     }

--- a/native/agwinterm-core/src/lib.rs
+++ b/native/agwinterm-core/src/lib.rs
@@ -26,7 +26,7 @@ use screen::ScreenBuffer;
 /// Bumped whenever the exported C surface changes shape. The C# loader
 /// refuses a mismatch loudly (same hard-handshake philosophy as the
 /// pty-host protocol).
-pub const ABI_VERSION: u32 = 7;
+pub const ABI_VERSION: u32 = 8;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn agwcore_abi_version() -> u32 {
@@ -518,6 +518,137 @@ pub unsafe extern "C" fn agwcore_emu_seed_scrollback(p: *mut Terminal, text: *co
     let lines: Vec<&str> = s.split('\n').collect();
     t.emu.seed_scrollback(&lines);
     true
+}
+
+// ---- images (ABI v8): kitty/sixel surface for emulator-core = rust ----
+
+/// One image placement over the ABI (mirrors ImagePlacement).
+#[repr(C)]
+pub struct FfiPlacement {
+    pub image_id: i32,
+    pub row: i64,
+    pub col: i64,
+    pub cols: i32,
+    pub rows: i32,
+    pub src_x: i32,
+    pub src_y: i32,
+    pub src_w: i32,
+    pub src_h: i32,
+}
+
+/// Image metadata (not the pixels — those come via agwcore_emu_copy_image_data).
+#[repr(C)]
+pub struct FfiImageMeta {
+    pub id: i32,
+    pub format: i32,
+    pub width: i32,
+    pub height: i32,
+    pub data_len: u32,
+}
+
+/// Number of live placements (for the caller to size its buffer).
+/// # Safety
+/// `p` from `agwcore_emu_new`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn agwcore_emu_placement_count(p: *mut Terminal) -> u32 {
+    (unsafe { p.as_mut() }).map_or(0, |t| t.emu.placements().len() as u32)
+}
+
+/// Copy all placements (z-order of arrival) into `out`; returns how many were written.
+/// # Safety
+/// `p` from `agwcore_emu_new`; `out` points to `cap` writable FfiPlacements.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn agwcore_emu_copy_placements(p: *mut Terminal, out: *mut FfiPlacement, cap: u32) -> u32 {
+    let Some(t) = (unsafe { p.as_mut() }) else { return 0 };
+    if out.is_null() {
+        return 0;
+    }
+    let pl = t.emu.placements();
+    let n = pl.len().min(cap as usize);
+    let out = unsafe { core::slice::from_raw_parts_mut(out, n) };
+    for (i, p) in pl.iter().take(n).enumerate() {
+        out[i] = FfiPlacement {
+            image_id: p.image_id, row: p.row, col: p.col, cols: p.cols, rows: p.rows,
+            src_x: p.src_x, src_y: p.src_y, src_w: p.src_w, src_h: p.src_h,
+        };
+    }
+    n as u32
+}
+
+/// Copy image-id + metadata for every transmitted image (ascending id). Pixel data is fetched
+/// separately (agwcore_emu_copy_image_data), so the C# side uploads a texture only once per id.
+/// Returns the number written.
+/// # Safety
+/// `p` from `agwcore_emu_new`; `out` points to `cap` writable FfiImageMeta.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn agwcore_emu_image_metas(p: *mut Terminal, out: *mut FfiImageMeta, cap: u32) -> u32 {
+    let Some(t) = (unsafe { p.as_mut() }) else { return 0 };
+    if out.is_null() {
+        return 0;
+    }
+    let imgs = t.emu.images();
+    let n = imgs.len().min(cap as usize);
+    let out = unsafe { core::slice::from_raw_parts_mut(out, n) };
+    for (i, (id, img)) in imgs.iter().take(n).enumerate() {
+        out[i] = FfiImageMeta { id: *id, format: img.format, width: img.width, height: img.height, data_len: img.data.len() as u32 };
+    }
+    n as u32
+}
+
+/// Copy one image's raw bytes into `out` (size it from FfiImageMeta.data_len). Returns bytes written.
+/// # Safety
+/// `p` from `agwcore_emu_new`; `out` points to `cap` writable bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn agwcore_emu_copy_image_data(p: *mut Terminal, id: i32, out: *mut u8, cap: u32) -> u32 {
+    let Some(t) = (unsafe { p.as_mut() }) else { return 0 };
+    let Some(img) = t.emu.images().get(&id) else { return 0 };
+    if out.is_null() || (cap as usize) < img.data.len() {
+        return 0;
+    }
+    unsafe { core::ptr::copy_nonoverlapping(img.data.as_ptr(), out, img.data.len()) };
+    img.data.len() as u32
+}
+
+/// # Safety: `p` from `agwcore_emu_new`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn agwcore_emu_has_image(p: *mut Terminal, id: i32) -> bool {
+    (unsafe { p.as_mut() }).is_some_and(|t| t.emu.has_image(id))
+}
+
+/// # Safety: `p` from `agwcore_emu_new`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn agwcore_emu_clear_placements(p: *mut Terminal) {
+    if let Some(t) = (unsafe { p.as_mut() }) {
+        t.emu.clear_placements();
+    }
+}
+
+/// # Safety: `p` from `agwcore_emu_new`; `data` points to `len` readable bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn agwcore_emu_set_image_data(p: *mut Terminal, id: i32, format: i32, width: i32, height: i32, data: *const u8, len: u32) -> bool {
+    let Some(t) = (unsafe { p.as_mut() }) else { return false };
+    let bytes = if data.is_null() { Vec::new() } else { unsafe { core::slice::from_raw_parts(data, len as usize) }.to_vec() };
+    t.emu.set_image_data(id, format, width, height, bytes);
+    true
+}
+
+/// # Safety: `p` from `agwcore_emu_new`.
+#[unsafe(no_mangle)]
+#[allow(clippy::too_many_arguments)]
+pub unsafe extern "C" fn agwcore_emu_place_image(p: *mut Terminal, id: i32, row: i64, col: i64, cols: i32, rows: i32, src_x: i32, src_y: i32, src_w: i32, src_h: i32) -> bool {
+    let Some(t) = (unsafe { p.as_mut() }) else { return false };
+    t.emu.place_image(id, row, col, cols, rows, src_x, src_y, src_w, src_h);
+    true
+}
+
+/// # Safety: `p` from `agwcore_emu_new`; `data` points to `len` readable bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn agwcore_emu_place_sixel(p: *mut Terminal, data: *const u8, len: u32) -> bool {
+    let Some(t) = (unsafe { p.as_mut() }) else { return false };
+    if data.is_null() {
+        return false;
+    }
+    t.emu.place_sixel_public(unsafe { core::slice::from_raw_parts(data, len as usize) })
 }
 
 /// Copy the whole visible grid, row-major, into `out` (must hold cols*rows cells).

--- a/src/Agwinterm.Core/RustEmulatorCore.cs
+++ b/src/Agwinterm.Core/RustEmulatorCore.cs
@@ -16,7 +16,7 @@ namespace Agwinterm.Core;
 /// </summary>
 public sealed unsafe class RustEmulatorCore : IDisposable
 {
-    public const uint RequiredAbi = 7;
+    public const uint RequiredAbi = 8;
 
     [StructLayout(LayoutKind.Sequential)]
     public struct Info
@@ -97,6 +97,15 @@ public sealed unsafe class RustEmulatorCore : IDisposable
             _freeBuf = Get<FreeBufFn>("agwcore_free_buf");
             _marks = Get<EmuMarksFn>("agwcore_emu_marks");
             _seed = Get<EmuSeedFn>("agwcore_emu_seed_scrollback");
+            _placementCount = Get<EmuPlacementCountFn>("agwcore_emu_placement_count");
+            _copyPlacements = Get<EmuCopyPlacementsFn>("agwcore_emu_copy_placements");
+            _imageMetas = Get<EmuImageMetasFn>("agwcore_emu_image_metas");
+            _copyImageData = Get<EmuCopyImageDataFn>("agwcore_emu_copy_image_data");
+            _hasImage = Get<EmuHasImageFn>("agwcore_emu_has_image");
+            _clearPlacements = Get<EmuClearPlacementsFn>("agwcore_emu_clear_placements");
+            _setImageData = Get<EmuSetImageDataFn>("agwcore_emu_set_image_data");
+            _placeImage = Get<EmuPlaceImageFn>("agwcore_emu_place_image");
+            _placeSixel = Get<EmuPlaceSixelFn>("agwcore_emu_place_sixel");
             _lib = lib;
             return true;
         }
@@ -191,6 +200,82 @@ public sealed unsafe class RustEmulatorCore : IDisposable
     {
         byte[] bytes = System.Text.Encoding.UTF8.GetBytes(joinedLines);
         fixed (byte* p = bytes.Length == 0 ? new byte[1] : bytes) _seed(_handle, p, (uint)bytes.Length);
+    }
+
+    // ---- images (ABI v8) ----
+    [StructLayout(LayoutKind.Sequential)]
+    public struct NativePlacement
+    {
+        public int ImageId;
+        public long Row, Col;
+        public int Cols, Rows, SrcX, SrcY, SrcW, SrcH;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct NativeImageMeta
+    {
+        public int Id, Format, Width, Height;
+        public uint DataLen;
+    }
+
+    private delegate uint EmuPlacementCountFn(nint p);
+    private delegate uint EmuCopyPlacementsFn(nint p, NativePlacement* o, uint cap);
+    private delegate uint EmuImageMetasFn(nint p, NativeImageMeta* o, uint cap);
+    private delegate uint EmuCopyImageDataFn(nint p, int id, byte* o, uint cap);
+    private delegate bool EmuHasImageFn(nint p, int id);
+    private delegate void EmuClearPlacementsFn(nint p);
+    private delegate bool EmuSetImageDataFn(nint p, int id, int format, int width, int height, byte* data, uint len);
+    private delegate bool EmuPlaceImageFn(nint p, int id, long row, long col, int cols, int rows, int sx, int sy, int sw, int sh);
+    private delegate bool EmuPlaceSixelFn(nint p, byte* data, uint len);
+    private static EmuPlacementCountFn _placementCount = null!;
+    private static EmuCopyPlacementsFn _copyPlacements = null!;
+    private static EmuImageMetasFn _imageMetas = null!;
+    private static EmuCopyImageDataFn _copyImageData = null!;
+    private static EmuHasImageFn _hasImage = null!;
+    private static EmuClearPlacementsFn _clearPlacements = null!;
+    private static EmuSetImageDataFn _setImageData = null!;
+    private static EmuPlaceImageFn _placeImage = null!;
+    private static EmuPlaceSixelFn _placeSixel = null!;
+
+    public NativePlacement[] GetPlacements()
+    {
+        uint count = _placementCount(_handle);
+        if (count == 0) return Array.Empty<NativePlacement>();
+        var arr = new NativePlacement[count];
+        uint n; fixed (NativePlacement* p = arr) n = _copyPlacements(_handle, p, count);
+        return n == count ? arr : arr[..(int)n];
+    }
+
+    public NativeImageMeta[] GetImageMetas()
+    {
+        // Images are few; grow the buffer until the returned count fits inside it.
+        for (int cap = 16; ; cap *= 2)
+        {
+            var arr = new NativeImageMeta[cap];
+            uint n; fixed (NativeImageMeta* p = arr) n = _imageMetas(_handle, p, (uint)cap);
+            if (n < cap) return n == 0 ? Array.Empty<NativeImageMeta>() : arr[..(int)n];
+        }
+    }
+
+    public byte[] GetImageData(int id, int dataLen)
+    {
+        if (dataLen <= 0) return Array.Empty<byte>();
+        var buf = new byte[dataLen];
+        uint n; fixed (byte* p = buf) n = _copyImageData(_handle, id, p, (uint)dataLen);
+        return n == dataLen ? buf : buf[..(int)n];
+    }
+
+    public bool HasImage(int id) => _hasImage(_handle, id);
+    public void ClearPlacements() => _clearPlacements(_handle);
+    public void SetImageData(int id, int format, int width, int height, byte[] data)
+    {
+        fixed (byte* p = data.Length == 0 ? new byte[1] : data) _setImageData(_handle, id, format, width, height, p, (uint)data.Length);
+    }
+    public void PlaceImage(int id, int row, int col, int cols, int rows, int sx, int sy, int sw, int sh)
+        => _placeImage(_handle, id, row, col, cols, rows, sx, sy, sw, sh);
+    public bool PlaceSixel(byte[] data)
+    {
+        fixed (byte* p = data.Length == 0 ? new byte[1] : data) return _placeSixel(_handle, p, (uint)data.Length);
     }
 
     private string GetText(uint which)

--- a/src/Agwinterm.Core/RustTerminalCore.cs
+++ b/src/Agwinterm.Core/RustTerminalCore.cs
@@ -9,9 +9,10 @@ namespace Agwinterm.Core;
 /// reads (renderer snapshots, selection, dumps) stay lock-cheap managed accesses with
 /// unchanged semantics. All calls run under the session lock per the ISession contract.
 ///
-/// Phase-2 gaps (documented in the config text): host actions are not invoked
-/// (no OSC 52 clipboard / notifications / kitty-query responses), and images
-/// (kitty/sixel) are not surfaced — panes that need those want the managed core.
+/// Images (kitty/sixel) ARE surfaced as of ABI v8: the Rust core decodes them and this
+/// adapter exposes <see cref="Images"/> / <see cref="Placements"/> (see SyncImages).
+/// Remaining phase-2 gap: host actions are not invoked (no OSC 52 clipboard /
+/// notifications / kitty-query responses) — panes that need those want the managed core.
 /// </summary>
 public sealed class RustTerminalCore : ITerminalCore, IDisposable
 {
@@ -61,6 +62,7 @@ public sealed class RustTerminalCore : ITerminalCore, IDisposable
         _title = _rust.Title;
         _cwd = _rust.Cwd;
         _marks = _rust.GetMarks();
+        SyncImages();   // stream-delivered kitty/sixel become visible on the next frame
     }
 
     // ---- content ----
@@ -114,17 +116,57 @@ public sealed class RustTerminalCore : ITerminalCore, IDisposable
     // ---- host actions: stored but never invoked by the Rust core (phase 2) ----
     public IHostActions? Host { get; set; }
 
-    // ---- images: not surfaced in the experimental phase ----
-    private static readonly Dictionary<int, KittyImage> NoImages = new();
-    private static readonly List<ImagePlacement> NoPlacements = new();
-    public IReadOnlyDictionary<int, KittyImage> Images => NoImages;
-    public IReadOnlyList<ImagePlacement> Placements => NoPlacements;
-    public void ClearPlacements() { }
-    public bool HasImage(int id) => false;
-    public void SetImageData(int id, KittyFormat format, int width, int height, byte[] data) { }
+    // ---- images (ABI v8): surfaced from the Rust core; KittyImage pixels cached per id so the
+    // renderer uploads a texture only once, refreshed on Sync when the id set changes. ----
+    private readonly Dictionary<int, KittyImage> _imageCache = new();
+    private List<ImagePlacement> _placements = new();
+
+    private void SyncImages()
+    {
+        var metas = _rust.GetImageMetas();
+        // Add newly-transmitted images (fetch pixels once); drop images the core no longer holds.
+        var live = new HashSet<int>(metas.Length);
+        foreach (var m in metas)
+        {
+            live.Add(m.Id);
+            if (!_imageCache.ContainsKey(m.Id))
+                _imageCache[m.Id] = new KittyImage(m.Id, (KittyFormat)m.Format, m.Width, m.Height,
+                    _rust.GetImageData(m.Id, (int)m.DataLen));
+        }
+        if (_imageCache.Count > live.Count)
+            foreach (var id in _imageCache.Keys.Where(k => !live.Contains(k)).ToList())
+                _imageCache.Remove(id);
+
+        var pls = _rust.GetPlacements();
+        var list = new List<ImagePlacement>(pls.Length);
+        foreach (var p in pls)
+            list.Add(new ImagePlacement(p.ImageId, (int)p.Row, (int)p.Col, p.Cols, p.Rows, p.SrcX, p.SrcY, p.SrcW, p.SrcH));
+        _placements = list;
+    }
+
+    public IReadOnlyDictionary<int, KittyImage> Images => _imageCache;
+    public IReadOnlyList<ImagePlacement> Placements => _placements;
+    public void ClearPlacements() { _rust.ClearPlacements(); _placements = new(); }
+    public bool HasImage(int id) => _rust.HasImage(id);
+    public void SetImageData(int id, KittyFormat format, int width, int height, byte[] data)
+    {
+        _rust.SetImageData(id, (int)format, width, height, data);
+        SyncImages();
+    }
     public void PlaceImage(int id, int row, int col, int cols, int rows,
-        int srcX = 0, int srcY = 0, int srcW = 0, int srcH = 0) { }
-    public bool PlaceSixel(byte[] data) => false;
+        int srcX = 0, int srcY = 0, int srcW = 0, int srcH = 0)
+    {
+        _rust.PlaceImage(id, row, col, cols, rows, srcX, srcY, srcW, srcH);
+        SyncImages();
+    }
+    public bool PlaceSixel(byte[] data)
+    {
+        bool ok = _rust.PlaceSixel(data);
+        if (ok) { Sync(); }   // sixel advances the cursor + scrolls, so refresh everything
+        return ok;
+    }
+    // Cell pixel size for sixel layout — mirror to the Rust core is not needed (defaults match);
+    // exposed for interface parity.
     public int CellPixelWidth { get; set; } = 8;
     public int CellPixelHeight { get; set; } = 18;
 

--- a/src/Agwinterm.Core/TerminalConfig.cs
+++ b/src/Agwinterm.Core/TerminalConfig.cs
@@ -90,8 +90,8 @@ public sealed class TerminalConfig
     /// <summary>Which terminal core new sessions run on: "managed" (default — the C#
     /// TerminalEmulator) or "rust" (EXPERIMENTAL — the oracle-validated agwinterm-core crate
     /// behind the ITerminalCore seam; falls back to managed with a toast when the native dll
-    /// is missing). Known gaps in rust mode: kitty/sixel images and OSC host actions
-    /// (clipboard writes, notifications, kitty-keyboard query replies).</summary>
+    /// is missing). kitty/sixel images ARE surfaced (ABI v8); remaining gap in rust mode:
+    /// OSC host actions (clipboard writes, notifications, kitty-keyboard query replies).</summary>
     public string EmulatorCore { get; set; } = "managed";
 
     /// <summary>Rebuild each new session's environment from the registry at spawn (WT's
@@ -275,8 +275,8 @@ public sealed class TerminalConfig
         # Terminal core for NEW sessions: "managed" (default) or "rust" (EXPERIMENTAL - the
         # Rust agwinterm-core crate, differentially validated against the managed emulator).
         # Applies to sessions created after the change; falls back to managed with a toast if
-        # the native dll is missing. Known gaps in rust mode: kitty/sixel images and OSC host
-        # actions (clipboard writes, desktop notifications, kitty-keyboard query replies).
+        # the native dll is missing. kitty/sixel images are surfaced; remaining gap in rust
+        # mode: OSC host actions (clipboard writes, desktop notifications, kitty-keyboard replies).
         emulator-core = managed
 
         # Blocked sound: play a sound whenever a session enters the "blocked" agent status (needs

--- a/tests/Agwinterm.Core.Tests/RustEmulatorCoreTests.cs
+++ b/tests/Agwinterm.Core.Tests/RustEmulatorCoreTests.cs
@@ -18,7 +18,7 @@ public class RustEmulatorCoreTests
         var dir = new DirectoryInfo(AppContext.BaseDirectory);
         while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Agwinterm.slnx"))) dir = dir.Parent;
         if (dir is null) return false;
-        string dll = Path.Combine(dir.FullName, "native", "agwinterm-core", "target", "release", "agwinterm_core.dll");
+        string dll = Path.Combine(dir.FullName, "native", "target", "release", "agwinterm_core.dll");
         return RustEmulatorCore.TryLoad(dll, out _);
     }
 
@@ -111,5 +111,46 @@ public class RustEmulatorCoreTests
     {
         Assert.False(RustEmulatorCore.TryLoad(@"C:\nope\missing.dll", out var err) && !RustEmulatorCore.Loaded);
         if (!RustEmulatorCore.Loaded) Assert.NotNull(err);
+    }
+
+    [Fact]
+    public void Adapter_SurfacesSixelImages_LikeManagedCore()
+    {
+        if (!Available) return;
+        // A tiny sixel: "Pq" introducer, colour 1 select, three full sixels, ST.
+        byte[] sixel = System.Text.Encoding.ASCII.GetBytes("\x1bPq#1~~~\x1b\\");
+        var cs = new TerminalEmulator(20, 6);
+        using var rust = new RustTerminalCore(20, 6);
+        cs.Feed(sixel);
+        rust.Feed(sixel);
+
+        // Both must decode ONE image + ONE placement, with matching pixel dimensions and data.
+        Assert.Single(cs.Placements);
+        Assert.Single(rust.Placements);
+        Assert.Equal(cs.Placements[0].Cols, rust.Placements[0].Cols);
+        Assert.Equal(cs.Placements[0].Rows, rust.Placements[0].Rows);
+
+        var csImg = cs.Images.Values.Single();
+        var rustImg = rust.Images.Values.Single();
+        Assert.Equal(csImg.Width, rustImg.Width);
+        Assert.Equal(csImg.Height, rustImg.Height);
+        Assert.Equal(csImg.Data.Length, rustImg.Data.Length);
+        Assert.Equal(csImg.Data, rustImg.Data);   // identical RGBA — the whole point
+    }
+
+    [Fact]
+    public void Adapter_DirectImageApi_RoundTrips()
+    {
+        if (!Available) return;
+        using var rust = new RustTerminalCore(10, 4);
+        Assert.False(rust.HasImage(7));
+        rust.SetImageData(7, KittyFormat.Rgba, 2, 2, new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 });
+        Assert.True(rust.HasImage(7));
+        rust.PlaceImage(7, 1, 2, 3, 3);
+        var p = Assert.Single(rust.Placements);
+        Assert.Equal((7, 1, 2, 3, 3), (p.ImageId, p.Row, p.Col, p.Cols, p.Rows));
+        Assert.Equal(16, rust.Images[7].Data.Length);
+        rust.ClearPlacements();
+        Assert.Empty(rust.Placements);
     }
 }

--- a/tests/Agwinterm.Core.Tests/RustParityTests.cs
+++ b/tests/Agwinterm.Core.Tests/RustParityTests.cs
@@ -19,7 +19,7 @@ public class RustParityTests
         var dir = new DirectoryInfo(AppContext.BaseDirectory);
         while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Agwinterm.slnx"))) dir = dir.Parent;
         if (dir is null) return 0;
-        string dll = Path.Combine(dir.FullName, "native", "agwinterm-core", "target", "release", "agwinterm_core.dll");
+        string dll = Path.Combine(dir.FullName, "native", "target", "release", "agwinterm_core.dll");
         return File.Exists(dll) && NativeLibrary.TryLoad(dll, out nint h) ? h : 0;
     }
 


### PR DESCRIPTION
## What

Closes the **image gap** for `emulator-core = rust`. The Rust emulator already decodes kitty/sixel images (it maintains `images` + `placements`), but the `ITerminalCore` adapter stubbed them out — so rust-mode panes rendered no graphics. This exposes the already-decoded images across the C ABI and surfaces them in the adapter, bringing rust-mode to parity with the managed core for images.

## Changes

- **native/agwinterm-core**: ABI `7 → 8`. New public image API on `Emulator` (`clear_placements`/`has_image`/`set_image_data`/`place_image`/`place_sixel_public`) and FFI exports (`placement_count`, `copy_placements`, `image_metas`, `copy_image_data`, `has_image`, `clear_placements`, `set_image_data`, `place_image`, `place_sixel`).
- **RustEmulatorCore.cs**: `RequiredAbi = 8`; marshals `NativePlacement`/`NativeImageMeta`, binds the 9 new exports (grow-loop for image metas).
- **RustTerminalCore.cs**: `SyncImages()` surfaces `Images`/`Placements` with a **per-id pixel cache** so the renderer uploads each texture only once; forwards the direct-image API (control-pipe delivery). Runs on every `Sync()`.
- **lite**: `kRequiredAbi 7 → 8` so the lite client accepts the v8 core dll. Lite uses only the base FFI, so the new exports don't affect it — but the hard ABI check would otherwise `fatal()` on the shared v8 dll.
- **tests**: two adapter tests — sixel surfacing vs the managed core (identical RGBA), and a direct-image round-trip. Also fixes the test dll-load paths to the **workspace target** (`native/target/release`); the old member-dir path (`native/agwinterm-core/target/release`) is a stale pre-workspace leftover that returned ABI 7 — which is exactly what made `AbiVersion_Matches` fail and silently skipped the image tests.
- **docs**: rust-mode gap notes updated — images now surfaced; OSC host actions remain the open phase-2 gap.

## Verification

- `dotnet test --filter ~Rust` → **15 passed, 0 skipped** (image tests now actually run against the workspace dll, not vacuously skipped).
- lite rebuilds clean against the v8 dll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)