### PR TITLE
feat(vt): DECSCUSR cursor style (CSI Ps SP q) — apps set block/underline/bar (#98)

### DIFF
--- a/lite/src/main.cpp
+++ b/lite/src/main.cpp
@@ -23,7 +23,7 @@
 #include "proto/pb_decode.h"
 #include "control.h"
 
-// ---- agwinterm-core C ABI (ABI v11) ----
+// ---- agwinterm-core C ABI (ABI v12) ----
 struct FfiCell {
     int32_t rune;
     uint32_t fg, bg, attrs, width;
@@ -36,6 +36,7 @@ struct FfiEmuInfo {
     uint32_t mouseClick, mouseDrag, mouseMotion, mouseSgr, bracketedPaste;
     int32_t keyboardFlags;
     uint32_t scrollTop, scrollBottom, markCount, focusReporting, synchronizedOutput;
+    int32_t cursorShape;
 };
 struct FfiMark {   // FTCS / OSC 133 boundary; lines are buffer-absolute, -1 = unset
     int64_t promptLine, commandLine, outputLine, endLine;
@@ -52,7 +53,7 @@ static bool (*emu_copy_grid)(void*, FfiCell*, uint32_t);
 static bool (*emu_copy_history_row)(void*, uint32_t, FfiCell*, uint32_t);
 static uint32_t (*emu_marks)(void*, FfiMark*, uint32_t);
 
-static constexpr uint32_t kRequiredAbi = 11;
+static constexpr uint32_t kRequiredAbi = 12;
 static constexpr uint32_t kAttrBold = 1, kAttrItalic = 2, kAttrUnderline = 4,
                           kAttrInverse = 8, kAttrDim = 16, kAttrStrike = 32;
 static constexpr uint32_t kProtocolVersion = 2;
@@ -187,7 +188,7 @@ static void loadCore() {
     emu_marks = (decltype(emu_marks))GetProcAddress(m, "agwcore_emu_marks");
     if (!core_abi || !emu_new || !emu_feed || !emu_info || !emu_copy_grid || !emu_resize || !emu_free || !emu_copy_history_row || !emu_marks)
         fatal(L"agwinterm_core.dll: exports missing");
-    if (core_abi() != kRequiredAbi) fatal(L"agwinterm_core.dll: ABI mismatch (need v11)");
+    if (core_abi() != kRequiredAbi) fatal(L"agwinterm_core.dll: ABI mismatch (need v12)");
 }
 
 static void connectControl() {

--- a/native/agwinterm-core/src/emulator.rs
+++ b/native/agwinterm-core/src/emulator.rs
@@ -131,6 +131,7 @@ pub struct Emulator {
     pub bracketed_paste: bool,
     pub focus_reporting: bool,
     pub synchronized_output: bool,
+    pub cursor_shape: i32,
 
     scroll_top: usize,
     scroll_bottom: usize,
@@ -195,6 +196,7 @@ impl Emulator {
             bracketed_paste: false,
             focus_reporting: false,
             synchronized_output: false,
+            cursor_shape: 0,
             scroll_top: 0,
             scroll_bottom: rows - 1,
             history: Vec::new(),
@@ -834,6 +836,7 @@ impl Emulator {
         if self.mouse_sgr { s.push_str("\u{1b}[?1006h"); }
         if self.bracketed_paste { s.push_str("\u{1b}[?2004h"); }
         if self.focus_reporting { s.push_str("\u{1b}[?1004h"); }
+        if self.cursor_shape != 0 { s.push_str(&format!("\u{1b}[{} q", self.cursor_shape)); }
         if !self.title.is_empty() { s.push_str("\u{1b}]0;"); s.push_str(&self.title); s.push('\u{7}'); }
         if !self.cwd.is_empty() { s.push_str("\u{1b}]7;"); s.push_str(&self.cwd); s.push('\u{7}'); }
         s
@@ -1008,6 +1011,13 @@ impl Performer for Emulator {
             b'T' => {
                 for _ in 0..p(0, 1) {
                     self.scroll_region_down();
+                }
+            }
+            b'q' if prefix == 0 => {
+                // DECSCUSR (CSI Ps SP q) — cursor shape; the SP intermediate is dropped by the parser.
+                let ps = *params.first().unwrap_or(&0);
+                if (0..=6).contains(&ps) {
+                    self.cursor_shape = ps;
                 }
             }
             _ => {

--- a/native/agwinterm-core/src/lib.rs
+++ b/native/agwinterm-core/src/lib.rs
@@ -27,7 +27,7 @@ use screen::ScreenBuffer;
 /// Bumped whenever the exported C surface changes shape. The C# loader
 /// refuses a mismatch loudly (same hard-handshake philosophy as the
 /// pty-host protocol).
-pub const ABI_VERSION: u32 = 11;
+pub const ABI_VERSION: u32 = 12;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn agwcore_abi_version() -> u32 {
@@ -363,6 +363,7 @@ pub unsafe extern "C" fn agwcore_emu_state_dump(p: *mut Terminal, out_len: *mut 
     let _ = writeln!(s, "paste:{}", e.bracketed_paste as u8);
     let _ = writeln!(s, "focus:{}", e.focus_reporting as u8);
     let _ = writeln!(s, "sync:{}", e.synchronized_output as u8);
+    let _ = writeln!(s, "cursorshape:{}", e.cursor_shape);
     let _ = writeln!(s, "kbd:{}", e.keyboard_flags());
     let _ = writeln!(s, "title:{}", e.title);
     let _ = writeln!(s, "cwd:{}", e.cwd);
@@ -501,6 +502,7 @@ pub struct FfiEmuInfo {
     pub mark_count: u32,
     pub focus_reporting: u32,
     pub synchronized_output: u32,
+    pub cursor_shape: i32,
 }
 
 /// # Safety
@@ -534,6 +536,7 @@ pub unsafe extern "C" fn agwcore_emu_info(p: *mut Terminal, out: *mut FfiEmuInfo
             mark_count: e.marks().len() as u32,
             focus_reporting: e.focus_reporting as u32,
             synchronized_output: e.synchronized_output as u32,
+            cursor_shape: e.cursor_shape,
         };
     }
     true

--- a/src/Agwinterm.Core/ITerminalCore.cs
+++ b/src/Agwinterm.Core/ITerminalCore.cs
@@ -32,6 +32,7 @@ public interface ITerminalCore
     bool BracketedPaste { get; }
     bool FocusReporting { get; }
     bool SynchronizedOutput { get; }
+    int CursorShape { get; }
     int KeyboardFlags { get; }
 
     // ---- scrollback ----

--- a/src/Agwinterm.Core/RustEmulatorCore.cs
+++ b/src/Agwinterm.Core/RustEmulatorCore.cs
@@ -16,7 +16,7 @@ namespace Agwinterm.Core;
 /// </summary>
 public sealed unsafe class RustEmulatorCore : IDisposable
 {
-    public const uint RequiredAbi = 11;
+    public const uint RequiredAbi = 12;
 
     [StructLayout(LayoutKind.Sequential)]
     public struct Info
@@ -26,6 +26,7 @@ public sealed unsafe class RustEmulatorCore : IDisposable
         public uint MouseClick, MouseDrag, MouseMotion, MouseSgr, BracketedPaste;
         public int KeyboardFlags;
         public uint ScrollTop, ScrollBottom, MarkCount, FocusReporting, SynchronizedOutput;
+        public int CursorShape;
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/Agwinterm.Core/RustTerminalCore.cs
+++ b/src/Agwinterm.Core/RustTerminalCore.cs
@@ -91,6 +91,7 @@ public sealed class RustTerminalCore : ITerminalCore, IDisposable
     public bool BracketedPaste => _info.BracketedPaste != 0;
     public bool FocusReporting => _info.FocusReporting != 0;
     public bool SynchronizedOutput => _info.SynchronizedOutput != 0;
+    public int CursorShape => _info.CursorShape;
     public int KeyboardFlags => _info.KeyboardFlags;
 
     // ---- scrollback ----

--- a/src/Agwinterm.Core/TerminalEmulator.cs
+++ b/src/Agwinterm.Core/TerminalEmulator.cs
@@ -55,6 +55,10 @@ public sealed class TerminalEmulator : IParserPerformer, ITerminalCore
     /// Transient render hint — intentionally NOT persisted in <see cref="DumpModes"/>.</summary>
     public bool SynchronizedOutput { get; private set; }
 
+    /// <summary>Cursor shape set by DECSCUSR (CSI Ps SP q): 0 = terminal default (use user config),
+    /// 1/2 = block (blink/steady), 3/4 = underline, 5/6 = bar. The renderer decodes shape + blink.</summary>
+    public int CursorShape { get; private set; }
+
     private int _scrollTop;
     private int _scrollBottom;
 
@@ -337,6 +341,12 @@ public sealed class TerminalEmulator : IParserPerformer, ITerminalCore
             case 'P': DeleteChars(P(0, 1)); break;   // DCH
             case 'S': for (int i = 0; i < P(0, 1); i++) ScrollRegionUp(); break;   // SU
             case 'T': for (int i = 0; i < P(0, 1); i++) ScrollRegionDown(); break; // SD
+            case 'q' when prefix == '\0': // DECSCUSR (CSI Ps SP q) — cursor shape; the SP intermediate is dropped
+            {
+                int ps = parameters.Count > 0 ? parameters[0] : 0;
+                if (ps is >= 0 and <= 6) CursorShape = ps;   // out-of-range values are ignored
+                break;
+            }
             default:
                 Host?.Unhandled("CSI", $"{(prefix == '\0' ? "" : prefix + " ")}{string.Join(';', parameters)} {final}");
                 break;
@@ -877,6 +887,7 @@ public sealed class TerminalEmulator : IParserPerformer, ITerminalCore
         if (_mouseSgr) sb.Append("\x1b[?1006h");
         if (BracketedPaste) sb.Append("\x1b[?2004h");
         if (FocusReporting) sb.Append("\x1b[?1004h");
+        if (CursorShape != 0) sb.Append("\x1b[").Append(CursorShape).Append(" q");
         if (Title.Length > 0) sb.Append("\x1b]0;").Append(Title).Append('\x07');
         if (Cwd.Length > 0) sb.Append("\x1b]7;").Append(Cwd).Append('\x07');
         return sb.ToString();

--- a/src/Agwinterm.Win32/Program.Render.cs
+++ b/src/Agwinterm.Win32/Program.Render.cs
@@ -348,7 +348,7 @@ internal partial class Program
         // here while the pump held the lock — see docs/memory-profile-2026-07-09.md).
         var em = session.Emulator;
         int cols, rows, hist, off;
-        bool cursorVisible; int cursorCol, cursorRow;
+        bool cursorVisible; int cursorCol, cursorRow, cursorShape;
         bool drawImages;
         (int PromptLine, int? ExitCode)[] marks;
         lock (session.SyncRoot)
@@ -360,6 +360,7 @@ internal partial class Program
             bool isAlt = em.IsAltScreen;
             off = isAlt ? 0 : Math.Clamp(scrollOffset, 0, hist);
             cursorVisible = em.CursorVisible; cursorCol = em.CursorCol; cursorRow = em.CursorRow;
+            cursorShape = em.CursorShape;   // DECSCUSR (0 = use user config)
             drawImages = !_noImages && em.Placements.Count > 0 && off == 0;
             marks = !isAlt && em.Marks.Count > 0
                 ? em.Marks.Select(m => (m.PromptLine, m.ExitCode)).ToArray()
@@ -549,9 +550,19 @@ internal partial class Program
             {
                 float cx = ox + cursorCol * cw, cy = oy + cursorRow * ch;
                 brush.Color = C4(_theme.Cursor);
-                if (!_config.CursorBlink || _cursorOn)
+                // DECSCUSR (cursorShape): 0 = fall back to the user's config; 1/2 block, 3/4 underline,
+                // 5/6 bar; odd = blinking, even = steady. Style 0 also inherits the config blink.
+                CursorStyle shape = cursorShape switch
                 {
-                    switch (_config.CursorStyle)
+                    0 => _config.CursorStyle,
+                    1 or 2 => CursorStyle.Block,
+                    3 or 4 => CursorStyle.Underline,
+                    _ => CursorStyle.Bar,
+                };
+                bool blink = cursorShape == 0 ? _config.CursorBlink : (cursorShape % 2 == 1);
+                if (!blink || _cursorOn)
+                {
+                    switch (shape)
                     {
                         case CursorStyle.Block: rt.FillRectangle(new Rect(cx, cy, cw, ch), brush); break;
                         case CursorStyle.Underline:

--- a/tests/Agwinterm.Core.Tests/OscTests.cs
+++ b/tests/Agwinterm.Core.Tests/OscTests.cs
@@ -233,8 +233,9 @@ public class OscTests
     {
         var t = new TerminalEmulator(40, 3);
         var host = new RecordingHost(); t.Host = host;
-        t.Feed(Encoding.UTF8.GetBytes("\x1b[3 q"));       // DECSCUSR (not implemented; space intermediate dropped by parser)
+        t.Feed(Encoding.UTF8.GetBytes("\x1b[99z"));       // unassigned CSI final -> CSI tap
         t.Feed(Encoding.UTF8.GetBytes("\x1b[?9999h"));    // an unassigned private mode -> MODE tap
+        Assert.Contains(host.Unhandleds, u => u.Kind == "CSI" && u.Detail == "99 z");
         Assert.Contains(host.Unhandleds, u => u.Kind == "MODE" && u.Detail == "?9999 h");
         Assert.NotEmpty(host.Unhandleds);
     }

--- a/tests/Agwinterm.Core.Tests/RustEmulatorCoreTests.cs
+++ b/tests/Agwinterm.Core.Tests/RustEmulatorCoreTests.cs
@@ -235,6 +235,36 @@ public class RustEmulatorCoreTests
     }
 
     [Fact]
+    public void Adapter_CursorShape_Decscusr_MatchManagedCore()
+    {
+        if (!Available) return;
+        var cs = new TerminalEmulator(20, 5);
+        using var rust = new RustTerminalCore(20, 5);
+        Assert.Equal(0, cs.CursorShape);
+        Assert.Equal(0, rust.CursorShape);
+
+        // CSI 5 SP q -> blinking bar (the SP intermediate is dropped by the parser).
+        var bar = System.Text.Encoding.ASCII.GetBytes("\x1b[5 q");
+        cs.Feed(bar); rust.Feed(bar);
+        Assert.Equal(5, cs.CursorShape);
+        Assert.Equal(5, rust.CursorShape);                 // surfaced via the adapter Info snapshot
+        Assert.Contains("\x1b[5 q", rust.DumpModes());     // persisted for reattach
+        Assert.Equal(cs.DumpModes(), rust.DumpModes());
+
+        // Out-of-range values are ignored; 0 resets to the terminal default.
+        var bogus = System.Text.Encoding.ASCII.GetBytes("\x1b[9 q");
+        cs.Feed(bogus); rust.Feed(bogus);
+        Assert.Equal(5, cs.CursorShape);
+        Assert.Equal(5, rust.CursorShape);
+
+        var reset = System.Text.Encoding.ASCII.GetBytes("\x1b[0 q");
+        cs.Feed(reset); rust.Feed(reset);
+        Assert.Equal(0, cs.CursorShape);
+        Assert.Equal(0, rust.CursorShape);
+        Assert.Equal(cs.DumpModes(), rust.DumpModes());
+    }
+
+    [Fact]
     public void Adapter_DirectImageApi_RoundTrips()
     {
         if (!Available) return;

--- a/tests/Agwinterm.Core.Tests/RustParityTests.cs
+++ b/tests/Agwinterm.Core.Tests/RustParityTests.cs
@@ -311,6 +311,7 @@ public class RustParityTests
         sb.Append($"paste:{(e.BracketedPaste ? 1 : 0)}\n");
         sb.Append($"focus:{(e.FocusReporting ? 1 : 0)}\n");
         sb.Append($"sync:{(e.SynchronizedOutput ? 1 : 0)}\n");
+        sb.Append($"cursorshape:{e.CursorShape}\n");
         sb.Append($"kbd:{e.KeyboardFlags}\n");
         sb.Append($"title:{e.Title}\n");
         sb.Append($"cwd:{e.Cwd}\n");


### PR DESCRIPTION
## What

Implements **DECSCUSR** (`CSI Ps SP q`) — the one remaining `#98` gap that reaches the **renderer**. Programs switch the cursor shape dynamically (vim/nvim → bar in insert mode, block in normal; shells with mode-aware cursors). agwinterm now tracks it in both cores and draws the requested shape, falling back to the user's config when the app hasn't set one.

`Ps`: 0 = terminal default · 1/2 = block (blink/steady) · 3/4 = underline · 5/6 = bar.

## Changes

- **`TerminalEmulator` + Rust core**: `CSI Ps SP q` sets `CursorShape` (0 default; out-of-range ignored; the `SP` intermediate is dropped by the parser, so it dispatches as final `q`, prefix 0). **Persisted in `DumpModes`** (`CSI n SP q`) so a reattached session keeps the shape — unlike transient `?2026`.
- **ABI 11 → 12**: append `cursor_shape` to `FfiEmuInfo` (Rust + C# `Info` + lite mirror in lockstep); `RustTerminalCore` surfaces `ITerminalCore.CursorShape`.
- **renderer**: decode `CursorShape` → shape + blink. Shape 0 inherits `_config` (`CursorStyle` + `CursorBlink`); otherwise the DECSCUSR shape with odd = blinking, even = steady. Reuses the existing block/underline/bar draw.
- **lite**: `kRequiredAbi 11 → 12` + struct field (lite draws its own cursor; the value is carried for layout, not yet honored).
- **tests**: `Adapter_CursorShape_Decscusr_MatchManagedCore` (set / ignore-out-of-range / reset + `DumpModes` persistence, parity across cores); the `state_dump` oracle gains a `cursorshape:` line; the CSI/MODE unhandled-tap test now uses genuinely unassigned sequences (its old `CSI 3 SP q` example became DECSCUSR).

## Verification

Core.Tests **177/177**, Rust unit **26/26**, lite builds against v12, Win32 app builds. (The visual shape switch is renderer glue over the tested shape/blink decode.)

This clears the visible/renderer item on `#98`; remaining: `?9001` win32-input-mode and BEL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)