### PR TITLE
feat(vt): win32-input-mode (DECSET ?9001) — full Win32 key events to ConPTY (#98)

### DIFF
--- a/lite/src/main.cpp
+++ b/lite/src/main.cpp
@@ -23,7 +23,7 @@
 #include "proto/pb_decode.h"
 #include "control.h"
 
-// ---- agwinterm-core C ABI (ABI v13) ----
+// ---- agwinterm-core C ABI (ABI v14) ----
 struct FfiCell {
     int32_t rune;
     uint32_t fg, bg, attrs, width;
@@ -35,7 +35,7 @@ struct FfiEmuInfo {
     int64_t scrollGeneration;
     uint32_t mouseClick, mouseDrag, mouseMotion, mouseSgr, bracketedPaste;
     int32_t keyboardFlags;
-    uint32_t scrollTop, scrollBottom, markCount, focusReporting, synchronizedOutput;
+    uint32_t scrollTop, scrollBottom, markCount, focusReporting, synchronizedOutput, win32InputMode;
     int32_t cursorShape;
 };
 struct FfiMark {   // FTCS / OSC 133 boundary; lines are buffer-absolute, -1 = unset
@@ -53,7 +53,7 @@ static bool (*emu_copy_grid)(void*, FfiCell*, uint32_t);
 static bool (*emu_copy_history_row)(void*, uint32_t, FfiCell*, uint32_t);
 static uint32_t (*emu_marks)(void*, FfiMark*, uint32_t);
 
-static constexpr uint32_t kRequiredAbi = 13;
+static constexpr uint32_t kRequiredAbi = 14;
 static constexpr uint32_t kAttrBold = 1, kAttrItalic = 2, kAttrUnderline = 4,
                           kAttrInverse = 8, kAttrDim = 16, kAttrStrike = 32;
 static constexpr uint32_t kProtocolVersion = 2;
@@ -188,7 +188,7 @@ static void loadCore() {
     emu_marks = (decltype(emu_marks))GetProcAddress(m, "agwcore_emu_marks");
     if (!core_abi || !emu_new || !emu_feed || !emu_info || !emu_copy_grid || !emu_resize || !emu_free || !emu_copy_history_row || !emu_marks)
         fatal(L"agwinterm_core.dll: exports missing");
-    if (core_abi() != kRequiredAbi) fatal(L"agwinterm_core.dll: ABI mismatch (need v13)");
+    if (core_abi() != kRequiredAbi) fatal(L"agwinterm_core.dll: ABI mismatch (need v14)");
 }
 
 static void connectControl() {

--- a/native/agwinterm-core/src/emulator.rs
+++ b/native/agwinterm-core/src/emulator.rs
@@ -131,6 +131,7 @@ pub struct Emulator {
     pub bracketed_paste: bool,
     pub focus_reporting: bool,
     pub synchronized_output: bool,
+    pub win32_input_mode: bool,
     pub cursor_shape: i32,
 
     scroll_top: usize,
@@ -197,6 +198,7 @@ impl Emulator {
             bracketed_paste: false,
             focus_reporting: false,
             synchronized_output: false,
+            win32_input_mode: false,
             cursor_shape: 0,
             scroll_top: 0,
             scroll_bottom: rows - 1,
@@ -612,6 +614,7 @@ impl Emulator {
                 1006 => self.mouse_sgr = set,
                 1004 => self.focus_reporting = set,
                 2026 => self.synchronized_output = set,
+                9001 => self.win32_input_mode = set,
                 2004 => self.bracketed_paste = set,
                 _ => self.push_action(HostAction::Unhandled {
                     kind: "MODE".into(),
@@ -837,6 +840,7 @@ impl Emulator {
         if self.mouse_sgr { s.push_str("\u{1b}[?1006h"); }
         if self.bracketed_paste { s.push_str("\u{1b}[?2004h"); }
         if self.focus_reporting { s.push_str("\u{1b}[?1004h"); }
+        if self.win32_input_mode { s.push_str("\u{1b}[?9001h"); }
         if self.cursor_shape != 0 { s.push_str(&format!("\u{1b}[{} q", self.cursor_shape)); }
         if !self.title.is_empty() { s.push_str("\u{1b}]0;"); s.push_str(&self.title); s.push('\u{7}'); }
         if !self.cwd.is_empty() { s.push_str("\u{1b}]7;"); s.push_str(&self.cwd); s.push('\u{7}'); }

--- a/native/agwinterm-core/src/lib.rs
+++ b/native/agwinterm-core/src/lib.rs
@@ -27,7 +27,7 @@ use screen::ScreenBuffer;
 /// Bumped whenever the exported C surface changes shape. The C# loader
 /// refuses a mismatch loudly (same hard-handshake philosophy as the
 /// pty-host protocol).
-pub const ABI_VERSION: u32 = 13;
+pub const ABI_VERSION: u32 = 14;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn agwcore_abi_version() -> u32 {
@@ -363,6 +363,7 @@ pub unsafe extern "C" fn agwcore_emu_state_dump(p: *mut Terminal, out_len: *mut 
     let _ = writeln!(s, "paste:{}", e.bracketed_paste as u8);
     let _ = writeln!(s, "focus:{}", e.focus_reporting as u8);
     let _ = writeln!(s, "sync:{}", e.synchronized_output as u8);
+    let _ = writeln!(s, "win32input:{}", e.win32_input_mode as u8);
     let _ = writeln!(s, "cursorshape:{}", e.cursor_shape);
     let _ = writeln!(s, "kbd:{}", e.keyboard_flags());
     let _ = writeln!(s, "title:{}", e.title);
@@ -503,6 +504,7 @@ pub struct FfiEmuInfo {
     pub mark_count: u32,
     pub focus_reporting: u32,
     pub synchronized_output: u32,
+    pub win32_input_mode: u32,
     pub cursor_shape: i32,
 }
 
@@ -537,6 +539,7 @@ pub unsafe extern "C" fn agwcore_emu_info(p: *mut Terminal, out: *mut FfiEmuInfo
             mark_count: e.marks().len() as u32,
             focus_reporting: e.focus_reporting as u32,
             synchronized_output: e.synchronized_output as u32,
+            win32_input_mode: e.win32_input_mode as u32,
             cursor_shape: e.cursor_shape,
         };
     }

--- a/src/Agwinterm.Core/ITerminalCore.cs
+++ b/src/Agwinterm.Core/ITerminalCore.cs
@@ -32,6 +32,7 @@ public interface ITerminalCore
     bool BracketedPaste { get; }
     bool FocusReporting { get; }
     bool SynchronizedOutput { get; }
+    bool Win32InputMode { get; }
     int CursorShape { get; }
     int KeyboardFlags { get; }
 

--- a/src/Agwinterm.Core/RustEmulatorCore.cs
+++ b/src/Agwinterm.Core/RustEmulatorCore.cs
@@ -16,7 +16,7 @@ namespace Agwinterm.Core;
 /// </summary>
 public sealed unsafe class RustEmulatorCore : IDisposable
 {
-    public const uint RequiredAbi = 13;
+    public const uint RequiredAbi = 14;
 
     [StructLayout(LayoutKind.Sequential)]
     public struct Info
@@ -25,7 +25,7 @@ public sealed unsafe class RustEmulatorCore : IDisposable
         public long ScrollGeneration;
         public uint MouseClick, MouseDrag, MouseMotion, MouseSgr, BracketedPaste;
         public int KeyboardFlags;
-        public uint ScrollTop, ScrollBottom, MarkCount, FocusReporting, SynchronizedOutput;
+        public uint ScrollTop, ScrollBottom, MarkCount, FocusReporting, SynchronizedOutput, Win32InputMode;
         public int CursorShape;
     }
 

--- a/src/Agwinterm.Core/RustTerminalCore.cs
+++ b/src/Agwinterm.Core/RustTerminalCore.cs
@@ -91,6 +91,7 @@ public sealed class RustTerminalCore : ITerminalCore, IDisposable
     public bool BracketedPaste => _info.BracketedPaste != 0;
     public bool FocusReporting => _info.FocusReporting != 0;
     public bool SynchronizedOutput => _info.SynchronizedOutput != 0;
+    public bool Win32InputMode => _info.Win32InputMode != 0;
     public int CursorShape => _info.CursorShape;
     public int KeyboardFlags => _info.KeyboardFlags;
 

--- a/src/Agwinterm.Core/TerminalEmulator.cs
+++ b/src/Agwinterm.Core/TerminalEmulator.cs
@@ -59,6 +59,10 @@ public sealed class TerminalEmulator : IParserPerformer, ITerminalCore
     /// 1/2 = block (blink/steady), 3/4 = underline, 5/6 = bar. The renderer decodes shape + blink.</summary>
     public int CursorShape { get; private set; }
 
+    /// <summary>win32-input-mode (DECSET 9001, ConPTY extension): while set, the host encodes each key
+    /// as CSI Vk;Sc;Uc;Kd;Cs;Rc _ (full Win32 KEY_EVENT fidelity) instead of the usual VT input.</summary>
+    public bool Win32InputMode { get; private set; }
+
     private int _scrollTop;
     private int _scrollBottom;
 
@@ -391,6 +395,7 @@ public sealed class TerminalEmulator : IParserPerformer, ITerminalCore
                 case 1006: _mouseSgr = set; break;     // SGR extended mouse encoding
                 case 1004: FocusReporting = set; break; // focus in/out reporting
                 case 2026: SynchronizedOutput = set; break; // synchronized output (atomic frames)
+                case 9001: Win32InputMode = set; break; // ConPTY win32-input-mode
                 case 2004: BracketedPaste = set; break; // bracketed paste
                 default: Host?.Unhandled("MODE", $"?{mode} {(set ? 'h' : 'l')}"); break;
             }
@@ -888,6 +893,7 @@ public sealed class TerminalEmulator : IParserPerformer, ITerminalCore
         if (_mouseSgr) sb.Append("\x1b[?1006h");
         if (BracketedPaste) sb.Append("\x1b[?2004h");
         if (FocusReporting) sb.Append("\x1b[?1004h");
+        if (Win32InputMode) sb.Append("\x1b[?9001h");
         if (CursorShape != 0) sb.Append("\x1b[").Append(CursorShape).Append(" q");
         if (Title.Length > 0) sb.Append("\x1b]0;").Append(Title).Append('\x07');
         if (Cwd.Length > 0) sb.Append("\x1b]7;").Append(Cwd).Append('\x07');

--- a/src/Agwinterm.Win32/Program.Input.cs
+++ b/src/Agwinterm.Win32/Program.Input.cs
@@ -1044,6 +1044,12 @@ internal partial class Program
             && _active?.ActivePane?.S is { Status: AgentStatus.Active } asf)
         { asf.SetStatus(AgentStatus.Idle); RequestRedraw(); }
 
+        // win32-input-mode (ConPTY DECSET ?9001): encode every key as a full Win32 KEY_EVENT so
+        // ConPTY can reconstruct it. Key-DOWN only for now (the common case apps read); WM_CHAR for
+        // this pane is swallowed since the character rides in the sequence's Uc field.
+        if (ActiveSurface()?.S.Emulator.Win32InputMode == true)
+        { Send(Win32KeySeq(vk, ctrl, shift, alt)); return true; }
+
         // Kitty keyboard protocol: when an app has enabled it, encode keys in CSI-u form.
         if ((ActiveSurface()?.S.Emulator.KeyboardFlags ?? 0) != 0 && KittyKeyEncode(vk, ctrl, alt, shift) is { } ku)
         { Send(ku); _kittyAteChar = true; return true; }
@@ -1080,6 +1086,23 @@ internal partial class Program
         };
         if (seq is not null) { Send(seq); return true; }
         return false;
+    }
+
+    /// <summary>Encode a key-down in ConPTY win32-input-mode (DECSET ?9001):
+    /// <c>CSI Vk;Sc;Uc;Kd;Cs;Rc _</c> — Vk virtual-key, Sc scan code, Uc translated char (0 for
+    /// non-text keys; it also carries Ctrl/Shift semantics, e.g. Ctrl+A -> 0x01), Kd=1 (down),
+    /// Cs control-key-state bitmask, Rc=1. ConPTY decodes it back into a KEY_EVENT_RECORD.</summary>
+    private static string Win32KeySeq(int vk, bool ctrl, bool shift, bool alt)
+    {
+        uint sc = MapVirtualKeyW((uint)vk, 0);           // MAPVK_VK_TO_VSC
+        var ks = new byte[256];
+        GetKeyboardState(ks);
+        var buf = new char[8];
+        // wFlags bit 2 = don't mutate the kernel keyboard state (so the pending WM_CHAR is untouched).
+        int n = ToUnicodeEx((uint)vk, sc, ks, buf, buf.Length, 0x4, GetKeyboardLayout(0));
+        int uc = n >= 1 ? buf[0] : 0;
+        int cs = (shift ? 0x10 : 0) | (ctrl ? 0x8 : 0) | (alt ? 0x2 : 0); // SHIFT|LEFT_CTRL|LEFT_ALT
+        return $"\x1b[{vk};{sc};{uc};1;{cs};1_";
     }
 
     // Kitty keyboard: OnKeyDown encoded this key, so its following WM_CHAR must be dropped (else

--- a/src/Agwinterm.Win32/Program.WndProc.cs
+++ b/src/Agwinterm.Win32/Program.WndProc.cs
@@ -264,6 +264,9 @@ internal partial class Program
                 {
                     char c = (char)wParam;
                     if (_kittyAteChar) { _kittyAteChar = false; return IntPtr.Zero; }   // OnKeyDown already CSI-u-encoded this key
+                    // win32-input-mode encodes the char in the key-down sequence's Uc field, so the
+                    // normal WM_CHAR for this pane is redundant — drop it.
+                    if (ActiveSurface()?.S.Emulator.Win32InputMode == true) return IntPtr.Zero;
                     if (_coverKind == 3 && _ovlOwner is { OverlayExited: true }) { CloseActiveOverlay(); return IntPtr.Zero; }
                     if (_setOpen)
                     {

--- a/src/Agwinterm.Win32/Win32.cs
+++ b/src/Agwinterm.Win32/Win32.cs
@@ -346,6 +346,17 @@ internal static class Win32
     [DllImport("user32.dll")]
     public static extern short GetKeyState(int nVirtKey);
 
+    // Keyboard translation for ConPTY win32-input-mode (DECSET ?9001).
+    [DllImport("user32.dll")]
+    public static extern uint MapVirtualKeyW(uint uCode, uint uMapType);   // 0 = MAPVK_VK_TO_VSC
+    [DllImport("user32.dll")]
+    public static extern bool GetKeyboardState(byte[] lpKeyState);
+    [DllImport("user32.dll")]
+    public static extern IntPtr GetKeyboardLayout(uint idThread);
+    [DllImport("user32.dll")]
+    public static extern int ToUnicodeEx(uint wVirtKey, uint wScanCode, byte[] lpKeyState,
+        [Out] char[] pwszBuff, int cchBuff, uint wFlags, IntPtr dwhkl);
+
     [DllImport("user32.dll")]
     public static extern bool DestroyWindow(IntPtr hWnd);
 

--- a/tests/Agwinterm.Core.Tests/RustEmulatorCoreTests.cs
+++ b/tests/Agwinterm.Core.Tests/RustEmulatorCoreTests.cs
@@ -236,6 +236,29 @@ public class RustEmulatorCoreTests
     }
 
     [Fact]
+    public void Adapter_Win32InputMode_TracksMode_LikeManagedCore()
+    {
+        if (!Available) return;
+        var cs = new TerminalEmulator(20, 5);
+        using var rust = new RustTerminalCore(20, 5);
+        Assert.False(cs.Win32InputMode);
+        Assert.False(rust.Win32InputMode);
+
+        var on = System.Text.Encoding.ASCII.GetBytes("\x1b[?9001h");
+        cs.Feed(on); rust.Feed(on);
+        Assert.True(cs.Win32InputMode);
+        Assert.True(rust.Win32InputMode);                  // surfaced via the adapter Info snapshot
+        Assert.Contains("\x1b[?9001h", rust.DumpModes());  // persisted for reattach
+        Assert.Equal(cs.DumpModes(), rust.DumpModes());
+
+        var off = System.Text.Encoding.ASCII.GetBytes("\x1b[?9001l");
+        cs.Feed(off); rust.Feed(off);
+        Assert.False(cs.Win32InputMode);
+        Assert.False(rust.Win32InputMode);
+        Assert.Equal(cs.DumpModes(), rust.DumpModes());
+    }
+
+    [Fact]
     public void Adapter_Bell_FiresThroughHost_LikeManagedCore()
     {
         if (!Available) return;

--- a/tests/Agwinterm.Core.Tests/RustParityTests.cs
+++ b/tests/Agwinterm.Core.Tests/RustParityTests.cs
@@ -311,6 +311,7 @@ public class RustParityTests
         sb.Append($"paste:{(e.BracketedPaste ? 1 : 0)}\n");
         sb.Append($"focus:{(e.FocusReporting ? 1 : 0)}\n");
         sb.Append($"sync:{(e.SynchronizedOutput ? 1 : 0)}\n");
+        sb.Append($"win32input:{(e.Win32InputMode ? 1 : 0)}\n");
         sb.Append($"cursorshape:{e.CursorShape}\n");
         sb.Append($"kbd:{e.KeyboardFlags}\n");
         sb.Append($"title:{e.Title}\n");


### PR DESCRIPTION
## What

Implements **win32-input-mode** (`DECSET ?9001`, the ConPTY keyboard extension) — the **last `#98` item**. ConPTY emits `?9001h` when an inner console app wants full-fidelity key events; the terminal then encodes each key as `CSI Vk;Sc;Uc;Kd;Cs;Rc _` (a full Win32 `KEY_EVENT`) instead of VT input, and ConPTY reconstructs the `KEY_EVENT_RECORD` for the app.

## Changes

- **`TerminalEmulator` + Rust core**: `DECSET/DECRST ?9001` → `Win32InputMode`; persisted in `DumpModes` (`?9001h`) so a reattached view keeps the negotiated mode.
- **ABI 13 → 14**: append `win32_input_mode` to `FfiEmuInfo` (Rust + C# `Info` + lite mirror in lockstep); `RustTerminalCore` surfaces `ITerminalCore.Win32InputMode`.
- **app**: while the active pane's emulator has `?9001` on, `OnKeyDown` emits the win32 sequence and the pane's `WM_CHAR` is swallowed (the character rides in the sequence's `Uc`). `Uc` comes from `ToUnicodeEx` with the non-destructive flag (bit 2), so it carries the Ctrl/Shift char semantics ConPTY expects (e.g. Ctrl+A → `0x01`), and the pending `WM_CHAR` isn't disturbed.
- **lite**: `kRequiredAbi 13 → 14` + struct field.
- **tests**: `Adapter_Win32InputMode_TracksMode_LikeManagedCore` (toggle + `DumpModes` parity across cores); the `state_dump` oracle gains a `win32input:` line.

## Scope

**Key-down only** for now — the dominant case (apps reading `KEY_EVENT`s filter on `bKeyDown`). Correct key-up pairing (only for keys whose key-down reached the terminal, incl. `WM_SYSKEYUP` for Alt) is a clean follow-up; omitting it means apps that track held-key state won't see releases. Documented in the code.

## Verification

Core.Tests **179/179**, Rust unit **26/26**, lite builds against v14, Win32 app builds. Mode-tracking parity is unit-tested; the key encoding is app glue over the tested mode surface.

With this, the **`#98` VT-audit backlog is fully cleared.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)