### PR TITLE
feat(fonts): per-strike override system + CI validation of committed packs

### DIFF
--- a/fonts/README.md
+++ b/fonts/README.md
@@ -30,7 +30,7 @@ fonts/
   sources/        pinned source fonts (downloaded, gitignored; checksums above)
   manifests/
     agwin-bitmap.txt        glyph subset for the normal family (ranges + NF sets)
-  overrides/      per-strike hand-corrected glyph bitmaps (14/ 16/ 18/ 20/) — TODO
+  overrides/      per-strike hand-corrected glyph PNGs (14/ 16/ 18/ 20/, see its README)
   generated/      output packs + preview sheets (gitignored; `python fonts/generate.py`)
   generate.py     the deterministic generator
 ```
@@ -63,8 +63,8 @@ no subpixel placement).
 `AGWin Bitmap Complete` starts from the **full cmap of the source Nerd Font**
 (11,755 glyphs) and backfills **every remaining BMP code point** from pinned GNU
 Unifont (55,725 more; surrogates and PUA excluded — the PUA stays the Nerd Font's
-icon territory). Fallback order per the spec: Nerd Font → synthesized cell
-geometry → Unifont → hex missing-glyph cell.
+icon territory). Fallback order per the spec: hand-corrected override → Nerd Font
+→ synthesized cell geometry → Unifont → hex missing-glyph cell.
 
 Unifont glyphs are stored as **1-bit masks** (record flag 2) — Unifont is natively
 1-bit, and 8-bit alpha for ~56k extra glyphs would cost ~20 MB per strike instead
@@ -95,6 +95,9 @@ python fonts/generate.py --sizes 16            # subset of strikes
 Validation runs inside the generator: sorted/unique index, required coverage
 (box, blocks, Powerline, Cyrillic, U+FFFD), cell-width metadata, and for the
 Complete family spot checks that CJK/kana/hangul are wide 1-bit fallback glyphs.
+The **committed** packs are additionally validated on every CI run
+(`tests/Agwinterm.Core.Tests/AgbfPackTests.cs`: header sanity, CRC-32, sorted
+index, atlas bounds, per-family coverage) — a corrupted regeneration can't ship.
 
 ## Runtime (agwinterm-lite)
 
@@ -108,6 +111,6 @@ digits) instead of empty boxes.
 
 ## Status / TODO (tracked for the Complete family)
 
-- per-strike override bitmaps (double-line box set + rounded corners need hand
-  polish; the synthesis covers the single/heavy sets well)
 - emoji atlas (color records) + grapheme-cluster resolution; italic strikes
+- (the override *system* is live; no hand-drawn overrides are committed yet —
+  the explicit double-box stroke tables covered the known rough spots)

--- a/fonts/generate.py
+++ b/fonts/generate.py
@@ -27,7 +27,8 @@ packed in code-point order). Run: python fonts/generate.py [--sizes 14,16,18,20]
   record (20 bytes): u32 codepoint, u32 atlasOff, i16 bearingX, i16 bearingY,
                      u16 w, u16 h, u8 cellWidth (1 or 2 cells), u8 flags, u16 pad
   flags: 1 = synthesized (cell geometry), 2 = 1-bit glyph (rows bit-packed MSB-first,
-         padded to whole bytes), 4 = Unicode-fallback source (GNU Unifont)
+         padded to whole bytes), 4 = Unicode-fallback source (GNU Unifont),
+         8 = corrected (hand-drawn override bitmap from fonts/overrides/<px>/)
   atlas: at each glyph's atlasOff, h rows of w bytes (8-bit alpha) — or, when flags&2,
          h rows of ceil(w/8) bytes (1-bit mask; on = full-alpha foreground)
 
@@ -226,11 +227,31 @@ def synth_box(cp, w, h):
     return img
 
 
+def load_overrides(nominal, cellw, cellh):
+    """fonts/overrides/<px>/<hex>.png — hand-corrected glyphs, highest precedence.
+    Grayscale PNG, exactly cellw x cellh (or 2*cellw x cellh for a wide glyph);
+    pixel value = alpha. An all-black PNG deliberately blanks the glyph."""
+    out = {}
+    d = ROOT / "overrides" / str(nominal)
+    if not d.is_dir():
+        return out
+    for p in sorted(d.glob("*.png")):
+        cp = int(p.stem, 16)
+        img = Image.open(p).convert("L")
+        k = max(1, img.width // cellw)
+        if img.size not in ((cellw, cellh), (2 * cellw, cellh)):
+            raise SystemExit(f"{p}: size {img.size[0]}x{img.size[1]}, "
+                             f"want {cellw}x{cellh} or {2 * cellw}x{cellh}")
+        out[cp] = (img, k)
+    return out
+
+
 def rasterize(cps, ttf_path, nominal, fb_cps=None, fb_path=None):
     em, cellw, asc, desc, upos, uth = cell_geometry(ttf_path, nominal)
     cellh = asc + desc
     pil = ImageFont.truetype(str(ttf_path), em)
     cmap = TTFont(ttf_path).getBestCmap()
+    ovr = load_overrides(nominal, cellw, cellh)
     fb_cps = fb_cps or set()
     if fb_cps:
         # Fallback em: the largest size whose ascent AND descent both fit inside the pack's,
@@ -240,7 +261,17 @@ def rasterize(cps, ttf_path, nominal, fb_cps=None, fb_path=None):
         u_em = min(asc * u_upm // u_asc, desc * u_upm // u_desc if u_desc > 0 else 1 << 30)
         u_pil = ImageFont.truetype(str(fb_path), u_em)
     records, atlas = [], bytearray()
-    for cp in sorted(cps | fb_cps):
+    for cp in sorted(cps | fb_cps | set(ovr)):
+        if cp in ovr:     # corrected: hand-drawn bitmap wins over every other source
+            img8, wide = ovr[cp]
+            bbox = img8.getbbox()
+            if bbox is None:
+                records.append((cp, len(atlas), 0, 0, 0, 0, wide, 8))
+                continue
+            img = img8.crop(bbox)
+            records.append((cp, len(atlas), bbox[0], bbox[1], img.width, img.height, wide, 8))
+            atlas.extend(img.tobytes())
+            continue
         if cp in fb_cps:  # GNU Unifont fallback: 1-bit mask, wide chars span two cells
             ch = chr(cp)
             wide = 2 if unicodedata.east_asian_width(ch) in ("W", "F") else 1

--- a/fonts/overrides/README.md
+++ b/fonts/overrides/README.md
@@ -1,0 +1,18 @@
+# Per-strike glyph overrides ("corrected" source)
+
+Hand-drawn replacement bitmaps with the **highest precedence** in the fallback
+order (corrected → Nerd Font → synthesized → Unifont → missing-glyph cell).
+They apply to both families.
+
+- Location: `fonts/overrides/<px>/<hex>.png` — one directory per strike
+  (`14/ 16/ 18/ 20/`), file name is the bare hex code point (e.g. `2554.png`
+  for ╔, `e0b0.png` for the Powerline separator).
+- Format: grayscale PNG, pixel value = alpha. Size must be exactly the strike's
+  cell (`8×18`, `10×21`, `11×23`, `12×26`) — or twice the cell width for a wide
+  glyph. The generator errors on any other size.
+- An all-black PNG deliberately blanks the glyph (zero-size record, cell shows
+  background only).
+- Records carry flag 8 so a pack can be audited for hand-corrected glyphs.
+
+Overrides are per-strike on purpose: a shape that reads well at 10×21 rarely
+survives scaling to 8×18. Draw each size by hand.

--- a/tests/Agwinterm.Core.Tests/AgbfPackTests.cs
+++ b/tests/Agwinterm.Core.Tests/AgbfPackTests.cs
@@ -1,0 +1,141 @@
+using System.Buffers.Binary;
+using System.Text;
+
+namespace Agwinterm.Core.Tests;
+
+/// <summary>
+/// Golden validation of the COMMITTED .agbf font packs in lite/assets — the exact bytes the
+/// installer ships. Guards against a corrupted regeneration slipping into a release: header
+/// sanity, CRC-32, sorted index, atlas bounds, and the coverage each family promises.
+/// Format: fonts/generate.py docstring (v1, little-endian).
+/// </summary>
+public class AgbfPackTests
+{
+    private static readonly string AssetsDir = FindAssetsDir();
+
+    private static string FindAssetsDir()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir != null && !Directory.Exists(Path.Combine(dir, "lite", "assets")))
+            dir = Path.GetDirectoryName(dir);
+        Assert.NotNull(dir);
+        return Path.Combine(dir!, "lite", "assets");
+    }
+
+    private readonly record struct Rec(uint Cp, uint Off, short Bx, short By, ushort W, ushort H, byte CellW, byte Flags);
+
+    private sealed record Pack(byte[] Bytes, int Strike, ushort CellW, ushort CellH, ushort Baseline,
+                               uint AtlasOff, uint AtlasLen, string Family, Rec[] Recs);
+
+    private static Pack Load(string name)
+    {
+        var path = Path.Combine(AssetsDir, name);
+        Assert.True(File.Exists(path), $"missing committed pack: {path}");
+        var b = File.ReadAllBytes(path);
+        Assert.True(b.Length > 172, "truncated header");
+        Assert.Equal("AGBF", Encoding.ASCII.GetString(b, 0, 4));
+        Assert.Equal(1u, BinaryPrimitives.ReadUInt32LittleEndian(b.AsSpan(4)));
+        var strike = (int)BinaryPrimitives.ReadUInt32LittleEndian(b.AsSpan(8));
+        var cellW = BinaryPrimitives.ReadUInt16LittleEndian(b.AsSpan(12));
+        var cellH = BinaryPrimitives.ReadUInt16LittleEndian(b.AsSpan(14));
+        var baseline = BinaryPrimitives.ReadUInt16LittleEndian(b.AsSpan(16));
+        var count = BinaryPrimitives.ReadUInt32LittleEndian(b.AsSpan(24));
+        var recordsOff = BinaryPrimitives.ReadUInt32LittleEndian(b.AsSpan(28));
+        var atlasOff = BinaryPrimitives.ReadUInt32LittleEndian(b.AsSpan(32));
+        var atlasLen = BinaryPrimitives.ReadUInt32LittleEndian(b.AsSpan(36));
+        var crc = BinaryPrimitives.ReadUInt32LittleEndian(b.AsSpan(40));
+        var family = Encoding.UTF8.GetString(b, 44, 64).TrimEnd('\0');
+
+        Assert.Equal(172u, recordsOff);
+        Assert.Equal(172u + count * 20u, atlasOff);
+        Assert.Equal((long)atlasOff + atlasLen, b.LongLength);
+        Assert.Equal(crc, Crc32(b.AsSpan(172)));
+
+        var recs = new Rec[count];
+        for (var i = 0; i < count; i++)
+        {
+            var o = (int)recordsOff + i * 20;
+            recs[i] = new Rec(
+                BinaryPrimitives.ReadUInt32LittleEndian(b.AsSpan(o)),
+                BinaryPrimitives.ReadUInt32LittleEndian(b.AsSpan(o + 4)),
+                BinaryPrimitives.ReadInt16LittleEndian(b.AsSpan(o + 8)),
+                BinaryPrimitives.ReadInt16LittleEndian(b.AsSpan(o + 10)),
+                BinaryPrimitives.ReadUInt16LittleEndian(b.AsSpan(o + 12)),
+                BinaryPrimitives.ReadUInt16LittleEndian(b.AsSpan(o + 14)),
+                b[o + 16], b[o + 17]);
+        }
+        return new Pack(b, strike, cellW, cellH, baseline, atlasOff, atlasLen, family, recs);
+    }
+
+    private static uint Crc32(ReadOnlySpan<byte> data)
+    {
+        var crc = 0xFFFFFFFFu;
+        foreach (var by in data)
+        {
+            crc ^= by;
+            for (var k = 0; k < 8; k++)
+                crc = (crc >> 1) ^ (0xEDB88320u & (uint)-(crc & 1));
+        }
+        return ~crc;
+    }
+
+    public static TheoryData<string, int, bool> AllPacks() => new()
+    {
+        { "agwin-bitmap-14.agbf", 14, false }, { "agwin-bitmap-16.agbf", 16, false },
+        { "agwin-bitmap-18.agbf", 18, false }, { "agwin-bitmap-20.agbf", 20, false },
+        { "agwin-bitmap-complete-14.agbf", 14, true }, { "agwin-bitmap-complete-16.agbf", 16, true },
+        { "agwin-bitmap-complete-18.agbf", 18, true }, { "agwin-bitmap-complete-20.agbf", 20, true },
+    };
+
+    [Theory]
+    [MemberData(nameof(AllPacks))]
+    public void Header_Index_And_Atlas_AreConsistent(string name, int strike, bool complete)
+    {
+        var p = Load(name);
+        Assert.Equal(strike, p.Strike);
+        Assert.Equal(complete ? "AGWin Bitmap Complete" : "AGWin Bitmap", p.Family);
+        Assert.InRange(p.CellW, 1, 64);
+        Assert.True(p.CellH > p.CellW, "terminal cells are taller than wide");
+        Assert.InRange(p.Baseline, 1, p.CellH);
+
+        for (var i = 1; i < p.Recs.Length; i++)
+            Assert.True(p.Recs[i - 1].Cp < p.Recs[i].Cp, $"index not strictly sorted at #{i}");
+
+        foreach (var r in p.Recs)
+        {
+            Assert.True(r.CellW is 1 or 2, $"U+{r.Cp:X4}: cellWidth {r.CellW}");
+            var stride = (r.Flags & 2) != 0 ? (r.W + 7) / 8 : r.W;
+            Assert.True(r.Off + (long)stride * r.H <= p.AtlasLen, $"U+{r.Cp:X4}: atlas overrun");
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(AllPacks))]
+    public void RequiredCoverage_IsPresent(string name, int strike, bool complete)
+    {
+        _ = strike;
+        var p = Load(name);
+        var byCp = p.Recs.ToDictionary(r => r.Cp);
+        // Both families: synthesized box/blocks/Powerline, Cyrillic, replacement char.
+        foreach (var cp in new uint[] { 0x2500, 0x2502, 0x2554, 0x253C, 0x2588, 0x2591, 0xE0B0, 0x0410, 0x044F, 0xFFFD })
+            Assert.True(byCp.ContainsKey(cp), $"missing required glyph U+{cp:X4}");
+        foreach (var cp in new uint[] { 0x2500, 0x2588, 0xE0B0 })
+            Assert.Equal(1, byCp[cp].Flags & 1);   // synthesized from cell geometry
+
+        if (!complete)
+        {
+            Assert.All(p.Recs, r => Assert.Equal(1, r.CellW));
+            Assert.All(p.Recs, r => Assert.Equal(0, r.Flags & 2));   // curated family is all 8-bit
+            return;
+        }
+        // Complete: BMP fallback — CJK/kana/hangul are wide 1-bit Unifont glyphs, Hebrew/IPA narrow.
+        foreach (var (cp, wide) in new (uint, byte)[] { (0x4E2D, 2), (0x3042, 2), (0xAC00, 2), (0x05D0, 1), (0x0250, 1) })
+        {
+            Assert.True(byCp.TryGetValue(cp, out var r), $"missing fallback glyph U+{cp:X4}");
+            Assert.Equal(wide, r.CellW);
+            Assert.Equal(2, r.Flags & 2);
+            Assert.Equal(4, r.Flags & 4);
+        }
+        Assert.True(p.Recs.Length > 60000, $"complete pack holds the BMP, got {p.Recs.Length} glyphs");
+    }
+}


### PR DESCRIPTION
Continues the AGWin Bitmap spec (task #73) — two more spec deliverables:

## Override system ("corrected" source)

Highest precedence in the fallback order: **corrected → Nerd Font → synthesized → Unifont → missing-glyph cell**, both families.

- `fonts/overrides/<px>/<hex>.png` — grayscale PNG, pixel value = alpha, sized exactly to the strike's cell (`10×21` at 16) or twice the width for a wide glyph; any other size is a generator error.
- Rasterized over every other source, record **flag 8** for auditability; an all-black PNG deliberately blanks a glyph.
- Per-strike by design — a shape that reads at 10×21 rarely survives 8×18.
- Verified round-trip: test override for U+00A9 landed as `8x11 bearings (1,5) cellW 1 flags 8`; deleting it restored the shipped pack **byte-for-byte** (`e814eba6…`). No hand-drawn overrides are committed yet (the explicit double-box stroke tables from #168 covered the known rough spots).

## Golden validation of committed packs (CI)

`tests/Agwinterm.Core.Tests/AgbfPackTests.cs` validates the **exact committed bytes** in `lite/assets/` that the installer ships, on every CI run:

- header layout (`recordsOff`/`atlasOff`/file length consistency), CRC-32 over records+atlas
- strictly sorted code-point index, per-record atlas bounds (1-bit stride aware), cellWidth ∈ {1,2}
- both families: box/blocks/Powerline present + flagged synthesized, Cyrillic, U+FFFD
- curated family: all narrow, all 8-bit
- Complete family: CJK/kana/hangul present as **wide 1-bit Unifont fallback** records, >60k glyphs

All 16 tests pass locally (`Passed: 16, Duration: 812 ms`). A corrupted regeneration can no longer reach a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k