### PR TITLE
build(installer): ship lite as its own Inno setup, drop the zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,21 +26,15 @@ jobs:
       - name: Install Inno Setup
         run: choco install innosetup -y --no-progress
 
-      - name: Build installer
+      # Builds BOTH Inno setups: agwinterm-setup-<ver>.exe (main) and
+      # agwinterm-lite-setup-<ver>.exe (the C++/GDI client, standalone).
+      - name: Build installers
         shell: pwsh
         run: ./installer/build.ps1
 
       - name: Build portable exe
         shell: pwsh
         run: ./installer/build-portable.ps1
-
-      # agwinterm-lite (experimental C++/GDI client for old/low-RAM machines): built with cl.exe
-      # (VS C++ tools are on windows-latest) + the Rust core/host, zipped self-contained. Best-
-      # effort — a lite build break must NOT fail the main release.
-      - name: Build agwinterm-lite (experimental)
-        shell: pwsh
-        continue-on-error: true
-        run: ./installer/build-lite.ps1
 
       # Free, certless supply-chain signing: a Sigstore-backed attestation binding each artifact to
       # this commit + workflow. Verify with:  gh attestation verify <file> --repo yeroo/agwinterm
@@ -50,6 +44,7 @@ jobs:
         with:
           subject-path: |
             installer/Output/agwinterm-setup-*.exe
+            installer/Output/agwinterm-lite-setup-*.exe
             installer/Output/agwinterm-portable-*.exe
 
       - name: Publish GitHub Release
@@ -57,10 +52,10 @@ jobs:
         with:
           files: |
             installer/Output/agwinterm-setup-*.exe
+            installer/Output/agwinterm-lite-setup-*.exe
             installer/Output/agwinterm-portable-*.exe
-            installer/Output/agwinterm-lite-*.zip
           generate_release_notes: true
-          fail_on_unmatched_files: false   # lite zip is best-effort; don't fail the release if absent
+          fail_on_unmatched_files: true    # all three are hard build products now — a missing one is a broken release
 
   # Opens the version-bump PR to microsoft/winget-pkgs for each release. Runs as a job here
   # (not a `release:` workflow) because releases published with GITHUB_TOKEN don't trigger

--- a/README.md
+++ b/README.md
@@ -225,8 +225,8 @@ status bar — in the classic Windows look.
 - **CLI**: `-p/--profile`, `-d/--dir`, `--maximized`, `--no-restore`, `--pipe` — the full app's
   flag names.
 
-Grab **`agwinterm-lite-<version>-win-x64.zip`** from Releases, or build it (needs the VC++ ATL
-component): `./lite/build.ps1`.
+Grab **`agwinterm-lite-setup-<version>.exe`** from Releases (per-user, no admin), or build it
+(needs the VC++ ATL component): `./lite/build.ps1` (dev build) / `./installer/build-lite.ps1` (setup).
 
 ## Keyboard essentials
 

--- a/installer/README.md
+++ b/installer/README.md
@@ -1,18 +1,22 @@
-# agwinterm installer
+# agwinterm installers
 
-Builds a **per-user** Windows installer (`agwinterm-setup-<ver>.exe`) from a self-contained
-publish of the app — end users need **no** .NET runtime installed.
+Builds **per-user** Windows installers — end users need **no** .NET runtime installed:
 
-It installs **both terminals**: the full `agwinterm` (.NET) app and the lightweight
-`agwinterm-lite` (C++/GDI) client for old / low-RAM machines. Both ride the **Rust pty-host**
-(`agwinterm-ptyhost.exe`) — lite always does, and the main app's shortcuts pass
-`--default-session-host server-rust` so a fresh install defaults new sessions to it (a first-run
-seed only; it never overrides an existing config, and the Settings UI stays authoritative after).
+- **`agwinterm-setup-<ver>.exe`** — the full `agwinterm` (.NET) terminal + `agwintermctl`, from a
+  self-contained publish. Its shortcuts pass `--default-session-host server-rust` so a fresh
+  install defaults new sessions to the Rust pty-host (a first-run seed only; it never overrides
+  an existing config, and the Settings UI stays authoritative after).
+- **`agwinterm-lite-setup-<ver>.exe`** — the lightweight `agwinterm-lite` (C++/GDI) client for
+  old / low-RAM machines, standalone. Always rides the Rust pty-host.
+
+Each setup ships its own copy of the shared `agwinterm-ptyhost.exe` + `agwinterm_core.dll`, so
+either installs (and uninstalls) cleanly without the other.
 
 ## Build
 
 ```powershell
-installer\build.ps1
+installer\build.ps1        # both setups (what CI/releases run)
+installer\build-lite.ps1   # lite setup only — skips the .NET publish, handy when iterating on lite
 ```
 
 Prereqs:
@@ -21,24 +25,28 @@ Prereqs:
 - [Inno Setup 6](https://jrsoftware.org/isinfo.php) — `ISCC.exe` on PATH, the default install location,
   or the per-user winget location (`winget install JRSoftware.InnoSetup`).
 
-The script:
+`build.ps1`:
 1. publishes `Agwinterm.Win32` (the app) and `Agwinterm.Ctl` (`agwintermctl`) as **self-contained win-x64**
    (a folder, not single-file — robust for the Vortice native libs and the on-disk `themes\`/`assets\`)
    into `installer\stage`,
-2. builds the Rust core + pty-host and the `agwinterm-lite` client, and stages them (lite flat next to
-   the main app so it shares the same `agwinterm_core.dll` / `agwinterm-ptyhost.exe`),
-3. compiles `installer\agwinterm.iss`,
-4. writes `installer\Output\agwinterm-setup-<ver>.exe`.
+2. builds the Rust core + pty-host and the `agwinterm-lite` client, staging lite (exe + its copies of
+   the core dll / pty-host + bundled fonts) into `installer\stage-lite`,
+3. compiles `installer\agwinterm.iss` and `installer\agwinterm-lite.iss`,
+4. writes `installer\Output\agwinterm-setup-<ver>.exe` and `installer\Output\agwinterm-lite-setup-<ver>.exe`.
 
-## What the installer does
+## What the installers do
 
-Deliberately **minimal / non-invasive** (agterm-style): it only copies files and creates shortcuts.
-It does **not** touch your `PATH`, profile, or config.
+Deliberately **minimal / non-invasive** (agterm-style): they only copy files and create shortcuts.
+They do **not** touch your `PATH`, profile, or config.
 
-- **Per-user, no admin** (`PrivilegesRequired=lowest`); installs to `%LOCALAPPDATA%\Programs\agwinterm`.
-- **Start-menu** shortcuts for both `agwinterm` and `agwinterm lite`; **desktop** shortcuts for both via a checkbox (task).
-- **Launch on finish**: a "Launch agwinterm" checkbox (interactive installs).
-- **Uninstall** removes the app files (your `%LOCALAPPDATA%\agwinterm` config/sessions are left intact).
+- **Per-user, no admin** (`PrivilegesRequired=lowest`); main installs to
+  `%LOCALAPPDATA%\Programs\agwinterm`, lite to `%LOCALAPPDATA%\Programs\agwinterm-lite`.
+- **Start-menu** shortcut (`agwinterm` / `agwinterm lite`); **desktop** shortcut via a checkbox (task).
+- **Launch on finish**: a "Launch …" checkbox (interactive installs).
+- **Uninstall** removes the app files (your `%LOCALAPPDATA%\agwinterm` / `%LOCALAPPDATA%\agwinterm-lite`
+  config/sessions are left intact).
+- Upgrading the main setup from 0.15.0–0.16.0 (which bundled lite) removes the bundled
+  `agwinterm-lite.exe` and its old shortcuts — install the lite setup to keep lite.
 
 ### Integrations are opt-in (from inside the app)
 
@@ -57,8 +65,10 @@ Each is reversible / re-runnable and can also be driven headless: `agwintermctl 
 
 ```powershell
 agwinterm-setup-<ver>.exe /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+agwinterm-lite-setup-<ver>.exe /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
 # uninstall:
 "%LOCALAPPDATA%\Programs\agwinterm\unins000.exe" /VERYSILENT
+"%LOCALAPPDATA%\Programs\agwinterm-lite\unins000.exe" /VERYSILENT
 ```
 
 ## Signing (not done)

--- a/installer/agwinterm.iss
+++ b/installer/agwinterm.iss
@@ -41,6 +41,13 @@ Name: "desktopicon"; Description: "Create a &desktop shortcut"; GroupDescription
 [Files]
 Source: "stage\*"; DestDir: "{app}"; Flags: recursesubdirs createallsubdirs ignoreversion
 
+[InstallDelete]
+; 0.15.0–0.16.0 bundled the lite terminal inside THIS setup; it now ships from its own installer
+; (agwinterm-lite-setup-<ver>.exe) — an upgrade must clean up what those versions left behind.
+Type: files; Name: "{app}\agwinterm-lite.exe"
+Type: files; Name: "{autoprograms}\{#AppName} lite.lnk"
+Type: files; Name: "{autodesktop}\{#AppName} lite.lnk"
+
 [Icons]
 ; Main terminal — its shortcut seeds server-rust on a first run (harmless once configured).
 Name: "{autoprograms}\{#AppName}"; Filename: "{app}\{#AppExe}"; Parameters: "{#RustHostArg}"; IconFilename: "{app}\assets\agwinterm.ico"

--- a/installer/build-lite.ps1
+++ b/installer/build-lite.ps1
@@ -1,30 +1,52 @@
-# Package agwinterm-lite: build the C++/GDI client (+ its Rust core & pty-host) via
-# lite/build.ps1, then zip lite\bin -> installer\Output\agwinterm-lite-<ver>-win-x64.zip.
-# The zip is self-contained: lite exe + agwinterm-ptyhost.exe + agwinterm_core.dll + font.
+# Build ONLY the agwinterm-lite Inno setup (installer\Output\agwinterm-lite-setup-<ver>.exe) —
+# handy when iterating on lite, since it skips the .NET publish of the main app entirely.
+# installer\build.ps1 builds BOTH setups and is what CI/releases run.
+# The setup is self-contained: lite exe + agwinterm-ptyhost.exe + agwinterm_core.dll + fonts.
 $ErrorActionPreference = "Stop"
 $here = Split-Path -Parent $MyInvocation.MyCommand.Definition
 $root = Split-Path -Parent $here
-$outDir = Join-Path $here "Output"
+$stageLite = Join-Path $here "stage-lite"
 
-# version = the installer's AppVersion define (single source of truth)
-$iss = Get-Content (Join-Path $here "agwinterm.iss") -Raw
-if ($iss -notmatch '#define\s+AppVersion\s+"([^"]+)"') { throw "AppVersion not found in agwinterm.iss" }
+# resolve ISCC (Inno Setup compiler): PATH, machine-wide (choco/CI), and the per-user winget location.
+$iscc = (Get-Command iscc.exe -ErrorAction SilentlyContinue).Source
+if (-not $iscc) {
+  $iscc = @("${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe", "$env:ProgramFiles\Inno Setup 6\ISCC.exe",
+            "$env:LOCALAPPDATA\Programs\Inno Setup 6\ISCC.exe") |
+    Where-Object { Test-Path $_ } | Select-Object -First 1
+}
+if (-not $iscc) { throw "ISCC (Inno Setup compiler) not found. Install Inno Setup 6 (winget install JRSoftware.InnoSetup)." }
+
+# version lock-step: agwinterm-lite.iss must match agwinterm.iss (single source of truth).
+$issText = Get-Content (Join-Path $here "agwinterm.iss") -Raw
+if ($issText -notmatch '#define\s+AppVersion\s+"([^"]+)"') { throw "AppVersion not found in agwinterm.iss" }
 $ver = $Matches[1]
+$liteText = Get-Content (Join-Path $here "agwinterm-lite.iss") -Raw
+if ($liteText -match '#define\s+AppVersion\s+"([^"]+)"' -and $Matches[1] -ne $ver) {
+  throw "version mismatch: agwinterm.iss=$ver but agwinterm-lite.iss=$($Matches[1]) - keep them in step"
+}
 
 Write-Host "== build agwinterm-lite (v$ver) ==" -ForegroundColor Cyan
 & (Join-Path $root "lite\build.ps1")
 if ($LASTEXITCODE -ne 0) { throw "lite build failed" }
 
+# Stage: the lite exe + its copy of the shared core/pty-host (lite\build.ps1 drops all three in
+# lite\bin) + ALL bundled assets (fonts + licenses) + the app icon for its shortcut.
+Write-Host "== stage lite ==" -ForegroundColor Cyan
+if (Test-Path $stageLite) { Remove-Item -Recurse -Force $stageLite }
+New-Item -ItemType Directory -Force $stageLite | Out-Null
 $bin = Join-Path $root "lite\bin"
-# Ship only the RUNTIME files (cl.exe leaves .obj intermediates in bin\ — exclude them).
-$ship = @("agwinterm-lite.exe", "agwinterm-ptyhost.exe", "agwinterm_core.dll",
-          "MesloLGLDZNerdFont-Regular.ttf", "FONT-LICENSE.txt")
-foreach ($f in $ship) {
+foreach ($f in @("agwinterm-lite.exe", "agwinterm-ptyhost.exe", "agwinterm_core.dll")) {
   if (-not (Test-Path (Join-Path $bin $f))) { throw "lite bin missing $f" }
+  Copy-Item (Join-Path $bin $f) $stageLite -Force
+}
+Copy-Item (Join-Path $root "lite\assets\*") $stageLite -Force
+Copy-Item (Join-Path $root "src\Agwinterm.Win32\assets\agwinterm.ico") $stageLite -Force
+foreach ($f in @("agwinterm.ico", "CozetteVector.ttf", "MesloLGLDZNerdFont-Regular.ttf")) {
+  if (-not (Test-Path (Join-Path $stageLite $f))) { throw "lite stage missing $f" }
 }
 
-New-Item -ItemType Directory -Force $outDir | Out-Null
-$zip = Join-Path $outDir "agwinterm-lite-$ver-win-x64.zip"
-if (Test-Path $zip) { Remove-Item $zip -Force }
-Compress-Archive -Path ($ship | ForEach-Object { Join-Path $bin $_ }) -DestinationPath $zip -CompressionLevel Optimal
-Write-Host ("== done: {0} ({1:N1} MB) ==" -f $zip, ((Get-Item $zip).Length / 1MB)) -ForegroundColor Green
+Write-Host "== compile lite installer (ISCC) ==" -ForegroundColor Cyan
+& $iscc (Join-Path $here "agwinterm-lite.iss")
+if ($LASTEXITCODE -ne 0) { throw "ISCC (lite) failed" }
+$out = Join-Path $here "Output\agwinterm-lite-setup-$ver.exe"
+Write-Host ("== done: {0} ({1:N1} MB) ==" -f $out, ((Get-Item $out).Length / 1MB)) -ForegroundColor Green


### PR DESCRIPTION
## What

Boris asked for agwinterm-lite to ship as an **Inno setup**, not a zip — and for lite to be fully out of the main setup.

- **release.yml** now publishes `agwinterm-lite-setup-<ver>.exe` (built by `installer/build.ps1` all along, previously discarded) instead of `agwinterm-lite-<ver>-win-x64.zip`; the lite setup is attested like the other assets, and `fail_on_unmatched_files: true` since all three assets are now hard build products.
- **build-lite.ps1** repurposed: builds only the lite setup (skips the .NET publish of the main app) for quick lite iteration.
- **agwinterm.iss** gains `[InstallDelete]`: the 0.15.0–0.16.0 combined setup staged `agwinterm-lite.exe` + "agwinterm lite" Start-menu/desktop shortcuts into the main `{app}`; upgrades now clean those up (lite lives only in its own installer, `%LOCALAPPDATA%\Programs\agwinterm-lite`).
- READMEs updated for the two-setup layout.

## Verification (local, live)

- `installer/build.ps1` compiles **both** setups: `agwinterm-setup-0.16.1.exe` (29.5 MB, main stage contains no lite exe) + `agwinterm-lite-setup-0.16.1.exe` (3.8 MB).
- Lite setup E2E: silent install → 18 files in `%LOCALAPPDATA%\Programs\agwinterm-lite` (exe + core dll + pty-host + icon + all 8 bundled fonts + licenses), Start-menu shortcut, ARP entry "agwinterm lite 0.16.1".
- Installed exe **runs from the install dir** (isolated `--pipe smoke` instance): control pipe answers `ping` → `agwinterm-lite 0.1`, `tree` returns a live session; dark theme + toolbar + Cozette render fine (screenshot in comments). Closing the last window shut the shared pty-host down (last-window-out guard).
- Silent uninstall: install dir, shortcut and ARP entry all gone; user config/sessions preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k