### PR TITLE
feat(vt): terminal bell (BEL 0x07) — audible/visual per config (#98)

### DIFF
--- a/lite/src/main.cpp
+++ b/lite/src/main.cpp
@@ -23,7 +23,7 @@
 #include "proto/pb_decode.h"
 #include "control.h"
 
-// ---- agwinterm-core C ABI (ABI v12) ----
+// ---- agwinterm-core C ABI (ABI v13) ----
 struct FfiCell {
     int32_t rune;
     uint32_t fg, bg, attrs, width;
@@ -53,7 +53,7 @@ static bool (*emu_copy_grid)(void*, FfiCell*, uint32_t);
 static bool (*emu_copy_history_row)(void*, uint32_t, FfiCell*, uint32_t);
 static uint32_t (*emu_marks)(void*, FfiMark*, uint32_t);
 
-static constexpr uint32_t kRequiredAbi = 12;
+static constexpr uint32_t kRequiredAbi = 13;
 static constexpr uint32_t kAttrBold = 1, kAttrItalic = 2, kAttrUnderline = 4,
                           kAttrInverse = 8, kAttrDim = 16, kAttrStrike = 32;
 static constexpr uint32_t kProtocolVersion = 2;
@@ -188,7 +188,7 @@ static void loadCore() {
     emu_marks = (decltype(emu_marks))GetProcAddress(m, "agwcore_emu_marks");
     if (!core_abi || !emu_new || !emu_feed || !emu_info || !emu_copy_grid || !emu_resize || !emu_free || !emu_copy_history_row || !emu_marks)
         fatal(L"agwinterm_core.dll: exports missing");
-    if (core_abi() != kRequiredAbi) fatal(L"agwinterm_core.dll: ABI mismatch (need v12)");
+    if (core_abi() != kRequiredAbi) fatal(L"agwinterm_core.dll: ABI mismatch (need v13)");
 }
 
 static void connectControl() {

--- a/native/agwinterm-core/src/emulator.rs
+++ b/native/agwinterm-core/src/emulator.rs
@@ -175,6 +175,7 @@ pub enum HostAction {
     Progress { state: i32, value: i32 },
     Clipboard { text: String },
     Respond { reply: String },
+    Bell,
     Unhandled { kind: String, detail: String },
 }
 
@@ -921,6 +922,7 @@ impl Performer for Emulator {
                 let cols = self.screen().cols();
                 self.cursor_col = (cols - 1).min((self.cursor_col / 8 + 1) * 8);
             }
+            7 => self.push_action(HostAction::Bell), // BEL — ring the bell (host decides how)
             0 => {} // NUL — historical padding, deliberately ignored (would flood the tap)
             _ => self.push_action(HostAction::Unhandled {
                 kind: "C0".into(),

--- a/native/agwinterm-core/src/lib.rs
+++ b/native/agwinterm-core/src/lib.rs
@@ -27,7 +27,7 @@ use screen::ScreenBuffer;
 /// Bumped whenever the exported C surface changes shape. The C# loader
 /// refuses a mismatch loudly (same hard-handshake philosophy as the
 /// pty-host protocol).
-pub const ABI_VERSION: u32 = 12;
+pub const ABI_VERSION: u32 = 13;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn agwcore_abi_version() -> u32 {
@@ -469,6 +469,7 @@ pub unsafe extern "C" fn agwcore_emu_take_host_actions(p: *mut Terminal, out_len
                 put_str(&mut buf, kind);
                 put_str(&mut buf, detail);
             }
+            HostAction::Bell => buf.push(6), // no payload
         }
     }
     let mut boxed = buf.into_boxed_slice();

--- a/src/Agwinterm.Core/IHostActions.cs
+++ b/src/Agwinterm.Core/IHostActions.cs
@@ -27,6 +27,10 @@ public interface IHostActions
     /// (e.g. the kitty keyboard-protocol flags query reply).</summary>
     void Respond(string reply);
 
+    /// <summary>The program rang the bell (BEL, 0x07). The host decides what that means —
+    /// an audible beep, a visual flash, an attention cue, or nothing — per user config.</summary>
+    void Bell();
+
     /// <summary>A syntactically valid escape sequence the emulator has no handler for. A debug tap:
     /// hosts typically log it under an env flag (or no-op) — never user-visible. This is what turns
     /// a protocol gap into one grep instead of a stack of symptom reports.</summary>

--- a/src/Agwinterm.Core/RustEmulatorCore.cs
+++ b/src/Agwinterm.Core/RustEmulatorCore.cs
@@ -16,7 +16,7 @@ namespace Agwinterm.Core;
 /// </summary>
 public sealed unsafe class RustEmulatorCore : IDisposable
 {
-    public const uint RequiredAbi = 12;
+    public const uint RequiredAbi = 13;
 
     [StructLayout(LayoutKind.Sequential)]
     public struct Info

--- a/src/Agwinterm.Core/RustTerminalCore.cs
+++ b/src/Agwinterm.Core/RustTerminalCore.cs
@@ -141,6 +141,7 @@ public sealed class RustTerminalCore : ITerminalCore, IDisposable
                 case 3: host.ClipboardWrite(ReadStr(br)); break;
                 case 4: host.Respond(ReadStr(br)); break;
                 case 5: { string kind = ReadStr(br), detail = ReadStr(br); host.Unhandled(kind, detail); break; }
+                case 6: host.Bell(); break;      // no payload
                 default: return;                 // unknown tag — blob is corrupt; stop rather than misread
             }
         }

--- a/src/Agwinterm.Core/TerminalConfig.cs
+++ b/src/Agwinterm.Core/TerminalConfig.cs
@@ -70,6 +70,10 @@ public sealed class TerminalConfig
     /// background (agterm's Dock bounce, #215): "none" (default) | "once" | "until-focused".</summary>
     public string NotificationFlash { get; set; } = "none";
 
+    /// <summary>What the terminal bell (BEL, 0x07) does: "audible" (default — a system beep) |
+    /// "visual" (a brief window flash) | "both" | "none".</summary>
+    public string Bell { get; set; } = "audible";
+
     /// <summary>Periodically check the npm registry for a newer Claude Code release and surface a
     /// hint (toast + palette) when one ships. Awareness only — the update itself always stays a
     /// manual, visible <c>claude update</c> (palette → "Update Claude Code").</summary>
@@ -353,6 +357,9 @@ public sealed class TerminalConfig
         notification-badges = true
         attention-button = true
 
+        # Terminal bell (BEL, 0x07): audible (system beep) | visual (brief window flash) | both | none.
+        bell = audible
+
         # Agent-status glyph colors (#RRGGBB) for the sidebar dot + title-bar bell.
         status-color-active = #3C8CFF
         status-color-blocked = #F0A028
@@ -393,6 +400,9 @@ public sealed class TerminalConfig
                 case "clipboard-write": cfg.ClipboardWrite = ParseBool(val, cfg.ClipboardWrite); break;
                 case "notification-flash":
                     if (val is "none" or "once" or "until-focused") cfg.NotificationFlash = val;
+                    break;
+                case "bell":
+                    if (val is "none" or "audible" or "visual" or "both") cfg.Bell = val;
                     break;
                 case "claude-update-check": cfg.ClaudeUpdateCheck = ParseBool(val, cfg.ClaudeUpdateCheck); break;
                 case "update-check": cfg.UpdateCheck = ParseBool(val, cfg.UpdateCheck); break;

--- a/src/Agwinterm.Core/TerminalEmulator.cs
+++ b/src/Agwinterm.Core/TerminalEmulator.cs
@@ -258,8 +258,9 @@ public sealed class TerminalEmulator : IParserPerformer, ITerminalCore
             case 9:                                              // HT
                 CursorCol = Math.Min(Screen.Cols - 1, ((CursorCol / 8) + 1) * 8);
                 break;
+            case 7: Host?.Bell(); break;                         // BEL — ring the bell (host decides how)
             case 0: break; // NUL — historical padding, deliberately ignored (would flood the tap)
-            default: Host?.Unhandled("C0", $"0x{control:X2}"); break; // e.g. BEL 0x07 (no bell yet)
+            default: Host?.Unhandled("C0", $"0x{control:X2}"); break;
         }
     }
 

--- a/src/Agwinterm.Win32/Program.Render.cs
+++ b/src/Agwinterm.Win32/Program.Render.cs
@@ -639,6 +639,15 @@ internal partial class Program
                 if (_coverKind == 3) DrawOverlayFooter(rt, brush);          // overlay-only footer
             }
         }
+
+        // Visual bell (config `bell = visual|both`): a brief translucent flash over the content area,
+        // cleared by the BellFlashTimer repaint once the window elapses.
+        if (Environment.TickCount64 < _bellFlashUntil)
+        {
+            var (bx, by, bw, bh) = ContentArea();
+            brush.Color = WithA(C4(_theme.Cursor), 0.22f);
+            rt.FillRectangle(new Rect(bx, by, bw, bh), brush);
+        }
     }
 
     /// <summary>The Ctrl+Tab switcher HUD: a centered panel listing sessions in recency order with the

--- a/src/Agwinterm.Win32/Program.Services.cs
+++ b/src/Agwinterm.Win32/Program.Services.cs
@@ -92,6 +92,24 @@ internal partial class Program
         RequestRedraw();
     }
 
+    /// <summary>The terminal bell (BEL, 0x07): beep and/or flash per the `bell` config. A BEL flood
+    /// (e.g. `yes` piping bells) coalesces into one ring; the visual flash only shows for an on-screen
+    /// pane. Called on the UI thread via Post from the pane's host.</summary>
+    private void RingBell(Pane pane)
+    {
+        long now = Environment.TickCount64;
+        if (now - _lastBellTick < 120) return;   // coalesce a rapid BEL flood into a single ring
+        _lastBellTick = now;
+        string mode = _config.Bell;
+        if (mode is "audible" or "both") MessageBeep(MB_OK);
+        if ((mode is "visual" or "both") && IsSurfaceVisible(pane))
+        {
+            _bellFlashUntil = now + 100;                                  // ~100 ms flash
+            SetTimer(_hwnd, (IntPtr)BellFlashTimer, 120, IntPtr.Zero);    // repaint to clear it
+            RequestRedraw();
+        }
+    }
+
     /// <summary>Total unread notifications across a session's panes (for the sidebar badge).</summary>
     private static int UnreadOf(Ses s) { int n = 0; foreach (var p in s.Panes) n += p.Unread; return n; }
 

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -281,6 +281,7 @@ internal partial class Program
             _app.Post(() => _app.ClipboardSet(text));
         }
         public void Respond(string reply) { _s.NotifyActivity(); _s.Write(Encoding.UTF8.GetBytes(reply)); } // query reply -> PTY
+        public void Bell() => _app.Post(() => _app.RingBell(_pane));                                     // BEL -> beep/flash per config
         public void Unhandled(string kind, string detail) => VtLog.Write(_pane.Id, kind, detail);       // AGWINTERM_VT_LOG tap
     }
 

--- a/src/Agwinterm.Win32/Program.WndProc.cs
+++ b/src/Agwinterm.Win32/Program.WndProc.cs
@@ -197,6 +197,12 @@ internal partial class Program
                     AnnounceNewOutput();
                     return IntPtr.Zero;
                 }
+                if ((int)wParam == BellFlashTimer)
+                {
+                    KillTimer(hwnd, (IntPtr)BellFlashTimer);
+                    RequestRedraw();   // repaint once the flash window has elapsed to clear the overlay
+                    return IntPtr.Zero;
+                }
                 _cursorOn = !_cursorOn;
                 InvalidateRect(hwnd, IntPtr.Zero, false);
                 return IntPtr.Zero;

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -320,6 +320,9 @@ internal partial class Program : ISessionHost, IWindowHost
     private const int RedrawMinIntervalMs = 15;
     private const int UiaAnnounceTimer = 11;          // debounce: announce new output to a screen reader
     private const int UiaAnnounceQuietMs = 350;       // speak once output has settled this long
+    private const int BellFlashTimer = 13;            // WM_TIMER id: clear the visual-bell flash overlay
+    private long _bellFlashUntil;                     // TickCount64 the visual-bell flash is drawn until
+    private long _lastBellTick;                       // coalesce a BEL flood into one ring
     private long _lastPaintTick;                      // Environment.TickCount64 of the last WM_PAINT render
     private bool _redrawTimerArmed;
 

--- a/src/Agwinterm.Win32/Win32.cs
+++ b/src/Agwinterm.Win32/Win32.cs
@@ -109,6 +109,9 @@ internal static class Win32
     [DllImport("user32.dll")]
     public static extern bool FlashWindowEx(ref FLASHWINFO pwfi);
     public const uint FLASHW_STOP = 0, FLASHW_CAPTION = 1, FLASHW_TRAY = 2, FLASHW_ALL = 3, FLASHW_TIMERNOFG = 12;
+    [DllImport("user32.dll")]
+    public static extern bool MessageBeep(uint uType);
+    public const uint MB_OK = 0;   // the standard system beep
     public const uint TPM_RETURNCMD = 0x0100, TPM_RIGHTBUTTON = 0x0002, TPM_LEFTALIGN = 0x0000, TPM_BOTTOMALIGN = 0x0020;
     public const uint MF_STRING = 0x0000, MF_POPUP = 0x0010, MF_SEPARATOR = 0x0800, MF_GRAYED = 0x0001;
     public const uint BIF_RETURNONLYFSDIRS = 0x0001, BIF_NEWDIALOGSTYLE = 0x0040;

--- a/tests/Agwinterm.Core.Tests/RecordingHost.cs
+++ b/tests/Agwinterm.Core.Tests/RecordingHost.cs
@@ -9,10 +9,12 @@ public sealed class RecordingHost : IHostActions
     public readonly List<string> ClipboardWrites = new();
     public readonly List<string> Responses = new();
     public readonly List<(string Kind, string Detail)> Unhandleds = new();
+    public int Bells;
 
     public void Notify(string title, string body) => Notifications.Add((title, body));
     public void Progress(int state, int value) => ProgressReports.Add((state, value));
     public void ClipboardWrite(string text) => ClipboardWrites.Add(text);
     public void Respond(string reply) => Responses.Add(reply);
     public void Unhandled(string kind, string detail) => Unhandleds.Add((kind, detail));
+    public void Bell() => Bells++;
 }

--- a/tests/Agwinterm.Core.Tests/RustEmulatorCoreTests.cs
+++ b/tests/Agwinterm.Core.Tests/RustEmulatorCoreTests.cs
@@ -146,6 +146,7 @@ public class RustEmulatorCoreTests
         public void ClipboardWrite(string text) => Log.Add($"Clipboard|{text}");
         public void Respond(string reply) => Log.Add($"Respond|{reply}");
         public void Unhandled(string kind, string detail) => Log.Add($"Unhandled|{kind}|{detail}");
+        public void Bell() => Log.Add("Bell");
     }
 
     [Fact]
@@ -232,6 +233,20 @@ public class RustEmulatorCoreTests
         // Same DECRPM replies, same order, through both cores.
         Assert.Equal(mgHost.Log, rsHost.Log);
         Assert.Equal(new[] { "Respond|\x1b[?2026;2$y", "Respond|\x1b[?2026;1$y" }, rsHost.Log);
+    }
+
+    [Fact]
+    public void Adapter_Bell_FiresThroughHost_LikeManagedCore()
+    {
+        if (!Available) return;
+        var mgHost = new RecordingHost();
+        var rsHost = new RecordingHost();
+        var cs = new TerminalEmulator(20, 5) { Host = mgHost };
+        using var rust = new RustTerminalCore(20, 5) { Host = rsHost };
+        byte[] bytes = { 0x07, (byte)'x', 0x07 };   // BEL, a printable, BEL
+        cs.Feed(bytes); rust.Feed(bytes);
+        Assert.Equal(mgHost.Log, rsHost.Log);
+        Assert.Equal(2, rsHost.Log.Count(l => l == "Bell"));   // BEL no longer falls through to the C0 tap
     }
 
     [Fact]


### PR DESCRIPTION
## What

Wires up the **terminal bell** (BEL, `0x07`) — the last user-visible `#98` gap. It was only tapped as an unhandled C0 byte; now it flows through the `IHostActions` seam as a real `Bell()` action, and the app beeps and/or flashes per config.

## Changes

- **`IHostActions`**: new `Bell()` member (all implementers updated). `TerminalEmulator.Execute(7)` and the Rust `execute(7)` emit it instead of the C0 debug tap.
- **host-action pipeline**: `HostAction::Bell` (blob kind 6, no payload); **ABI 12 → 13**; `RustTerminalCore.DrainHostActions` forwards it. lite `kRequiredAbi → 13` (unaffected — it doesn't drain host actions, just needs the handshake).
- **config**: `bell = audible` — `none | audible | visual | both`.
- **app**: `PaneHost.Bell → RingBell` — `MessageBeep` for audible; a brief (~100 ms) translucent flash over the content area for visual (cleared by a `BellFlashTimer` repaint). A BEL flood (e.g. `yes` piping bells) **coalesces into one ring** (120 ms window); the visual flash only shows for an on-screen pane.
- **tests**: `Adapter_Bell_FiresThroughHost_LikeManagedCore` (BEL fires `Bell` in both cores, byte-identical, no longer a C0 tap); the `RecordingHost` fakes gain `Bell`.

## Verification

Core.Tests **178/178**, Rust unit **26/26**, lite builds against v13, Win32 app builds. (The beep/flash is app glue over the tested host-action delivery.)

This closes the visible items on `#98` — only `?9001` win32-input-mode remains (niche: full Win32 key events through ConPTY).

🤖 Generated with [Claude Code](https://claude.com/claude-code)