### PR TITLE
feat(rust-core): wire OSC host actions over ABI v9 (close last emulator-core=rust gap)

### DIFF
--- a/lite/src/main.cpp
+++ b/lite/src/main.cpp
@@ -23,7 +23,7 @@
 #include "proto/pb_decode.h"
 #include "control.h"
 
-// ---- agwinterm-core C ABI (ABI v8) ----
+// ---- agwinterm-core C ABI (ABI v9) ----
 struct FfiCell {
     int32_t rune;
     uint32_t fg, bg, attrs, width;
@@ -52,7 +52,7 @@ static bool (*emu_copy_grid)(void*, FfiCell*, uint32_t);
 static bool (*emu_copy_history_row)(void*, uint32_t, FfiCell*, uint32_t);
 static uint32_t (*emu_marks)(void*, FfiMark*, uint32_t);
 
-static constexpr uint32_t kRequiredAbi = 8;
+static constexpr uint32_t kRequiredAbi = 9;
 static constexpr uint32_t kAttrBold = 1, kAttrItalic = 2, kAttrUnderline = 4,
                           kAttrInverse = 8, kAttrDim = 16, kAttrStrike = 32;
 static constexpr uint32_t kProtocolVersion = 2;
@@ -187,7 +187,7 @@ static void loadCore() {
     emu_marks = (decltype(emu_marks))GetProcAddress(m, "agwcore_emu_marks");
     if (!core_abi || !emu_new || !emu_feed || !emu_info || !emu_copy_grid || !emu_resize || !emu_free || !emu_copy_history_row || !emu_marks)
         fatal(L"agwinterm_core.dll: exports missing");
-    if (core_abi() != kRequiredAbi) fatal(L"agwinterm_core.dll: ABI mismatch (need v8)");
+    if (core_abi() != kRequiredAbi) fatal(L"agwinterm_core.dll: ABI mismatch (need v9)");
 }
 
 static void connectControl() {

--- a/native/agwinterm-core/src/emulator.rs
+++ b/native/agwinterm-core/src/emulator.rs
@@ -158,6 +158,21 @@ pub struct Emulator {
     sixel_seq: i32,
     pub cell_pixel_width: i32,
     pub cell_pixel_height: i32,
+
+    // Host actions (the IHostActions seam) queued during feed and drained by the C# adapter
+    // after each feed — the Rust core is headless, so it can't invoke the host directly.
+    host_actions: Vec<HostAction>,
+}
+
+/// One host-visible side effect the embedder must perform — the Rust mirror of the C#
+/// `IHostActions` members. Queued during dispatch, drained (and cleared) after each feed.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum HostAction {
+    Notify { title: String, body: String },
+    Progress { state: i32, value: i32 },
+    Clipboard { text: String },
+    Respond { reply: String },
+    Unhandled { kind: String, detail: String },
 }
 
 impl Emulator {
@@ -198,6 +213,21 @@ impl Emulator {
             sixel_seq: -1,
             cell_pixel_width: 8,
             cell_pixel_height: 18,
+            host_actions: Vec::new(),
+        }
+    }
+
+    /// Drain the queued host actions (Notify/Progress/Clipboard/Respond/Unhandled), clearing
+    /// the queue. The C# adapter calls this after each feed and forwards them to `IHostActions`.
+    pub fn take_host_actions(&mut self) -> Vec<HostAction> {
+        core::mem::take(&mut self.host_actions)
+    }
+
+    fn push_action(&mut self, a: HostAction) {
+        // Defensive cap: one feed rarely emits more than a handful; the C# adapter drains after
+        // every feed, so this only bounds a pathological producer that the adapter never reads.
+        if self.host_actions.len() < 4096 {
+            self.host_actions.push(a);
         }
     }
 
@@ -574,7 +604,10 @@ impl Emulator {
                 1003 => self.mouse_motion = set,
                 1006 => self.mouse_sgr = set,
                 2004 => self.bracketed_paste = set,
-                _ => {} // Host.Unhandled — headless drop
+                _ => self.push_action(HostAction::Unhandled {
+                    kind: "MODE".into(),
+                    detail: format!("?{mode} {}", if set { 'h' } else { 'l' }),
+                }),
             }
         }
     }
@@ -754,7 +787,11 @@ impl Emulator {
 
     fn kitty_keyboard(&mut self, prefix: u8, params: &[i32]) {
         match prefix {
-            b'?' => {} // query — Host.Respond, headless drop
+            b'?' => {
+                // query — report the current flags back to the PTY (CSI ? <flags> u).
+                let reply = format!("\u{1b}[?{}u", self.keyboard_flags());
+                self.push_action(HostAction::Respond { reply });
+            }
             b'>' => self.kbd_stack.push(*params.first().unwrap_or(&0)),
             b'=' => {
                 let flags = *params.first().unwrap_or(&0);
@@ -874,7 +911,11 @@ impl Performer for Emulator {
                 let cols = self.screen().cols();
                 self.cursor_col = (cols - 1).min((self.cursor_col / 8 + 1) * 8);
             }
-            _ => {} // NUL ignored; others → Host.Unhandled (headless drop)
+            0 => {} // NUL — historical padding, deliberately ignored (would flood the tap)
+            _ => self.push_action(HostAction::Unhandled {
+                kind: "C0".into(),
+                detail: format!("0x{control:02X}"),
+            }),
         }
     }
 
@@ -888,7 +929,10 @@ impl Performer for Emulator {
                 self.cursor_col = 0;
                 self.index();
             }
-            _ => {}
+            _ => self.push_action(HostAction::Unhandled {
+                kind: "ESC".into(),
+                detail: (ch as char).to_string(),
+            }),
         }
     }
 
@@ -908,6 +952,11 @@ impl Performer for Emulator {
         if prefix == b'?' {
             if ch == b'h' || ch == b'l' {
                 self.set_private_mode(params, ch == b'h');
+            } else {
+                self.push_action(HostAction::Unhandled {
+                    kind: "CSI".into(),
+                    detail: format!("? {} {}", join_params(params), ch as char),
+                });
             }
             return;
         }
@@ -950,7 +999,13 @@ impl Performer for Emulator {
                     self.scroll_region_down();
                 }
             }
-            _ => {}
+            _ => {
+                let pfx = if prefix == 0 { String::new() } else { format!("{} ", prefix as char) };
+                self.push_action(HostAction::Unhandled {
+                    kind: "CSI".into(),
+                    detail: format!("{pfx}{} {}", join_params(params), ch as char),
+                });
+            }
         }
     }
 
@@ -960,13 +1015,74 @@ impl Performer for Emulator {
             0 | 2 => self.title = text,
             7 => self.cwd = text,
             133 => self.ftcs_dispatch(&text),
-            _ => {} // 9/777/52: Host-only side effects; others → Unhandled (headless drop)
+            9 => {
+                // OSC 9;<message> — body-only notification; OSC 9;4;<state>;<value> = ConEmu/WT progress.
+                if let Some(rest) = text.strip_prefix("4;") {
+                    let pp: Vec<&str> = rest.split(';').collect();
+                    let state = pp.first().and_then(|s| s.parse::<i32>().ok()).unwrap_or(0);
+                    let value = pp
+                        .get(1)
+                        .and_then(|s| s.parse::<i32>().ok())
+                        .map(|v| v.clamp(0, 100))
+                        .unwrap_or(0);
+                    self.push_action(HostAction::Progress { state, value });
+                } else {
+                    self.push_action(HostAction::Notify { title: String::new(), body: text });
+                }
+            }
+            777 => {
+                // OSC 777 ; notify ; <title> ; <body>
+                let parts: Vec<&str> = text.split(';').collect();
+                if parts.len() >= 2 && parts[0] == "notify" {
+                    let title = parts[1].to_string();
+                    let body = if parts.len() >= 3 { parts[2..].join(";") } else { String::new() };
+                    self.push_action(HostAction::Notify { title, body });
+                }
+            }
+            52 => {
+                // OSC 52 ; Pc ; Pd — program writes the clipboard (base64). "?" is a read-back query,
+                // never answered; cap the payload as the managed core does.
+                if let Some(semi) = text.find(';') {
+                    let data = &text[semi + 1..];
+                    if !data.is_empty() && data != "?" && data.len() <= 4_000_000 {
+                        // Tolerate unpadded base64 (some emitters strip '='), like the managed
+                        // core's PadRight before Convert.FromBase64String.
+                        let mut padded = data.to_string();
+                        while padded.len() % 4 != 0 {
+                            padded.push('=');
+                        }
+                        if let Some(bytes) = base64_decode(&padded) {
+                            let decoded = String::from_utf8_lossy(&bytes).into_owned();
+                            if !decoded.is_empty() {
+                                self.push_action(HostAction::Clipboard { text: decoded });
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {
+                let detail = if text.chars().count() > 40 {
+                    let head: String = text.chars().take(40).collect();
+                    format!("{command};{head}…")
+                } else {
+                    format!("{command};{text}")
+                };
+                self.push_action(HostAction::Unhandled { kind: "OSC".into(), detail });
+            }
         }
     }
 
     fn apc_dispatch(&mut self, data: &str) {
         if !data.starts_with('G') {
-            return; // only Kitty graphics (_G...); others → Host.Unhandled (headless drop)
+            // only Kitty graphics (_G...); everything else is a debug-tap Unhandled.
+            let detail = if data.chars().count() > 24 {
+                let head: String = data.chars().take(24).collect();
+                format!("{head}…")
+            } else {
+                data.to_string()
+            };
+            self.push_action(HostAction::Unhandled { kind: "APC".into(), detail });
+            return;
         }
         let body = &data[1..];
         let (control, payload) = match body.find(';') {
@@ -986,7 +1102,16 @@ impl Performer for Emulator {
     }
 
     fn dcs_dispatch(&mut self, payload: &[u8]) {
-        let _ = self.place_sixel(payload); // non-sixel → Host.Unhandled (headless drop)
+        if self.place_sixel(payload) {
+            return;
+        }
+        // Non-sixel DCS (DECRQSS "$q", XTGETTCAP "+q", …): identify by its readable prefix.
+        let n = payload.len().min(16);
+        let head: String = payload[..n].iter().map(|&b| b as char).collect();
+        self.push_action(HostAction::Unhandled {
+            kind: "DCS".into(),
+            detail: format!("{} bytes \"{head}\"", payload.len()),
+        });
     }
 }
 
@@ -1004,6 +1129,11 @@ fn parse_kitty_keys(control: &str) -> HashMap<String, String> {
 
 fn kitty_int(d: &HashMap<String, String>, key: &str, def: i32) -> i32 {
     d.get(key).and_then(|v| v.parse::<i32>().ok()).unwrap_or(def)
+}
+
+/// Semicolon-join CSI parameters for the Unhandled debug tap (mirrors C#'s `string.Join(';', …)`).
+fn join_params(params: &[i32]) -> String {
+    params.iter().map(|p| p.to_string()).collect::<Vec<_>>().join(";")
 }
 
 impl Emulator {

--- a/native/agwinterm-core/src/lib.rs
+++ b/native/agwinterm-core/src/lib.rs
@@ -21,12 +21,13 @@ pub mod vtparser;
 pub mod wcwidth;
 
 use cell::{Cell, Color, ColorSpec, ColorSpecKind};
+use emulator::HostAction;
 use screen::ScreenBuffer;
 
 /// Bumped whenever the exported C surface changes shape. The C# loader
 /// refuses a mismatch loudly (same hard-handshake philosophy as the
 /// pty-host protocol).
-pub const ABI_VERSION: u32 = 8;
+pub const ABI_VERSION: u32 = 9;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn agwcore_abi_version() -> u32 {
@@ -407,6 +408,70 @@ pub unsafe extern "C" fn agwcore_emu_state_dump(p: *mut Terminal, out_len: *mut 
     unsafe { *out_len = buf.len() as u32 };
     let ptr = buf.as_mut_ptr();
     core::mem::forget(buf);
+    ptr
+}
+
+/// Drain the queued host actions (the IHostActions seam) into a flat blob and CLEAR the queue.
+/// The C# adapter calls this after each feed and forwards each action to `IHostActions`.
+/// Free the returned buffer with `agwcore_free_buf`. Layout (all integers little-endian):
+///   u32 count, then `count` records — u8 kind + payload:
+///     1 Notify    : str title, str body
+///     2 Progress  : i32 state, i32 value
+///     3 Clipboard : str text
+///     4 Respond   : str reply
+///     5 Unhandled : str kind, str detail
+///   where str = u32 byte-length + UTF-8 bytes.
+/// # Safety
+/// `p` from `agwcore_emu_new`; `out_len` writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn agwcore_emu_take_host_actions(p: *mut Terminal, out_len: *mut u32) -> *mut u8 {
+    let Some(t) = (unsafe { p.as_mut() }) else { return core::ptr::null_mut() };
+    if out_len.is_null() {
+        return core::ptr::null_mut();
+    }
+    let actions = t.emu.take_host_actions();
+    if actions.is_empty() {
+        // The common case — no host effects this feed. Signal "nothing" without allocating.
+        unsafe { *out_len = 0 };
+        return core::ptr::null_mut();
+    }
+    fn put_str(buf: &mut Vec<u8>, s: &str) {
+        buf.extend_from_slice(&(s.len() as u32).to_le_bytes());
+        buf.extend_from_slice(s.as_bytes());
+    }
+    let mut buf: Vec<u8> = Vec::new();
+    buf.extend_from_slice(&(actions.len() as u32).to_le_bytes());
+    for a in &actions {
+        match a {
+            HostAction::Notify { title, body } => {
+                buf.push(1);
+                put_str(&mut buf, title);
+                put_str(&mut buf, body);
+            }
+            HostAction::Progress { state, value } => {
+                buf.push(2);
+                buf.extend_from_slice(&state.to_le_bytes());
+                buf.extend_from_slice(&value.to_le_bytes());
+            }
+            HostAction::Clipboard { text } => {
+                buf.push(3);
+                put_str(&mut buf, text);
+            }
+            HostAction::Respond { reply } => {
+                buf.push(4);
+                put_str(&mut buf, reply);
+            }
+            HostAction::Unhandled { kind, detail } => {
+                buf.push(5);
+                put_str(&mut buf, kind);
+                put_str(&mut buf, detail);
+            }
+        }
+    }
+    let mut boxed = buf.into_boxed_slice();
+    unsafe { *out_len = boxed.len() as u32 };
+    let ptr = boxed.as_mut_ptr();
+    core::mem::forget(boxed);
     ptr
 }
 

--- a/src/Agwinterm.Core/RustEmulatorCore.cs
+++ b/src/Agwinterm.Core/RustEmulatorCore.cs
@@ -16,7 +16,7 @@ namespace Agwinterm.Core;
 /// </summary>
 public sealed unsafe class RustEmulatorCore : IDisposable
 {
-    public const uint RequiredAbi = 8;
+    public const uint RequiredAbi = 9;
 
     [StructLayout(LayoutKind.Sequential)]
     public struct Info
@@ -54,6 +54,7 @@ public sealed unsafe class RustEmulatorCore : IDisposable
     private delegate bool EmuCopyGridFn(nint p, NativeCell* cells, uint cap);
     private delegate bool EmuCopyHistoryRowFn(nint p, uint row, NativeCell* cells, uint cap);
     private delegate byte* EmuGetTextFn(nint p, uint which, uint* outLen);
+    private delegate byte* EmuTakeHostActionsFn(nint p, uint* outLen);
     private delegate void FreeBufFn(byte* ptr, uint len);
 
     private static nint _lib;
@@ -65,6 +66,7 @@ public sealed unsafe class RustEmulatorCore : IDisposable
     private static EmuCopyGridFn _copyGrid = null!;
     private static EmuCopyHistoryRowFn _copyHistory = null!;
     private static EmuGetTextFn _getText = null!;
+    private static EmuTakeHostActionsFn _takeHostActions = null!;
     private static FreeBufFn _freeBuf = null!;
 
     /// <summary>Load the native core from <paramref name="dllPath"/> and verify the ABI.
@@ -94,6 +96,7 @@ public sealed unsafe class RustEmulatorCore : IDisposable
             _copyGrid = Get<EmuCopyGridFn>("agwcore_emu_copy_grid");
             _copyHistory = Get<EmuCopyHistoryRowFn>("agwcore_emu_copy_history_row");
             _getText = Get<EmuGetTextFn>("agwcore_emu_get_text");
+            _takeHostActions = Get<EmuTakeHostActionsFn>("agwcore_emu_take_host_actions");
             _freeBuf = Get<FreeBufFn>("agwcore_free_buf");
             _marks = Get<EmuMarksFn>("agwcore_emu_marks");
             _seed = Get<EmuSeedFn>("agwcore_emu_seed_scrollback");
@@ -284,6 +287,18 @@ public sealed unsafe class RustEmulatorCore : IDisposable
         byte* buf = _getText(_handle, which, &len);
         if (buf == null) return "";
         try { return System.Text.Encoding.UTF8.GetString(buf, (int)len); }
+        finally { _freeBuf(buf, len); }
+    }
+
+    /// <summary>Drain the queued host actions (the IHostActions seam) as the raw native blob
+    /// and CLEAR the queue. Returns an empty array when nothing was queued this feed (the
+    /// common case — the native side returns null then). See RustTerminalCore for the layout.</summary>
+    public byte[] TakeHostActions()
+    {
+        uint len;
+        byte* buf = _takeHostActions(_handle, &len);
+        if (buf == null) return Array.Empty<byte>();
+        try { var arr = new byte[len]; Marshal.Copy((nint)buf, arr, 0, (int)len); return arr; }
         finally { _freeBuf(buf, len); }
     }
 

--- a/src/Agwinterm.Core/RustTerminalCore.cs
+++ b/src/Agwinterm.Core/RustTerminalCore.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Text;
 
 namespace Agwinterm.Core;
@@ -9,10 +10,11 @@ namespace Agwinterm.Core;
 /// reads (renderer snapshots, selection, dumps) stay lock-cheap managed accesses with
 /// unchanged semantics. All calls run under the session lock per the ISession contract.
 ///
-/// Images (kitty/sixel) ARE surfaced as of ABI v8: the Rust core decodes them and this
-/// adapter exposes <see cref="Images"/> / <see cref="Placements"/> (see SyncImages).
-/// Remaining phase-2 gap: host actions are not invoked (no OSC 52 clipboard /
-/// notifications / kitty-query responses) — panes that need those want the managed core.
+/// Images (kitty/sixel) are surfaced (ABI v8) via <see cref="Images"/> / <see cref="Placements"/>,
+/// and host actions are wired (ABI v9): the Rust core queues them during feed and this adapter
+/// drains them after each Sync and forwards to <see cref="Host"/> (OSC 52 clipboard, OSC 9/777
+/// notifications, OSC 9;4 progress, kitty keyboard-query replies, and the Unhandled debug tap) —
+/// so `emulator-core = rust` is now at parity with the managed core for the host seam.
 /// </summary>
 public sealed class RustTerminalCore : ITerminalCore, IDisposable
 {
@@ -62,7 +64,8 @@ public sealed class RustTerminalCore : ITerminalCore, IDisposable
         _title = _rust.Title;
         _cwd = _rust.Cwd;
         _marks = _rust.GetMarks();
-        SyncImages();   // stream-delivered kitty/sixel become visible on the next frame
+        SyncImages();       // stream-delivered kitty/sixel become visible on the next frame
+        DrainHostActions(); // OSC 52 clipboard / notifications / progress / query replies / taps
     }
 
     // ---- content ----
@@ -113,8 +116,38 @@ public sealed class RustTerminalCore : ITerminalCore, IDisposable
     public string Title => _title;
     public string Cwd => _cwd;
 
-    // ---- host actions: stored but never invoked by the Rust core (phase 2) ----
+    // ---- host actions (ABI v9): the Rust core queues them during feed; DrainHostActions()
+    // (called from Sync) decodes the native blob and forwards each to Host, matching the
+    // managed emulator's IHostActions call sites. ----
     public IHostActions? Host { get; set; }
+
+    private void DrainHostActions()
+    {
+        byte[] blob = _rust.TakeHostActions();   // always drains the native queue (even if Host is null)
+        if (blob.Length == 0) return;
+        var host = Host;
+        if (host is null) return;                // nothing to forward to; queue already cleared
+        using var br = new BinaryReader(new MemoryStream(blob, writable: false));
+        uint count = br.ReadUInt32();
+        for (uint i = 0; i < count; i++)
+        {
+            switch (br.ReadByte())
+            {
+                case 1: { string title = ReadStr(br), body = ReadStr(br); host.Notify(title, body); break; }
+                case 2: { int state = br.ReadInt32(), value = br.ReadInt32(); host.Progress(state, value); break; }
+                case 3: host.ClipboardWrite(ReadStr(br)); break;
+                case 4: host.Respond(ReadStr(br)); break;
+                case 5: { string kind = ReadStr(br), detail = ReadStr(br); host.Unhandled(kind, detail); break; }
+                default: return;                 // unknown tag — blob is corrupt; stop rather than misread
+            }
+        }
+    }
+
+    private static string ReadStr(BinaryReader br)
+    {
+        int len = (int)br.ReadUInt32();
+        return Encoding.UTF8.GetString(br.ReadBytes(len));
+    }
 
     // ---- images (ABI v8): surfaced from the Rust core; KittyImage pixels cached per id so the
     // renderer uploads a texture only once, refreshed on Sync when the id set changes. ----

--- a/src/Agwinterm.Core/TerminalConfig.cs
+++ b/src/Agwinterm.Core/TerminalConfig.cs
@@ -90,8 +90,8 @@ public sealed class TerminalConfig
     /// <summary>Which terminal core new sessions run on: "managed" (default — the C#
     /// TerminalEmulator) or "rust" (EXPERIMENTAL — the oracle-validated agwinterm-core crate
     /// behind the ITerminalCore seam; falls back to managed with a toast when the native dll
-    /// is missing). kitty/sixel images ARE surfaced (ABI v8); remaining gap in rust mode:
-    /// OSC host actions (clipboard writes, notifications, kitty-keyboard query replies).</summary>
+    /// is missing). kitty/sixel images (ABI v8) and OSC host actions (ABI v9 — clipboard,
+    /// notifications, progress, kitty-keyboard query replies) are both surfaced now.</summary>
     public string EmulatorCore { get; set; } = "managed";
 
     /// <summary>Rebuild each new session's environment from the registry at spawn (WT's
@@ -275,8 +275,8 @@ public sealed class TerminalConfig
         # Terminal core for NEW sessions: "managed" (default) or "rust" (EXPERIMENTAL - the
         # Rust agwinterm-core crate, differentially validated against the managed emulator).
         # Applies to sessions created after the change; falls back to managed with a toast if
-        # the native dll is missing. kitty/sixel images are surfaced; remaining gap in rust
-        # mode: OSC host actions (clipboard writes, desktop notifications, kitty-keyboard replies).
+        # the native dll is missing. kitty/sixel images and OSC host actions (clipboard writes,
+        # desktop notifications, progress, kitty-keyboard query replies) are both surfaced now.
         emulator-core = managed
 
         # Blocked sound: play a sound whenever a session enters the "blocked" agent status (needs

--- a/tests/Agwinterm.Core.Tests/RustEmulatorCoreTests.cs
+++ b/tests/Agwinterm.Core.Tests/RustEmulatorCoreTests.cs
@@ -138,6 +138,49 @@ public class RustEmulatorCoreTests
         Assert.Equal(csImg.Data, rustImg.Data);   // identical RGBA — the whole point
     }
 
+    private sealed class RecordingHost : IHostActions
+    {
+        public readonly List<string> Log = new();
+        public void Notify(string title, string body) => Log.Add($"Notify|{title}|{body}");
+        public void Progress(int state, int value) => Log.Add($"Progress|{state}|{value}");
+        public void ClipboardWrite(string text) => Log.Add($"Clipboard|{text}");
+        public void Respond(string reply) => Log.Add($"Respond|{reply}");
+        public void Unhandled(string kind, string detail) => Log.Add($"Unhandled|{kind}|{detail}");
+    }
+
+    [Fact]
+    public void Adapter_HostActions_MatchManagedCore()
+    {
+        if (!Available) return;
+        // Exercise every IHostActions member through the VT stream: OSC 9 notify, OSC 9;4 progress,
+        // OSC 777 notify, OSC 52 clipboard (base64 "aGk=" -> "hi"), the kitty keyboard-flags query
+        // (Respond), and one each of the Unhandled taps (CSI, C0 BEL, ESC).
+        string script =
+            "\x1b]9;build done\x07" +
+            "\x1b]9;4;1;42\x07" +
+            "\x1b]777;notify;Title;Body;x\x07" +
+            "\x1b]52;c;aGk=\x07" +
+            "\x1b[?u" +
+            "\x1b[99z" +
+            "\x07" +
+            "\x1bH";
+        byte[] bytes = System.Text.Encoding.ASCII.GetBytes(script);
+
+        var mgHost = new RecordingHost();
+        var rsHost = new RecordingHost();
+        var cs = new TerminalEmulator(40, 10) { Host = mgHost };
+        using var rust = new RustTerminalCore(40, 10) { Host = rsHost };
+        cs.Feed(bytes);
+        rust.Feed(bytes);
+
+        // Same actions, same order, same payloads — through the adapter's drain path, not the oracle.
+        Assert.Equal(mgHost.Log, rsHost.Log);
+        // And it genuinely fired (guard against "both empty" passing vacuously).
+        Assert.Contains("Clipboard|hi", rsHost.Log);
+        Assert.Contains("Respond|\x1b[?0u", rsHost.Log);
+        Assert.Contains("Progress|1|42", rsHost.Log);
+    }
+
     [Fact]
     public void Adapter_DirectImageApi_RoundTrips()
     {


### PR DESCRIPTION
## What

Closes the **last phase-2 gap** for `emulator-core = rust`. The Rust core decoded OSC/CSI host-effecting sequences but **dropped** them (it was designed headless, oracle-validated for grid state only) — so rust-mode had no clipboard writes, notifications, taskbar progress, or kitty keyboard-query replies. This queues host actions during feed and drains them to the C# adapter, which forwards to `IHostActions`, reaching parity with the managed core for the host seam.

## How

Same **queue-and-drain** shape the adapter already uses for images/marks (Rust authoritative, C# mirrors after each feed):

- **native/agwinterm-core**: a `HostAction` enum + a per-feed queue. Emitted from the *same triggers* as the managed `TerminalEmulator`:
  - OSC 9 → `Notify("", body)`; OSC 9;4 → `Progress(state, value)`; OSC 777 → `Notify(title, body)`
  - OSC 52 → `ClipboardWrite` (unpadded-base64 tolerant like the managed `PadRight`, `?` read-back refused, 4 MB cap)
  - kitty `CSI ? u` → `Respond("\e[?<flags>u")`
  - plus the `Unhandled` debug taps (C0 / ESC / CSI / MODE / OSC / DCS / APC) so rust-mode's `AGWINTERM_VT_LOG` matches the managed core.
- **ABI 8 → 9**: `agwcore_emu_take_host_actions` drains the queue into a flat little-endian blob (freed via `agwcore_free_buf`), returning **null when empty** so the overwhelmingly common no-action feed allocates nothing on either side.
- **RustEmulatorCore**: `RequiredAbi = 9`; binds + exposes `TakeHostActions` (raw blob).
- **RustTerminalCore**: `DrainHostActions()` (from `Sync`) decodes the blob and forwards to `Host`, matching the managed call sites. It **always drains** even when `Host` is null, so the native queue can't grow unbounded.
- **lite**: `kRequiredAbi 8 → 9` (accepts the v9 dll; it uses only the base FFI).

## Verification

- **`Adapter_HostActions_MatchManagedCore`** feeds one script exercising *every* member (notify/progress/notify-777/clipboard/respond + CSI/C0/ESC unhandled) through both the managed `TerminalEmulator` and `RustTerminalCore`, and asserts **byte-identical, same-order** host actions through the adapter's own drain path.
- Core.Tests **174/174** (incl. 16 rust adapter/parity, 0 skipped); Rust unit tests **26/26**; lite builds clean against v9.

With this, `emulator-core = rust` is at parity with the managed core for both images (v8) and the host seam (v9) — no phase-2 gaps remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)