### PR TITLE
feat(lite): diagnostics log + --diagnose so field failures explain themselves

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,10 +225,33 @@ status bar — in the classic Windows look.
 - **Multi-window, the lite way**: every window is its own tiny process (`--pipe <name>`), all
   sharing one pty-host; `agwintermctl window new/list/select/...` drives them.
 - **CLI**: `-p/--profile`, `-d/--dir`, `--maximized`, `--no-restore`, `--pipe` — the full app's
-  flag names.
+  flag names — plus `--diagnose` (see below).
+- **Explains itself**: lite keeps a small always-on log of its own decisions — session saves and
+  restores (with counts, byte totals, and the exact error when a write fails), focus handoffs, and
+  font/pack resolution — at `%LOCALAPPDATA%\agwinterm-lite\lite.log` (`lite-<instance>.log` for named
+  instances), rotating at ~1 MB into `.log.old`. It records what lite *did*, never terminal output,
+  pasted text, or your command lines, so it's safe to attach to an issue.
 
 Grab **`agwinterm-lite-setup-<version>.exe`** from Releases (per-user, no admin), or build it
 (needs the VC++ ATL component): `./lite/build.ps1` (dev build) / `./installer/build-lite.ps1` (setup).
+
+### Reporting a lite problem
+
+Run `agwinterm-lite --diagnose` and attach its output plus `lite.log`. The report is read-only and
+safe to run while lite is open; it prints the state file's path, whether that directory is genuinely
+writable (a real write probe, which is what catches a redirected or policy-locked profile), the state
+file's contents, the resolved font, and the bundled pack inventory:
+
+```
+> agwinterm-lite --diagnose
+  version: 0.17.2
+  instance: (default)
+state
+  dir: C:\Users\you\AppData\Local\agwinterm-lite
+  dir writable: yes
+  session file: ...\sessions.tsv
+    size: 59 bytes
+```
 
 ## Keyboard essentials
 

--- a/docs/plans/2026-07-31-lite-diagnostics-logging.md
+++ b/docs/plans/2026-07-31-lite-diagnostics-logging.md
@@ -1,0 +1,196 @@
+# lite diagnostics logging
+
+## Overview
+
+agwinterm-lite has no way to explain itself after the fact. Every field report from the 2026-07-29→31
+dogfood cost hours because the failure happened on the work laptop and left no trace:
+
+- **"restore sessions doesn't work at all"** — still unreproduced. Both a named instance and the
+  default instance save and restore correctly on the dev machine, and the obvious suspects
+  (`stateFilePath()` creating its directory, `saveSessionState()`'s only bail being a failed
+  `CreateFileW`, `g_restoring` being cleared) are all clean. Without knowing whether the laptop is
+  failing to **write** the file or failing to **rebuild** from it, any fix is a guess — and the two
+  fixes are opposite.
+- **render artefacts when switching sessions** — a screenshot, no mechanism. One real bug was found
+  and fixed along the way (the selection was keyed by pane index, so it suppressed the caret and
+  painted over the next session), but it does not explain the clipped left edge or the second column.
+- **"can't type after switching sessions"** — this one WAS pinned, but only because `GetGUIThreadInfo`
+  could be run live on the dev machine. The same trick is not available remotely.
+
+This plan adds a small always-on logging subsystem to lite and makes session save/restore its first
+customer, so the next report arrives with evidence attached instead of needing a re-enactment.
+
+Explicit non-goal: fixing the restore break itself. The log is what tells us which fix to write.
+
+## Context (from discovery)
+
+- **Files/components involved**: `lite/src/main.cpp` (single translation unit, ~5300 lines),
+  `lite/build.ps1`. No other project touches this.
+- **Related patterns found**:
+  - `stateFilePath()` (line ~1513) resolves `%LOCALAPPDATA%\agwinterm-lite\sessions.tsv` for the
+    default instance, `sessions-<instance>.tsv` otherwise, and `CreateDirectoryW`s the parent.
+  - `saveSessionState()` (~1579) writes the whole file with `CREATE_ALWAYS`; it returns silently on a
+    failed open — currently the single most likely place for a silent field failure.
+  - `restoreSessions()` (~5042) returns false on: missing file, empty file, no `S` lines, or no
+    session successfully created. Four distinct causes, all indistinguishable from outside.
+  - `updDir()`/`updCleanup()` (~2469) already use the same `%LOCALAPPDATA%\agwinterm-lite` root, and
+    the self-update helper writes a `.log` next to its payload — precedent for logging to that dir.
+  - `fatal()` exists for hard failures; there is no non-fatal diagnostic channel.
+- **Dependencies identified**: none new. Win32 file APIs only, consistent with lite's no-dependency
+  posture (it links agwinterm_core + nanopb and nothing else).
+- **Threads that will call the logger**: the UI thread, one `readerThread` per session (line 1194),
+  `updWorker` (2675), `ctlServerThread` (5299) and a `ctlClientThread` per control connection (5042).
+  The logger must therefore be thread-safe on its own — `g_lock` guards emulator state, not this.
+
+## Development Approach
+
+- **Testing approach**: Regular (code first, then tests). lite has no C++ test harness and this plan
+  does not add one; "tests" here are behavioural checks driven from PowerShell against the built exe,
+  in the style already used this session (posted messages + `PrintWindow`, never global input).
+- Complete each task fully before moving to the next
+- Make small, focused changes
+- **CRITICAL: every task MUST include new/updated tests** for code changes in that task
+  - tests are not optional - they are a required part of the checklist
+  - for this plan a "test" is a scripted check under `lite/test/` that runs the built exe and asserts
+    on the log file / diagnose output
+  - tests cover both success and error scenarios (e.g. an unwritable state directory)
+- **CRITICAL: all tests must pass before starting next task** - no exceptions
+- **CRITICAL: update this plan file when scope changes during implementation**
+- Run tests after each change
+- Maintain backward compatibility
+
+## Testing Strategy
+
+- **Unit tests**: not available for lite (no C++ harness). Each task instead ships a PowerShell check
+  under `lite/test/` that drives the built exe and asserts on observable output.
+- **E2E tests**: this project's e2e style for lite is: launch with `--pipe <sandbox>`, drive with
+  `agwintermctl` and posted window messages, capture with `PrintWindow`. Never inject global input
+  (`keybd_event`/`SendInput`) — it lands in whatever window has focus, which on a machine in use
+  means typing into the user's windows. Never run the default instance against real user state.
+- Treat these checks with the same rigor as unit tests: they must pass before the next task.
+
+## Progress Tracking
+
+- Mark completed items with `[x]` immediately when done
+- Add newly discovered tasks with ➕ prefix
+- Document issues/blockers with ⚠️ prefix
+- Update plan if implementation deviates from original scope
+- Keep plan in sync with actual work done
+
+## What Goes Where
+
+- **Implementation Steps** (`[ ]` checkboxes): changes inside this repo — logger, call sites, checks, docs
+- **Post-Completion** (no checkboxes): running the new build on the work laptop and reading what it says
+
+## Implementation Steps
+
+### Task 1: Add the logging core
+- [x] add `logInit()` / `logWrite(level, fmt, ...)` to `lite/src/main.cpp`, above the first caller
+- [x] resolve the path once at startup: `%LOCALAPPDATA%\agwinterm-lite\lite.log` (default instance) or
+      `lite-<instance>.log`, so multi-window instances never interleave into one file
+- [x] make it thread-safe with its own `CRITICAL_SECTION` — callers include the UI thread, per-session
+      reader threads, the control server and its per-client threads, and the update worker
+- [x] open with `FILE_APPEND_DATA` + `FILE_SHARE_READ` so the file can be read while lite runs
+- [x] format each line `YYYY-MM-DD HH:MM:SS.mmm  LEVEL  message` (local time, matching the self-update
+      helper's log so both read the same way)
+- [x] rotate at ~1 MB: rename to `lite.log.old` (replacing any previous) and start a new file
+- [x] write one INFO line at startup recording version, instance name, exe path, and argv
+- [x] add `lite/test/log-basics.ps1`: launch a sandbox instance, assert the log file is created,
+      contains the startup line, and is readable while the process runs
+- [x] add an error case to the same check: point `%LOCALAPPDATA%` at an unwritable path and assert
+      lite still starts and does not crash (logging must never be fatal)
+- [x] run the checks - must pass before task 2
+
+### Task 2: Instrument session save/restore
+- [x] log in `saveSessionState()`: resolved path, session count written, bytes written, and on failure
+      the `GetLastError()` from `CreateFileW`/`WriteFile` — this is the "did the laptop even write it"
+      question, currently a silent `return`
+- [x] log in `stateFilePath()` when `CreateDirectoryW` fails with anything other than
+      `ERROR_ALREADY_EXISTS`
+- [x] log in `restoreSessions()` which of its four exits was taken: file missing (with the path),
+      file empty, no `S` lines parsed, or no session created — plus, on success, the spec count and
+      how many sessions were actually built
+- [x] log each spec that fails to produce a session, with its app/cwd, so a shell that no longer
+      launches on that machine is visible by name
+- [x] add `lite/test/log-restore.ps1`: create sessions in a sandbox instance, close, assert the log
+      shows a save with a nonzero count and byte total; relaunch, assert it shows a restore with a
+      matching spec count
+- [x] add the failure case: corrupt the state file to zero bytes and assert the log names the
+      "file empty" exit rather than going quiet
+- [x] run the checks - must pass before task 3
+
+### Task 3: Instrument focus and font resolution
+- [x] log the focus handoffs added in #182: sidebar `WM_SETFOCUS` bounce, `WM_ACTIVATE` re-claim, and
+      any `WM_APP_FOCUSTERM` skipped because a rename owns the keyboard — the "can't type" class of
+      report should be answerable from the log alone
+- [x] log font resolution at startup: which catalog face+size was chosen, whether it came from the
+      registry or `setDefaultFont()`, and which `.agbf` packs were found next to the exe
+- [x] add `lite/test/log-focus-font.ps1`: post a click at a sidebar row, assert the log records the
+      bounce and that `GetGUIThreadInfo` still reports the frame as focus owner
+- [x] add the font case: clear the saved selection, launch, assert the log names
+      `AGWin Bitmap Complete 16` as the first-run default
+- [x] run the checks - must pass before task 4
+
+### Task 4: Add `--diagnose`
+- [x] add a `--diagnose` argument that prints a single report to stdout (via `AttachConsole`, the
+      same technique `--bench-agbf` already uses) and exits without creating a window
+- [x] report: lite version and exe path; instance name; state file path, existence, size, mtime, and a
+      real writability probe (create + delete a temp file in that directory); the state file's
+      contents; resolved font and pack inventory; log file path and size; `%LOCALAPPDATA%` value
+- [x] make it safe to run while another lite is live (read-only, shares reads, never writes state)
+- [x] add `lite/test/diagnose.ps1`: assert the output names the state path, reports writable=true on a
+      normal profile, and exits 0 with no window created
+- [x] add the error case: run it with an unwritable state dir and assert it reports writable=false
+      rather than failing
+- [x] run the checks - must pass before task 5
+
+### Task 5: Verify acceptance criteria
+- [x] verify all requirements from Overview are implemented
+- [x] verify edge cases are handled: unwritable directory, missing directory, log rotation at the
+      threshold, two instances logging concurrently to their own files
+- [x] confirm the steady-state cost is acceptable for the target machines: logging is per structural
+      event (session create/close/save/restore/focus change), NOT per output chunk or per frame
+- [x] run the full `lite/test/` check suite (added `lite/test/run-all.ps1` as the entry point,
+      and ➕ `lite/test/log-rotation.ps1` — rotation and per-instance isolation had no coverage,
+      they were only listed as Task 5 edge cases)
+- [x] run the existing .NET + Rust suites to confirm nothing outside lite moved
+- [x] confirm lite still builds clean via `lite/build.ps1`
+
+### Task 6: [Final] Update documentation
+- [x] document the log location, rotation, and `--diagnose` in `README.md`'s lite section
+- [x] add a short "reporting a lite problem" note: run `--diagnose`, attach `lite.log`
+- [x] record the diagnosis-first lesson in the build-and-test gotchas memory
+
+## Technical Details
+
+- **Log line format**: `2026-07-31 13:22:41.508  INFO  restore: 3 specs, 3 sessions built` — fixed-width
+  level so the file greps cleanly.
+- **Levels**: INFO and WARN only. lite has `fatal()` for unrecoverable cases; a third level would be
+  ceremony without a consumer.
+- **Rotation**: checked on write, not on a timer. At ~1 MB, `MoveFileExW(..., MOVEFILE_REPLACE_EXISTING)`
+  to `*.log.old`, then reopen. Two generations is enough to survive one restart.
+- **Failure policy**: logging never throws, never blocks startup, and never becomes fatal. If the file
+  cannot be opened, the logger degrades to a no-op for the process lifetime and lite runs unchanged.
+- **Per-instance files**: multi-window lite is one process per window (`--pipe <name>`), so a shared
+  file would interleave. Each instance writes its own, named the same way the state file is.
+- **What is NOT logged**: terminal output, pasted text, typed keys, or command lines from sessions.
+  The log records lite's own decisions — paths, counts, error codes, focus transitions — so it can be
+  attached to an issue without leaking what the user was working on.
+
+## Post-Completion
+
+*Items requiring manual intervention or external systems - no checkboxes, informational only*
+
+**Manual verification**:
+- Install the resulting build on the work laptop and reproduce the restore failure normally
+- Read `lite.log` there: it should say either "save failed, GetLastError=..." (the laptop cannot write
+  the state file) or "restore: file missing / 0 specs / N specs, 0 sessions built" (it can write but
+  cannot rebuild). Those point at opposite fixes, which is exactly the fork this plan exists to settle.
+- Run `agwinterm-lite --diagnose` on the laptop and compare the state path and writability against
+  this machine
+- While there, capture the outstanding M1 perf-gate numbers (<150 ms start, <40 MB at 3 sessions)
+
+**Follow-on work unblocked by this** (separate plans, not part of this one):
+- the session-restore fix itself, once the log names the cause
+- the switch-time render artefacts, which may need frame-level instrumentation this logger does not
+  attempt

--- a/lite/src/main.cpp
+++ b/lite/src/main.cpp
@@ -114,6 +114,7 @@ static std::string  g_argDir;             // -d/--dir/--startingDirectory <path>
 static bool g_argMaximized = false;       // --maximized
 static bool g_argNoRestore = false;       // --no-restore: don't rebuild the saved sessions
 static bool g_argBenchAgbf = false;       // --bench-agbf: print pack benchmarks to the console, exit
+static bool g_argDiagnose = false;        // --diagnose: print an environment/state report, exit
 static std::wstring g_argPipe;            // --pipe <name>: control-pipe name (default agwinterm-lite)
 
 static HWND g_hwnd;   // main frame (declared early: the instance registry compares against it)
@@ -868,6 +869,80 @@ static void fatal(const wchar_t* msg) {
     ExitProcess(1);
 }
 
+// ---- diagnostics log ------------------------------------------------------------------------
+// Every lite field report so far ("restore doesn't work", "can't type after switching", the render
+// artefacts) arrived from a machine we cannot attach a debugger to, and left nothing behind — so
+// each one cost hours of re-enactment that mostly failed to reproduce. lite now records its own
+// decisions (paths, counts, error codes, focus transitions) to a small rotating file next to its
+// state, so the NEXT report comes with evidence.
+//
+// Deliberately NOT logged: terminal output, pasted text, typed keys, session command lines. The log
+// is about what lite did, so it can be attached to an issue without leaking what you were doing.
+//
+// Rules: never fatal, never blocking, no-op forever if the file can't be opened. Callers span the UI
+// thread, one readerThread per session, the control server + a thread per client, and the update
+// worker, so it carries its own lock (g_lock guards emulator state, not this).
+static CRITICAL_SECTION g_logLock;
+static std::wstring g_logPath;
+static bool g_logReady = false;      // logInit ran and the file opened at least once
+static bool g_logDead = false;       // an open failed: degrade to a no-op rather than retry forever
+static const DWORD kLogRotateBytes = 1024 * 1024;
+
+static void logRotateIfBig() {   // call under g_logLock
+    WIN32_FILE_ATTRIBUTE_DATA fa{};
+    if (!GetFileAttributesExW(g_logPath.c_str(), GetFileExInfoStandard, &fa)) return;
+    if (fa.nFileSizeHigh == 0 && fa.nFileSizeLow < kLogRotateBytes) return;
+    MoveFileExW(g_logPath.c_str(), (g_logPath + L".old").c_str(), MOVEFILE_REPLACE_EXISTING);
+}
+
+static void logWriteV(const char* level, const char* fmt, va_list ap) {
+    if (!g_logReady || g_logDead) return;
+    char body[1024];
+    _vsnprintf_s(body, sizeof body, _TRUNCATE, fmt, ap);
+    SYSTEMTIME t; GetLocalTime(&t);
+    char line[1200];
+    int n = _snprintf_s(line, sizeof line, _TRUNCATE, "%04d-%02d-%02d %02d:%02d:%02d.%03d  %-4s  %s\r\n",
+                        t.wYear, t.wMonth, t.wDay, t.wHour, t.wMinute, t.wSecond, t.wMilliseconds,
+                        level, body);
+    if (n <= 0) return;
+    EnterCriticalSection(&g_logLock);
+    logRotateIfBig();
+    // FILE_SHARE_READ|WRITE so the file can be tailed (and a second instance never blocks) while lite runs.
+    HANDLE f = CreateFileW(g_logPath.c_str(), FILE_APPEND_DATA, FILE_SHARE_READ | FILE_SHARE_WRITE,
+                           nullptr, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (f == INVALID_HANDLE_VALUE) {
+        g_logDead = true;   // unwritable profile: stop trying, lite carries on unchanged
+    } else {
+        DWORD wr; WriteFile(f, line, (DWORD)n, &wr, nullptr);
+        CloseHandle(f);
+    }
+    LeaveCriticalSection(&g_logLock);
+}
+
+static void logInfo(const char* fmt, ...) { va_list ap; va_start(ap, fmt); logWriteV("INFO", fmt, ap); va_end(ap); }
+static void logWarn(const char* fmt, ...) { va_list ap; va_start(ap, fmt); logWriteV("WARN", fmt, ap); va_end(ap); }
+
+/// Resolve the per-instance log path and record the startup line. Per-instance because multi-window
+/// lite is one process per window — a shared file would interleave four writers' lines.
+static void logInit(int argc, wchar_t** argv) {
+    InitializeCriticalSection(&g_logLock);
+    wchar_t base[MAX_PATH];
+    if (GetEnvironmentVariableW(L"LOCALAPPDATA", base, MAX_PATH) == 0) { g_logDead = true; return; }
+    std::wstring dir = std::wstring(base) + L"\\agwinterm-lite";
+    CreateDirectoryW(dir.c_str(), nullptr);
+    g_logPath = dir + (g_isDefaultInstance ? L"\\lite.log" : (L"\\lite-" + g_instance + L".log"));
+    g_logReady = true;
+
+    wchar_t exe[MAX_PATH]{};
+    GetModuleFileNameW(nullptr, exe, MAX_PATH);
+    std::wstring cmd;
+    for (int i = 1; i < argc; i++) { if (i > 1) cmd += L" "; cmd += argv[i]; }
+    logInfo("---- agwinterm-lite %s starting ----", AGWL_VERSION_STR);
+    logInfo("instance=%s exe=%s args=[%s]",
+            narrow(g_isDefaultInstance ? L"(default)" : g_instance).c_str(),
+            narrow(exe).c_str(), narrow(cmd).c_str());
+}
+
 // ---- control pipe: protobuf frames (4-byte LE length prefix) ----
 static CRITICAL_SECTION g_reqLock;   // the control pipe is shared by the UI thread and the ctl server thread
 static bool request(const agwinterm_ptyhost_Request& req, agwinterm_ptyhost_Reply* reply) {
@@ -1405,7 +1480,9 @@ static void saveFontSel() {
     RegSetKeyValueW(HKEY_CURRENT_USER, L"Software\\agwinterm-lite", L"FontH", REG_DWORD, &h, sizeof(h));
     RegSetKeyValueW(HKEY_CURRENT_USER, L"Software\\agwinterm-lite", L"FontW", REG_DWORD, &w, sizeof(w));
 }
+static bool g_fontFromReg = false;   // did the remembered selection resolve, or did we fall back?
 static void loadFontSel() {
+    g_fontFromReg = false;
     wchar_t face[64] = L""; DWORD sz = sizeof(face);
     if (RegGetValueW(HKEY_CURRENT_USER, L"Software\\agwinterm-lite", L"FontFace", RRF_RT_REG_SZ, nullptr, face, &sz) != ERROR_SUCCESS) { setDefaultFont(); return; }
     DWORD h = 0, w = 0, s = sizeof(DWORD);
@@ -1414,8 +1491,8 @@ static void loadFontSel() {
     for (int fi = 0; fi < (int)g_catalog.size(); fi++) {
         if (wcscmp(g_catalog[fi].face, face) != 0) continue;
         for (int si = 0; si < (int)g_catalog[fi].sizes.size(); si++)
-            if ((DWORD)(int)g_catalog[fi].sizes[si].h == h && (DWORD)(int)g_catalog[fi].sizes[si].w == w) { g_faceIdx = fi; g_sizeIdx = si; return; }
-        g_faceIdx = fi; g_sizeIdx = 0; return;   // face matched, size didn't — keep the face
+            if ((DWORD)(int)g_catalog[fi].sizes[si].h == h && (DWORD)(int)g_catalog[fi].sizes[si].w == w) { g_faceIdx = fi; g_sizeIdx = si; g_fontFromReg = true; return; }
+        g_faceIdx = fi; g_sizeIdx = 0; g_fontFromReg = true; return;   // face matched, size didn't — keep the face
     }
     setDefaultFont();
 }
@@ -1520,7 +1597,10 @@ static std::wstring stateFilePath() {
     wchar_t base[MAX_PATH];
     if (GetEnvironmentVariableW(L"LOCALAPPDATA", base, MAX_PATH) == 0) return {};
     std::wstring dir = std::wstring(base) + L"\\agwinterm-lite";
-    CreateDirectoryW(dir.c_str(), nullptr);
+    if (!CreateDirectoryW(dir.c_str(), nullptr)) {
+        DWORD e = GetLastError();
+        if (e != ERROR_ALREADY_EXISTS) logWarn("state dir could not be created: %s (err %lu)", narrow(dir).c_str(), e);
+    }
     // Named instances keep their own session state; the default instance keeps the classic name.
     return dir + (g_isDefaultInstance ? L"\\sessions.tsv" : (L"\\sessions-" + g_instance + L".tsv"));
 }
@@ -1603,9 +1683,21 @@ static void saveSessionState() {
     if (!flagLine.empty()) out += "F" + flagLine + "\n";
     out += "A\t" + std::to_string(g_activeWs) + "\n";
     HANDLE f = CreateFileW(path.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
-    if (f == INVALID_HANDLE_VALUE) return;
-    DWORD wr; WriteFile(f, out.data(), (DWORD)out.size(), &wr, nullptr);
+    if (f == INVALID_HANDLE_VALUE) {
+        // The silent return that made "restore doesn't work" unanswerable in the field: if the
+        // state file can't be opened, nothing is saved and nothing says so.
+        logWarn("save FAILED to open %s (err %lu) — %d session(s) not saved",
+                narrow(path).c_str(), GetLastError(), saved);
+        return;
+    }
+    DWORD wr = 0;
+    BOOL ok = WriteFile(f, out.data(), (DWORD)out.size(), &wr, nullptr);
+    DWORD werr = ok ? 0 : GetLastError();
     CloseHandle(f);
+    if (!ok || wr != out.size())
+        logWarn("save PARTIAL to %s: wrote %lu of %zu bytes (err %lu)", narrow(path).c_str(), wr, out.size(), werr);
+    else
+        logInfo("save ok: %d session(s), %zu bytes -> %s", saved, out.size(), narrow(path).c_str());
 }
 
 // Select a face+size, apply it, and persist the choice (used by the Properties dialog).
@@ -1877,6 +1969,89 @@ static void agbfPaintGrid(HDC mem, RECT pr, const FfiCell* view, const FfiEmuInf
 
 // --bench-agbf: the spec's benchmark deliverable — load time, glyph lookup, full-grid render and
 // resident size for every committed pack, printed to the launching console. No window, no session.
+// --diagnose: one report you can run on a machine that misbehaves and paste into an issue. Strictly
+// read-only — it never writes state, never opens the control pipe, and is safe while lite is running.
+// It answers the questions that cost this project the most time: where does state live, can lite
+// actually write there, what is in it, and what did the font/pack resolution decide.
+static int liteDiagnose() {
+    AttachConsole(ATTACH_PARENT_PROCESS);
+    HANDLE out = GetStdHandle(STD_OUTPUT_HANDLE);
+    auto say = [&](const std::string& s) { DWORD wr; WriteFile(out, s.data(), (DWORD)s.size(), &wr, nullptr); };
+    auto line = [&](const char* k, const std::string& v) { say(std::string("  ") + k + ": " + v + "\r\n"); };
+
+    wchar_t exe[MAX_PATH]{}; GetModuleFileNameW(nullptr, exe, MAX_PATH);
+    wchar_t lad[MAX_PATH]{}; DWORD ladOk = GetEnvironmentVariableW(L"LOCALAPPDATA", lad, MAX_PATH);
+
+    say("\nagwinterm-lite --diagnose\r\n\r\n");
+    line("version", AGWL_VERSION_STR);
+    line("exe", narrow(exe));
+    line("instance", g_isDefaultInstance ? "(default)" : narrow(g_instance));
+    line("LOCALAPPDATA", ladOk ? narrow(lad) : "(not set!)");
+
+    std::wstring dir = std::wstring(ladOk ? lad : L"") + L"\\agwinterm-lite";
+    std::wstring state = dir + (g_isDefaultInstance ? L"\\sessions.tsv" : (L"\\sessions-" + g_instance + L".tsv"));
+    std::wstring log = dir + (g_isDefaultInstance ? L"\\lite.log" : (L"\\lite-" + g_instance + L".log"));
+
+    say("\r\nstate\r\n");
+    line("dir", narrow(dir));
+    line("dir exists", (GetFileAttributesW(dir.c_str()) != INVALID_FILE_ATTRIBUTES) ? "yes" : "NO");
+    // A real write probe, not an attribute guess: redirected or policy-locked profiles fail here.
+    std::wstring probe = dir + L"\\.diagnose-probe";
+    HANDLE ph = CreateFileW(probe.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_TEMPORARY, nullptr);
+    if (ph == INVALID_HANDLE_VALUE) {
+        line("dir writable", "NO (err " + std::to_string(GetLastError()) + ")  <-- saves cannot work here");
+    } else {
+        CloseHandle(ph); DeleteFileW(probe.c_str());
+        line("dir writable", "yes");
+    }
+
+    WIN32_FILE_ATTRIBUTE_DATA fa{};
+    if (GetFileAttributesExW(state.c_str(), GetFileExInfoStandard, &fa)) {
+        SYSTEMTIME st{}; FILETIME lt{};
+        FileTimeToLocalFileTime(&fa.ftLastWriteTime, &lt); FileTimeToSystemTime(&lt, &st);
+        char when[64];
+        _snprintf_s(when, sizeof when, _TRUNCATE, "%04d-%02d-%02d %02d:%02d:%02d",
+                    st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond);
+        line("session file", narrow(state));
+        line("  size", std::to_string(fa.nFileSizeLow) + " bytes");
+        line("  modified", when);
+        HANDLE f = CreateFileW(state.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr,
+                               OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+        if (f != INVALID_HANDLE_VALUE) {
+            std::string data; char buf[4096]; DWORD rd;
+            while (ReadFile(f, buf, sizeof buf, &rd, nullptr) && rd) data.append(buf, rd);
+            CloseHandle(f);
+            say("\r\nsession file contents\r\n");
+            say(data.empty() ? std::string("  (empty)\r\n") : ("  " + data + "\r\n"));
+        }
+    } else {
+        line("session file", narrow(state) + "  <-- DOES NOT EXIST (nothing to restore)");
+    }
+
+    say("\r\nlog\r\n");
+    line("path", narrow(log));
+    if (GetFileAttributesExW(log.c_str(), GetFileExInfoStandard, &fa))
+        line("size", std::to_string(fa.nFileSizeLow) + " bytes");
+    else
+        line("size", "(no log yet)");
+
+    say("\r\nfonts\r\n");
+    std::wstring ed = exeDir();
+    for (const wchar_t* p : { L"agwin-bitmap-14.agbf", L"agwin-bitmap-16.agbf", L"agwin-bitmap-18.agbf",
+                              L"agwin-bitmap-20.agbf", L"agwin-bitmap-complete-14.agbf",
+                              L"agwin-bitmap-complete-16.agbf", L"agwin-bitmap-complete-18.agbf",
+                              L"agwin-bitmap-complete-20.agbf", L"MesloLGLDZNerdFont-Regular.ttf" }) {
+        std::wstring fp = ed + L"\\" + p;
+        line(narrow(p).c_str(), GetFileAttributesW(fp.c_str()) != INVALID_FILE_ATTRIBUTES ? "present" : "missing");
+    }
+    wchar_t face[64] = L""; DWORD sz = sizeof(face);
+    bool haveReg = RegGetValueW(HKEY_CURRENT_USER, L"Software\\agwinterm-lite", L"FontFace",
+                                RRF_RT_REG_SZ, nullptr, face, &sz) == ERROR_SUCCESS;
+    line("remembered face", haveReg ? narrow(face) : "(none -> first-run default)");
+    say("\r\n");
+    return 0;
+}
+
 static int agbfBench() {
     AttachConsole(ATTACH_PARENT_PROCESS);
     HANDLE out = GetStdHandle(STD_OUTPUT_HANDLE);
@@ -3892,8 +4067,12 @@ static LRESULT CALLBACK treeProc(HWND h, UINT m, WPARAM w, LPARAM l, UINT_PTR id
             // or just Alt-Tabbing back, since Windows restores focus to the child that had it —
             // left the tree focused and the next keystroke went to the sidebar instead of the
             // shell. Renaming is the one case that legitimately wants the keyboard here.
-            if (!g_treeRenaming && !TreeView_GetEditControl(h))
+            if (!g_treeRenaming && !TreeView_GetEditControl(h)) {
+                logInfo("focus: sidebar took focus -> bouncing back to the terminal");
                 ::PostMessageW(g_hwnd, WM_APP_FOCUSTERM, 0, 0);
+            } else {
+                logInfo("focus: sidebar keeps focus (inline rename in progress)");
+            }
             break;
         case WM_LBUTTONDOWN: {
             g_armIdx = -1;
@@ -4213,7 +4392,10 @@ public:
     // Windows restores focus to whichever child held it last, which after any sidebar interaction
     // is the tree — so returning to lite left you typing into the sidebar.
     void OnActivateFrame(UINT state, BOOL, CWindow) {
-        if (state != WA_INACTIVE) ::PostMessageW(m_hWnd, WM_APP_FOCUSTERM, 0, 0);
+        if (state != WA_INACTIVE) {
+            logInfo("focus: window activated -> reclaiming the keyboard for the terminal");
+            ::PostMessageW(m_hWnd, WM_APP_FOCUSTERM, 0, 0);
+        }
     }
     void OnSetFocusFrame(CWindow) { g_winFocused = true;  g_caretOn = true; InvalidateCaret(); }
     void OnKillFocusFrame(CWindow) { g_winFocused = false; g_caretOn = true; InvalidateCaret(); }
@@ -4270,8 +4452,9 @@ public:
     /// Restore keyboard focus to the terminal after the sidebar finished handling a click. Skipped
     /// while a tree label is being edited (rename) — that edit box legitimately owns the keyboard.
     LRESULT OnFocusTerm(UINT, WPARAM, LPARAM, BOOL&) {
-        if (g_tree && TreeView_GetEditControl(g_tree)) return 0;
+        if (g_tree && TreeView_GetEditControl(g_tree)) { logInfo("focus: restore SKIPPED (rename edit owns the keyboard)"); return 0; }
         SetFocus();
+        logInfo("focus: terminal has the keyboard (focus owner now %p)", (void*)::GetFocus());
         return 0;
     }
 
@@ -5048,11 +5231,16 @@ static DWORD WINAPI ctlServerThread(void*) {
 static bool restoreSessions() {
     std::wstring path = stateFilePath();
     HANDLE f = CreateFileW(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
-    if (f == INVALID_HANDLE_VALUE) return false;
+    if (f == INVALID_HANDLE_VALUE) {
+        // Exit 1 of 4. "No state file" and "state file I refused to use" look identical from
+        // outside, so each exit says which one it was.
+        logInfo("restore: no state file at %s (err %lu) — starting fresh", narrow(path).c_str(), GetLastError());
+        return false;
+    }
     std::string data; char buf[4096]; DWORD rd;
     while (ReadFile(f, buf, sizeof buf, &rd, nullptr) && rd) data.append(buf, rd);
     CloseHandle(f);
-    if (data.empty()) return false;
+    if (data.empty()) { logWarn("restore: state file is EMPTY: %s", narrow(path).c_str()); return false; }   // exit 2 of 4
 
     std::vector<std::wstring> wss;
     struct Spec { int ws; std::string name, app, cwd; std::vector<std::string> args; bool flagged = false; };
@@ -5084,20 +5272,38 @@ static bool restoreSessions() {
         } else if (ff[0] == "O" && ff.size() >= 2) focusWs = atoi(ff[1].c_str());
         else if (ff[0] == "A" && ff.size() >= 2) activeWs = atoi(ff[1].c_str());
     }
-    if (specs.empty()) return false;
+    if (specs.empty()) {   // exit 3 of 4: the file exists and has content, but no S lines parsed
+        logWarn("restore: %s parsed to 0 session specs (%zu bytes, %zu workspace lines)",
+                narrow(path).c_str(), data.size(), wss.size());
+        return false;
+    }
+    logInfo("restore: %zu spec(s) from %s (%zu bytes)", specs.size(), narrow(path).c_str(), data.size());
 
     g_restoring = true;
     if (!wss.empty()) g_workspaces = wss;
     int cols, rows; paneGridSize(0, &cols, &rows);
-    int firstIdx = -1;
+    int firstIdx = -1, built = 0;
     for (const auto& sp : specs) {
         g_activeWs = (sp.ws >= 0 && sp.ws < (int)g_workspaces.size()) ? sp.ws : 0;
         Session* s = newSession(cols, rows, sp.app.empty() ? nullptr : sp.app.c_str(),
                                 sp.args.empty() ? nullptr : &sp.args, sp.cwd.empty() ? nullptr : sp.cwd.c_str());
-        if (s) { s->name = widen(sp.name); s->flagged = sp.flagged; if (firstIdx < 0) firstIdx = (int)g_sessions.size() - 1; }
+        if (s) {
+            s->name = widen(sp.name); s->flagged = sp.flagged;
+            if (firstIdx < 0) firstIdx = (int)g_sessions.size() - 1;
+            built++;
+        } else {
+            // A spec that won't start is invisible otherwise — the session simply doesn't come back.
+            // Name it, so a shell that no longer exists on that machine is obvious from the log.
+            logWarn("restore: session '%s' FAILED to start (app='%s' cwd='%s')",
+                    sp.name.c_str(), sp.app.c_str(), sp.cwd.c_str());
+        }
     }
     g_restoring = false;
-    if (firstIdx < 0) return false;
+    logInfo("restore: %d of %zu session(s) built", built, specs.size());
+    if (firstIdx < 0) {   // exit 4 of 4: specs parsed but nothing could be started
+        logWarn("restore: no session could be started from %zu spec(s) — starting fresh", specs.size());
+        return false;
+    }
     g_pane[0] = firstIdx; g_pane[1] = -1; g_focus = 0;
     g_activeWs = (activeWs >= 0 && activeWs < (int)g_workspaces.size()) ? activeWs : 0;
     g_focusWs = (focusWs >= 0 && focusWs < (int)g_workspaces.size()) ? focusWs : -1;
@@ -5121,6 +5327,7 @@ static void parseLaunchArgs() {
         else if (a == L"--maximized")  g_argMaximized = true;
         else if (a == L"--no-restore") g_argNoRestore = true;
         else if (a == L"--bench-agbf") g_argBenchAgbf = true;
+        else if (a == L"--diagnose")   g_argDiagnose = true;
         else if (a == L"--pipe" && v)  { g_argPipe = v; i++; }
     }
     LocalFree(argv);
@@ -5155,6 +5362,13 @@ int WINAPI wWinMain(HINSTANCE inst, HINSTANCE, PWSTR, int show) {
     _Module.Init(nullptr, inst);   // ATL/WTL module (window class registration lives here)
     parseLaunchArgs();
     if (g_argBenchAgbf) return agbfBench();   // headless pack benchmark, no window/session
+    if (g_argDiagnose) return liteDiagnose();  // headless state/environment report, no window/session
+    {   // diagnostics log: after parseLaunchArgs so it lands in the right per-instance file
+        int argc = 0;
+        wchar_t** argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+        logInit(argc, argv);
+        if (argv) LocalFree(argv);
+    }
     InitializeCriticalSection(&g_lock);
     InitializeCriticalSection(&g_reqLock);
     loadCore();
@@ -5187,8 +5401,14 @@ int WINAPI wWinMain(HINSTANCE inst, HINSTANCE, PWSTR, int show) {
     buildFontCatalog();
     loadColors();      // Properties->Colors overrides, remembered across restarts
     loadKeys();        // configurable key bindings (unbound by default)
-    loadFontSel();     // resolve the remembered face+size (first run -> Terminal 8x12)
+    loadFontSel();     // resolve the remembered face+size (first run -> AGWin Bitmap Complete 16)
     applyFont();       // creates g_fonts + sets g_cw/g_ch (g_hwnd still null, so no relayout yet)
+    if (g_faceIdx >= 0 && g_faceIdx < (int)g_catalog.size())
+        logInfo("font: %s %s (%s) cell=%dx%d | packs: agbf=%d complete=%d",
+                narrow(g_catalog[g_faceIdx].label).c_str(),
+                narrow(g_catalog[g_faceIdx].sizes[g_sizeIdx].label).c_str(),
+                g_fontFromReg ? "remembered" : "first-run default", g_cw, g_ch,
+                g_haveAgbf ? 1 : 0, g_haveAgbfC ? 1 : 0);
 
     connectControl();
 

--- a/lite/test/diagnose.ps1
+++ b/lite/test/diagnose.ps1
@@ -1,0 +1,48 @@
+# lite diagnostics — Task 4 checks: --diagnose must be a safe, useful one-shot report.
+param([string]$Exe = "$PSScriptRoot\..\bin\agwinterm-lite.exe")
+
+$ErrorActionPreference = 'Stop'
+$fail = 0
+function Check([string]$name, [bool]$ok, [string]$detail = '') {
+    if ($ok) { "  PASS  $name" }
+    else { $script:fail++; "  FAIL  $name$(if ($detail) { " — $detail" })" }
+}
+
+"== diagnose =="
+
+# --- normal profile ---------------------------------------------------------------------------
+$before = @(Get-Process -Name 'agwinterm-lite' -ErrorAction SilentlyContinue).Count
+$out = & $Exe --pipe diagchk --diagnose 2>&1 | Out-String
+$code = $LASTEXITCODE
+Start-Sleep -Seconds 2
+$after = @(Get-Process -Name 'agwinterm-lite' -ErrorAction SilentlyContinue).Count
+
+Check 'exits 0' ($code -eq 0) "exit=$code"
+Check 'leaves no process behind (no window)' ($after -le $before) "before=$before after=$after"
+Check 'reports the version' ($out -match 'version: \d+\.\d+\.\d+|version: dev')
+Check 'reports the instance' ($out -match 'instance: diagchk')
+Check 'reports the state dir' ($out -match 'dir: .*agwinterm-lite')
+Check 'reports writability' ($out -match 'dir writable: yes')
+Check 'reports the session file' ($out -match 'session file:')
+Check 'reports the log path' ($out -match 'log\s+path: .*\.log')
+Check 'reports the pack inventory' ($out -match 'agwin-bitmap-complete-16\.agbf: (present|missing)')
+
+# --- error case: an unwritable profile must be REPORTED, not crash ----------------------------
+# %LOCALAPPDATA% points at a file, so every path beneath it is unopenable.
+$bogus = Join-Path ([IO.Path]::GetTempPath()) ("lite-diag-" + [Guid]::NewGuid().ToString('N'))
+Set-Content -Path $bogus -Value 'not a directory'
+$old = $env:LOCALAPPDATA
+try {
+    $env:LOCALAPPDATA = $bogus
+    $out2 = & $Exe --pipe diagchk2 --diagnose 2>&1 | Out-String
+    $code2 = $LASTEXITCODE
+} finally {
+    $env:LOCALAPPDATA = $old
+    Remove-Item $bogus -ErrorAction SilentlyContinue
+}
+Check 'still exits 0 with an unwritable profile' ($code2 -eq 0) "exit=$code2"
+Check 'names the profile as not writable' ($out2 -match 'dir writable: NO') `
+    ($out2 -split "`n" | Where-Object { $_ -match 'writable' } | Select-Object -First 1)
+Check 'flags that saves cannot work' ($out2 -match 'saves cannot work here')
+
+if ($fail) { "diagnose: $fail FAILED"; exit 1 } else { "diagnose: all passed"; exit 0 }

--- a/lite/test/log-basics.ps1
+++ b/lite/test/log-basics.ps1
@@ -1,0 +1,61 @@
+# lite diagnostics log — Task 1 checks.
+#
+# lite has no C++ test harness, so its checks drive the BUILT exe and assert on observable output.
+# Rules that this suite obeys (learned the hard way):
+#   - always a sandbox instance (--pipe <name>); never the default instance, which owns real state
+#   - never inject global input (keybd_event/SendInput) — it lands wherever focus happens to be
+#   - capture windows with PrintWindow, never CopyFromScreen, which grabs whatever overlaps
+param([string]$Exe = "$PSScriptRoot\..\bin\agwinterm-lite.exe")
+
+$ErrorActionPreference = 'Stop'
+$fail = 0
+function Check([string]$name, [bool]$ok, [string]$detail = '') {
+    if ($ok) { "  PASS  $name" }
+    else { $script:fail++; "  FAIL  $name$(if ($detail) { " — $detail" })" }
+}
+
+$pipe = 'logtest'
+$logDir = "$env:LOCALAPPDATA\agwinterm-lite"
+$log = "$logDir\lite-$pipe.log"
+Remove-Item $log, "$log.old" -ErrorAction SilentlyContinue
+
+"== log-basics =="
+
+# --- 1. the log is created and carries the startup lines -------------------------------------
+$p = Start-Process $Exe -ArgumentList @('--pipe', $pipe) -PassThru
+Start-Sleep -Seconds 7
+Check 'log file created' (Test-Path $log) $log
+$text = if (Test-Path $log) { Get-Content $log -Raw } else { '' }
+Check 'records the startup banner' ($text -match 'agwinterm-lite .* starting')
+Check 'records instance + exe + args' ($text -match "instance=$pipe" -and $text -match 'args=\[')
+Check 'timestamped, levelled lines' ($text -match '\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}\s+INFO\s+')
+
+# --- 2. readable WHILE lite is running (share mode) -------------------------------------------
+$readable = $true
+try { [IO.File]::ReadAllText($log) | Out-Null } catch { $readable = $false }
+Check 'readable while lite is running' $readable
+
+$p.CloseMainWindow() | Out-Null
+Start-Sleep -Seconds 3
+if (-not $p.HasExited) { Stop-Process -Id $p.Id -Force }
+
+# --- 3. error case: an unwritable profile must not stop lite ----------------------------------
+# Point %LOCALAPPDATA% at a file (not a directory) so every path under it is unopenable. lite must
+# still start and serve the control pipe — logging degrades to a no-op, it is never fatal.
+$bogusRoot = Join-Path ([IO.Path]::GetTempPath()) ("lite-nolog-" + [Guid]::NewGuid().ToString('N'))
+Set-Content -Path $bogusRoot -Value 'not a directory'
+$p2 = Start-Process $Exe -ArgumentList @('--pipe', "$pipe-nolog") -PassThru -Environment @{ LOCALAPPDATA = $bogusRoot }
+Start-Sleep -Seconds 7
+$p2.Refresh()
+Check 'starts with an unwritable profile' (-not $p2.HasExited) "exit 0x$('{0:X8}' -f $(if ($p2.HasExited) { $p2.ExitCode } else { 0 }))"
+if (-not $p2.HasExited) {
+    $ctl = "$env:LOCALAPPDATA\Programs\agwinterm\agwintermctl.exe"
+    $tree = (& $ctl tree --json --pipe "$pipe-nolog" 2>&1) -join ''
+    Check 'still serves the control pipe' ($tree -match '"ok":true')
+    $p2.CloseMainWindow() | Out-Null
+    Start-Sleep -Seconds 3
+    if (-not $p2.HasExited) { Stop-Process -Id $p2.Id -Force }
+}
+Remove-Item $bogusRoot -ErrorAction SilentlyContinue
+
+if ($fail) { "log-basics: $fail FAILED"; exit 1 } else { "log-basics: all passed"; exit 0 }

--- a/lite/test/log-focus-font.ps1
+++ b/lite/test/log-focus-font.ps1
@@ -1,0 +1,76 @@
+# lite diagnostics log — Task 3 checks: focus handoffs and font resolution must be in the log.
+#
+# "I can't type after switching sessions" was only pinned because GetGUIThreadInfo could be run live
+# on the dev machine. These lines make the same story readable from a laptop's log file.
+param([string]$Exe = "$PSScriptRoot\..\bin\agwinterm-lite.exe")
+
+$ErrorActionPreference = 'Stop'
+$fail = 0
+function Check([string]$name, [bool]$ok, [string]$detail = '') {
+    if ($ok) { "  PASS  $name" }
+    else { $script:fail++; "  FAIL  $name$(if ($detail) { " — $detail" })" }
+}
+
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public class FF {
+  [DllImport("user32.dll")] public static extern bool PostMessageW(IntPtr h, uint m, IntPtr w, IntPtr l);
+  [DllImport("user32.dll", CharSet = CharSet.Unicode)] public static extern IntPtr FindWindowExW(IntPtr p, IntPtr c, string cls, string win);
+  [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, IntPtr pid);
+  [DllImport("user32.dll")] public static extern bool GetGUIThreadInfo(uint tid, ref GUITHREADINFO i);
+  [StructLayout(LayoutKind.Sequential)] public struct RECT { public int L, T, R, B; }
+  [StructLayout(LayoutKind.Sequential)] public struct GUITHREADINFO {
+    public int cbSize; public int flags; public IntPtr hwndActive, hwndFocus, hwndCapture,
+    hwndMenuOwner, hwndMoveSize, hwndCaret; public RECT rcCaret; }
+  public static IntPtr LP(int x, int y) { return (IntPtr)((y << 16) | (x & 0xFFFF)); }
+}
+"@
+
+$pipe = 'logfoc'
+$dir  = "$env:LOCALAPPDATA\agwinterm-lite"
+$log  = "$dir\lite-$pipe.log"
+$ctl  = "$env:LOCALAPPDATA\Programs\agwinterm\agwintermctl.exe"
+Remove-Item $log, "$dir\sessions-$pipe.tsv" -ErrorAction SilentlyContinue
+
+"== log-focus-font =="
+
+$p = Start-Process $Exe -ArgumentList @('--pipe', $pipe) -PassThru
+Start-Sleep -Seconds 7
+$p.Refresh(); $h = $p.MainWindowHandle
+& $ctl session new --pipe $pipe 2>&1 | Out-Null
+Start-Sleep -Seconds 3
+
+# --- font resolution is recorded, with its source and the pack inventory ----------------------
+$text = Get-Content $log -Raw
+$font = [regex]::Match($text, 'font: (.+?) \((remembered|first-run default)\) cell=(\d+)x(\d+) \| packs: agbf=(\d) complete=(\d)')
+Check 'font resolution is logged' $font.Success
+if ($font.Success) {
+    Check 'names the source of the selection' ($font.Groups[2].Value -in @('remembered','first-run default'))
+    Check 'reports a real cell size' ([int]$font.Groups[3].Value -gt 0 -and [int]$font.Groups[4].Value -gt 0)
+    Check 'reports pack inventory' ($font.Groups[5].Value -eq '1' -and $font.Groups[6].Value -eq '1') `
+        "agbf=$($font.Groups[5].Value) complete=$($font.Groups[6].Value)"
+}
+
+# --- clicking the sidebar is narrated, and focus really does end up on the frame ---------------
+$tree = [FF]::FindWindowExW($h, [IntPtr]::Zero, "SysTreeView32", $null)
+[FF]::PostMessageW($tree, 0x0201, [IntPtr]1, [FF]::LP(60, 49)) | Out-Null   # WM_LBUTTONDOWN
+Start-Sleep -Milliseconds 400
+[FF]::PostMessageW($tree, 0x0202, [IntPtr]0, [FF]::LP(60, 49)) | Out-Null   # WM_LBUTTONUP
+Start-Sleep -Seconds 2
+
+$text2 = Get-Content $log -Raw
+Check 'sidebar focus grab is logged' ($text2 -match 'focus: sidebar took focus')
+Check 'handing the keyboard back is logged' ($text2 -match 'focus: terminal has the keyboard')
+
+$tid = [FF]::GetWindowThreadProcessId($h, [IntPtr]::Zero)
+$gi = New-Object FF+GUITHREADINFO
+$gi.cbSize = [Runtime.InteropServices.Marshal]::SizeOf($gi)
+[FF]::GetGUIThreadInfo($tid, [ref]$gi) | Out-Null
+Check 'focus owner is the frame, not the tree' ($gi.hwndFocus -eq $h) "focus=$($gi.hwndFocus) frame=$h tree=$tree"
+
+$p.CloseMainWindow() | Out-Null
+Start-Sleep -Seconds 3
+if (-not $p.HasExited) { Stop-Process -Id $p.Id -Force }
+
+if ($fail) { "log-focus-font: $fail FAILED"; exit 1 } else { "log-focus-font: all passed"; exit 0 }

--- a/lite/test/log-restore.ps1
+++ b/lite/test/log-restore.ps1
@@ -1,0 +1,73 @@
+# lite diagnostics log — Task 2 checks: session save/restore must narrate itself.
+#
+# The point of these lines is the work-laptop report "restore doesn't work at all", which was
+# unanswerable because a failed save and a failed rebuild look identical from outside. The log now
+# distinguishes them, and this check pins the wording so it can't silently regress.
+param([string]$Exe = "$PSScriptRoot\..\bin\agwinterm-lite.exe")
+
+$ErrorActionPreference = 'Stop'
+$fail = 0
+function Check([string]$name, [bool]$ok, [string]$detail = '') {
+    if ($ok) { "  PASS  $name" }
+    else { $script:fail++; "  FAIL  $name$(if ($detail) { " — $detail" })" }
+}
+
+$pipe  = 'logrst'
+$dir   = "$env:LOCALAPPDATA\agwinterm-lite"
+$log   = "$dir\lite-$pipe.log"
+$state = "$dir\sessions-$pipe.tsv"
+$ctl   = "$env:LOCALAPPDATA\Programs\agwinterm\agwintermctl.exe"
+Remove-Item $log, "$log.old", $state -ErrorAction SilentlyContinue
+
+"== log-restore =="
+
+# --- run 1: create sessions, close, and expect a narrated save --------------------------------
+$p = Start-Process $Exe -ArgumentList @('--pipe', $pipe) -PassThru
+Start-Sleep -Seconds 7
+& $ctl session new --pipe $pipe 2>&1 | Out-Null
+Start-Sleep -Seconds 3
+$p.CloseMainWindow() | Out-Null
+Start-Sleep -Seconds 4
+if (-not $p.HasExited) { Stop-Process -Id $p.Id -Force }
+Start-Sleep -Seconds 1
+
+$text = Get-Content $log -Raw
+Check 'first run reports no state file' ($text -match 'restore: no state file')
+# Saves fire on every structural change, so the state that survives the run is the LAST one.
+$saves = [regex]::Matches($text, 'save ok: (\d+) session\(s\), (\d+) bytes')
+$save = if ($saves.Count) { $saves[$saves.Count - 1] } else { [regex]::Match('', 'x') }
+Check 'save is recorded with a count and byte total' ($saves.Count -gt 0)
+if ($save.Success) {
+    Check 'saved at least 2 sessions' ([int]$save.Groups[1].Value -ge 2) "count=$($save.Groups[1].Value)"
+    Check 'byte total is nonzero' ([int]$save.Groups[2].Value -gt 0) "bytes=$($save.Groups[2].Value)"
+}
+
+# --- run 2: relaunch and expect a narrated restore ---------------------------------------------
+$p2 = Start-Process $Exe -ArgumentList @('--pipe', $pipe) -PassThru
+Start-Sleep -Seconds 8
+$text2 = Get-Content $log -Raw
+$spec = [regex]::Match($text2, 'restore: (\d+) spec\(s\) from')
+Check 'restore reports the spec count' $spec.Success
+$built = [regex]::Match($text2, 'restore: (\d+) of (\d+) session\(s\) built')
+Check 'restore reports how many were built' $built.Success
+if ($built.Success -and $save.Success) {
+    Check 'built count matches what was saved' ($built.Groups[1].Value -eq $save.Groups[1].Value) `
+        "built=$($built.Groups[1].Value) saved=$($save.Groups[1].Value)"
+}
+$p2.CloseMainWindow() | Out-Null
+Start-Sleep -Seconds 4
+if (-not $p2.HasExited) { Stop-Process -Id $p2.Id -Force }
+Start-Sleep -Seconds 1
+
+# --- error case: a zero-byte state file must be NAMED, not silently ignored --------------------
+Remove-Item $log -ErrorAction SilentlyContinue
+Set-Content -Path $state -Value '' -NoNewline
+$p3 = Start-Process $Exe -ArgumentList @('--pipe', $pipe) -PassThru
+Start-Sleep -Seconds 8
+$text3 = Get-Content $log -Raw
+Check 'empty state file is reported as EMPTY' ($text3 -match 'restore: state file is EMPTY')
+$p3.CloseMainWindow() | Out-Null
+Start-Sleep -Seconds 4
+if (-not $p3.HasExited) { Stop-Process -Id $p3.Id -Force }
+
+if ($fail) { "log-restore: $fail FAILED"; exit 1 } else { "log-restore: all passed"; exit 0 }

--- a/lite/test/log-rotation.ps1
+++ b/lite/test/log-rotation.ps1
@@ -1,0 +1,59 @@
+# lite diagnostics log — rotation and per-instance isolation.
+#
+# Rotation matters because the log is always on: it must not grow without bound on a machine that
+# runs lite for weeks. Per-instance files matter because multi-window lite is one process per window
+# — a shared file would interleave several writers' lines and be unreadable.
+param([string]$Exe = "$PSScriptRoot\..\bin\agwinterm-lite.exe")
+
+$ErrorActionPreference = 'Stop'
+$fail = 0
+function Check([string]$name, [bool]$ok, [string]$detail = '') {
+    if ($ok) { "  PASS  $name" }
+    else { $script:fail++; "  FAIL  $name$(if ($detail) { " — $detail" })" }
+}
+
+$dir  = "$env:LOCALAPPDATA\agwinterm-lite"
+$ctl  = "$env:LOCALAPPDATA\Programs\agwinterm\agwintermctl.exe"
+
+"== log-rotation =="
+
+# --- rotation: pre-fill past the 1 MB threshold, then make lite write ------------------------
+$pipe = 'logrot'
+$log = "$dir\lite-$pipe.log"
+Remove-Item $log, "$log.old", "$dir\sessions-$pipe.tsv" -ErrorAction SilentlyContinue
+Set-Content -Path $log -Value ('x' * 1048600) -NoNewline     # just over 1 MiB
+$preSize = (Get-Item $log).Length
+Check 'seeded an oversized log' ($preSize -gt 1048576) "size=$preSize"
+
+$p = Start-Process $Exe -ArgumentList @('--pipe', $pipe) -PassThru
+Start-Sleep -Seconds 7
+Check 'rotated to .old' (Test-Path "$log.old") "$log.old"
+if (Test-Path "$log.old") { Check 'the .old copy holds the previous content' ((Get-Item "$log.old").Length -gt 1048576) }
+$new = Get-Item $log
+Check 'a fresh log was started' ($new.Length -lt 10240) "size=$($new.Length)"
+Check 'the fresh log has the startup banner' ((Get-Content $log -Raw) -match 'starting')
+$p.CloseMainWindow() | Out-Null
+Start-Sleep -Seconds 3
+if (-not $p.HasExited) { Stop-Process -Id $p.Id -Force }
+
+# --- per-instance isolation: two instances must not share a file -----------------------------
+$a = 'logiso1'; $b = 'logiso2'
+Remove-Item "$dir\lite-$a.log", "$dir\lite-$b.log", "$dir\sessions-$a.tsv", "$dir\sessions-$b.tsv" -ErrorAction SilentlyContinue
+$pa = Start-Process $Exe -ArgumentList @('--pipe', $a) -PassThru
+$pb = Start-Process $Exe -ArgumentList @('--pipe', $b) -PassThru
+Start-Sleep -Seconds 9
+Check 'instance A has its own log' (Test-Path "$dir\lite-$a.log")
+Check 'instance B has its own log' (Test-Path "$dir\lite-$b.log")
+if ((Test-Path "$dir\lite-$a.log") -and (Test-Path "$dir\lite-$b.log")) {
+    $ta = Get-Content "$dir\lite-$a.log" -Raw
+    $tb = Get-Content "$dir\lite-$b.log" -Raw
+    Check "A's log mentions only A" (($ta -match "instance=$a") -and ($ta -notmatch "instance=$b"))
+    Check "B's log mentions only B" (($tb -match "instance=$b") -and ($tb -notmatch "instance=$a"))
+}
+foreach ($proc in @($pa, $pb)) {
+    $proc.CloseMainWindow() | Out-Null
+    Start-Sleep -Seconds 2
+    if (-not $proc.HasExited) { Stop-Process -Id $proc.Id -Force }
+}
+
+if ($fail) { "log-rotation: $fail FAILED"; exit 1 } else { "log-rotation: all passed"; exit 0 }

--- a/lite/test/run-all.ps1
+++ b/lite/test/run-all.ps1
@@ -1,0 +1,16 @@
+# Run every lite check. These drive the BUILT exe (lite has no C++ unit-test harness), so build
+# first: lite\build.ps1
+param([string]$Exe = "$PSScriptRoot\..\bin\agwinterm-lite.exe")
+
+$ErrorActionPreference = 'Continue'
+$failed = @()
+foreach ($t in 'log-basics', 'log-restore', 'log-focus-font', 'log-rotation', 'diagnose') {
+    $script = Join-Path $PSScriptRoot "$t.ps1"
+    if (-not (Test-Path $script)) { continue }
+    & $script -Exe $Exe
+    if ($LASTEXITCODE -ne 0) { $failed += $t }
+    ""
+}
+if ($failed.Count) { "FAILED: $($failed -join ', ')"; exit 1 }
+"all lite checks passed"
+exit 0


### PR DESCRIPTION
Implements `docs/plans/2026-07-31-lite-diagnostics-logging.md` — all six tasks.

## Why

Three field reports in a row each cost hours: **"restore doesn't work at all"**, **"can't type after switching sessions"**, and the **switch-time render artefacts**. All three happened on the work laptop and left nothing behind, so every diagnosis became a re-enactment on a different machine — and mostly failed to reproduce. The restore one is *still* open for exactly this reason: a failed **write** and a failed **rebuild** look identical from outside and need opposite fixes.

## What

**Logging core.** `%LOCALAPPDATA%\agwinterm-lite\lite.log`, or `lite-<instance>.log` — per instance, because multi-window lite is one process per window and a shared file would interleave four writers. Its own `CRITICAL_SECTION` (callers span the UI thread, a `readerThread` per session, the control server plus a thread per client, and the update worker — `g_lock` guards emulator state, not this). Appends with `FILE_SHARE_READ|WRITE` so it can be tailed live; rotates at ~1 MB into `.log.old`. **Never fatal, never blocking**: if the file can't be opened it degrades to a no-op for the process lifetime and lite runs unchanged.

**Save/restore is the first customer.**

- `saveSessionState()` logs path, session count and byte total — and on failure the `GetLastError` from `CreateFileW`/`WriteFile`. That silent `return` is the whole reason the report was unanswerable.
- `restoreSessions()` names **which of its four false-exits** it took (file missing / file empty / zero specs parsed / nothing started), plus specs-vs-built counts on success.
- A spec that fails to start is named with its app and cwd, so a shell that no longer exists on that machine is obvious.

**Focus and font** are logged too — the "can't type" class was only pinned last time because `GetGUIThreadInfo` could be run live here, which isn't available remotely.

**`--diagnose`** prints a one-shot report and exits without a window (same `AttachConsole` technique as `--bench-agbf`). Read-only and safe while lite runs:

```
  version: 0.17.2
  instance: (default)
state
  dir: C:\Users\boris\AppData\Local\agwinterm-lite
  dir exists: yes
  dir writable: yes
  session file: ...\sessions-logrst.tsv
    size: 59 bytes
    modified: 2026-07-31 14:14:50
session file contents
  V1
  W	workspace 1
  S	0			C:\Users\boris\source\agwinterm
```

`dir writable` is a real create/delete probe, not an attribute guess — that's what catches a redirected or policy-locked profile.

**Deliberately not logged**: terminal output, pasted text, typed keys, session command lines. The log is about what lite *did*, so it can be attached to an issue without leaking what you were working on.

## Verification

lite has no C++ unit harness, so the checks drive the built exe — `lite/test/run-all.ps1`:

| check | covers |
|---|---|
| `log-basics` | file created, banner, timestamps, readable while running; **unwritable profile still starts and serves the control pipe** |
| `log-restore` | save count + byte total, restore spec count, built-matches-saved; **zero-byte state file is named EMPTY, not ignored** |
| `log-focus-font` | font source + cell + pack inventory; sidebar grab and hand-back logged, and `GetGUIThreadInfo` confirms the frame really owns focus |
| `log-rotation` | rotation at the 1 MB threshold into `.old`; two concurrent instances never share a file |
| `diagnose` | exits 0, leaves no window, reports every field; **unwritable profile reported as `writable: NO`** |

All pass. .NET 316 and Rust 27 unchanged. Follows the house rules: sandbox instances only, posted messages not global input, `PrintWindow` not screen capture.

## Scope

Fixing the restore break is **not** in here. The log is what tells us which fix to write. Next step is on the laptop: reproduce restore failing normally, then read whether it says `save FAILED to open ... (err N)` or `restore: N spec(s) ... 0 session(s) built`.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)