### PR TITLE
ci(release): fix winget update - pin the installer URL to x64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,9 @@ jobs:
           $version = '${{ github.ref_name }}'.TrimStart('v')
           $url = "https://github.com/${{ github.repository }}/releases/download/v$version/agwinterm-setup-$version.exe"
           Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
-          .\wingetcreate.exe update yeroo.agwinterm --version $version --urls $url --submit --token $env:WINGET_TOKEN
+          # "|x64" pins the architecture: wingetcreate sniffs the Inno stub as x86 and otherwise
+          # can't match the manifest's x64 installer node (this kept winget stuck at 0.10.0).
+          .\wingetcreate.exe update yeroo.agwinterm --version $version --urls "$url|x64" --submit --token $env:WINGET_TOKEN
 
   # Packs and pushes the Chocolatey package to the community feed on each release. Every version
   # then goes through Chocolatey's moderation queue (automated validation + VM install test +


### PR DESCRIPTION
wingetcreate sniffs the Inno setup stub as an x86 installer and then fails
to match the published manifest's single x64 installer node ("Multiple
matches found for X86 Inno installer"), so every update since the 0.10.0
package merged has failed and winget stayed stuck at 0.10.0. The "<url>|x64"
override pins the architecture. Verified locally: wingetcreate update
0.16.2 with the override generates a manifest and passes validation.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k
