### PR TITLE
feat(vt): focus reporting (DECSET ?1004) — emit CSI I/O on window focus change (#98)

### DIFF
--- a/lite/src/main.cpp
+++ b/lite/src/main.cpp
@@ -23,7 +23,7 @@
 #include "proto/pb_decode.h"
 #include "control.h"
 
-// ---- agwinterm-core C ABI (ABI v9) ----
+// ---- agwinterm-core C ABI (ABI v10) ----
 struct FfiCell {
     int32_t rune;
     uint32_t fg, bg, attrs, width;
@@ -35,7 +35,7 @@ struct FfiEmuInfo {
     int64_t scrollGeneration;
     uint32_t mouseClick, mouseDrag, mouseMotion, mouseSgr, bracketedPaste;
     int32_t keyboardFlags;
-    uint32_t scrollTop, scrollBottom, markCount;
+    uint32_t scrollTop, scrollBottom, markCount, focusReporting;
 };
 struct FfiMark {   // FTCS / OSC 133 boundary; lines are buffer-absolute, -1 = unset
     int64_t promptLine, commandLine, outputLine, endLine;
@@ -52,7 +52,7 @@ static bool (*emu_copy_grid)(void*, FfiCell*, uint32_t);
 static bool (*emu_copy_history_row)(void*, uint32_t, FfiCell*, uint32_t);
 static uint32_t (*emu_marks)(void*, FfiMark*, uint32_t);
 
-static constexpr uint32_t kRequiredAbi = 9;
+static constexpr uint32_t kRequiredAbi = 10;
 static constexpr uint32_t kAttrBold = 1, kAttrItalic = 2, kAttrUnderline = 4,
                           kAttrInverse = 8, kAttrDim = 16, kAttrStrike = 32;
 static constexpr uint32_t kProtocolVersion = 2;
@@ -187,7 +187,7 @@ static void loadCore() {
     emu_marks = (decltype(emu_marks))GetProcAddress(m, "agwcore_emu_marks");
     if (!core_abi || !emu_new || !emu_feed || !emu_info || !emu_copy_grid || !emu_resize || !emu_free || !emu_copy_history_row || !emu_marks)
         fatal(L"agwinterm_core.dll: exports missing");
-    if (core_abi() != kRequiredAbi) fatal(L"agwinterm_core.dll: ABI mismatch (need v9)");
+    if (core_abi() != kRequiredAbi) fatal(L"agwinterm_core.dll: ABI mismatch (need v10)");
 }
 
 static void connectControl() {

--- a/native/agwinterm-core/src/emulator.rs
+++ b/native/agwinterm-core/src/emulator.rs
@@ -129,6 +129,7 @@ pub struct Emulator {
     mouse_motion: bool,
     mouse_sgr: bool,
     pub bracketed_paste: bool,
+    pub focus_reporting: bool,
 
     scroll_top: usize,
     scroll_bottom: usize,
@@ -191,6 +192,7 @@ impl Emulator {
             mouse_motion: false,
             mouse_sgr: false,
             bracketed_paste: false,
+            focus_reporting: false,
             scroll_top: 0,
             scroll_bottom: rows - 1,
             history: Vec::new(),
@@ -603,6 +605,7 @@ impl Emulator {
                 1002 => self.mouse_drag = set,
                 1003 => self.mouse_motion = set,
                 1006 => self.mouse_sgr = set,
+                1004 => self.focus_reporting = set,
                 2004 => self.bracketed_paste = set,
                 _ => self.push_action(HostAction::Unhandled {
                     kind: "MODE".into(),
@@ -827,6 +830,7 @@ impl Emulator {
         if self.mouse_motion { s.push_str("\u{1b}[?1003h"); }
         if self.mouse_sgr { s.push_str("\u{1b}[?1006h"); }
         if self.bracketed_paste { s.push_str("\u{1b}[?2004h"); }
+        if self.focus_reporting { s.push_str("\u{1b}[?1004h"); }
         if !self.title.is_empty() { s.push_str("\u{1b}]0;"); s.push_str(&self.title); s.push('\u{7}'); }
         if !self.cwd.is_empty() { s.push_str("\u{1b}]7;"); s.push_str(&self.cwd); s.push('\u{7}'); }
         s

--- a/native/agwinterm-core/src/lib.rs
+++ b/native/agwinterm-core/src/lib.rs
@@ -27,7 +27,7 @@ use screen::ScreenBuffer;
 /// Bumped whenever the exported C surface changes shape. The C# loader
 /// refuses a mismatch loudly (same hard-handshake philosophy as the
 /// pty-host protocol).
-pub const ABI_VERSION: u32 = 9;
+pub const ABI_VERSION: u32 = 10;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn agwcore_abi_version() -> u32 {
@@ -361,6 +361,7 @@ pub unsafe extern "C" fn agwcore_emu_state_dump(p: *mut Terminal, out_len: *mut 
     let _ = writeln!(s, "alt:{}", e.is_alt_screen() as u8);
     let _ = writeln!(s, "mouse:{}{}{}{}", mc as u8, md as u8, mm as u8, ms as u8);
     let _ = writeln!(s, "paste:{}", e.bracketed_paste as u8);
+    let _ = writeln!(s, "focus:{}", e.focus_reporting as u8);
     let _ = writeln!(s, "kbd:{}", e.keyboard_flags());
     let _ = writeln!(s, "title:{}", e.title);
     let _ = writeln!(s, "cwd:{}", e.cwd);
@@ -497,6 +498,7 @@ pub struct FfiEmuInfo {
     pub scroll_top: u32,
     pub scroll_bottom: u32,
     pub mark_count: u32,
+    pub focus_reporting: u32,
 }
 
 /// # Safety
@@ -528,6 +530,7 @@ pub unsafe extern "C" fn agwcore_emu_info(p: *mut Terminal, out: *mut FfiEmuInfo
             scroll_top: e.scroll_top() as u32,
             scroll_bottom: e.scroll_bottom() as u32,
             mark_count: e.marks().len() as u32,
+            focus_reporting: e.focus_reporting as u32,
         };
     }
     true

--- a/src/Agwinterm.Core/ITerminalCore.cs
+++ b/src/Agwinterm.Core/ITerminalCore.cs
@@ -30,6 +30,7 @@ public interface ITerminalCore
     bool MouseDrag { get; }
     bool MouseMotion { get; }
     bool BracketedPaste { get; }
+    bool FocusReporting { get; }
     int KeyboardFlags { get; }
 
     // ---- scrollback ----

--- a/src/Agwinterm.Core/RustEmulatorCore.cs
+++ b/src/Agwinterm.Core/RustEmulatorCore.cs
@@ -16,7 +16,7 @@ namespace Agwinterm.Core;
 /// </summary>
 public sealed unsafe class RustEmulatorCore : IDisposable
 {
-    public const uint RequiredAbi = 9;
+    public const uint RequiredAbi = 10;
 
     [StructLayout(LayoutKind.Sequential)]
     public struct Info
@@ -25,7 +25,7 @@ public sealed unsafe class RustEmulatorCore : IDisposable
         public long ScrollGeneration;
         public uint MouseClick, MouseDrag, MouseMotion, MouseSgr, BracketedPaste;
         public int KeyboardFlags;
-        public uint ScrollTop, ScrollBottom, MarkCount;
+        public uint ScrollTop, ScrollBottom, MarkCount, FocusReporting;
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/Agwinterm.Core/RustTerminalCore.cs
+++ b/src/Agwinterm.Core/RustTerminalCore.cs
@@ -89,6 +89,7 @@ public sealed class RustTerminalCore : ITerminalCore, IDisposable
     public bool MouseReporting => MouseClick || MouseDrag || MouseMotion;
     public bool MouseReportsMotion => MouseDrag || MouseMotion;
     public bool BracketedPaste => _info.BracketedPaste != 0;
+    public bool FocusReporting => _info.FocusReporting != 0;
     public int KeyboardFlags => _info.KeyboardFlags;
 
     // ---- scrollback ----

--- a/src/Agwinterm.Core/TerminalEmulator.cs
+++ b/src/Agwinterm.Core/TerminalEmulator.cs
@@ -46,6 +46,10 @@ public sealed class TerminalEmulator : IParserPerformer, ITerminalCore
     /// <summary>Bracketed paste mode (DECSET 2004): wrap pasted text in ESC[200~ … ESC[201~.</summary>
     public bool BracketedPaste { get; private set; }
 
+    /// <summary>Focus reporting (DECSET 1004): the host emits ESC[I when the terminal gains focus
+    /// and ESC[O when it loses focus, so the program can pause/resume (cursor blink, refresh).</summary>
+    public bool FocusReporting { get; private set; }
+
     private int _scrollTop;
     private int _scrollBottom;
 
@@ -366,6 +370,7 @@ public sealed class TerminalEmulator : IParserPerformer, ITerminalCore
                 case 1002: _mouseDrag = set; break;    // button-event (drag) tracking
                 case 1003: _mouseMotion = set; break;  // any-motion tracking
                 case 1006: _mouseSgr = set; break;     // SGR extended mouse encoding
+                case 1004: FocusReporting = set; break; // focus in/out reporting
                 case 2004: BracketedPaste = set; break; // bracketed paste
                 default: Host?.Unhandled("MODE", $"?{mode} {(set ? 'h' : 'l')}"); break;
             }
@@ -862,6 +867,7 @@ public sealed class TerminalEmulator : IParserPerformer, ITerminalCore
         if (_mouseMotion) sb.Append("\x1b[?1003h");
         if (_mouseSgr) sb.Append("\x1b[?1006h");
         if (BracketedPaste) sb.Append("\x1b[?2004h");
+        if (FocusReporting) sb.Append("\x1b[?1004h");
         if (Title.Length > 0) sb.Append("\x1b]0;").Append(Title).Append('\x07');
         if (Cwd.Length > 0) sb.Append("\x1b]7;").Append(Cwd).Append('\x07');
         return sb.ToString();

--- a/src/Agwinterm.Win32/Program.WndProc.cs
+++ b/src/Agwinterm.Win32/Program.WndProc.cs
@@ -526,7 +526,12 @@ internal partial class Program
                 return DefWindowProcW(hwnd, msg, wParam, lParam);
 
             case WM_ACTIVATE:
+                bool wasActive = _windowActive;
                 _windowActive = LoWord(wParam) != 0;   // WA_ACTIVE/WA_CLICKACTIVE vs WA_INACTIVE (drives unfocused dim)
+                // Focus reporting (DECSET ?1004): on a real focus transition, tell the active pane's
+                // app the terminal gained (ESC[I) or lost (ESC[O) focus, so it can pause/resume.
+                if (_windowActive != wasActive && _session is { } fs && fs.Emulator.FocusReporting)
+                    fs.Write(_windowActive ? "\x1b[I"u8.ToArray() : "\x1b[O"u8.ToArray());
                 if (_config.UnfocusedDim > 0) RequestRedraw();
                 if (_windowActive && _frontmostId != Id) // this window is frontmost
                 {

--- a/tests/Agwinterm.Core.Tests/RustEmulatorCoreTests.cs
+++ b/tests/Agwinterm.Core.Tests/RustEmulatorCoreTests.cs
@@ -182,6 +182,29 @@ public class RustEmulatorCoreTests
     }
 
     [Fact]
+    public void Adapter_FocusReporting_TracksMode_LikeManagedCore()
+    {
+        if (!Available) return;
+        var cs = new TerminalEmulator(20, 5);
+        using var rust = new RustTerminalCore(20, 5);
+        Assert.False(cs.FocusReporting);
+        Assert.False(rust.FocusReporting);
+
+        var on = System.Text.Encoding.ASCII.GetBytes("\x1b[?1004h");
+        cs.Feed(on); rust.Feed(on);
+        Assert.True(cs.FocusReporting);
+        Assert.True(rust.FocusReporting);                 // surfaced via the adapter's Info snapshot
+        Assert.Equal(cs.DumpModes(), rust.DumpModes());   // and re-synthesized identically for reattach
+        Assert.Contains("\x1b[?1004h", rust.DumpModes());
+
+        var off = System.Text.Encoding.ASCII.GetBytes("\x1b[?1004l");
+        cs.Feed(off); rust.Feed(off);
+        Assert.False(cs.FocusReporting);
+        Assert.False(rust.FocusReporting);
+        Assert.Equal(cs.DumpModes(), rust.DumpModes());
+    }
+
+    [Fact]
     public void Adapter_DirectImageApi_RoundTrips()
     {
         if (!Available) return;

--- a/tests/Agwinterm.Core.Tests/RustParityTests.cs
+++ b/tests/Agwinterm.Core.Tests/RustParityTests.cs
@@ -309,6 +309,7 @@ public class RustParityTests
         sb.Append($"alt:{(e.IsAltScreen ? 1 : 0)}\n");
         sb.Append($"mouse:{(e.MouseClick ? 1 : 0)}{(e.MouseDrag ? 1 : 0)}{(e.MouseMotion ? 1 : 0)}{(e.MouseSgr ? 1 : 0)}\n");
         sb.Append($"paste:{(e.BracketedPaste ? 1 : 0)}\n");
+        sb.Append($"focus:{(e.FocusReporting ? 1 : 0)}\n");
         sb.Append($"kbd:{e.KeyboardFlags}\n");
         sb.Append($"title:{e.Title}\n");
         sb.Append($"cwd:{e.Cwd}\n");


### PR DESCRIPTION
## What

Implements **focus reporting** (`DECSET ?1004`) — the highest-value gap from the `AGWINTERM_VT_LOG` protocol audit (#98). Every shell requests it; without it, focus-aware programs (shell prompts, vim/nvim, fzf) can't pause/resume on window blur/focus. When enabled, the terminal emits `CSI I` on focus-in and `CSI O` on focus-out.

Done **emulator-first** in *both* cores (managed + Rust), with parity guarded by tests.

## Changes

- **`TerminalEmulator` + Rust core**: track `FocusReporting` via `DECSET/DECRST ?1004`; include `?1004h` in `DumpModes` (so a reattached session keeps the mode) at the same position in both, and in the Rust `state_dump` / C# oracle (`focus:` line).
- **ABI 9 → 10**: append `focus_reporting` to `FfiEmuInfo` — Rust struct, C# `Info`, and lite's mirror all in lockstep (Rust writes the whole struct through the pointer, so lite's copy must match). `RustTerminalCore` exposes `ITerminalCore.FocusReporting`.
- **app**: on `WM_ACTIVATE`, a *real* focus transition writes `ESC[I` / `ESC[O` to the **active pane's** session when its emulator has `?1004` on (guarded so repeat activations don't double-fire).
- **lite**: `kRequiredAbi 9 → 10` + the struct field.
- **tests**: `Adapter_FocusReporting_TracksMode_LikeManagedCore` (toggle + `DumpModes` parity through the adapter); the `state_dump` oracle now covers `focus:`.

## Scope

Window-level focus (the canonical `?1004` contract — "the terminal gained/lost focus"). Per-**pane-switch** focus events (sending focus-out/in when you switch splits while the window stays active) are a reasonable follow-up but out of scope here.

## Verification

Core.Tests **175/175** (incl. the focus parity test + the `focus:` oracle line across all existing parity cases), Rust unit tests pass, lite builds against v10, Win32 app builds. The `WM_ACTIVATE` emit is straightforward glue (mode tracking is the unit-tested part).

🤖 Generated with [Claude Code](https://claude.com/claude-code)