### PR TITLE
feat(fonts): AGWin Bitmap build-time pack generator + .agbf v1 format

### DIFF
--- a/THIRD_PARTY_FONTS.md
+++ b/THIRD_PARTY_FONTS.md
@@ -1,0 +1,24 @@
+# Third-party fonts
+
+Every font bundled with agwinterm / agwinterm-lite or rasterized into generated
+assets, with exact versions and licenses. License texts ship next to the font files
+in `lite/assets/` (and inside the installers).
+
+| Project | Version | URL | License | Used as | Modified? |
+|---|---|---|---|---|---|
+| Meslo LGL DZ Nerd Font | NF release (bundled) | https://github.com/ryanoasis/nerd-fonts | OFL 1.1 (Meslo: Apache 2.0) | `MesloLGLDZNerdFont-Regular.ttf` — default TrueType face (main app + lite) | no |
+| Cozette | (bundled) | https://github.com/the-moonwitch/Cozette | MIT | `CozetteVector*.ttf` — lite catalog | no |
+| Tamzen (For Powerline) | (bundled) | https://github.com/sunaku/tamzen-font | free redistribution (see Tamzen-LICENSE.txt) | `TamzenForPowerline*.ttf` — lite catalog | no |
+| Terminus (TTF) | 4.49.3 | https://files.ax86.net/terminus-ttf/ | SIL OFL 1.1 | `TerminusTTF*.ttf` — lite catalog | no |
+| Spleen | 2.1.0 | https://github.com/fcambus/spleen | BSD 2-Clause, © Frederic Cambus | `Spleen-*.otf` — lite catalog | no |
+| unscii | 2.1 | http://viznut.fi/unscii/ | Public Domain | `unscii-16.ttf`, `unscii-8.ttf` — lite catalog | unscii-8: name table renamed to "unscii-8" (family collision); glyphs untouched |
+| GNU Unifont | 16.0.04 | https://unifoundry.com/unifont/ | dual SIL OFL 1.1 / GPLv2+ with font embedding exception (redistributed under OFL) | `Unifont.otf` — lite catalog | no |
+| JetBrainsMono Nerd Font Mono | Nerd Fonts v3.4.0 (JetBrains Mono 2.304), sha256 `ef552a3e…c1582` (JetBrainsMono.tar.xz) | https://github.com/ryanoasis/nerd-fonts | SIL OFL 1.1 (JetBrains Mono © 2020 JetBrains); NF-patched icon sets carry their own licenses (see the NF release's LICENSE files) | **rasterized** into `fonts/generated/agwin-bitmap-*.agbf` (AGWin Bitmap) | rasterized to bitmaps; box/block/Powerline glyphs replaced by cell-geometry synthesis |
+
+Notes:
+- Nerd Fonts patched fonts aggregate glyphs from several icon projects (Font
+  Awesome, Devicons, Octicons, Codicons, Powerline Extra, Seti-UI, Weather, Font
+  Logos, Pomicons); licensing/attribution per set is documented in the pinned Nerd
+  Fonts release. The AGWin Bitmap packs inherit those obligations.
+- SIL OFL 1.1 permits redistribution and format conversion (including
+  rasterization) provided the fonts are not sold standalone; agwinterm complies.

--- a/fonts/.gitignore
+++ b/fonts/.gitignore
@@ -1,0 +1,2 @@
+sources/
+generated/

--- a/fonts/README.md
+++ b/fonts/README.md
@@ -1,0 +1,72 @@
+# AGWin Bitmap — build-time raster font packs for agwinterm-lite
+
+Lite targets slow/old machines; the goal is text rendering with **no runtime vector
+rasterization**. These packs pre-rasterize a pinned Nerd Font into compact binary
+strikes that the renderer can memory-map and blit.
+
+## Source font
+
+**JetBrainsMono Nerd Font Mono**, Nerd Fonts release **v3.4.0** (JetBrains Mono 2.304).
+
+- archive: `JetBrainsMono.tar.xz`, sha256 `ef552a3e638f25125c6ad4c51176a6adcdce295ab1d2ffacf0db060caf8c1582`
+- file used: `JetBrainsMonoNerdFontMono-Regular.ttf` → put in `fonts/sources/` (gitignored)
+- license: SIL OFL 1.1 (see THIRD_PARTY_FONTS.md at the repo root)
+
+Why JetBrainsMono over the other candidates (DejaVuSansM, Hack, Cascadia, Iosevka
+Nerd Font Mono): complete practical Cyrillic + Greek, distinct `0O`/`Il1`, the
+cleanest unhinted grayscale at 14–20 px in side-by-side rasters, OFL-licensed, and
+the `Mono` NF variant keeps every icon inside one cell.
+
+## Layout
+
+```
+fonts/
+  sources/        pinned source fonts (downloaded, gitignored; checksums above)
+  manifests/
+    agwin-bitmap.txt        glyph subset for the normal family (ranges + NF sets)
+  overrides/      per-strike hand-corrected glyph bitmaps (14/ 16/ 18/ 20/) — TODO
+  generated/      output packs + preview sheets (gitignored; `python fonts/generate.py`)
+  generate.py     the deterministic generator
+```
+
+## Strikes and geometry
+
+Nominal size = terminal **cell height**. The generator picks the largest em whose
+ascent+descent fits the cell; cell width = the font's mono advance at that em.
+
+| pack | cell | em | glyphs | size |
+|---|---|---|---|---|
+| agwin-bitmap-14.agbf | 7×14 | 11 | 3840 | 272 KiB |
+| agwin-bitmap-16.agbf | 7×16 | 12 | 3840 | 311 KiB |
+| agwin-bitmap-18.agbf | 8×18 | 14 | 3840 | 386 KiB |
+| agwin-bitmap-20.agbf | 9×20 | 15 | 3840 | 415 KiB |
+
+Box drawing (U+2500–257F), block elements (U+2580–259F) and the solid/round
+Powerline separators are **synthesized from the exact cell geometry** — strokes
+reach the cell edges, so adjacent cells join without gaps at every size. Everything
+else is rasterized unhinted to 8-bit alpha at integer pixel positions (no ClearType,
+no subpixel placement).
+
+## .agbf v1
+
+Little-endian; full field list in the `generate.py` docstring. Header (172 bytes,
+magic `AGBF`) → glyph records (20 B each, sorted by code point → binary search) →
+8-bit alpha atlas. CRC-32 over records+atlas. Deterministic: same inputs, same bytes.
+
+## Rebuilding
+
+```
+python fonts/generate.py            # needs fontTools + Pillow
+python fonts/generate.py --sizes 16 # subset of strikes
+```
+
+Validation runs inside the generator: sorted/unique index, required coverage
+(box, blocks, Powerline, Cyrillic, U+FFFD), single-cell metadata.
+
+## Status / TODO (tracked for the Complete family)
+
+- per-strike override bitmaps (double-line box set + rounded corners need hand
+  polish; the synthesis covers the single/heavy sets well)
+- `AGWin Bitmap Complete`: full NF repertoire + GNU Unifont fallback + emoji atlas,
+  grapheme-cluster resolution
+- lite runtime loader (memory-mapped) + font UI entries

--- a/fonts/generate.py
+++ b/fonts/generate.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""AGWin Bitmap font-pack generator.
+
+Rasterizes the pinned JetBrainsMono Nerd Font Mono at build time into compact
+versioned binary packs (.agbf) at 14/16/18/20 px cell heights, so agwinterm-lite
+can render bitmap text without touching vector fonts at runtime.
+
+Box drawing (U+2500-257F), block elements (U+2580-259F) and the solid Powerline
+separators (U+E0B0/B2/B4/B6, U+E0A0 column) are SYNTHESIZED from the exact cell
+geometry instead of rasterized, so adjacent cells join without gaps at every size.
+
+Deterministic: identical inputs -> byte-identical packs (no timestamps, glyphs
+packed in code-point order). Run: python fonts/generate.py [--sizes 14,16,18,20]
+
+.agbf v1 layout (little-endian):
+  0   magic  "AGBF"
+  4   u32    version (1)
+  8   u32    strike px (nominal cell height)
+  12  u16    cellW, u16 cellH
+  16  u16    baseline (ascent), u16 underlinePos, u16 underlineTh, u16 strikePos
+  24  u32    glyphCount
+  28  u32    recordsOff, u32 atlasOff, u32 atlasLen
+  40  u32    crc32 of records+atlas
+  44  64s    family name (utf-8, zero-padded)
+  108 64s    source id (font + version, utf-8, zero-padded)
+  172 ...    records[glyphCount] (sorted by codepoint, binary-searchable), then atlas
+  record (20 bytes): u32 codepoint, u32 atlasOff, i16 bearingX, i16 bearingY,
+                     u16 w, u16 h, u8 cellWidth, u8 flags(1=synthesized), u16 pad
+  atlas: 8-bit alpha, each glyph w*h bytes row-major at its atlasOff
+"""
+import argparse, hashlib, io, struct, sys, zlib
+from pathlib import Path
+
+from fontTools.ttLib import TTFont
+from PIL import Image, ImageDraw, ImageFont
+
+ROOT = Path(__file__).resolve().parent
+SOURCES = ROOT / "sources"
+GENERATED = ROOT / "generated"
+
+SRC_TTF = "JetBrainsMonoNerdFontMono-Regular.ttf"
+SRC_ID = "JetBrainsMono Nerd Font Mono v3.4.0 (JetBrains Mono 2.304)"
+SRC_SHA256 = "ef552a3e638f25125c6ad4c51176a6adcdce295ab1d2ffacf0db060caf8c1582"  # JetBrainsMono.tar.xz
+FAMILY = "AGWin Bitmap"
+
+BOX = range(0x2500, 0x2580)
+BLOCKS = range(0x2580, 0x25A0)
+PL_SOLID = {0xE0B0, 0xE0B2}          # solid triangular Powerline separators
+PL_ROUND = {0xE0B4, 0xE0B6}          # rounded (half-circle) separators
+
+
+def parse_manifest(path):
+    cps = set()
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        kind, _, arg = line.partition(" ")
+        arg = arg.strip()
+        if kind == "RANGE":
+            lo, hi = (int(x, 16) for x in arg.split("-"))
+            cps.update(range(lo, hi + 1))
+        elif kind == "CP":
+            cps.add(int(arg, 16))
+        else:
+            raise SystemExit(f"manifest: bad line: {raw!r}")
+    return cps
+
+
+def cell_geometry(ttf_path, nominal):
+    """Largest em size whose ascent+descent fits the nominal cell height."""
+    font = TTFont(ttf_path)
+    hhea, upm = font["hhea"], font["head"].unitsPerEm
+    asc, desc = hhea.ascent, -hhea.descent
+    em = nominal
+    while em > 4:
+        a = round(asc * em / upm)
+        d = round(desc * em / upm)
+        if a + d <= nominal:
+            break
+        em -= 1
+    advance = font["hmtx"]["x"][0]  # 'x' advance == the mono advance
+    cellw = round(advance * em / upm)
+    post = font["post"]
+    upos = round(-post.underlinePosition * em / upm) or 1
+    uth = max(1, round(post.underlineThickness * em / upm))
+    return em, cellw, round(asc * em / upm), round(desc * em / upm), upos, uth
+
+
+def synth_box(cp, w, h):
+    """Box drawing / blocks / Powerline drawn on the exact cell grid (edge-to-edge)."""
+    img = Image.new("L", (w, h), 0)
+    d = ImageDraw.Draw(img)
+    cx, cy = w // 2, h // 2
+    lt = max(1, h // 14)                       # light stroke
+    hv = max(lt + 1, h // 7)                   # heavy stroke
+    def hline(x0, x1, th=lt, y=None):
+        if x1 - 1 >= x0: d.rectangle([x0, (y or cy) - th // 2, x1 - 1, (y or cy) - th // 2 + th - 1], fill=255)
+    def vline(y0, y1, th=lt, x=None):
+        if y1 - 1 >= y0: d.rectangle([(x or cx) - th // 2, y0, (x or cx) - th // 2 + th - 1, y1 - 1], fill=255)
+    C = cp
+    if C in BLOCKS:  # block elements: exact fractional fills
+        if C == 0x2588: d.rectangle([0, 0, w - 1, h - 1], fill=255)
+        elif 0x2581 <= C <= 0x2587: d.rectangle([0, h - (C - 0x2580) * h // 8, w - 1, h - 1], fill=255)
+        elif C == 0x2580: d.rectangle([0, 0, w - 1, h // 2 - 1], fill=255)
+        elif 0x2589 <= C <= 0x258F: d.rectangle([0, 0, max(1, (0x2590 - C) * w // 8) - 1, h - 1], fill=255)
+        elif C == 0x2590: d.rectangle([w // 2, 0, w - 1, h - 1], fill=255)
+        elif C in (0x2591, 0x2592, 0x2593):    # shades: ordered dither patterns
+            level = {0x2591: 1, 0x2592: 2, 0x2593: 3}[C]
+            for y in range(h):
+                for x in range(w):
+                    if (x + 2 * y) % 4 < level: img.putpixel((x, y), 255)
+        elif C == 0x2594: d.rectangle([0, 0, w - 1, h // 8 - 1], fill=255)
+        elif C == 0x2595: d.rectangle([w - max(1, w // 8), 0, w - 1, h - 1], fill=255)
+        elif 0x2596 <= C <= 0x259F:            # quadrants
+            q = {0x2596: "bl", 0x2597: "br", 0x2598: "tl", 0x2599: "tl bl br", 0x259A: "tl br",
+                 0x259B: "tl tr bl", 0x259C: "tl tr br", 0x259D: "tr", 0x259E: "tr bl", 0x259F: "tr bl br"}[C]
+            for part in q.split():
+                x0, x1 = (0, w // 2 - 1) if "l" in part else (w // 2, w - 1)
+                y0, y1 = (0, h // 2 - 1) if "t" in part else (h // 2, h - 1)
+                d.rectangle([x0, y0, x1, y1], fill=255)
+        return img
+    if C in PL_SOLID:                          # gap-free triangles using full cell
+        pts = [(0, 0), (w, cy), (0, h)] if C == 0xE0B0 else [(w, 0), (0, cy), (w, h)]
+        d.polygon(pts, fill=255)
+        return img
+    if C in PL_ROUND:
+        box = [-w, 0, w - 1, h - 1] if C == 0xE0B4 else [0, 0, 2 * w - 1, h - 1]
+        d.ellipse(box, fill=255)
+        return img
+    # box drawing: build from up/down/left/right stroke flags
+    L = {}
+    def seg(up=0, dn=0, lf=0, rt=0):
+        if lf: hline(0, cx + max(lt, hv) // 2 + 1, lf)
+        if rt: hline(cx - max(lt, hv) // 2, w, rt)
+        if up: vline(0, cy + max(lt, hv) // 2 + 1, up)
+        if dn: vline(cy - max(lt, hv) // 2, h, dn)
+    t = {0x2500: (0, 0, lt, lt), 0x2501: (0, 0, hv, hv), 0x2502: (lt, lt, 0, 0), 0x2503: (hv, hv, 0, 0),
+         0x250C: (0, lt, 0, lt), 0x250F: (0, hv, 0, hv), 0x2510: (0, lt, lt, 0), 0x2513: (0, hv, hv, 0),
+         0x2514: (lt, 0, 0, lt), 0x2517: (hv, 0, 0, hv), 0x2518: (lt, 0, lt, 0), 0x251B: (hv, 0, hv, 0),
+         0x251C: (lt, lt, 0, lt), 0x2523: (hv, hv, 0, hv), 0x2524: (lt, lt, lt, 0), 0x252B: (hv, hv, hv, 0),
+         0x252C: (0, lt, lt, lt), 0x2533: (0, hv, hv, hv), 0x2534: (lt, 0, lt, lt), 0x253B: (hv, 0, hv, hv),
+         0x253C: (lt, lt, lt, lt), 0x254B: (hv, hv, hv, hv),
+         0x2574: (0, 0, lt, 0), 0x2575: (lt, 0, 0, 0), 0x2576: (0, 0, 0, lt), 0x2577: (0, lt, 0, 0)}
+    if C in t:
+        seg(*t[C]); return img
+    if C in (0x2550,):  # double horizontal
+        hline(0, w, lt, cy - lt - 1); hline(0, w, lt, cy + lt + 1); return img
+    if C in (0x2551,):
+        vline(0, h, lt, cx - lt - 1); vline(0, h, lt, cx + lt + 1); return img
+    if 0x2552 <= C <= 0x256C:  # double corners/tees: approximate with doubled strokes
+        hline(0, w, lt, cy - lt - 1); hline(0, w, lt, cy + lt + 1)
+        vline(0, h, lt, cx - lt - 1); vline(0, h, lt, cx + lt + 1); return img
+    if 0x256D <= C <= 0x2570:  # rounded corners: quarter arcs
+        r = min(cx, cy)
+        arcbox = {0x256D: [cx, cy, cx + 2 * r, cy + 2 * r], 0x256E: [cx - 2 * r, cy, cx, cy + 2 * r],
+                  0x256F: [cx - 2 * r, cy - 2 * r, cx, cy], 0x2570: [cx, cy - 2 * r, cx + 2 * r, cy]}[C]
+        start = {0x256D: 180, 0x256E: 270, 0x256F: 0, 0x2570: 90}[C]
+        d.arc(arcbox, start, start + 90, fill=255, width=lt)
+        if C in (0x256D, 0x256E): vline(cy + r, h)
+        else: vline(0, cy - r + 1)
+        if C in (0x256D, 0x2570): hline(cx + r, w)
+        else: hline(0, cx - r + 1)
+        return img
+    if C == 0x2571: d.line([(0, h - 1), (w - 1, 0)], fill=255, width=lt); return img
+    if C == 0x2572: d.line([(0, 0), (w - 1, h - 1)], fill=255, width=lt); return img
+    if C == 0x2573:
+        d.line([(0, h - 1), (w - 1, 0)], fill=255, width=lt)
+        d.line([(0, 0), (w - 1, h - 1)], fill=255, width=lt); return img
+    if 0x2504 <= C <= 0x250B or 0x254C <= C <= 0x254F:  # dashed
+        horiz = C in (0x2504, 0x2505, 0x2508, 0x2509, 0x254C, 0x254D)
+        th = hv if C in (0x2505, 0x2509, 0x254D, 0x254F) else lt
+        n = 3 if C in (0x2504, 0x2505, 0x2506, 0x2507, 0x254C, 0x254D) else 4
+        if horiz:
+            for i in range(n): hline(i * w // n, i * w // n + max(1, w // n - 1), th)
+        else:
+            for i in range(n): vline(i * h // n, i * h // n + max(1, h // n - 1), th)
+        return img
+    seg(lt, lt, lt, lt)  # anything else in the box range: safe cross
+    return img
+
+
+def rasterize(cps, ttf_path, nominal):
+    em, cellw, asc, desc, upos, uth = cell_geometry(ttf_path, nominal)
+    cellh = nominal
+    pil = ImageFont.truetype(str(ttf_path), em)
+    cmap = TTFont(ttf_path).getBestCmap()
+    records, atlas = [], bytearray()
+    for cp in sorted(cps):
+        synth = cp in BOX or cp in BLOCKS or cp in PL_SOLID or cp in PL_ROUND or cp == 0xE0A0
+        if not synth and cp not in cmap:
+            continue
+        if synth:
+            img = synth_box(cp, cellw, cellh) if cp != 0xE0A0 else synth_box(0x2502, cellw, cellh)
+            bx = by = 0
+        else:
+            ch = chr(cp)
+            img8 = Image.new("L", (cellw * 3, cellh * 3), 0)
+            d = ImageDraw.Draw(img8)
+            d.text((cellw, asc), ch, font=pil, fill=255, anchor="ls")
+            bbox = img8.getbbox()
+            if bbox is None:  # blank (e.g. space): zero-size record keeps lookup complete
+                records.append((cp, len(atlas), 0, 0, 0, 0, 1, 0))
+                continue
+            x0, y0, x1, y1 = bbox
+            img = img8.crop(bbox)
+            bx, by = x0 - cellw, y0 - 0  # bearings vs cell origin (top-left)
+        wpx, hpx = img.size
+        records.append((cp, len(atlas), bx, by, wpx, hpx, 1, 1 if synth else 0))
+        atlas.extend(img.tobytes())
+    return records, bytes(atlas), dict(em=em, cellw=cellw, cellh=cellh, asc=asc, upos=upos, uth=uth)
+
+
+def write_pack(path, nominal, records, atlas, geo):
+    recs = b"".join(struct.pack("<IIhhHHBBH", cp, off, bx, by, w, h, cw, fl, 0)
+                    for cp, off, bx, by, w, h, cw, fl in records)
+    crc = zlib.crc32(recs + atlas) & 0xFFFFFFFF
+    hdr = struct.pack("<4sIIHHHHHHI III I",
+                      b"AGBF", 1, nominal, geo["cellw"], geo["cellh"],
+                      geo["asc"], geo["asc"] + geo["upos"], geo["uth"], geo["asc"] - geo["cellh"] * 3 // 10,
+                      len(records), 172, 172 + len(recs), len(atlas), crc)
+    hdr += FAMILY.encode().ljust(64, b"\0") + SRC_ID.encode().ljust(64, b"\0")
+    assert len(hdr) == 172, len(hdr)
+    path.write_bytes(hdr + recs + atlas)
+    return crc
+
+
+def preview(path, records, atlas, geo, nominal):
+    text_rows = ["The quick brown fox jumps over the lazy dog. 0123456789 Il1 O0 {}[]()<>/\\|_",
+                 "Съешь ещё этих мягких французских булок, да выпей чаю.",
+                 "┌────────────┬──────────┐ ╭───────╮ ░░▒▒▓▓████ ▀▄▌▐",
+                 "│ AGWin OK   │ main   │ ╰───────╯      "]
+    idx = {r[0]: r for r in records}
+    W, H = geo["cellw"] * 80, geo["cellh"] * (len(text_rows) + 1)
+    img = Image.new("L", (W, H), 0)
+    for row, line in enumerate(text_rows):
+        for col, ch in enumerate(line[:79]):
+            r = idx.get(ord(ch))
+            if not r or r[4] == 0:
+                continue
+            cp, off, bx, by, w, h, cw, fl = r
+            g = Image.frombytes("L", (w, h), atlas[off:off + w * h])
+            img.paste(g, (col * geo["cellw"] + bx, row * geo["cellh"] + by), g)
+    img.save(path)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--sizes", default="14,16,18,20")
+    ap.add_argument("--src", default=str(SOURCES / SRC_TTF))
+    args = ap.parse_args()
+    src = Path(args.src)
+    if not src.exists():
+        raise SystemExit(f"source font missing: {src}\n(download JetBrainsMono.tar.xz v3.4.0, "
+                         f"sha256 {SRC_SHA256}, extract {SRC_TTF} into fonts/sources/)")
+    cps = parse_manifest(ROOT / "manifests" / "agwin-bitmap.txt")
+    GENERATED.mkdir(exist_ok=True)
+    for nominal in (int(s) for s in args.sizes.split(",")):
+        records, atlas, geo = rasterize(cps, src, nominal)
+        out = GENERATED / f"agwin-bitmap-{nominal}.agbf"
+        crc = write_pack(out, nominal, records, atlas, geo)
+        preview(GENERATED / f"agwin-bitmap-{nominal}-preview.png", records, atlas, geo, nominal)
+        # validation: sorted unique index, box+powerline+cyrillic coverage, mono cell widths
+        cps_out = [r[0] for r in records]
+        assert cps_out == sorted(set(cps_out)), "index not sorted/unique"
+        for need in (0x2500, 0x2502, 0x253C, 0x2588, 0x2591, 0xE0B0, 0x0410, 0x044F, 0xFFFD):
+            assert need in set(cps_out), f"missing required glyph U+{need:04X}"
+        assert all(r[6] == 1 for r in records), "non-single-cell glyph in v1"
+        print(f"agwin-bitmap-{nominal}.agbf: {len(records)} glyphs, cell {geo['cellw']}x{geo['cellh']} "
+              f"(em {geo['em']}), atlas {len(atlas)//1024} KiB, crc {crc:08x}, "
+              f"file {out.stat().st_size//1024} KiB")
+
+
+if __name__ == "__main__":
+    main()

--- a/fonts/manifests/agwin-bitmap.txt
+++ b/fonts/manifests/agwin-bitmap.txt
@@ -1,0 +1,42 @@
+# AGWin Bitmap glyph manifest — what goes into the normal (non-Complete) packs.
+# Lines: "RANGE lo-hi" (inclusive, hex), "CP xx" (single code point), "# comment".
+# The generator includes a listed code point only if the source font actually covers it.
+
+# -- text ---------------------------------------------------------------------
+RANGE 0020-007E    # printable ASCII
+RANGE 00A0-00FF    # Latin-1 Supplement
+RANGE 0100-017F    # Latin Extended-A (the useful European set)
+RANGE 0370-03FF    # Greek (technical text)
+RANGE 0400-04FF    # Cyrillic (complete practical coverage)
+RANGE 0500-052F    # Cyrillic Supplement
+RANGE 2010-205E    # general punctuation (dashes, quotes, bullet, ellipsis...)
+RANGE 20A0-20BF    # currency symbols
+RANGE 2100-214F    # letterlike (№ ™ Ω ℓ ...)
+RANGE 2190-21FF    # arrows
+RANGE 2200-22FF    # mathematical operators
+RANGE 2300-23FF    # technical symbols
+RANGE 2500-257F    # box drawing (SYNTHESIZED from cell geometry, see generator)
+RANGE 2580-259F    # block elements (synthesized)
+RANGE 25A0-25FF    # geometric shapes
+RANGE 2600-26FF    # misc symbols (warnings, stars...)
+RANGE 2700-27BF    # dingbats (check marks, crosses)
+RANGE 2800-28FF    # Braille patterns
+CP FFFD            # replacement character
+
+# -- Nerd Fonts private-use sets (from the patched font) ----------------------
+RANGE E000-E00A    # Pomicons
+RANGE E0A0-E0A3    # Powerline (synthesized separators where solid)
+RANGE E0B0-E0BF    # Powerline Extra separators (solid ones synthesized)
+RANGE E0C0-E0D7    # Powerline Extra (flames, digits, honeycomb...)
+RANGE E200-E2A9    # Font Awesome Extension
+RANGE E300-E3E3    # Weather
+RANGE E5FA-E6B7    # Seti-UI + Custom (folder/file-type icons)
+RANGE E700-E8EF    # Devicons
+RANGE EA60-EC1E    # Codicons (VS Code: error/warning/info/git...)
+RANGE F000-F2FF    # Font Awesome (classic set: status, files, arrows)
+RANGE F300-F381    # Font Logos (OS logos)
+RANGE F400-F533    # Octicons (git branch/commit/PR...)
+RANGE 23FB-23FE    # IEC power symbols
+CP 2665            # heart
+CP 26A1            # zap
+CP F2A1            # (FA continued)


### PR DESCRIPTION
First slice of the AGWin Bitmap spec: a deterministic build-time tool that
rasterizes the pinned JetBrainsMono Nerd Font Mono (NF v3.4.0, sha256-
verified) into compact versioned binary strikes for agwinterm-lite:

- fonts/generate.py: manifest-driven subset (3840 glyphs: ASCII, Latin-1/
  Ext-A, Greek, full Cyrillic, punctuation/currency/arrows/math/technical,
  geometric, Braille, dingbats + the NF PUA icon sets: Powerline+Extra,
  Seti-UI, Devicons, Codicons, Font Awesome, Octicons, Font Logos,
  Weather, Pomicons), rasterized unhinted to 8-bit alpha at integer
  positions - no ClearType, no subpixel, no runtime vector work.
- Box drawing, block elements and solid/round Powerline separators are
  SYNTHESIZED from the exact cell geometry (strokes reach cell edges -
  gap-free joins at every strike).
- .agbf v1: 172-byte header (magic/version/cell metrics/underline/CRC-32),
  binary-searchable sorted glyph records, raw alpha atlas. Byte-identical
  output for identical inputs (verified: two runs, identical hashes).
- Strikes 14/16/18/20 px (cells 7x14, 7x16, 8x18, 9x20; 272-415 KiB).
- Built-in validation (sorted unique index, required coverage incl.
  Cyrillic/box/Powerline/U+FFFD, single-cell metadata) + preview sheets.
- THIRD_PARTY_FONTS.md: every bundled/rasterized font with version + license.

Not yet (tracked): per-strike override bitmaps (double-line box set +
rounded corners need hand polish), AGWin Bitmap Complete (full NF
repertoire + Unifont fallback + emoji), and the lite runtime loader/UI.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k
