### PR TITLE
feat(vt): synchronized output (DECSET ?2026) — atomic frames + DECRQM detection (#98)

### DIFF
--- a/lite/src/main.cpp
+++ b/lite/src/main.cpp
@@ -23,7 +23,7 @@
 #include "proto/pb_decode.h"
 #include "control.h"
 
-// ---- agwinterm-core C ABI (ABI v10) ----
+// ---- agwinterm-core C ABI (ABI v11) ----
 struct FfiCell {
     int32_t rune;
     uint32_t fg, bg, attrs, width;
@@ -35,7 +35,7 @@ struct FfiEmuInfo {
     int64_t scrollGeneration;
     uint32_t mouseClick, mouseDrag, mouseMotion, mouseSgr, bracketedPaste;
     int32_t keyboardFlags;
-    uint32_t scrollTop, scrollBottom, markCount, focusReporting;
+    uint32_t scrollTop, scrollBottom, markCount, focusReporting, synchronizedOutput;
 };
 struct FfiMark {   // FTCS / OSC 133 boundary; lines are buffer-absolute, -1 = unset
     int64_t promptLine, commandLine, outputLine, endLine;
@@ -52,7 +52,7 @@ static bool (*emu_copy_grid)(void*, FfiCell*, uint32_t);
 static bool (*emu_copy_history_row)(void*, uint32_t, FfiCell*, uint32_t);
 static uint32_t (*emu_marks)(void*, FfiMark*, uint32_t);
 
-static constexpr uint32_t kRequiredAbi = 10;
+static constexpr uint32_t kRequiredAbi = 11;
 static constexpr uint32_t kAttrBold = 1, kAttrItalic = 2, kAttrUnderline = 4,
                           kAttrInverse = 8, kAttrDim = 16, kAttrStrike = 32;
 static constexpr uint32_t kProtocolVersion = 2;
@@ -187,7 +187,7 @@ static void loadCore() {
     emu_marks = (decltype(emu_marks))GetProcAddress(m, "agwcore_emu_marks");
     if (!core_abi || !emu_new || !emu_feed || !emu_info || !emu_copy_grid || !emu_resize || !emu_free || !emu_copy_history_row || !emu_marks)
         fatal(L"agwinterm_core.dll: exports missing");
-    if (core_abi() != kRequiredAbi) fatal(L"agwinterm_core.dll: ABI mismatch (need v10)");
+    if (core_abi() != kRequiredAbi) fatal(L"agwinterm_core.dll: ABI mismatch (need v11)");
 }
 
 static void connectControl() {

--- a/native/agwinterm-core/src/emulator.rs
+++ b/native/agwinterm-core/src/emulator.rs
@@ -130,6 +130,7 @@ pub struct Emulator {
     mouse_sgr: bool,
     pub bracketed_paste: bool,
     pub focus_reporting: bool,
+    pub synchronized_output: bool,
 
     scroll_top: usize,
     scroll_bottom: usize,
@@ -193,6 +194,7 @@ impl Emulator {
             mouse_sgr: false,
             bracketed_paste: false,
             focus_reporting: false,
+            synchronized_output: false,
             scroll_top: 0,
             scroll_bottom: rows - 1,
             history: Vec::new(),
@@ -606,6 +608,7 @@ impl Emulator {
                 1003 => self.mouse_motion = set,
                 1006 => self.mouse_sgr = set,
                 1004 => self.focus_reporting = set,
+                2026 => self.synchronized_output = set,
                 2004 => self.bracketed_paste = set,
                 _ => self.push_action(HostAction::Unhandled {
                     kind: "MODE".into(),
@@ -956,6 +959,10 @@ impl Performer for Emulator {
         if prefix == b'?' {
             if ch == b'h' || ch == b'l' {
                 self.set_private_mode(params, ch == b'h');
+            } else if ch == b'p' && params.first() == Some(&2026) {
+                // DECRQM ?2026$p — report synchronized-output support (1 set, 2 reset).
+                let reply = format!("\u{1b}[?2026;{}$y", if self.synchronized_output { 1 } else { 2 });
+                self.push_action(HostAction::Respond { reply });
             } else {
                 self.push_action(HostAction::Unhandled {
                     kind: "CSI".into(),

--- a/native/agwinterm-core/src/lib.rs
+++ b/native/agwinterm-core/src/lib.rs
@@ -27,7 +27,7 @@ use screen::ScreenBuffer;
 /// Bumped whenever the exported C surface changes shape. The C# loader
 /// refuses a mismatch loudly (same hard-handshake philosophy as the
 /// pty-host protocol).
-pub const ABI_VERSION: u32 = 10;
+pub const ABI_VERSION: u32 = 11;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn agwcore_abi_version() -> u32 {
@@ -362,6 +362,7 @@ pub unsafe extern "C" fn agwcore_emu_state_dump(p: *mut Terminal, out_len: *mut 
     let _ = writeln!(s, "mouse:{}{}{}{}", mc as u8, md as u8, mm as u8, ms as u8);
     let _ = writeln!(s, "paste:{}", e.bracketed_paste as u8);
     let _ = writeln!(s, "focus:{}", e.focus_reporting as u8);
+    let _ = writeln!(s, "sync:{}", e.synchronized_output as u8);
     let _ = writeln!(s, "kbd:{}", e.keyboard_flags());
     let _ = writeln!(s, "title:{}", e.title);
     let _ = writeln!(s, "cwd:{}", e.cwd);
@@ -499,6 +500,7 @@ pub struct FfiEmuInfo {
     pub scroll_bottom: u32,
     pub mark_count: u32,
     pub focus_reporting: u32,
+    pub synchronized_output: u32,
 }
 
 /// # Safety
@@ -531,6 +533,7 @@ pub unsafe extern "C" fn agwcore_emu_info(p: *mut Terminal, out: *mut FfiEmuInfo
             scroll_bottom: e.scroll_bottom() as u32,
             mark_count: e.marks().len() as u32,
             focus_reporting: e.focus_reporting as u32,
+            synchronized_output: e.synchronized_output as u32,
         };
     }
     true

--- a/src/Agwinterm.Core/ITerminalCore.cs
+++ b/src/Agwinterm.Core/ITerminalCore.cs
@@ -31,6 +31,7 @@ public interface ITerminalCore
     bool MouseMotion { get; }
     bool BracketedPaste { get; }
     bool FocusReporting { get; }
+    bool SynchronizedOutput { get; }
     int KeyboardFlags { get; }
 
     // ---- scrollback ----

--- a/src/Agwinterm.Core/RustEmulatorCore.cs
+++ b/src/Agwinterm.Core/RustEmulatorCore.cs
@@ -16,7 +16,7 @@ namespace Agwinterm.Core;
 /// </summary>
 public sealed unsafe class RustEmulatorCore : IDisposable
 {
-    public const uint RequiredAbi = 10;
+    public const uint RequiredAbi = 11;
 
     [StructLayout(LayoutKind.Sequential)]
     public struct Info
@@ -25,7 +25,7 @@ public sealed unsafe class RustEmulatorCore : IDisposable
         public long ScrollGeneration;
         public uint MouseClick, MouseDrag, MouseMotion, MouseSgr, BracketedPaste;
         public int KeyboardFlags;
-        public uint ScrollTop, ScrollBottom, MarkCount, FocusReporting;
+        public uint ScrollTop, ScrollBottom, MarkCount, FocusReporting, SynchronizedOutput;
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/Agwinterm.Core/RustTerminalCore.cs
+++ b/src/Agwinterm.Core/RustTerminalCore.cs
@@ -90,6 +90,7 @@ public sealed class RustTerminalCore : ITerminalCore, IDisposable
     public bool MouseReportsMotion => MouseDrag || MouseMotion;
     public bool BracketedPaste => _info.BracketedPaste != 0;
     public bool FocusReporting => _info.FocusReporting != 0;
+    public bool SynchronizedOutput => _info.SynchronizedOutput != 0;
     public int KeyboardFlags => _info.KeyboardFlags;
 
     // ---- scrollback ----

--- a/src/Agwinterm.Core/TerminalEmulator.cs
+++ b/src/Agwinterm.Core/TerminalEmulator.cs
@@ -50,6 +50,11 @@ public sealed class TerminalEmulator : IParserPerformer, ITerminalCore
     /// and ESC[O when it loses focus, so the program can pause/resume (cursor blink, refresh).</summary>
     public bool FocusReporting { get; private set; }
 
+    /// <summary>Synchronized output (DECSET 2026): while set, the host defers painting so a mid-frame
+    /// TUI redraw never reaches the screen partially; the closing 2026l paints the frame atomically.
+    /// Transient render hint — intentionally NOT persisted in <see cref="DumpModes"/>.</summary>
+    public bool SynchronizedOutput { get; private set; }
+
     private int _scrollTop;
     private int _scrollBottom;
 
@@ -298,6 +303,9 @@ public sealed class TerminalEmulator : IParserPerformer, ITerminalCore
         {
             if (final is 'h' or 'l')
                 SetPrivateMode(parameters, set: final == 'h');
+            else if (final == 'p' && parameters.Count > 0 && parameters[0] == 2026)
+                // DECRQM ?2026$p — report synchronized-output support so apps enable it (1 set, 2 reset).
+                Host?.Respond($"\x1b[?2026;{(SynchronizedOutput ? 1 : 2)}$y");
             else
                 Host?.Unhandled("CSI", $"? {string.Join(';', parameters)} {final}"); // e.g. DECRQM ?…$p
             return;
@@ -371,6 +379,7 @@ public sealed class TerminalEmulator : IParserPerformer, ITerminalCore
                 case 1003: _mouseMotion = set; break;  // any-motion tracking
                 case 1006: _mouseSgr = set; break;     // SGR extended mouse encoding
                 case 1004: FocusReporting = set; break; // focus in/out reporting
+                case 2026: SynchronizedOutput = set; break; // synchronized output (atomic frames)
                 case 2004: BracketedPaste = set; break; // bracketed paste
                 default: Host?.Unhandled("MODE", $"?{mode} {(set ? 'h' : 'l')}"); break;
             }

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -88,7 +88,11 @@ internal partial class Program
         {
             long gen = session.Emulator.ScrollGeneration;
             if (gen != pane.LastScrollGen) { pane.LastScrollGen = gen; pane.ScrollOffset = 0; pane.ClearSel(); }
-            if (IsSurfaceVisible(pane)) RequestRedraw();
+            // Synchronized output (DECSET ?2026): while the app is mid-frame, defer painting so a
+            // partial redraw never reaches the screen — the closing 2026l chunk clears the mode and
+            // paints the frame atomically. The cursor-blink InvalidateRect still repaints within ~one
+            // blink interval, so a crash that leaves ?2026 open can't freeze the pane for long.
+            if (IsSurfaceVisible(pane) && !session.Emulator.SynchronizedOutput) RequestRedraw();
         };
         // On a transition INTO blocked, play the configured blocked-sound (best-effort, off the UI thread).
         AgentStatus lastStatus = session.Status;

--- a/tests/Agwinterm.Core.Tests/OscTests.cs
+++ b/tests/Agwinterm.Core.Tests/OscTests.cs
@@ -234,8 +234,8 @@ public class OscTests
         var t = new TerminalEmulator(40, 3);
         var host = new RecordingHost(); t.Host = host;
         t.Feed(Encoding.UTF8.GetBytes("\x1b[3 q"));       // DECSCUSR (not implemented; space intermediate dropped by parser)
-        t.Feed(Encoding.UTF8.GetBytes("\x1b[?2026h"));    // synchronized output mode (not implemented)
-        Assert.Contains(host.Unhandleds, u => u.Kind == "MODE" && u.Detail == "?2026 h");
+        t.Feed(Encoding.UTF8.GetBytes("\x1b[?9999h"));    // an unassigned private mode -> MODE tap
+        Assert.Contains(host.Unhandleds, u => u.Kind == "MODE" && u.Detail == "?9999 h");
         Assert.NotEmpty(host.Unhandleds);
     }
 

--- a/tests/Agwinterm.Core.Tests/RustEmulatorCoreTests.cs
+++ b/tests/Agwinterm.Core.Tests/RustEmulatorCoreTests.cs
@@ -205,6 +205,36 @@ public class RustEmulatorCoreTests
     }
 
     [Fact]
+    public void Adapter_SynchronizedOutput_ModeAndDecrqm_MatchManagedCore()
+    {
+        if (!Available) return;
+        var mgHost = new RecordingHost();
+        var rsHost = new RecordingHost();
+        var cs = new TerminalEmulator(20, 5) { Host = mgHost };
+        using var rust = new RustTerminalCore(20, 5) { Host = rsHost };
+        void Feed(string s) { var b = System.Text.Encoding.ASCII.GetBytes(s); cs.Feed(b); rust.Feed(b); }
+
+        Feed("\x1b[?2026$p");                              // DECRQM while reset -> reports 2 (reset)
+        Assert.False(cs.SynchronizedOutput);
+        Assert.False(rust.SynchronizedOutput);
+
+        Feed("\x1b[?2026h");                               // enter synchronized output
+        Assert.True(cs.SynchronizedOutput);
+        Assert.True(rust.SynchronizedOutput);              // surfaced via the adapter Info snapshot
+        Assert.DoesNotContain("2026", rust.DumpModes());   // transient — NOT persisted for reattach
+        Assert.Equal(cs.DumpModes(), rust.DumpModes());
+        Feed("\x1b[?2026$p");                              // DECRQM while set -> reports 1 (set)
+
+        Feed("\x1b[?2026l");                               // leave synchronized output
+        Assert.False(cs.SynchronizedOutput);
+        Assert.False(rust.SynchronizedOutput);
+
+        // Same DECRPM replies, same order, through both cores.
+        Assert.Equal(mgHost.Log, rsHost.Log);
+        Assert.Equal(new[] { "Respond|\x1b[?2026;2$y", "Respond|\x1b[?2026;1$y" }, rsHost.Log);
+    }
+
+    [Fact]
     public void Adapter_DirectImageApi_RoundTrips()
     {
         if (!Available) return;

--- a/tests/Agwinterm.Core.Tests/RustParityTests.cs
+++ b/tests/Agwinterm.Core.Tests/RustParityTests.cs
@@ -310,6 +310,7 @@ public class RustParityTests
         sb.Append($"mouse:{(e.MouseClick ? 1 : 0)}{(e.MouseDrag ? 1 : 0)}{(e.MouseMotion ? 1 : 0)}{(e.MouseSgr ? 1 : 0)}\n");
         sb.Append($"paste:{(e.BracketedPaste ? 1 : 0)}\n");
         sb.Append($"focus:{(e.FocusReporting ? 1 : 0)}\n");
+        sb.Append($"sync:{(e.SynchronizedOutput ? 1 : 0)}\n");
         sb.Append($"kbd:{e.KeyboardFlags}\n");
         sb.Append($"title:{e.Title}\n");
         sb.Append($"cwd:{e.Cwd}\n");


### PR DESCRIPTION
## What

Implements **synchronized output** (`DECSET ?2026`) — the next `#98` protocol gap. TUIs (neovim, tmux) bracket a full repaint with `?2026h … ?2026l` so the terminal shows it as **one atomic frame**, eliminating tearing/flicker on full-screen redraws.

Crucially this does *both* halves — mode-tracking alone would advertise a no-op:
1. **Gates rendering** while the mode is set (defers painting until the frame closes).
2. **Answers DECRQM** (`CSI ?2026$p`), the probe apps use to *detect* support before they'll use it.

Done in both cores with parity.

## Changes

- **`TerminalEmulator` + Rust core**: track `SynchronizedOutput` via `DECSET/DECRST ?2026`; answer DECRQM `CSI ?2026$p` with DECRPM `CSI ?2026;{1 set|2 reset}$y` through the host-action `Respond` seam. **Not** persisted in `DumpModes` — it's a transient render hint, so a mid-frame reattach can't freeze the restored view.
- **ABI 10 → 11**: append `synchronized_output` to `FfiEmuInfo` (Rust + C# `Info` + lite mirror in lockstep); `RustTerminalCore` surfaces `ITerminalCore.SynchronizedOutput`.
- **app**: `OutputReceived` defers `RequestRedraw` while the active pane is mid-frame; the closing `?2026l` chunk clears the mode and paints atomically. **Crash safety**: the cursor-blink `InvalidateRect` still repaints within ~one blink interval, so an app that dies with `?2026` open can't freeze a pane.
- **lite**: `kRequiredAbi 10 → 11` + the struct field.
- **tests**: `Adapter_SynchronizedOutput_ModeAndDecrqm_MatchManagedCore` (mode toggle + DECRQM replies byte-identical across cores; asserts absence from `DumpModes`); the `state_dump` oracle gains a `sync:` line; the stale test that used `?2026` as its "unimplemented mode" example now probes an unassigned mode.

## Scope / design notes

- **Render gating is per active pane**, in the single `OutputReceived` redraw path — no new timer. The existing blink `InvalidateRect` is the safety net (bounded ~one blink interval), and `WM_PAINT` always paints current buffer state, so a rare blink landing mid-frame is at worst one slightly-torn frame (no worse than pre-`?2026`).
- **Not in `DumpModes`** by design (transient), unlike `?1004`/`?2004`.

## Verification

Core.Tests **176/176**, Rust unit **26/26**, lite builds against v11, Win32 app builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)