### PR TITLE
feat(installer): bundle both terminals, default both to the Rust pty-host

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -3,6 +3,12 @@
 Builds a **per-user** Windows installer (`agwinterm-setup-<ver>.exe`) from a self-contained
 publish of the app — end users need **no** .NET runtime installed.
 
+It installs **both terminals**: the full `agwinterm` (.NET) app and the lightweight
+`agwinterm-lite` (C++/GDI) client for old / low-RAM machines. Both ride the **Rust pty-host**
+(`agwinterm-ptyhost.exe`) — lite always does, and the main app's shortcuts pass
+`--default-session-host server-rust` so a fresh install defaults new sessions to it (a first-run
+seed only; it never overrides an existing config, and the Settings UI stays authoritative after).
+
 ## Build
 
 ```powershell
@@ -11,14 +17,18 @@ installer\build.ps1
 
 Prereqs:
 - .NET SDK with the `net10.0-windows` target (the repo pins .NET 10).
-- [Inno Setup 6](https://jrsoftware.org/isinfo.php) — `ISCC.exe` on PATH or in the default install location.
+- Rust + MSVC C++ build tools (for the Rust core/host and the lite client).
+- [Inno Setup 6](https://jrsoftware.org/isinfo.php) — `ISCC.exe` on PATH, the default install location,
+  or the per-user winget location (`winget install JRSoftware.InnoSetup`).
 
 The script:
 1. publishes `Agwinterm.Win32` (the app) and `Agwinterm.Ctl` (`agwintermctl`) as **self-contained win-x64**
    (a folder, not single-file — robust for the Vortice native libs and the on-disk `themes\`/`assets\`)
    into `installer\stage`,
-2. compiles `installer\agwinterm.iss`,
-3. writes `installer\Output\agwinterm-setup-<ver>.exe`.
+2. builds the Rust core + pty-host and the `agwinterm-lite` client, and stages them (lite flat next to
+   the main app so it shares the same `agwinterm_core.dll` / `agwinterm-ptyhost.exe`),
+3. compiles `installer\agwinterm.iss`,
+4. writes `installer\Output\agwinterm-setup-<ver>.exe`.
 
 ## What the installer does
 
@@ -26,9 +36,9 @@ Deliberately **minimal / non-invasive** (agterm-style): it only copies files and
 It does **not** touch your `PATH`, profile, or config.
 
 - **Per-user, no admin** (`PrivilegesRequired=lowest`); installs to `%LOCALAPPDATA%\Programs\agwinterm`.
-- **Start-menu** shortcut always; **desktop** shortcut via a checkbox (task).
+- **Start-menu** shortcuts for both `agwinterm` and `agwinterm lite`; **desktop** shortcuts for both via a checkbox (task).
 - **Launch on finish**: a "Launch agwinterm" checkbox (interactive installs).
-- **Uninstall** removes the app files.
+- **Uninstall** removes the app files (your `%LOCALAPPDATA%\agwinterm` config/sessions are left intact).
 
 ### Integrations are opt-in (from inside the app)
 

--- a/installer/agwinterm.iss
+++ b/installer/agwinterm.iss
@@ -4,7 +4,11 @@
 #define AppName    "agwinterm"
 #define AppVersion "0.14.7"
 #define AppExe     "Agwinterm.Win32.exe"
+#define LiteExe    "agwinterm-lite.exe"
 #define AppPublisher "Boris Kudriashov"
+; Both terminals default new sessions to the Rust pty-host. The main app reads this as a
+; first-run seed only (it never overrides an existing config); lite always uses the Rust host.
+#define RustHostArg "--default-session-host server-rust"
 
 [Setup]
 AppId={{A7E3F1C2-5B9D-4E6A-8C21-3F0D9B4A7E15}
@@ -33,18 +37,23 @@ OutputBaseFilename=agwinterm-setup-{#AppVersion}
 ; writes to the user's profile/config behind their back.
 
 [Tasks]
-Name: "desktopicon"; Description: "Create a &desktop shortcut"; GroupDescription: "Shortcuts:"
+Name: "desktopicon"; Description: "Create &desktop shortcuts (both terminals)"; GroupDescription: "Shortcuts:"
 
 [Files]
 Source: "stage\*"; DestDir: "{app}"; Flags: recursesubdirs createallsubdirs ignoreversion
 
 [Icons]
-Name: "{autoprograms}\{#AppName}"; Filename: "{app}\{#AppExe}"; IconFilename: "{app}\assets\agwinterm.ico"
-Name: "{autodesktop}\{#AppName}";  Filename: "{app}\{#AppExe}"; IconFilename: "{app}\assets\agwinterm.ico"; Tasks: desktopicon
+; Main terminal — its shortcut seeds server-rust on a first run (harmless once configured).
+Name: "{autoprograms}\{#AppName}"; Filename: "{app}\{#AppExe}"; Parameters: "{#RustHostArg}"; IconFilename: "{app}\assets\agwinterm.ico"
+Name: "{autodesktop}\{#AppName}";  Filename: "{app}\{#AppExe}"; Parameters: "{#RustHostArg}"; IconFilename: "{app}\assets\agwinterm.ico"; Tasks: desktopicon
+; Lite terminal — always rides the Rust pty-host; uses the main app's icon.
+Name: "{autoprograms}\{#AppName} lite"; Filename: "{app}\{#LiteExe}"; IconFilename: "{app}\assets\agwinterm.ico"
+Name: "{autodesktop}\{#AppName} lite";  Filename: "{app}\{#LiteExe}"; IconFilename: "{app}\assets\agwinterm.ico"; Tasks: desktopicon
 
 [Run]
-; Launch-on-finish checkbox (interactive installs only).
-Filename: "{app}\{#AppExe}"; Description: "Launch {#AppName}"; Flags: nowait postinstall skipifsilent
+; Launch-on-finish checkbox (interactive installs only) — passes the seed so the very first run
+; (typically this launch) defaults the main app to the Rust pty-host.
+Filename: "{app}\{#AppExe}"; Parameters: "{#RustHostArg}"; Description: "Launch {#AppName}"; Flags: nowait postinstall skipifsilent
 
 [UninstallDelete]
 Type: filesandordirs; Name: "{app}"

--- a/installer/build.ps1
+++ b/installer/build.ps1
@@ -7,13 +7,16 @@ $root   = Split-Path -Parent $here
 $dotnet = if (Test-Path "C:\Program Files\dotnet\dotnet.exe") { "C:\Program Files\dotnet\dotnet.exe" } else { "dotnet" }
 $stage  = Join-Path $here "stage"
 
-# resolve ISCC (Inno Setup compiler)
+# resolve ISCC (Inno Setup compiler): PATH, the machine-wide installs (choco/CI land here), and
+# the per-user winget location (%LOCALAPPDATA%\Programs) so a `winget install JRSoftware.InnoSetup`
+# is found too.
 $iscc = (Get-Command iscc.exe -ErrorAction SilentlyContinue).Source
 if (-not $iscc) {
-  $iscc = @("${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe", "$env:ProgramFiles\Inno Setup 6\ISCC.exe") |
+  $iscc = @("${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe", "$env:ProgramFiles\Inno Setup 6\ISCC.exe",
+            "$env:LOCALAPPDATA\Programs\Inno Setup 6\ISCC.exe") |
     Where-Object { Test-Path $_ } | Select-Object -First 1
 }
-if (-not $iscc) { throw "ISCC (Inno Setup compiler) not found. Install Inno Setup 6." }
+if (-not $iscc) { throw "ISCC (Inno Setup compiler) not found. Install Inno Setup 6 (winget install JRSoftware.InnoSetup)." }
 
 Write-Host "== clean stage ==" -ForegroundColor Cyan
 if (Test-Path $stage) { Remove-Item -Recurse -Force $stage }
@@ -46,8 +49,18 @@ if ($LASTEXITCODE -ne 0) { throw "cargo build (native) failed" }
 Copy-Item (Join-Path $root "native\target\release\agwinterm_core.dll") $stage -Force
 Copy-Item (Join-Path $root "native\target\release\agwinterm-ptyhost.exe") $stage -Force
 
+# The lite terminal (agwinterm-lite.exe): a tiny GDI client that rides the SAME Rust pty-host +
+# core dll (both already staged above), so we install both terminals from one setup. It's staged
+# FLAT next to the main app so lite finds agwinterm_core.dll / agwinterm-ptyhost.exe in its own
+# exe dir; only its bundled font + license are unique to it.
+Write-Host "== build agwinterm-lite (C++/GDI) ==" -ForegroundColor Cyan
+& (Join-Path $root "lite\build.ps1")
+if ($LASTEXITCODE -ne 0) { throw "lite build failed" }
+Copy-Item (Join-Path $root "lite\bin\agwinterm-lite.exe") $stage -Force
+Copy-Item (Join-Path $root "lite\assets\*") $stage -Force   # MesloLGLDZ Nerd Font + FONT-LICENSE
+
 # sanity: required payload present
-foreach ($f in @("Agwinterm.Win32.exe","agwintermctl.exe","agwinterm_core.dll","agwinterm-ptyhost.exe","assets\agwinterm.ico")) {
+foreach ($f in @("Agwinterm.Win32.exe","agwintermctl.exe","agwinterm_core.dll","agwinterm-ptyhost.exe","agwinterm-lite.exe","MesloLGLDZNerdFont-Regular.ttf","assets\agwinterm.ico")) {
   if (-not (Test-Path (Join-Path $stage $f))) { throw "stage missing $f" }
 }
 if (-not (Get-ChildItem (Join-Path $stage "themes") -Filter *.conf -ErrorAction SilentlyContinue)) { throw "stage missing themes\*.conf" }

--- a/src/Agwinterm.Win32/Program.Services.cs
+++ b/src/Agwinterm.Win32/Program.Services.cs
@@ -1572,10 +1572,23 @@ internal partial class Program
             if (!File.Exists(path))
             {
                 Directory.CreateDirectory(Path.GetDirectoryName(path)!);
-                File.WriteAllText(path, TerminalConfig.DefaultText);
+                File.WriteAllText(path, SeedConfigText());
             }
             return TerminalConfig.Load(path);
         }
         catch { return new TerminalConfig(); }
+    }
+
+    // The first-run config template. Honors --default-session-host (the installer passes
+    // "server-rust" so a fresh install defaults new sessions to the Rust pty-host) without
+    // touching the compiled global default — existing configs are never rewritten, and the
+    // Settings UI stays authoritative from then on. Unknown values leave the template as-is.
+    private static string SeedConfigText()
+    {
+        string text = TerminalConfig.DefaultText;
+        if (_argDefaultSessionHost is "in-process" or "server" or "server-rust")
+            text = System.Text.RegularExpressions.Regex.Replace(
+                text, @"(?m)^(\s*session-host\s*=).*$", "$1 " + _argDefaultSessionHost);
+        return text;
     }
 }

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -382,6 +382,7 @@ internal partial class Program : ISessionHost, IWindowHost
     private static string? _argDir;
     private static bool _argMaximized, _argFullscreen;
     private static bool _argPtyHost;   // run as the headless pty-host (#105) instead of a window
+    private static string? _argDefaultSessionHost;   // first-run seed for session-host (installer hook)
 
     private static void ParseLaunchArgs(string[] args)
     {
@@ -396,6 +397,7 @@ internal partial class Program : ISessionHost, IWindowHost
                 case "--no-restore": _argNoRestore = true; break;
                 case "--pipe" when i + 1 < args.Length: _argPipe = args[++i]; break;
                 case "--pty-host": _argPtyHost = true; break;
+                case "--default-session-host" when i + 1 < args.Length: _argDefaultSessionHost = args[++i]; break;
                 case "--app-id" when i + 1 < args.Length: ++i; break; // consumed by ResolveAppId (namespaces data dir + pipe)
                 // unknown args are ignored (forward compatibility)
             }


### PR DESCRIPTION
## What

One setup now installs **both terminals** and wires both to the **Rust pty-host** (`agwinterm-ptyhost.exe`), so a fresh install is rust-server by default:

- **agwinterm** — the full `Agwinterm.Win32` (.NET) app
- **agwinterm lite** — the lightweight C++/GDI client for old / low-RAM machines

Both ride the same `agwinterm-ptyhost.exe` + `agwinterm_core.dll` (already staged for the main app). Lite is rust-server-only by nature; the main app is nudged to it via a first-run seed.

## Changes

- **installer/build.ps1**: builds the lite client and stages it **flat** next to the main app (so lite finds `agwinterm_core.dll` / `agwinterm-ptyhost.exe` in its own exe dir — no duplication); stages lite's bundled Nerd Font + license; adds both to the payload sanity check. Also resolves `ISCC` from the **per-user winget location** (`%LOCALAPPDATA%\Programs\Inno Setup 6`) so a local `winget install JRSoftware.InnoSetup` build works, not just choco/CI.
- **agwinterm.iss**: Start-menu + (opt-in) desktop shortcuts for **agwinterm lite**; the main app's shortcuts and launch-on-finish pass `--default-session-host server-rust`.
- **app** (`Program.cs` / `Program.Services.cs`): new `--default-session-host` arg — a **first-run seed** for the config's `session-host`. It applies **only when no config exists yet**; it never rewrites an existing config and never touches the compiled global default (still `in-process`). So the Settings UI stays authoritative and existing users are untouched.

## Design notes

- **No global default flip.** `session-host`'s compiled default stays `in-process` (the global default-flip decision remains yours, per the dogfooding plan). The installer opts *its* installs into server-rust via the seed; `server-rust` already falls back to in-process if the host binary is missing, so it's safe.
- **Lite is now a required payload.** Bundling it into the main installer promotes it from a best-effort separate artifact to a required one — a lite build failure now fails the installer build. The standalone lite zip in `release.yml` stays best-effort (`continue-on-error`).

## Verification

- Full installer build green **locally**: `agwinterm-setup-0.14.7.exe` (29.6 MB, 798 files), both exes + font staged, ISCC compile clean.
- Seed verified functionally: launching with `--default-session-host server-rust` (throwaway app-id) wrote `session-host = server-rust` into a fresh config while preserving the full commented template; cleaned up after.
- `ci.yml` already builds `lite/build.ps1` every push and runs the .NET suite; the `.iss` itself is compiled at release time (`release.yml` choco-installs Inno Setup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)