### PR TITLE
fix(input): ToUnicodeEx marshalled ANSI — heap corruption on every keystroke

### DIFF
--- a/src/Agwinterm.Win32/Win32.cs
+++ b/src/Agwinterm.Win32/Win32.cs
@@ -354,7 +354,11 @@ internal static class Win32
     public static extern bool GetKeyboardState(byte[] lpKeyState);
     [DllImport("user32.dll")]
     public static extern IntPtr GetKeyboardLayout(uint idThread);
-    [DllImport("user32.dll")]
+    // CharSet.Unicode is REQUIRED: the default (Ansi) marshals pwszBuff as one byte per element, so
+    // user32 gets a cchBuff-BYTE buffer while being told it has cchBuff WCHARs — it writes UTF-16 off
+    // the end of the block and smashes the heap (0xC0000374 at the next free). It also never returned
+    // a usable char, so win32-input-mode's Uc field was always 0.
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
     public static extern int ToUnicodeEx(uint wVirtKey, uint wScanCode, byte[] lpKeyState,
         [Out] char[] pwszBuff, int cchBuff, uint wFlags, IntPtr dwhkl);
 
@@ -376,7 +380,7 @@ internal static class Win32
     [DllImport("user32.dll")]
     public static extern bool SetProcessDpiAwarenessContext(IntPtr value);
 
-    [DllImport("kernel32.dll")]
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]   // W entry point: the name must marshal as UTF-16
     public static extern IntPtr GetModuleHandleW(string? lpModuleName);
 
     [DllImport("user32.dll")]

--- a/tests/Agwinterm.Core.Tests/PInvokeCharSetTests.cs
+++ b/tests/Agwinterm.Core.Tests/PInvokeCharSetTests.cs
@@ -1,0 +1,71 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Agwinterm.Core.Tests;
+
+/// <summary>
+/// Guards the whole P/Invoke text-marshalling bug class across the UI assembly.
+///
+/// A [DllImport] with no CharSet defaults to Ansi. For a text OUT parameter that means the runtime
+/// hands the OS a buffer of one BYTE per element while the callee is told it has that many WCHARs —
+/// so a W entry point writes UTF-16 straight off the end of the block. That is exactly how
+/// ToUnicodeEx (win32-input-mode, DECSET ?9001) smashed the heap on ordinary typing: the app died
+/// with STATUS_HEAP_CORRUPTION (0xC0000374) inside ntdll a few hundred keystrokes in, and the
+/// translated character came back as 0 the whole time, so the feature was silently dead too.
+///
+/// Every P/Invoke taking string / char[] / StringBuilder must therefore declare CharSet.Unicode.
+/// </summary>
+public class PInvokeCharSetTests
+{
+    /// <summary>Locate the built Agwinterm.Win32 assembly (CI builds the solution before testing).</summary>
+    private static string FindUiAssembly()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir != null && !Directory.Exists(Path.Combine(dir, "src", "Agwinterm.Win32")))
+            dir = Path.GetDirectoryName(dir);
+        Assert.NotNull(dir);
+        var bin = Path.Combine(dir!, "src", "Agwinterm.Win32", "bin");
+        Assert.True(Directory.Exists(bin), $"build Agwinterm.Win32 first (no {bin})");
+        var hits = Directory.GetFiles(bin, "Agwinterm.Win32.dll", SearchOption.AllDirectories)
+                            .OrderByDescending(File.GetLastWriteTimeUtc).ToArray();
+        Assert.True(hits.Length > 0, $"build Agwinterm.Win32 first (no dll under {bin})");
+        return hits[0];
+    }
+
+    private static bool IsText(Type t) => t == typeof(string) || t == typeof(char[]) || t == typeof(StringBuilder)
+                                       || t == typeof(string[]) || t == typeof(char).MakeByRefType();
+
+    [Fact]
+    public void EveryPInvokeWithTextParameters_DeclaresUnicodeCharSet()
+    {
+        var asm = Assembly.LoadFrom(FindUiAssembly());
+        Type[] types;
+        try { types = asm.GetTypes(); }
+        catch (ReflectionTypeLoadException ex) { types = ex.Types.Where(t => t is not null).ToArray()!; }
+
+        const BindingFlags All = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static
+                               | BindingFlags.Instance | BindingFlags.DeclaredOnly;
+        var offenders = new List<string>();
+        int checkedCount = 0;
+
+        foreach (var t in types)
+        foreach (var m in t.GetMethods(All))
+        {
+            if (!m.Attributes.HasFlag(MethodAttributes.PinvokeImpl)) continue;
+            var di = m.GetCustomAttribute<DllImportAttribute>();
+            if (di is null) continue;   // metadata-only import; nothing to assert
+            checkedCount++;
+
+            var textParams = m.GetParameters().Where(p => IsText(p.ParameterType)).ToArray();
+            if (textParams.Length > 0 && di.CharSet != CharSet.Unicode)
+                offenders.Add($"{t.Name}.{m.Name} (CharSet={di.CharSet}, "
+                            + $"text params: {string.Join(", ", textParams.Select(p => p.Name))})");
+        }
+
+        Assert.True(checkedCount > 50, $"expected the UI's P/Invoke surface, found only {checkedCount}");
+        Assert.True(offenders.Count == 0,
+            "P/Invokes with text parameters must declare CharSet.Unicode — Ansi marshalling of a W "
+            + "entry point's OUT buffer overruns the heap:\n  " + string.Join("\n  ", offenders));
+    }
+}


### PR DESCRIPTION
## The crash

Every release since **0.15.0** dies with `STATUS_HEAP_CORRUPTION` (`0xC0000374`, faulting module `ntdll.dll`) a couple hundred keystrokes into ordinary use. Field report: after updating 0.14.x → 0.16.6 the app crashed on launch-and-type, repeatedly (alive 53 s, then 10 s, then 6.5 s).

```
Faulting application name: Agwinterm.Win32.exe, version: 0.16.6.0
Faulting module name: ntdll.dll
Exception code: 0xc0000374
```

## Root cause

`win32-input-mode` (DECSET `?9001`, PR #154, first shipped in 0.15.0) declared:

```csharp
[DllImport("user32.dll")]
public static extern int ToUnicodeEx(uint wVirtKey, uint wScanCode, byte[] lpKeyState,
    [Out] char[] pwszBuff, int cchBuff, uint wFlags, IntPtr dwhkl);
```

No `CharSet`, so it defaults to **Ansi**. The runtime marshals the `[Out] char[]` as one *byte* per element — user32 receives a `cchBuff`-BYTE buffer while being told it has room for `cchBuff` **WCHARs**. The W entry point writes UTF-16 into it and runs off the end of the block; the heap manager trips on the smashed metadata at the next free.

Two consequences:

1. **The crash.** Non-deterministic in timing, always fatal.
2. **The feature was silently dead.** The Ansi round-trip never produced a usable character, so `Uc` in `CSI Vk;Sc;Uc;Kd;Cs;Rc _` was always `0`.

ConPTY enables `?9001` on its own, so this fired on **ordinary typing in any pane**. That is why it never reproduced from `agwintermctl session type` (writes to the pty, never runs `OnKeyDown`) and never reproduced on an idle window — including a 180 s idle run against the exact failing profile with both `claude --resume` panes restored.

## Verification

Isolated P/Invoke harness — no UI, no keyboard, no focus, just the shipped signatures in a loop:

| variant | result |
|---|---|
| `GetKeyboardState` only | clean |
| `ToUnicodeEx` **as shipped** (no `CharSet`) | **`0xC0000374`** |
| `ToUnicodeEx` with `CharSet.Unicode` | clean, and returns real characters |

App level, driven by `PostMessage(WM_KEYDOWN/WM_KEYUP)` so nothing touches real focus:

| build | result |
|---|---|
| installed 0.16.6 | **crashed after ~214 keys**, `0xC0000374` |
| local build, fix reverted | **crashed after ~208 keys**, `0xC0000374` |
| local build, `CharSet.Unicode` | **survived 600 keys** |

Same source tree, same compiler, only the attribute differs.

## The fix

`CharSet = CharSet.Unicode` on `ToUnicodeEx`. `GetModuleHandleW` carried the identical defect — benign today because every call site passes `null`, fixed anyway.

## Regression guard

`PInvokeCharSetTests` reflects over the UI assembly's **126** P/Invokes and fails any import that takes `string` / `char[]` / `StringBuilder` with a non-Unicode `CharSet`. Negative control: run against the shipped 0.16.6 binary it reports exactly

```
BAD  Win32.ToUnicodeEx      CharSet=None  textParams=1
BAD  Win32.GetModuleHandleW CharSet=None  textParams=1
```

and it passes on this branch. Full suite green: 197 + 116 = 313 tests.

## Release note

Every published build from **0.15.0** through **0.16.6** carries this bug; 0.14.x and earlier predate `?9001` and are unaffected. agwinterm-lite is unaffected (it takes characters from `WM_CHAR` and never calls `ToUnicodeEx`).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)