### PR TITLE
fix(core): a resize to the same geometry no longer clears the scroll region

### DIFF
--- a/lite/src/main.cpp
+++ b/lite/src/main.cpp
@@ -190,6 +190,7 @@ struct Session {
     void* emu = nullptr;
     HANDLE data = INVALID_HANDLE_VALUE;
     HANDLE reader = nullptr;
+    int cols = 0, rows = 0;     // geometry last pushed to the host (0 = never sized yet)
     int scrollOff = 0;          // rows scrolled up into history (0 = live)
     bool exited = false;
     std::vector<FfiCell> grid;  // paint snapshot buffer
@@ -990,6 +991,13 @@ static HWND windowForSession(Session* s) {
 }
 
 static void hostResize(Session* s, int cols, int rows) {
+    // syncPaneSizes() runs on every session switch / select / split change, so most calls here ask
+    // for the geometry the session already has. Forwarding those is not free: ConPTY reflows and
+    // re-emits its screen on ANY resize, which garbles a full-screen TUI (the app was never told
+    // anything changed, so it never redraws). Only a real change goes to the host.
+    if (s->cols == cols && s->rows == rows) return;
+    s->cols = cols;
+    s->rows = rows;
     agwinterm_ptyhost_Request req = agwinterm_ptyhost_Request_init_default;
     agwinterm_ptyhost_Reply rep = agwinterm_ptyhost_Reply_init_default;
     req.which_cmd = agwinterm_ptyhost_Request_resize_tag;

--- a/native/agwinterm-core/src/emulator.rs
+++ b/native/agwinterm-core/src/emulator.rs
@@ -314,6 +314,13 @@ impl Emulator {
         if cols == 0 || rows == 0 {
             return;
         }
+        // A "resize" to the SAME geometry is not a resize: bail before the margin reset below.
+        // Hosts call this on events that need not have changed the size (lite re-syncs both panes
+        // on every session switch), and clearing DECSTBM under a full-screen TUI that still thinks
+        // its margins are set scrambles the display — with no SIGWINCH to make it redraw.
+        if cols == self.main.cols() && rows == self.main.rows() {
+            return;
+        }
         self.main.resize(cols, rows);
         self.alt.resize(cols, rows);
         self.scroll_top = 0;
@@ -1392,5 +1399,26 @@ mod tests {
         assert_eq!(t.emu.cwd, "file://h/c");
         assert_eq!(t.emu.marks().len(), 1);
         assert_eq!(t.emu.marks()[0].exit_code, Some(3));
+    }
+
+    #[test]
+    fn resize_to_same_geometry_keeps_scroll_region() {
+        // lite re-syncs both panes on every session switch, so most resize calls ask for the
+        // geometry already in effect. Those must not clear DECSTBM: a full-screen TUI still
+        // believes its margins are set and gets no SIGWINCH telling it to redraw.
+        let mut t = Terminal::new(20, 10);
+        t.feed(b"[3;8r");
+        assert_eq!((t.emu.scroll_top(), t.emu.scroll_bottom()), (2, 7));
+
+        t.emu.resize(20, 10);
+        assert_eq!(
+            (t.emu.scroll_top(), t.emu.scroll_bottom()),
+            (2, 7),
+            "a same-size resize must not reset the scroll region"
+        );
+
+        // A REAL size change still resets the margins (xterm behaviour).
+        t.emu.resize(20, 12);
+        assert_eq!((t.emu.scroll_top(), t.emu.scroll_bottom()), (0, 11));
     }
 }

--- a/src/Agwinterm.Core/TerminalEmulator.cs
+++ b/src/Agwinterm.Core/TerminalEmulator.cs
@@ -204,10 +204,16 @@ public sealed class TerminalEmulator : IParserPerformer, ITerminalCore
 
     public void Feed(ReadOnlySpan<byte> bytes) => _parser.Feed(bytes);
 
-    /// <summary>Resize both screen buffers, reset the scroll region, and clamp the cursor.</summary>
+    /// <summary>Resize both screen buffers, reset the scroll region, and clamp the cursor.
+    /// A resize to the geometry already in effect is a no-op (see the guard).</summary>
     public void Resize(int cols, int rows)
     {
         if (cols <= 0 || rows <= 0) return;
+        // A "resize" to the SAME geometry is not a resize: bail before the margin reset below.
+        // Hosts call this on events that need not have changed the size (lite re-syncs both panes
+        // on every session switch), and clearing DECSTBM under a full-screen TUI that still thinks
+        // its margins are set scrambles the display — with no SIGWINCH to make it redraw.
+        if (cols == _main.Cols && rows == _main.Rows) return;
         _main.Resize(cols, rows);
         _alt.Resize(cols, rows);
         _scrollTop = 0;

--- a/tests/Agwinterm.Core.Tests/ResizeScrollRegionTests.cs
+++ b/tests/Agwinterm.Core.Tests/ResizeScrollRegionTests.cs
@@ -1,0 +1,59 @@
+using System.Text;
+
+namespace Agwinterm.Core.Tests;
+
+/// <summary>
+/// A resize to the geometry already in effect must be a no-op.
+///
+/// Hosts call Resize on events that need not have changed the size — agwinterm-lite re-syncs both
+/// panes on every session switch — and the margin reset inside Resize then clears DECSTBM under a
+/// full-screen TUI that still believes its margins are set. Nothing tells the app to redraw (the
+/// size never changed, so there is no SIGWINCH), so the scrambled screen just stays there. That was
+/// the "render artefacts when I switch between sessions" report.
+/// </summary>
+public class ResizeScrollRegionTests
+{
+    private static TerminalEmulator Emu(int cols, int rows, string vt)
+    {
+        var e = new TerminalEmulator(cols, rows);
+        e.Feed(Encoding.UTF8.GetBytes(vt));
+        return e;
+    }
+
+    [Fact]
+    public void ResizeToSameGeometry_KeepsScrollRegion()
+    {
+        var e = Emu(20, 10, "\x1b[3;8r");          // DECSTBM rows 3..8 (0-based 2..7)
+        Assert.Equal(2, e.ScrollTop);
+        Assert.Equal(7, e.ScrollBottom);
+
+        e.Resize(20, 10);
+
+        Assert.Equal(2, e.ScrollTop);
+        Assert.Equal(7, e.ScrollBottom);
+    }
+
+    [Fact]
+    public void ResizeToNewGeometry_StillResetsScrollRegion()
+    {
+        var e = Emu(20, 10, "\x1b[3;8r");
+
+        e.Resize(20, 12);                           // a real change resets the margins (xterm behaviour)
+
+        Assert.Equal(0, e.ScrollTop);
+        Assert.Equal(11, e.ScrollBottom);
+    }
+
+    [Fact]
+    public void ResizeToSameGeometry_KeepsCursorAndContent()
+    {
+        var e = Emu(20, 10, "hello\x1b[5;7H");
+        int row = e.CursorRow, col = e.CursorCol;
+
+        e.Resize(20, 10);
+
+        Assert.Equal(row, e.CursorRow);
+        Assert.Equal(col, e.CursorCol);
+        Assert.Equal('h', (char)e.Screen[0, 0].Rune);
+    }
+}


### PR DESCRIPTION
## What

`Emulator::resize` (Rust) and `TerminalEmulator.Resize` (managed) reset the DECSTBM scroll region unconditionally — including when `cols`/`rows` are unchanged:

```rust
self.main.resize(cols, rows);
self.alt.resize(cols, rows);
self.scroll_top = 0;              // <- runs even when nothing changed
self.scroll_bottom = rows - 1;
```

lite's `syncPaneSizes()` re-pushes the current geometry on **every** sidebar click and Ctrl+Tab, so switching sessions silently cleared a full-screen TUI's margins. Because the size never actually changed there is no SIGWINCH, so the application never learns it should redraw — the broken layout just sits there.

## Fix

Both cores bail before the margin reset when the geometry already matches. A real size change still resets the margins (xterm behaviour).

lite additionally skips the host round-trip entirely for an unchanged size — ConPTY reflows and re-emits its screen on *any* resize, which is its own way to garble a TUI that was never told anything changed. It also removes a pointless pty-host request per switch.

## Tests

| test | asserts |
|---|---|
| `ResizeToSameGeometry_KeepsScrollRegion` (C#) | DECSTBM 3;8 survives `Resize(20,10)` on a 20x10 emulator |
| `ResizeToNewGeometry_StillResetsScrollRegion` (C#) | a real resize still resets margins |
| `ResizeToSameGeometry_KeepsCursorAndContent` (C#) | cursor position and cell content unchanged |
| `resize_to_same_geometry_keeps_scroll_region` (Rust) | both halves, on the Rust core |

Negative control: `ResizeToSameGeometry_KeepsScrollRegion` **fails** on the unfixed core (1 of 3 failing), passes on this branch. Full suites green — Core 200, Pty 116, Rust 27 — and lite builds.

## What this does NOT claim

This is **not** a confirmed fix for the reported "render artefacts when switching sessions". A before/after harness — set a header, set a scroll region under it, switch away and back through the real sidebar path (`TVM_SELECTITEM` -> `TVN_SELCHANGED` -> `syncPaneSizes`), then emit enough lines to force scrolling — kept the header on **both** builds. So the visible symptom is still unexplained and the hunt continues separately.

It stands on its own merits: a resize to the geometry already in effect is not a resize, and lite should not be resizing ConPTY on every session switch.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)