### PR TITLE
fix(lite): never restore against a dying pty-host — the real cause of "restore doesn't work"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ installer/Output/
 
 # ralphex progress logs
 .ralphex/progress/
+
+# throwaway UI mock-ups: vendored FLTK, cmake/ninja trees and their build output (~1 GB),
+# none of which belongs in the repo — one `git add -A` away from being committed.
+lite/design-mocks/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ installer/stage/
 installer/stage-lite/
 installer/stage-portable/
 installer/Output/
+
+# ralphex progress logs
+.ralphex/progress/

--- a/README.md
+++ b/README.md
@@ -267,9 +267,11 @@ the next launch (`--no-restore` starts empty instead). Everything about that is 
   that has already exited, or one another window is currently driving, is not adopted — it is
   relaunched (or left to its owner) instead.
 - **Recovering by hand.** `--no-restore` starts empty, and the next save publishes *that* over
-  `sessions.tsv` — but the generation you wanted survives as `sessions.tsv.bak`. With lite closed,
-  copy the `.bak` over the primary and relaunch. `--diagnose` prints both files with their sizes (and
-  the primary's contents), so you can tell which one holds your sessions before you copy anything.
+  `sessions.tsv` — but the generation you wanted survives as `sessions.tsv.bak`. **Copy the `.bak`
+  somewhere safe first**: only one generation is kept, so the next save of the window you are looking
+  at overwrites it in turn. Then close lite, copy your saved file over `sessions.tsv`, and relaunch.
+  `--diagnose` prints both files with their sizes (and the primary's contents), so you can tell which
+  one holds your sessions before you copy anything.
 - **"Restart everything"** (*File → Restart everything*) relaunches the **same** instance — it carries
   this window's `--pipe <name>` over, so it comes back reading the same state file. `--diagnose`
   prints the exact command line it would use.

--- a/README.md
+++ b/README.md
@@ -262,8 +262,9 @@ the next launch (`--no-restore` starts empty instead). Everything about that is 
 - **Restore order**: `sessions.tsv` → `.bak` if the primary is missing, empty, or parses to zero
   sessions → a fresh window. If the pty-host still holds the shells — lite was killed or the machine
   was shut down rather than closed — those shells are **still running** and get adopted live instead
-  of relaunched. An adopted shell keeps everything it was running, but its **screen starts empty**:
-  lite re-attaches to the live process, it does not replay the history the old window had. A shell
+  of relaunched. An adopted shell keeps everything it was running, and lite asks it to redraw, so the
+  **screen comes back** — but the **scrollback does not**: lite re-attaches to the live process with a
+  fresh emulator, so only what is on screen is repainted, not the history the old window had. A shell
   that has already exited, or one another window is currently driving, is not adopted — it is
   relaunched (or left to its owner) instead.
 - **Recovering by hand.** `--no-restore` starts empty, and the next save publishes *that* over

--- a/README.md
+++ b/README.md
@@ -235,12 +235,52 @@ status bar — in the classic Windows look.
 Grab **`agwinterm-lite-setup-<version>.exe`** from Releases (per-user, no admin), or build it
 (needs the VC++ ATL component): `./lite/build.ps1` (dev build) / `./installer/build-lite.ps1` (setup).
 
+### Session restore & the state file
+
+Lite saves its workspaces and sessions whenever the tree changes and on exit, and rebuilds them on
+the next launch (`--no-restore` starts empty instead). Everything about that is on disk and readable:
+
+- **One state file per instance.** `%LOCALAPPDATA%\agwinterm-lite\sessions.tsv` for the default
+  instance, `sessions-<instance>.tsv` for a named one. **Because every lite window is its own
+  process, each window restores only its own sessions** — sessions you created in
+  `--pipe work` come back in `--pipe work`, never in the default window. That is the mundane
+  reading of "my sessions are gone": right sessions, wrong window.
+- **Format**: tab-separated UTF-8 text, `V1` header, one record per line — `W` workspace, `S` session
+  (workspace index, name, app, cwd, then args), `F` flagged indices, `D` host session ids, `A` active
+  workspace. The format grows by *adding* line types, so a file written by an older build still
+  restores, a line type this build doesn't write is still honoured when it finds one (`O`, focused
+  workspace), and a file from a **newer** build is read for the lines this one knows rather than
+  thrown away.
+- **What is saved**: the visible sessions, each with its *live* working directory (read from the
+  shell process, so it follows you as you `cd`). Split-pane shells are hidden and deliberately not
+  persisted — the split comes back as a single pane.
+- **Writes are atomic, and keep one generation.** The save writes `sessions.tsv.tmp`, rotates the
+  current file to **`sessions.tsv.bak`**, then renames the temp over the target — a crash or a full
+  disk mid-write can no longer leave a truncated file where a good one was. A zero-session save is
+  *refused* over a populated file (and says so in the log); the one legitimate empty is you closing
+  the last session, which also deletes the `.bak` so what you just closed doesn't come back.
+- **Restore order**: `sessions.tsv` → `.bak` if the primary is missing, empty, or parses to zero
+  sessions → a fresh window. If the pty-host still holds the shells — lite was killed or the machine
+  was shut down rather than closed — those shells are **still running** and get adopted live instead
+  of relaunched.
+- **"Restart everything"** (*File → Restart everything*) relaunches the **same** instance — it carries
+  this window's `--pipe <name>` over, so it comes back reading the same state file. `--diagnose`
+  prints the exact command line it would use.
+- **A spec that won't start on this machine** (a profile whose exe only exists on your other PC, a
+  cwd on an unmounted drive) stays in the tree as a `(failed to start)` entry with a note in its
+  pane, rather than silently vanishing. Its name, workspace, cwd and args are kept and re-saved, so
+  it starts normally again on the machine that has the app.
+
+Every one of those branches names itself in `lite.log`, and `lite/test/restore-matrix.ps1` drives the
+whole matrix — kill vs. graceful close, two windows at once, interrupted writes, `.bak` fallback,
+bogus apps, old and future file formats — as regression cover.
+
 ### Reporting a lite problem
 
 Run `agwinterm-lite --diagnose` and attach its output plus `lite.log`. The report is read-only and
 safe to run while lite is open; it prints the state file's path, whether that directory is genuinely
 writable (a real write probe, which is what catches a redirected or policy-locked profile), the state
-file's contents, the resolved font, and the bundled pack inventory:
+file's contents and its `.bak` generation, the resolved font, and the bundled pack inventory:
 
 ```
 > agwinterm-lite --diagnose
@@ -251,7 +291,12 @@ state
   dir writable: yes
   session file: ...\sessions.tsv
     size: 59 bytes
+    modified: 2026-07-31 20:14:02
+  backup file: ...\sessions.tsv.bak (59 bytes)
 ```
+
+Use `--pipe <instance> --diagnose` to ask about a named instance — it reports *that* instance's
+state file, which is the one its window restores from.
 
 ## Keyboard essentials
 

--- a/README.md
+++ b/README.md
@@ -262,18 +262,31 @@ the next launch (`--no-restore` starts empty instead). Everything about that is 
 - **Restore order**: `sessions.tsv` → `.bak` if the primary is missing, empty, or parses to zero
   sessions → a fresh window. If the pty-host still holds the shells — lite was killed or the machine
   was shut down rather than closed — those shells are **still running** and get adopted live instead
-  of relaunched.
+  of relaunched. An adopted shell keeps everything it was running, but its **screen starts empty**:
+  lite re-attaches to the live process, it does not replay the history the old window had. A shell
+  that has already exited, or one another window is currently driving, is not adopted — it is
+  relaunched (or left to its owner) instead.
+- **Recovering by hand.** `--no-restore` starts empty, and the next save publishes *that* over
+  `sessions.tsv` — but the generation you wanted survives as `sessions.tsv.bak`. With lite closed,
+  copy the `.bak` over the primary and relaunch. `--diagnose` prints both files with their sizes (and
+  the primary's contents), so you can tell which one holds your sessions before you copy anything.
 - **"Restart everything"** (*File → Restart everything*) relaunches the **same** instance — it carries
   this window's `--pipe <name>` over, so it comes back reading the same state file. `--diagnose`
   prints the exact command line it would use.
 - **A spec that won't start on this machine** (a profile whose exe only exists on your other PC, a
   cwd on an unmounted drive) stays in the tree as a `(failed to start)` entry with a note in its
   pane, rather than silently vanishing. Its name, workspace, cwd and args are kept and re-saved, so
-  it starts normally again on the machine that has the app.
+  it starts normally again on the machine that has the app. Scripts can spot one without reading the
+  log: `agwintermctl tree --json` reports `"failed"` and `"exited"` per session.
 
 Every one of those branches names itself in `lite.log`, and `lite/test/restore-matrix.ps1` drives the
 whole matrix — kill vs. graceful close, two windows at once, interrupted writes, `.bak` fallback,
 bogus apps, old and future file formats — as regression cover.
+
+If lite exits at startup with **"pty-host did not become usable"**, a previous `agwinterm-ptyhost.exe`
+is wedged: end it in Task Manager and relaunch. `lite.log` records the connection attempt by attempt,
+including the case it is really there for — a host left dying by a killed window, which answers a
+handshake for a moment while refusing every real command.
 
 ### Reporting a lite problem
 
@@ -286,6 +299,7 @@ file's contents and its `.bak` generation, the resolved font, and the bundled pa
 > agwinterm-lite --diagnose
   version: 0.17.2
   instance: (default)
+  restart cmdline: "C:\Users\you\AppData\Local\Programs\agwinterm\agwinterm-lite.exe"
 state
   dir: C:\Users\you\AppData\Local\agwinterm-lite
   dir writable: yes

--- a/docs/plans/2026-07-31-lite-restore-scenario-matrix.md
+++ b/docs/plans/2026-07-31-lite-restore-scenario-matrix.md
@@ -248,10 +248,28 @@ harness self-check. .NET: `Agwinterm.Core.Tests` 200/200, `Agwinterm.Pty.Tests` 
 `Ptyhost.cs`) differ by line endings alone — no content moved outside lite.
 
 ### Task 7: [Final] Update documentation
-- [ ] document the state file, its `.bak` generation, and the restore rules in the README lite section
-- [ ] note the multi-window/per-instance state rule, since "my sessions are gone" has that mundane
+- [x] document the state file, its `.bak` generation, and the restore rules in the README lite section
+- [x] note the multi-window/per-instance state rule, since "my sessions are gone" has that mundane
       reading
-- [ ] record whatever the matrix caught in the build-and-test gotchas memory
+- [x] record whatever the matrix caught in the build-and-test gotchas memory
+
+➕ The README's new **Session restore & the state file** section is written for the person reading it
+*because* sessions went missing, so it leads with the per-instance rule ("right sessions, wrong
+window" is the mundane reading) before the format, the atomic write, the `.bak`, and the restore
+order — every branch of which names itself in `lite.log`. "Restart everything" is documented as
+keeping the instance, since that was a real defect and is now a promise.
+
+⚠️ Documenting the format caught a small inaccuracy in the draft: `O` (focused workspace) is **parsed
+but never written** by this build. The README now says so rather than listing it as a record lite
+emits — the point of the bullet is that a line type this build doesn't write is still honoured, which
+is the same forward-compatibility rule as `V2`.
+
+➕ Memory (`agwinterm-build-and-test-gotchas`) gained the traps from Tasks 3b–5 beside the Task 2–3
+ones already recorded: a guard needs its legitimate-case escape hatch (and the `.bak` delete that goes
+with it), the transient-empty save is drivable via a split, and relaunch paths silently drop `--pipe`.
+
+**Docs validation (2026-07-31)**: `lite/build.ps1` clean, `lite/test/run-all.ps1` all checks pass —
+24/24 matrix cells plus the harness self-check. No code changed in this task.
 
 ## Technical Details
 

--- a/docs/plans/2026-07-31-lite-restore-scenario-matrix.md
+++ b/docs/plans/2026-07-31-lite-restore-scenario-matrix.md
@@ -159,16 +159,31 @@ the string instead. `--pipe` is the only arg that identifies the instance; `-d`/
 are first-launch session args that restore supersedes, so they are deliberately not carried over.
 
 ### Task 4: Never let a good state file be replaced by an empty one
-- [ ] write the state file atomically: temp file + `MoveFileExW(..., MOVEFILE_REPLACE_EXISTING)`, so a
+- [x] write the state file atomically: temp file + `MoveFileExW(..., MOVEFILE_REPLACE_EXISTING)`, so a
       crash or a full disk mid-write cannot leave a truncated file where a good one was
-- [ ] refuse to overwrite a non-empty state file with a zero-session save unless the session list is
+- [x] refuse to overwrite a non-empty state file with a zero-session save unless the session list is
       genuinely empty by user action (closing the last session), and log loudly when that is skipped
-- [ ] keep one previous generation (`sessions.tsv.bak`) and fall back to it when the primary parses to
+- [x] keep one previous generation (`sessions.tsv.bak`) and fall back to it when the primary parses to
       zero specs — restore currently has no second chance
-- [ ] add matrix cells: interrupted write leaves the previous state intact; a zero-session save does
+- [x] add matrix cells: interrupted write leaves the previous state intact; a zero-session save does
       not clobber a populated file; the `.bak` fallback actually restores
-- [ ] verify backward compatibility: a plain 0.17.x `sessions.tsv` with no `.bak` still restores
-- [ ] run the matrix - must pass before task 5
+- [x] verify backward compatibility: a plain 0.17.x `sessions.tsv` with no `.bak` still restores
+- [x] run the matrix - must pass before task 5
+
+➕ The transient-empty save turned out to be **drivable end to end**, so `zero-guard` is a real
+reproduction rather than an assertion about an internal branch: split shells are hidden and
+deliberately not persisted, so with a split open, closing the only *visible* session leaves lite
+running with zero persistable sessions. That save used to write a 0-session file over a good one.
+
+➕ A deliberate empty (`g_userEmptied`, set only when closing the last session) must also **delete the
+`.bak`** — otherwise the next launch falls back to it and resurrects exactly what the user just
+closed. `closed-last` is the cell that pins it, and it is the guard's real regression risk: refusing
+too much is as bad as refusing too little. Driven over the control pipe, closing the last session
+does not tear the window down (`DestroyWindow` only works from the UI thread) — a pre-existing quirk,
+noted here because the cell has to work around it; the save it exercises is the same one.
+
+➕ Restore now logs which file it used, and `--diagnose` reports the `.bak` generation beside the
+primary.
 
 ### Task 5: Make a failed spec visible and recoverable
 - [ ] when a spec fails to start, keep it in the tree as a dead session (or re-add it to the state)

--- a/docs/plans/2026-07-31-lite-restore-scenario-matrix.md
+++ b/docs/plans/2026-07-31-lite-restore-scenario-matrix.md
@@ -299,7 +299,11 @@ session-object lookup went from a regex that could span a workspace and the firs
 `ConvertFrom-Json`.
 
 **Post-review results (2026-07-31)**: `lite/build.ps1` clean; `lite/test/run-all.ps1` — all lite checks
-pass, 25 matrix cells plus the harness self-check.
+pass, 26 matrix cells plus the harness self-check. The second review pass added
+`closed-last-with-hidden`: the zero-session guard counted the raw session list while the save counts
+only visible sessions, so closing the last visible session with a quick terminal (or a split shell)
+open refused the save and the closed session came back on the next launch. Verified failing before
+the fix.
 
 ### Task 7: [Final] Update documentation
 - [x] document the state file, its `.bak` generation, and the restore rules in the README lite section

--- a/docs/plans/2026-07-31-lite-restore-scenario-matrix.md
+++ b/docs/plans/2026-07-31-lite-restore-scenario-matrix.md
@@ -146,11 +146,17 @@ session. Cost an hour of confusion when the health probe started failing on heal
 - [x] run the matrix - all cells pass
 
 ### Task 3b: Fix `restartApp()` losing the instance
-- [ ] preserve `--pipe <instance>` (and any other launch args that identify the instance) when
+- [x] preserve `--pipe <instance>` (and any other launch args that identify the instance) when
       relaunching, so "Restart everything" comes back as the SAME instance reading the SAME state
-- [ ] add the matrix cell: named instance, Restart everything, assert the sessions return
-- [ ] add the error case: assert the default instance still restarts correctly (no regression)
-- [ ] run the matrix - must pass before task 4
+- [x] add the matrix cell: named instance, Restart everything, assert the sessions return
+- [x] add the error case: assert the default instance still restarts correctly (no regression)
+- [x] run the matrix - must pass before task 4
+
+➕ `restartCommandLine()` is the seam: `restartApp()` launches it and `--diagnose` prints it. That
+matters because the no-regression half — "the default instance still relaunches as the default" —
+cannot be checked by running the default instance, which owns real user state. The matrix asserts
+the string instead. `--pipe` is the only arg that identifies the instance; `-d`/`-p`/`--maximized`
+are first-launch session args that restore supersedes, so they are deliberately not carried over.
 
 ### Task 4: Never let a good state file be replaced by an empty one
 - [ ] write the state file atomically: temp file + `MoveFileExW(..., MOVEFILE_REPLACE_EXISTING)`, so a

--- a/docs/plans/2026-07-31-lite-restore-scenario-matrix.md
+++ b/docs/plans/2026-07-31-lite-restore-scenario-matrix.md
@@ -231,12 +231,20 @@ saved" compared run 1's restore with run 1's last save. Fixed in the harness —
 | session ids in the `D` line, adopt live host sessions on restore (Task 3) | `killed` (asserts the log says `adopted live session`), `stale-ids`, `short-id-line` |
 | `SessionInfo.title` is *skipped* on decode so `list` can never overflow (Task 3, revised in review) | `killed` (via the health probe) |
 | `restartCommandLine()` preserves `--pipe` (Task 3b) | `restart-named`, `restart-cmdline` |
-| atomic temp-file + `MoveFileExW` write (Task 4) | `interrupted-write` |
+| atomic temp-file write, published with `ReplaceFileW` (Task 4) | `interrupted-write`, `bak-rotation` |
+| protocol fields are fixed-size and `strcpy_s` *terminates* rather than truncates (review pass 2) | `oversize-fields` |
+| a session name cannot forge a state-file line (review pass 2) | `name-injection` |
 | refuse a zero-session save over a populated file (Task 4) | `zero-guard` |
 | a deliberate empty also deletes the `.bak` (Task 4) | `closed-last` |
 | `.bak` fallback when the primary yields zero specs (Task 4) | `bak-fallback`, `compat-0.17` |
 | `failedSpecSession()` keeps an unstartable spec as a dead entry (Task 5) | `failed-spec`, `bogus-app` |
 | tolerate an unknown `V` header instead of silently swallowing it (Task 6) | `future-v2` |
+
+⚠️ `interrupted-write` is a weaker anchor than it reads as: nothing in lite ever *reads* `sessions.tsv.tmp`,
+so seeding a stray one only proves a good primary still restores beside it. `bak-rotation` is what
+actually pins the publish (lite writes the `.bak` itself, and the primary holds the newer generation),
+which is why it is listed above too. A cell that forces a *failed* publish — holding the primary open
+with a deny-write share — is still not written.
 
 ➕ Task 2 had checked off a multi-window cell that was never actually written — every cell used a
 single instance. Caught by this task's audit and added: `two-windows` runs two instances at once and

--- a/docs/plans/2026-07-31-lite-restore-scenario-matrix.md
+++ b/docs/plans/2026-07-31-lite-restore-scenario-matrix.md
@@ -212,12 +212,40 @@ saved" compared run 1's restore with run 1's last save. Fixed in the harness —
 `.bak`/`.tmp`, and the run-2 assertions read the LAST restore line, not the first.
 
 ### Task 6: Verify acceptance criteria
-- [ ] verify every scenario in the matrix passes, and that each fix is tied to the cell that failed
-- [ ] verify edge cases: empty file, truncated file, unknown future `V2` header, missing `W` lines,
+- [x] verify every scenario in the matrix passes, and that each fix is tied to the cell that failed
+- [x] verify edge cases: empty file, truncated file, unknown future `V2` header, missing `W` lines,
       a spec referencing a workspace index that no longer exists
-- [ ] run the full `lite/test/run-all.ps1` suite
-- [ ] run the .NET and Rust suites to confirm nothing outside lite moved
-- [ ] confirm lite builds clean via `lite/build.ps1`
+- [x] run the full `lite/test/run-all.ps1` suite
+- [x] run the .NET and Rust suites to confirm nothing outside lite moved
+- [x] confirm lite builds clean via `lite/build.ps1`
+
+**Fix → the cell that caught it** (every fix in this plan is anchored to a cell that fails without it):
+
+| Fix | Cell |
+| --- | --- |
+| `controlHandshake()` probes with `list`; `connectControl()` retries a fresh host (Task 3) | `killed` |
+| session ids in the `D` line, adopt live host sessions on restore (Task 3) | `killed`, `two-windows` |
+| `SessionInfo.title` gets real storage so `list` decodes (Task 3) | `killed` (via the health probe) |
+| `restartCommandLine()` preserves `--pipe` (Task 3b) | `restart-named`, `restart-cmdline` |
+| atomic temp-file + `MoveFileExW` write (Task 4) | `interrupted-write` |
+| refuse a zero-session save over a populated file (Task 4) | `zero-guard` |
+| a deliberate empty also deletes the `.bak` (Task 4) | `closed-last` |
+| `.bak` fallback when the primary yields zero specs (Task 4) | `bak-fallback`, `compat-0.17` |
+| `failedSpecSession()` keeps an unstartable spec as a dead entry (Task 5) | `failed-spec`, `bogus-app` |
+| tolerate an unknown `V` header instead of silently swallowing it (Task 6) | `future-v2` |
+
+➕ Task 2 had checked off a multi-window cell that was never actually written — every cell used a
+single instance. Caught by this task's audit and added: `two-windows` runs two instances at once and
+asserts each restores only its own sessions, which is the mundane reading of "my sessions are gone".
+
+➕ A future-build file is now READ for the line types this build recognises rather than discarded —
+refusing it would lose the sessions *and* then overwrite the newer file with a V1 one. `parseStateFile()`
+records the version so the log can say which it did.
+
+**Results (2026-07-31)**: `lite/test/run-all.ps1` — all checks pass, including 24 matrix cells and the
+harness self-check. .NET: `Agwinterm.Core.Tests` 200/200, `Agwinterm.Pty.Tests` 116/116. Rust workspace:
+27/27. `lite/build.ps1` builds clean. The only non-lite files touched on this branch (`persist.rs`,
+`Ptyhost.cs`) differ by line endings alone — no content moved outside lite.
 
 ### Task 7: [Final] Update documentation
 - [ ] document the state file, its `.bak` generation, and the restore rules in the README lite section

--- a/docs/plans/2026-07-31-lite-restore-scenario-matrix.md
+++ b/docs/plans/2026-07-31-lite-restore-scenario-matrix.md
@@ -186,13 +186,30 @@ noted here because the cell has to work around it; the save it exercises is the 
 primary.
 
 ### Task 5: Make a failed spec visible and recoverable
-- [ ] when a spec fails to start, keep it in the tree as a dead session (or re-add it to the state)
+- [x] when a spec fails to start, keep it in the tree as a dead session (or re-add it to the state)
       rather than dropping it, so a machine-specific launch failure loses the NAME but not the entry
-- [ ] surface it in the UI the way an exited session already is, so the user can see what happened
-- [ ] add the matrix cell: a spec with a deliberately bogus app, asserting the session is visible and
+- [x] surface it in the UI the way an exited session already is, so the user can see what happened
+- [x] add the matrix cell: a spec with a deliberately bogus app, asserting the session is visible and
       the log names it
-- [ ] add the success case: a spec with a valid app still restores normally
-- [ ] run the matrix - must pass before task 6
+- [x] add the success case: a spec with a valid app still restores normally
+- [x] run the matrix - must pass before task 6
+
+➕ `failedSpecSession()` builds the dead entry: a `Session` with an EMPTY id (there is no host session
+behind it), `exited` + a new `failed` flag, its own emulator, and the spec's name/ws/cwd/app/args. The
+empty id is the seam — `killSession()` and the host half of `hostResize()` return early on it, so a
+placeholder is inert, while the emulator still resizes and paints. Its pane carries a short "this
+session could not be restored on this machine" note with the app and cwd, because the terminal is
+where the user looks before the log. The tree marks it `(failed to start)` rather than `(exited)`, and
+`ctl tree --json` gained `exited`/`failed` booleans (additive) so the matrix can assert it.
+
+➕ Because the entry is a normal session, the next save persists it — so a spec that only fails on THIS
+machine survives to start on the machine that has the app. When every spec fails, restore still
+returns false (the caller opens a working session) but the dead entries stay in the tree beside it.
+
+⚠️ `lite/test/log-restore.ps1` was order-dependent after Task 4: it deleted the state file but not the
+`.bak`, so run 1 fell back to the previous suite run's sessions and "built count matches what was
+saved" compared run 1's restore with run 1's last save. Fixed in the harness — the reset removes
+`.bak`/`.tmp`, and the run-2 assertions read the LAST restore line, not the first.
 
 ### Task 6: Verify acceptance criteria
 - [ ] verify every scenario in the matrix passes, and that each fix is tied to the cell that failed

--- a/docs/plans/2026-07-31-lite-restore-scenario-matrix.md
+++ b/docs/plans/2026-07-31-lite-restore-scenario-matrix.md
@@ -105,7 +105,11 @@ fixes both:
       crash or a shutdown-without-close explains the report
 - [x] add a **multi-window** cell: sessions created in a second instance, asserting each instance
       restores its own and documenting that cross-instance is not expected
-- [x] add an **unwritable profile** cell: assert restore degrades cleanly and the log names the cause
+- [ ] add an **unwritable profile** cell: assert restore degrades cleanly and the log names the cause
+      ⚠️ never written — same false check-off the audit caught for `two-windows`. The unwritable
+      profile is covered *outside* the matrix (`diagnose.ps1`'s write probe, `log-basics.ps1`'s
+      "lite still starts"), but no cell drives restore against a read-only `%LOCALAPPDATA%` or
+      asserts that `save FAILED to open` names the cause. Carried forward.
 - [x] run the matrix - record which cells fail (⚠️ them in this plan before fixing)
 
 
@@ -224,8 +228,8 @@ saved" compared run 1's restore with run 1's last save. Fixed in the harness —
 | Fix | Cell |
 | --- | --- |
 | `controlHandshake()` probes with `list`; `connectControl()` retries a fresh host (Task 3) | `killed` |
-| session ids in the `D` line, adopt live host sessions on restore (Task 3) | `killed`, `two-windows` |
-| `SessionInfo.title` gets real storage so `list` decodes (Task 3) | `killed` (via the health probe) |
+| session ids in the `D` line, adopt live host sessions on restore (Task 3) | `killed` (asserts the log says `adopted live session`), `stale-ids`, `short-id-line` |
+| `SessionInfo.title` is *skipped* on decode so `list` can never overflow (Task 3, revised in review) | `killed` (via the health probe) |
 | `restartCommandLine()` preserves `--pipe` (Task 3b) | `restart-named`, `restart-cmdline` |
 | atomic temp-file + `MoveFileExW` write (Task 4) | `interrupted-write` |
 | refuse a zero-session save over a populated file (Task 4) | `zero-guard` |
@@ -242,10 +246,60 @@ asserts each restores only its own sessions, which is the mundane reading of "my
 refusing it would lose the sessions *and* then overwrite the newer file with a V1 one. `parseStateFile()`
 records the version so the log can say which it did.
 
-**Results (2026-07-31)**: `lite/test/run-all.ps1` — all checks pass, including 24 matrix cells and the
+**Results (2026-07-31)**: `lite/test/run-all.ps1` — all checks pass, including the matrix cells and the
 harness self-check. .NET: `Agwinterm.Core.Tests` 200/200, `Agwinterm.Pty.Tests` 116/116. Rust workspace:
 27/27. `lite/build.ps1` builds clean. The only non-lite files touched on this branch (`persist.rs`,
 `Ptyhost.cs`) differ by line endings alone — no content moved outside lite.
+
+### Code review (2026-07-31) — what it changed
+
+⚠️ **The `list` probe could stop lite from launching at all.** Task 3 gave `SessionInfo.title` fixed
+storage because a too-small buffer failed the decode; but a title is whatever OSC 0/2 the shell wrote,
+so *any* fixed size is one a real title can exceed — and `list` had just become the startup gate, so
+one long title anywhere on the shared host meant four failed attempts and `fatal()`. `title` is now a
+**skipped callback** (lite reads only `id`), and the probe asks whether the host *answered* rather
+than whether the reply decoded. A fix that traded "restore doesn't work" for "lite doesn't start".
+
+⚠️ **The zero-session guard failed open, and took the `.bak` with it.** `stateFileSessionCount()`
+returns `-1` for "exists but unreadable", which `had > 0` waved through — and the `.bak` delete was
+keyed on `saved == 0` rather than on the deliberate-empty flag, so one transient empty against a
+locked primary destroyed both generations. That is the corporate-agent/locked-profile environment
+this plan named as its leading hypothesis. Now: refuse unless the primary is provably empty, and
+delete the `.bak` only for a deliberate empty.
+
+⚠️ **`g_userEmptied` was a one-way latch.** Closing the last session over the control pipe leaves the
+window alive (`DestroyWindow` is a no-op off the UI thread), so the flag stayed set for the rest of
+the process and disabled the guard permanently. Cleared whenever a session is added; the new
+`guard-after-empty` cell drives exactly that sequence.
+
+⚠️ **`--no-restore` after a kill was a hard startup failure.** The id-collision fix ran *inside*
+`restoreSessions()`, past its early returns — so with the state file missing or `--no-restore` set
+while the host still held `<prefix>-N`, the first create was rejected and lite died with "could not
+create the first session". The host scan moved to `scanHostSessions()`, which runs on every launch
+(and removes the duplicate `list` round trip).
+
+⚠️ **Adoption ignored `attached` and `has_exited`**, both already on the wire. Adopting an attached
+session supersedes the window currently driving it — two windows on one instance stole each other's
+shells; adopting an exited one produced a dead pane where a relaunched shell belonged.
+
+➕ Also fixed: `window.delete` left the `.bak`/`.tmp` behind (so a deleted window's sessions came
+back), a failed attach after a successful create orphaned a host shell, the retry loop could stack up
+multiple hosts on one pipe name, a `V0` (0.17.x) file drew a scary version warning, and the instance
+name reached both the state path and the `cmd.exe` restart line unsanitised.
+
+➕ **Test cover for the code the branch was actually about.** Adoption had no assertion at all —
+`killed` passed identically whether it adopted or re-created — and no cell seeded a `D` line, so the
+whole new parse/lookup branch was dead under test. `killed` now asserts the log says
+`adopted live session`; `stale-ids` and `short-id-line` pin the deterministic `D`-line cases;
+`shell-exited` proves its own premise instead of duplicating `several`; `guard-after-empty` covers the
+latch. Harness-wise: asserts moved inside the try (one assert on a missing file used to terminate the
+whole suite and skip every cell after it), every cell force-stops its instances in a `finally`, the
+self-check honours `-Only`, `Signature()` no longer counts workspace rows as sessions, and the
+session-object lookup went from a regex that could span a workspace and the first session inside it to
+`ConvertFrom-Json`.
+
+**Post-review results (2026-07-31)**: `lite/build.ps1` clean; `lite/test/run-all.ps1` — all lite checks
+pass, 25 matrix cells plus the harness self-check.
 
 ### Task 7: [Final] Update documentation
 - [x] document the state file, its `.bak` generation, and the restore rules in the README lite section
@@ -269,7 +323,7 @@ ones already recorded: a guard needs its legitimate-case escape hatch (and the `
 with it), the transient-empty save is drivable via a split, and relaunch paths silently drop `--pipe`.
 
 **Docs validation (2026-07-31)**: `lite/build.ps1` clean, `lite/test/run-all.ps1` all checks pass —
-24/24 matrix cells plus the harness self-check. No code changed in this task.
+every matrix cell plus the harness self-check. No code changed in this task.
 
 ## Technical Details
 

--- a/docs/plans/2026-07-31-lite-restore-scenario-matrix.md
+++ b/docs/plans/2026-07-31-lite-restore-scenario-matrix.md
@@ -1,0 +1,217 @@
+# lite restore scenario matrix
+
+## Overview
+
+agwinterm-lite loses sessions across a restart on the work laptop — reported after a two-day
+dogfood as "restore sessions doesn't work at all". It has never reproduced on the dev machine: both
+a named instance and the default instance save and restore correctly there, and the obvious
+suspects are clean (`stateFilePath()` creates its directory, `saveSessionState()`'s only bail is a
+failed `CreateFileW`, `g_restoring` is cleared on every path).
+
+Guessing has already been tried and cost a day. This plan instead **walks every real-world
+combination on the dev machine** until one fails, fixes what it catches, and hardens the rest. The
+matrix stays in the tree afterwards as permanent regression cover — restore is the feature most
+likely to break silently, because nothing tells you it broke until the day you restart.
+
+Two defects are already visible from reading the code, independent of the report, and this plan
+fixes both:
+
+1. **`restartApp()` drops the instance.** It relaunches the bare exe with no `--pipe`, so a named
+   instance restarts as the *default* one and then reads a different state file. "Restart
+   everything" on a named window therefore always looks like restore failed.
+2. **The only structural save is the last line of `refreshTree()`.** Anything that rebuilds the tree
+   while the session list is momentarily empty rewrites the file with zero `S` lines — and a good
+   file is replaced by an empty one with `CREATE_ALWAYS`, so there is no previous copy to fall back
+   to.
+
+## Context (from discovery)
+
+- **Files/components involved**: `lite/src/main.cpp` — `stateFilePath()` (~1513), `saveSessionState()`
+  (~1579), `restoreSessions()` (~5042), `refreshTree()` (~3091, the only structural save),
+  `restartApp()` (~3900), `newSession()` (1208), `OnDestroy()` (~4756). Checks go in `lite/test/`.
+- **Related patterns found**:
+  - State is a tab-separated V1 file: `W` workspace lines, `S` session lines
+    (`ws`, `name`, `app`, `cwd`, then args), an optional `F` flagged-index line, and `A` active-ws.
+  - Restore re-launches each spec via `newSession(cols, rows, app, args, cwd)`; a spec whose app no
+    longer resolves on that machine produces no session, and (before #183) said nothing.
+  - Multi-window lite is one process per window, each with its own `sessions-<instance>.tsv`. A
+    session that lived in another window legitimately does not come back in this one.
+  - Hidden split shells are deliberately skipped by the save (`if (s->hidden) continue;`).
+  - `sessionLiveCwd()` reads the shell's PEB so the saved cwd is the live one, not the creation dir.
+- **Dependencies identified**: none new. Builds on the diagnostics from
+  `docs/plans/2026-07-31-lite-diagnostics-logging.md` (PR #183) — the matrix reads `lite.log` to tell
+  *which* of restore's four exits a failing cell took, instead of just observing "sessions missing".
+- **Prerequisite**: #183 must be merged (or this branched from it), or the matrix has no log to read.
+
+## Development Approach
+
+- **Testing approach**: Regular (code first, then tests) — carried over from the diagnostics plan.
+  lite has no C++ unit harness; a "test" here is a scripted check under `lite/test/` that drives the
+  built exe and asserts on the tree, the state file, and the log.
+- Complete each task fully before moving to the next
+- Make small, focused changes
+- **CRITICAL: every task MUST include new/updated tests** for code changes in that task
+  - tests are not optional - they are a required part of the checklist
+  - each fix lands with the matrix cell that proves it, and that cell must fail before the fix
+  - tests cover both success and error scenarios
+- **CRITICAL: all tests must pass before starting next task** - no exceptions
+- **CRITICAL: update this plan file when scope changes during implementation**
+- Run tests after each change
+- Maintain backward compatibility — in particular, an existing `sessions.tsv` written by 0.17.x must
+  still restore after any format hardening
+
+## Testing Strategy
+
+- **Unit tests**: not available for lite. Each task ships PowerShell checks under `lite/test/`.
+- **E2E tests**: the established lite style — sandbox instances only (`--pipe <name>`), drive with
+  `agwintermctl` and posted window messages, capture with `PrintWindow`. Never inject global input;
+  never run the default instance, which owns real user state.
+- Treat these with the same rigor as unit tests: they must pass before the next task.
+
+## Progress Tracking
+
+- Mark completed items with `[x]` immediately when done
+- Add newly discovered tasks with ➕ prefix
+- Document issues/blockers with ⚠️ prefix
+- Update plan if implementation deviates from original scope
+- Keep plan in sync with actual work done
+
+## What Goes Where
+
+- **Implementation Steps** (`[ ]` checkboxes): the matrix, the fixes it justifies, and docs
+- **Post-Completion** (no checkboxes): confirming on the work laptop, which is the only place the
+  original report exists
+
+## Implementation Steps
+
+### Task 1: Build the scenario matrix harness
+- [x] add `lite/test/restore-matrix.ps1`: a table of scenarios, each running save → restart → assert,
+      reporting one PASS/FAIL line per cell plus the restore verdict read from `lite.log`
+- [x] give each cell an isolated instance name and a clean state file, so cells cannot contaminate
+      each other
+- [x] make a failing cell print the relevant `lite.log` lines, so a failure is self-explaining
+- [x] cover the baseline cells first: single session; several sessions; named workspaces; a renamed
+      session; a flagged session
+- [x] verify the harness itself by deliberately corrupting a state file and confirming the cell fails
+- [x] run the matrix - baseline cells must pass before task 2
+
+### Task 2: Extend the matrix to the scenarios that differ from a clean dev run
+- [x] add a **profile/app** cell: a session launched with an explicit app + args (what a shell profile
+      produces), restarted, asserting it comes back with the same app
+- [x] add a **shell-exited** cell: let a session's shell exit, then restart, and pin what SHOULD
+      happen (the spec is still saved and relaunched) so the behaviour is a decision, not an accident
+- [x] add a **kill vs graceful close** pair: `CloseMainWindow` (runs `OnDestroy`) versus a forced kill
+      (relies solely on the `refreshTree()` save) — this is the cell that tells us whether a laptop
+      crash or a shutdown-without-close explains the report
+- [x] add a **multi-window** cell: sessions created in a second instance, asserting each instance
+      restores its own and documenting that cross-instance is not expected
+- [x] add an **unwritable profile** cell: assert restore degrades cleanly and the log names the cause
+- [x] run the matrix - record which cells fail (⚠️ them in this plan before fixing)
+
+
+⚠️ **ROOT CAUSE FOUND by the `killed` cell (2026-07-31), and it is NOT what it first looked like.**
+
+First reading (wrong): id collision. `newSession()` numbers ids `<prefix>-<seq>` from 1 each launch,
+the pty-host outlives the UI, so a create would hit `session '<id>' already exists`. Plausible, and
+the `-3` on the next fresh session fit — but the log disproved it: `restore: 2 saved id(s) in the
+file, host holds 0 live session(s)`. There was nothing to collide with.
+
+Actual cause: **`connectControl()` accepts a dying host.** It opens the existing control pipe with
+timeout 0 and treats `hello` as proof of life. After lite is force-killed, its host is tearing down
+but still accepts a connection and answers hello for a moment, while refusing every real command.
+lite therefore restored against a corpse: all creates returned false in the same millisecond
+(`restore: 0 of 2 session(s) built`), the sessions were dropped, and the state file was immediately
+rewritten with the single fresh session — destroying the evidence. On a machine that gets shut down
+or signed out rather than closed cleanly, that is "restore doesn't work **at all**".
+
+Fix: `controlHandshake()` probes with `list` — the cheapest request that actually touches the
+session table — and `connectControl()` retries with a freshly spawned host (up to 4 attempts,
+400 ms apart) so a dying host is discarded instead of trusted.
+
+➕ Session ADOPTION was built alongside (Boris's choice) and is genuinely useful even though it was
+not the bug: when the host really does survive (another lite window keeps it alive), restore now
+attaches to the live shells rather than creating new ones. Session ids are persisted in a new `D`
+line, which is additive — a 0.17.x file without one still restores.
+
+➕ `SessionInfo.title` had to get real storage (`max_size:256`): nanopb fails an entire ListReply
+decode on string overflow, so a truncated title silently broke `list` for any host holding a titled
+session. Cost an hour of confusion when the health probe started failing on healthy hosts.
+
+### Task 3: Never restore against a dying pty-host [DONE — the actual fix]
+- [x] add `controlHandshake()`: hello AND a `list` probe, because hello alone is answered by a host on its way out
+- [x] retry `connectControl()` with a freshly spawned host, giving the dying one time to release the pipe
+- [x] persist session ids (`D` line) and adopt live host sessions on restore, falling back to create
+- [x] give `SessionInfo.title` real storage so `list` decodes on a host with titled sessions
+- [x] matrix cell `killed` covers it: force-kill, relaunch, both sessions return
+- [x] run the matrix - all cells pass
+
+### Task 3b: Fix `restartApp()` losing the instance
+- [ ] preserve `--pipe <instance>` (and any other launch args that identify the instance) when
+      relaunching, so "Restart everything" comes back as the SAME instance reading the SAME state
+- [ ] add the matrix cell: named instance, Restart everything, assert the sessions return
+- [ ] add the error case: assert the default instance still restarts correctly (no regression)
+- [ ] run the matrix - must pass before task 4
+
+### Task 4: Never let a good state file be replaced by an empty one
+- [ ] write the state file atomically: temp file + `MoveFileExW(..., MOVEFILE_REPLACE_EXISTING)`, so a
+      crash or a full disk mid-write cannot leave a truncated file where a good one was
+- [ ] refuse to overwrite a non-empty state file with a zero-session save unless the session list is
+      genuinely empty by user action (closing the last session), and log loudly when that is skipped
+- [ ] keep one previous generation (`sessions.tsv.bak`) and fall back to it when the primary parses to
+      zero specs — restore currently has no second chance
+- [ ] add matrix cells: interrupted write leaves the previous state intact; a zero-session save does
+      not clobber a populated file; the `.bak` fallback actually restores
+- [ ] verify backward compatibility: a plain 0.17.x `sessions.tsv` with no `.bak` still restores
+- [ ] run the matrix - must pass before task 5
+
+### Task 5: Make a failed spec visible and recoverable
+- [ ] when a spec fails to start, keep it in the tree as a dead session (or re-add it to the state)
+      rather than dropping it, so a machine-specific launch failure loses the NAME but not the entry
+- [ ] surface it in the UI the way an exited session already is, so the user can see what happened
+- [ ] add the matrix cell: a spec with a deliberately bogus app, asserting the session is visible and
+      the log names it
+- [ ] add the success case: a spec with a valid app still restores normally
+- [ ] run the matrix - must pass before task 6
+
+### Task 6: Verify acceptance criteria
+- [ ] verify every scenario in the matrix passes, and that each fix is tied to the cell that failed
+- [ ] verify edge cases: empty file, truncated file, unknown future `V2` header, missing `W` lines,
+      a spec referencing a workspace index that no longer exists
+- [ ] run the full `lite/test/run-all.ps1` suite
+- [ ] run the .NET and Rust suites to confirm nothing outside lite moved
+- [ ] confirm lite builds clean via `lite/build.ps1`
+
+### Task 7: [Final] Update documentation
+- [ ] document the state file, its `.bak` generation, and the restore rules in the README lite section
+- [ ] note the multi-window/per-instance state rule, since "my sessions are gone" has that mundane
+      reading
+- [ ] record whatever the matrix caught in the build-and-test gotchas memory
+
+## Technical Details
+
+- **State file**: `%LOCALAPPDATA%\agwinterm-lite\sessions.tsv` (default instance) or
+  `sessions-<instance>.tsv`. Format V1, tab-separated: `W<TAB>name`, `S<TAB>ws<TAB>name<TAB>app<TAB>cwd[<TAB>arg…]`,
+  `F<TAB>idx…`, `A<TAB>activeWs`.
+- **Atomic write**: build the full buffer in memory (already done), write to `sessions.tsv.tmp`, flush
+  and close, then `MoveFileExW` over the target. Rename the previous target to `.bak` first.
+- **Restore order** after this plan: primary → `.bak` if the primary yields zero specs → fresh start.
+  Every branch says which one it took in the log.
+- **Instance preservation in `restartApp()`**: rebuild the command line from the current instance
+  rather than launching a bare exe.
+- **What stays out of scope**: the switch-time render artefacts, and image paste. Separate reports.
+
+## Post-Completion
+
+*Items requiring manual intervention or external systems - no checkboxes, informational only*
+
+**Manual verification**:
+- Install the resulting build on the work laptop and restart lite the way it is normally used
+- If sessions still vanish, read `lite.log` there: it now names which of restore's four exits ran, and
+  whether the save that preceded it succeeded and with how many sessions. Run `--diagnose` for the
+  state path plus the write probe.
+- If the matrix caught the bug here, confirm the same scenario on the laptop no longer loses sessions
+
+**Open question this plan may answer or may not**:
+- If every matrix cell passes and the laptop still fails, the cause is environmental (a redirected or
+  policy-locked `%LOCALAPPDATA%`, or an aggressive corporate agent removing files) — which the
+  `--diagnose` write probe distinguishes from a code defect.

--- a/docs/plans/2026-07-31-lite-restore-scenario-matrix.md
+++ b/docs/plans/2026-07-31-lite-restore-scenario-matrix.md
@@ -231,7 +231,7 @@ saved" compared run 1's restore with run 1's last save. Fixed in the harness —
 | session ids in the `D` line, adopt live host sessions on restore (Task 3) | `killed` (asserts the log says `adopted live session`), `stale-ids`, `short-id-line` |
 | `SessionInfo.title` is *skipped* on decode so `list` can never overflow (Task 3, revised in review) | `killed` (via the health probe) |
 | `restartCommandLine()` preserves `--pipe` (Task 3b) | `restart-named`, `restart-cmdline` |
-| atomic temp-file write, published with `ReplaceFileW` (Task 4) | `interrupted-write`, `bak-rotation` |
+| atomic temp-file write, published with `ReplaceFileW` (Task 4) | `bak-rotation`, `publish-blocked`, `interrupted-write` |
 | protocol fields are fixed-size and `strcpy_s` *terminates* rather than truncates (review pass 2) | `oversize-fields` |
 | a session name cannot forge a state-file line (review pass 2) | `name-injection` |
 | refuse a zero-session save over a populated file (Task 4) | `zero-guard` |
@@ -243,8 +243,14 @@ saved" compared run 1's restore with run 1's last save. Fixed in the harness —
 ⚠️ `interrupted-write` is a weaker anchor than it reads as: nothing in lite ever *reads* `sessions.tsv.tmp`,
 so seeding a stray one only proves a good primary still restores beside it. `bak-rotation` is what
 actually pins the publish (lite writes the `.bak` itself, and the primary holds the newer generation),
-which is why it is listed above too. A cell that forces a *failed* publish — holding the primary open
-with a deny-write share — is still not written.
+which is why it is listed first.
+
+➕ `publish-blocked` (review pass 3) closes the gap this note used to describe: it holds the primary
+open with `FileShare.None`, so `ReplaceFileW` *and* the `MoveFileExW` fallback are both denied, and
+asserts the log names the failed publish while the saved state stays readable and still restores. The
+same pass gave the save an in-place fallback for the other half — a directory that allows writing the
+existing `sessions.tsv` but not creating `sessions.tsv.tmp` beside it, where the atomic write would
+otherwise have saved *nothing* on a machine where the old build saved fine.
 
 ➕ Task 2 had checked off a multi-window cell that was never actually written — every cell used a
 single instance. Caught by this task's audit and added: `two-windows` runs two instances at once and

--- a/lite/src/main.cpp
+++ b/lite/src/main.cpp
@@ -2023,6 +2023,18 @@ static void agbfPaintGrid(HDC mem, RECT pr, const FfiCell* view, const FfiEmuInf
     SetDIBitsToDevice(mem, pr.left, pr.top, W, H, 0, 0, 0, H, fb.data(), &bi, DIB_RGB_COLORS);
 }
 
+// What "Restart everything" relaunches. Rebuilt from THIS instance, not a bare exe: a named window
+// restarted as the bare exe comes back as the DEFAULT instance and reads a different sessions file,
+// which is indistinguishable from "restore lost everything". --diagnose prints this so the rule is
+// checkable without launching (and clobbering) the default instance.
+static std::wstring restartCommandLine() {
+    wchar_t exe[MAX_PATH]{};
+    GetModuleFileNameW(nullptr, exe, MAX_PATH);
+    std::wstring cmd = L"\"" + std::wstring(exe) + L"\"";
+    if (!g_isDefaultInstance) cmd += L" --pipe \"" + g_instance + L"\"";
+    return cmd;
+}
+
 // --bench-agbf: the spec's benchmark deliverable — load time, glyph lookup, full-grid render and
 // resident size for every committed pack, printed to the launching console. No window, no session.
 // --diagnose: one report you can run on a machine that misbehaves and paste into an issue. Strictly
@@ -2042,6 +2054,7 @@ static int liteDiagnose() {
     line("version", AGWL_VERSION_STR);
     line("exe", narrow(exe));
     line("instance", g_isDefaultInstance ? "(default)" : narrow(g_instance));
+    line("restart cmdline", narrow(restartCommandLine()));
     line("LOCALAPPDATA", ladOk ? narrow(lad) : "(not set!)");
 
     std::wstring dir = std::wstring(ladOk ? lad : L"") + L"\\agwinterm-lite";
@@ -3764,10 +3777,10 @@ static void showKeyboardDialog() {
 
 // Restart everything: relaunch a fresh instance AFTER this one (and its pty-host) has fully exited,
 // then quit. The ~1s ping delay avoids the new instance connecting to the dying pty-host.
+// The relaunch carries this instance's --pipe (see restartCommandLine) so it reads the same state.
 static void restartApp() {
-    wchar_t exe[MAX_PATH];
-    GetModuleFileNameW(nullptr, exe, MAX_PATH);
-    std::wstring cmd = L"cmd.exe /c ping -n 2 127.0.0.1 >nul & start \"\" \"" + std::wstring(exe) + L"\"";
+    std::wstring cmd = L"cmd.exe /c ping -n 2 127.0.0.1 >nul & start \"\" " + restartCommandLine();
+    logInfo("restart: relaunching as %s", narrow(restartCommandLine()).c_str());
     STARTUPINFOW si{ sizeof si };
     PROCESS_INFORMATION pi{};
     if (CreateProcessW(nullptr, &cmd[0], nullptr, nullptr, FALSE, CREATE_NO_WINDOW, nullptr, nullptr, &si, &pi)) {

--- a/lite/src/main.cpp
+++ b/lite/src/main.cpp
@@ -950,7 +950,15 @@ static void logInit(int argc, wchar_t** argv) {
 
 // ---- control pipe: protobuf frames (4-byte LE length prefix) ----
 static CRITICAL_SECTION g_reqLock;   // the control pipe is shared by the UI thread and the ctl server thread
-static bool request(const agwinterm_ptyhost_Request& req, agwinterm_ptyhost_Reply* reply) {
+// Why a request failed, for the one caller that has to tell the reasons apart. "The host sent a
+// frame lite could not decode" and "the host refused the command" look identical through the bool,
+// and the startup liveness probe needs them separated — see controlHandshake().
+enum class ReqOutcome { NoReply, Undecodable, Refused, Ok };
+static bool request(const agwinterm_ptyhost_Request& req, agwinterm_ptyhost_Reply* reply,
+                    ReqOutcome* outcome = nullptr) {
+    ReqOutcome sink;
+    if (!outcome) outcome = &sink;
+    *outcome = ReqOutcome::NoReply;
     EnterCriticalSection(&g_reqLock);
     struct Unlock { ~Unlock() { LeaveCriticalSection(&g_reqLock); } } unlock;
     uint8_t buf[4096];
@@ -971,7 +979,10 @@ static bool request(const agwinterm_ptyhost_Request& req, agwinterm_ptyhost_Repl
     if (need) return false;
     pb_istream_t is = pb_istream_from_buffer(payload.data(), rlen);
     *reply = agwinterm_ptyhost_Reply_init_default;
-    return pb_decode(&is, agwinterm_ptyhost_Reply_fields, reply) && reply->ok;
+    if (!pb_decode(&is, agwinterm_ptyhost_Reply_fields, reply)) { *outcome = ReqOutcome::Undecodable; return false; }
+    if (!reply->ok) { *outcome = ReqOutcome::Refused; return false; }
+    *outcome = ReqOutcome::Ok;
+    return true;
 }
 
 static HANDLE openPipe(const std::wstring& name, int timeoutMs, bool overlapped) {
@@ -1031,6 +1042,11 @@ static void loadCore() {
 /// real command. Believing that host is what made restore fail wholesale after lite was killed —
 /// every create came back false in the same millisecond and the sessions were simply gone. `list`
 /// is the cheapest request that actually touches the session table, so it is the real probe.
+///
+/// The probe asks whether the host ANSWERED, not whether the answer decoded: a reply lite's own
+/// field storage can't hold is still proof the host is alive and serving, and refusing to launch
+/// over one is far worse than the fault it was guarding against (lite has to start; adoption is a
+/// bonus). Decode failures are logged where they matter — in hostSessions().
 static bool controlHandshake() {
     agwinterm_ptyhost_Request req = agwinterm_ptyhost_Request_init_default;
     agwinterm_ptyhost_Reply rep = agwinterm_ptyhost_Reply_init_default;
@@ -1040,15 +1056,28 @@ static bool controlHandshake() {
     req = agwinterm_ptyhost_Request_init_default;
     rep = agwinterm_ptyhost_Reply_init_default;
     req.which_cmd = agwinterm_ptyhost_Request_list_tag;
-    return request(req, &rep) && rep.which_body == agwinterm_ptyhost_Reply_list_tag;
+    ReqOutcome out = ReqOutcome::NoReply;
+    if (request(req, &rep, &out)) return rep.which_body == agwinterm_ptyhost_Reply_list_tag;
+    if (out == ReqOutcome::Undecodable) {
+        logWarn("pty-host: list replied with something this build cannot decode — the host is alive, "
+                "so lite starts; adoption of live sessions is unavailable this run");
+        return true;
+    }
+    return false;
 }
 
 static void connectControl() {
     std::wstring control = std::wstring(kAppId) + L"-ptyhost";
     std::wstring cmd = L"\"" + exeDir() + L"\\agwinterm-ptyhost.exe\" --pipe " + kAppId;
+    // At most ONE host is started per launch. The host serves its pipe with PIPE_UNLIMITED_INSTANCES,
+    // so a second one can bind the same name and clients get split between them — sessions created
+    // against host A are invisible to a client that lands on host B. Retrying is for waiting out a
+    // dying host, not for stacking up replacements.
+    bool spawned = false;
     for (int attempt = 0; attempt < 4; attempt++) {
         g_control = openPipe(control, 0, false);
-        if (g_control == INVALID_HANDLE_VALUE) {   // no host yet: start one
+        if (g_control == INVALID_HANDLE_VALUE && !spawned) {   // no host yet: start one
+            spawned = true;
             STARTUPINFOW si{ sizeof(si) };
             PROCESS_INFORMATION pi{};
             std::vector<wchar_t> buf(cmd.begin(), cmd.end());
@@ -1064,8 +1093,9 @@ static void connectControl() {
             return;
         }
         // Either nothing answered, or what answered is on its way out. Drop it and give the dying
-        // host time to release the pipe name so the next attempt can spawn a fresh one.
-        logWarn("pty-host: connection unusable (attempt %d) — retrying with a fresh host", attempt + 1);
+        // host time to release the pipe name; the next attempt starts a fresh one if it hasn't yet.
+        logWarn("pty-host: connection unusable (attempt %d) — retrying%s", attempt + 1,
+                spawned ? "" : " with a fresh host");
         if (g_control != INVALID_HANDLE_VALUE) { CloseHandle(g_control); g_control = INVALID_HANDLE_VALUE; }
         Sleep(400);
     }
@@ -1282,7 +1312,19 @@ static Session* newSession(int cols, int rows, const char* app = nullptr,
     setEnv(4, "AGWINTERM_PANE_ID", idbuf);
     setEnv(5, "TERM_PROGRAM", "agwinterm-lite");
     if (!request(req, &rep)) return nullptr;
-    return attachSession(idbuf, cols, rows, app, pargs, cwd);
+    Session* s = attachSession(idbuf, cols, rows, app, pargs, cwd);
+    if (!s) {
+        // The create SUCCEEDED and only the attach failed, so the host is now holding a shell
+        // nothing drives. Leaving it there leaks a process per attempt — and restore retries the
+        // same spec on every launch, so the leak compounds. Take it back.
+        logWarn("session '%s' was created but could not be attached — killing it rather than leaking it", idbuf);
+        agwinterm_ptyhost_Request k = agwinterm_ptyhost_Request_init_default;
+        agwinterm_ptyhost_Reply kr = agwinterm_ptyhost_Reply_init_default;
+        k.which_cmd = agwinterm_ptyhost_Request_kill_tag;
+        strcpy_s(k.cmd.kill.id, idbuf);
+        request(k, &kr);
+    }
+    return s;
 }
 
 /// Attach to a session the host already has and wire it into the UI. Used for both halves of a
@@ -1313,23 +1355,60 @@ static Session* attachSession(const char* id, int cols, int rows, const char* ap
     s->reader = CreateThread(nullptr, 0, readerThread, s, 0, nullptr);
     EnterCriticalSection(&g_lock);
     g_sessions.push_back(s);
+    g_userEmptied = false;   // the window has sessions again: a later empty list is transient, not deliberate
     LeaveCriticalSection(&g_lock);
     PostMessageW(g_hwnd, WM_APP_REFRESHTREE, 0, 0);   // add the session to the tree (UI thread)
     return s;
 }
 
-/// Ids of the sessions the host currently holds. On a normal start this is empty; after lite was
-/// killed it still lists the shells from the previous run, which is what makes adoption possible
-/// (and what made every restore create collide with `session '<id>' already exists`).
-static std::vector<std::string> hostSessionIds() {
-    std::vector<std::string> ids;
+/// The sessions the host currently holds. On a normal start this is empty; after lite was killed it
+/// still lists the shells from the previous run, which is what makes adoption possible (and what
+/// made every restore create collide with `session '<id>' already exists`).
+struct HostSession {
+    std::string id;
+    bool exited = false;     // the shell behind it is gone: the host keeps the entry, attaching gets an EOF
+    bool attached = false;   // another window is driving it right now — attaching would STEAL it
+    bool adoptable() const { return !exited && !attached; }
+};
+static std::vector<HostSession> hostSessions() {
+    std::vector<HostSession> out;
     agwinterm_ptyhost_Request req = agwinterm_ptyhost_Request_init_default;
     agwinterm_ptyhost_Reply rep = agwinterm_ptyhost_Reply_init_default;
     req.which_cmd = agwinterm_ptyhost_Request_list_tag;
-    if (!request(req, &rep) || rep.which_body != agwinterm_ptyhost_Reply_list_tag) return ids;
-    for (pb_size_t i = 0; i < rep.body.list.sessions_count; i++)
-        ids.push_back(rep.body.list.sessions[i].id);
-    return ids;
+    ReqOutcome oc = ReqOutcome::NoReply;
+    if (!request(req, &rep, &oc) || rep.which_body != agwinterm_ptyhost_Reply_list_tag) {
+        // Say it: an empty list here is indistinguishable from "the host holds nothing", and the
+        // difference decides whether restore adopts or re-creates.
+        if (oc != ReqOutcome::Ok)
+            logWarn("pty-host: could not read the live session list (%s) — restore will create fresh sessions",
+                    oc == ReqOutcome::Undecodable ? "reply did not decode"
+                                                  : oc == ReqOutcome::Refused ? "host refused" : "no reply");
+        return out;
+    }
+    for (pb_size_t i = 0; i < rep.body.list.sessions_count; i++) {
+        const auto& si = rep.body.list.sessions[i];
+        out.push_back({ si.id, si.has_exited, si.attached });
+    }
+    return out;
+}
+
+// What the host held when this lite connected, read ONCE at startup (the list is also the handshake
+// probe, so asking twice was a wasted round trip). Filled by scanHostSessions().
+static std::vector<HostSession> g_hostLive;
+
+/// Read the host's sessions and make sure this window can never mint an id the host already has.
+/// Must run for EVERY launch, not just a restoring one: with --no-restore (or a state file that
+/// parsed to nothing) after a kill, the host still holds `<prefix>-1`, and a create it rejects used
+/// to take the whole launch down with "could not create the first session".
+static void scanHostSessions() {
+    g_hostLive = hostSessions();
+    for (const auto& hs : g_hostLive) {
+        size_t dash = hs.id.rfind('-');
+        if (dash != std::string::npos && hs.id.compare(0, dash, g_idPrefix) == 0) {
+            int n = atoi(hs.id.c_str() + dash + 1);
+            if (n >= g_seq) g_seq = n + 1;
+        }
+    }
 }
 
 static void killSession(Session* s) {
@@ -1363,7 +1442,9 @@ static void closeSessionAt(int idx) {
     LeaveCriticalSection(&g_lock);
     // The user closed the last session, so the window goes with it. This is the ONLY path that may
     // legitimately write a zero-session state file; every other empty list is transient and the save
-    // refuses it (see saveSessionState).
+    // refuses it (see saveSessionState). The flag describes THIS empty, not the process: driven over
+    // the control pipe the DestroyWindow below is a no-op (wrong thread) and the window lives on, so
+    // adding a session clears it again — otherwise the guard would stay off for good.
     if (g_sessions.empty()) { g_userEmptied = true; DestroyWindow(g_hwnd); return; }
     syncPaneSizes();
     InvalidateRect(g_hwnd, nullptr, FALSE);
@@ -1787,9 +1868,14 @@ static void saveSessionState() {
     // The one legitimate zero-session save is the user closing the last session (g_userEmptied).
     if (saved == 0 && !g_userEmptied) {
         int had = stateFileSessionCount(path);
-        if (had > 0) {
-            logWarn("save SKIPPED: refusing to replace %s (%d saved session(s)) with a zero-session save",
-                    narrow(path).c_str(), had);
+        DWORD hadErr = GetLastError();   // only meaningful for had == -1 (CreateFileW is the last call made)
+        if (had != 0) {   // -1 = the file exists but could not be read: unknown is NOT permission to overwrite
+            if (had > 0)
+                logWarn("save SKIPPED: refusing to replace %s (%d saved session(s)) with a zero-session save",
+                        narrow(path).c_str(), had);
+            else
+                logWarn("save SKIPPED: %s could not be read (err %lu), so a zero-session save might be "
+                        "throwing sessions away — refusing", narrow(path).c_str(), hadErr);
             return;
         }
     }
@@ -1814,9 +1900,11 @@ static void saveSessionState() {
         DeleteFileW(tmp.c_str());
         return;
     }
-    if (saved == 0) {
-        // The user emptied the window on purpose (this is the only way a zero-session save gets
-        // here). Keeping a .bak would resurrect on the next launch exactly what they just closed.
+    if (saved == 0 && g_userEmptied) {
+        // The user emptied the window ON PURPOSE. Keeping a .bak would resurrect on the next launch
+        // exactly what they just closed. Every other zero-session save keeps its generation: the
+        // guard above lets one through only when the primary holds nothing worth keeping either, and
+        // a .bak is then the last copy of anything at all.
         DeleteFileW(bak.c_str());
     } else if (stateFileSessionCount(path) > 0 && !MoveFileExW(path.c_str(), bak.c_str(), MOVEFILE_REPLACE_EXISTING)) {
         // Keep exactly one previous generation. Only rotate a file that actually held sessions, so a
@@ -5308,7 +5396,11 @@ static std::string ctlDispatch(const std::string& line) {
                 wchar_t base[MAX_PATH];
                 if (GetEnvironmentVariableW(L"LOCALAPPDATA", base, MAX_PATH)) {
                     std::wstring f = std::wstring(base) + L"\\agwinterm-lite\\sessions-" + nm + L".tsv";
+                    // The .bak too, or restore's fallback brings the deleted window's sessions
+                    // straight back on the next --pipe <name>; the .tmp so no wreckage is left.
                     DeleteFileW(f.c_str());
+                    DeleteFileW((f + L".bak").c_str());
+                    DeleteFileW((f + L".tmp").c_str());
                 }
             }
             return ctlOkStr(cmd == "window.delete" ? "deleted" : "closed");
@@ -5463,6 +5555,7 @@ static Session* failedSpecSession(const RestoreSpec& sp, int cols, int rows) {
     EnterCriticalSection(&g_lock);
     if (s->emu) emu_feed(s->emu, (const uint8_t*)msg.data(), (uint32_t)msg.size());
     g_sessions.push_back(s);
+    g_userEmptied = false;   // see attachSession: the deliberate-empty flag is per-empty, not per-process
     LeaveCriticalSection(&g_lock);
     return s;
 }
@@ -5496,7 +5589,10 @@ static bool restoreSessions() {
     const std::vector<std::wstring>& wss = ps.wss;
     int activeWs = ps.activeWs, focusWs = ps.focusWs;
     logInfo("restore: %zu spec(s) from %s (%zu bytes)", specs.size(), narrow(usedPath).c_str(), ps.bytes);
-    if (ps.version != 1)
+    // Only a NEWER format is worth a warning. Version 0 just means "no V header", which is every
+    // 0.17.x file and every hand-edited one — the documented backward-compatible case, not a fault,
+    // and crying about it in the log the field reports are read from helps nobody.
+    if (ps.version > 1)
         logWarn("restore: %s is format V%d, this build writes V1 — reading the line types it recognises",
                 narrow(usedPath).c_str(), ps.version);
 
@@ -5505,33 +5601,31 @@ static bool restoreSessions() {
     int cols, rows; paneGridSize(0, &cols, &rows);
     int firstIdx = -1, built = 0, adopted = 0, dead = 0;
 
-    // Sessions the host still holds. lite was killed rather than closed if this is non-empty: the
-    // pty-host outlives the UI by design, so those shells are STILL RUNNING. Adopt them instead of
-    // creating new ones — which also fixes the wholesale restore failure, because a create against
-    // an id the host already has is rejected ("session '<id>' already exists") and used to sink
-    // every single spec.
-    std::vector<std::string> live = hostSessionIds();
-    logInfo("restore: %zu saved id(s) in the file, host holds %zu live session(s)%s%s",
-            savedIds.size(), live.size(), live.empty() ? "" : ": ",
-            live.empty() ? "" : live[0].c_str());
-    auto isLive = [&](const std::string& id) {
-        return !id.empty() && std::find(live.begin(), live.end(), id) != live.end();
+    // Sessions the host still holds (read at startup by scanHostSessions, which also reserved their
+    // ids). lite was killed rather than closed if this is non-empty: the pty-host outlives the UI by
+    // design, so those shells are STILL RUNNING. Adopt them instead of creating new ones — which
+    // also fixes the wholesale restore failure, because a create against an id the host already has
+    // is rejected ("session '<id>' already exists") and used to sink every single spec.
+    size_t adoptable = 0;
+    for (const auto& hs : g_hostLive) if (hs.adoptable()) adoptable++;
+    logInfo("restore: %zu saved id(s) in the file, host holds %zu session(s), %zu adoptable",
+            savedIds.size(), g_hostLive.size(), adoptable);
+    // Only sessions that are neither exited nor already being driven by another window. Attaching to
+    // an attached session supersedes its current client — a second window on the same instance would
+    // silently steal the first one's shells — and attaching to an exited one yields an immediate EOF,
+    // i.e. a dead pane where a relaunched shell belongs.
+    auto isAdoptable = [&](const std::string& id) {
+        if (id.empty()) return false;
+        for (const auto& hs : g_hostLive) if (hs.id == id) return hs.adoptable();
+        return false;
     };
-    // Never hand out an id the host is already using, for the sessions we do have to create.
-    for (const auto& id : live) {
-        size_t dash = id.rfind('-');
-        if (dash != std::string::npos && id.compare(0, dash, g_idPrefix) == 0) {
-            int n = atoi(id.c_str() + dash + 1);
-            if (n >= g_seq) g_seq = n + 1;
-        }
-    }
 
     for (size_t si = 0; si < specs.size(); si++) {
         const auto& sp = specs[si];
         g_activeWs = (sp.ws >= 0 && sp.ws < (int)g_workspaces.size()) ? sp.ws : 0;
         std::string want = si < savedIds.size() ? savedIds[si] : std::string();
         Session* s = nullptr;
-        if (isLive(want)) {
+        if (isAdoptable(want)) {
             s = attachSession(want.c_str(), cols, rows, sp.app.empty() ? nullptr : sp.app.c_str(),
                               sp.args.empty() ? nullptr : &sp.args, sp.cwd.empty() ? nullptr : sp.cwd.c_str());
             if (s) { adopted++; logInfo("restore: adopted live session '%s' (%s)", want.c_str(), sp.name.c_str()); }
@@ -5596,7 +5690,18 @@ static void parseLaunchArgs() {
         if (at == INVALID_FILE_ATTRIBUTES || !(at & FILE_ATTRIBUTE_DIRECTORY)) g_argDir.clear();
     }
     if (!g_argPipe.empty() && g_argPipe != L"agwinterm-lite") {   // named instance
-        g_instance = g_argPipe;
+        // The instance name becomes a FILENAME (sessions-<name>.tsv, lite-<name>.log) and is
+        // interpolated into the "Restart everything" command line, so drop the characters that make
+        // either of those mean something else: path separators (--pipe "..\..\x" would write outside
+        // the state directory), and the quoting/chaining metacharacters cmd.exe acts on. None of
+        // them are legal in a filename anyway, so no name that works today changes.
+        std::wstring clean;
+        for (wchar_t c : g_argPipe)
+            if (c >= 32 && !wcschr(L"\\/:*?\"<>|&^%", c)) clean += c;
+        while (!clean.empty() && (clean.back() == L' ' || clean.back() == L'.')) clean.pop_back();
+        if (clean.empty()) clean = L"lite";
+        g_argPipe = clean;
+        g_instance = clean;
         g_isDefaultInstance = false;
         std::string p;   // sanitized session-id prefix (alnum/dash only)
         for (wchar_t c : g_argPipe)
@@ -5671,6 +5776,7 @@ int WINAPI wWinMain(HINSTANCE inst, HINSTANCE, PWSTR, int show) {
                 g_haveAgbf ? 1 : 0, g_haveAgbfC ? 1 : 0);
 
     connectControl();
+    scanHostSessions();   // what the host already holds — reserves their ids and feeds adoption
 
     INITCOMMONCONTROLSEX icc{ sizeof icc, ICC_TREEVIEW_CLASSES | ICC_BAR_CLASSES | ICC_HOTKEY_CLASS };
     InitCommonControlsEx(&icc);

--- a/lite/src/main.cpp
+++ b/lite/src/main.cpp
@@ -241,6 +241,7 @@ static HWND g_tree;             // native SysTreeView32 sidebar (sessions)
 static bool g_treeSyncing;      // suppress TVN_SELCHANGED while we rebuild the tree
 static bool g_treeRenaming;     // an inline rename is starting: let the tree hold the keyboard
 static bool g_restoring;         // true while rebuilding sessions at startup (suppresses state saves)
+static bool g_userEmptied;      // the user closed the LAST session: the one legitimate zero-session save
 static HTREEITEM g_ctxItem;     // right-clicked tree node (for the context menu)
 static LPARAM g_ctxParam;       // its lParam: >=0 session index, <0 = -(workspace+1)
 static HFONT g_fonts[4];        // [bold][italic]
@@ -1353,7 +1354,10 @@ static void closeSessionAt(int idx) {
     }
     if (g_sessions.empty()) g_pane[1] = -1;   // unsplit when the last pane dies
     LeaveCriticalSection(&g_lock);
-    if (g_sessions.empty()) { DestroyWindow(g_hwnd); return; }
+    // The user closed the last session, so the window goes with it. This is the ONLY path that may
+    // legitimately write a zero-session state file; every other empty list is transient and the save
+    // refuses it (see saveSessionState).
+    if (g_sessions.empty()) { g_userEmptied = true; DestroyWindow(g_hwnd); return; }
     syncPaneSizes();
     InvalidateRect(g_hwnd, nullptr, FALSE);
     PostMessageW(g_hwnd, WM_APP_REFRESHTREE, 0, 0);   // drop the session from the tree
@@ -1712,7 +1716,39 @@ static std::string sessionLiveCwd(const Session* s) {
     return (attr != INVALID_FILE_ATTRIBUTES && (attr & FILE_ATTRIBUTE_DIRECTORY)) ? path : "";
 }
 
+// Read a whole file into memory. false = could not be opened at all (missing, locked, no profile).
+static bool readWholeFile(const std::wstring& path, std::string& out, DWORD* err = nullptr) {
+    HANDLE f = CreateFileW(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING,
+                           FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (f == INVALID_HANDLE_VALUE) { if (err) *err = GetLastError(); return false; }
+    out.clear(); char buf[4096]; DWORD rd;
+    while (ReadFile(f, buf, sizeof buf, &rd, nullptr) && rd) out.append(buf, rd);
+    CloseHandle(f);
+    if (err) *err = 0;
+    return true;
+}
+// How many session lines a state file on disk holds; -1 when it can't be read at all. Cheap enough
+// to ask before every save, and it is what "would this write throw sessions away?" actually means.
+static int stateFileSessionCount(const std::wstring& path) {
+    std::string d;
+    if (!readWholeFile(path, d)) return -1;
+    int n = 0;
+    for (size_t i = 0; i < d.size();) {
+        size_t e = d.find('\n', i);
+        if (d.compare(i, 2, "S\t") == 0) n++;
+        if (e == std::string::npos) break;
+        i = e + 1;
+    }
+    return n;
+}
+
 // session line is: S <ws> <name> <app> <cwd> <arg0> <arg1>...  Split-shells (hidden) aren't persisted.
+//
+// The write is atomic and keeps one previous generation: build the buffer, write it to
+// sessions.tsv.tmp, rotate the current file to sessions.tsv.bak, then MoveFileExW the temp over the
+// target. A crash, a full disk or a killed process can therefore never leave a truncated file where
+// a good one was — the old CREATE_ALWAYS wrote in place, so the only copy was destroyed the instant
+// the write began.
 static void saveSessionState() {
     std::wstring path = stateFilePath();
     if (path.empty()) return;
@@ -1738,22 +1774,55 @@ static void saveSessionState() {
     if (!flagLine.empty()) out += "F" + flagLine + "\n";
     if (!idLine.empty()) out += "D" + idLine + "\n";
     out += "A\t" + std::to_string(g_activeWs) + "\n";
-    HANDLE f = CreateFileW(path.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+
+    // Anything that rebuilds the tree while the session list is momentarily empty used to rewrite the
+    // file with zero S lines — a good file replaced by a useless one, with nothing to fall back to.
+    // The one legitimate zero-session save is the user closing the last session (g_userEmptied).
+    if (saved == 0 && !g_userEmptied) {
+        int had = stateFileSessionCount(path);
+        if (had > 0) {
+            logWarn("save SKIPPED: refusing to replace %s (%d saved session(s)) with a zero-session save",
+                    narrow(path).c_str(), had);
+            return;
+        }
+    }
+
+    std::wstring tmp = path + L".tmp", bak = path + L".bak";
+    HANDLE f = CreateFileW(tmp.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
     if (f == INVALID_HANDLE_VALUE) {
         // The silent return that made "restore doesn't work" unanswerable in the field: if the
         // state file can't be opened, nothing is saved and nothing says so.
         logWarn("save FAILED to open %s (err %lu) — %d session(s) not saved",
-                narrow(path).c_str(), GetLastError(), saved);
+                narrow(tmp).c_str(), GetLastError(), saved);
         return;
     }
     DWORD wr = 0;
     BOOL ok = WriteFile(f, out.data(), (DWORD)out.size(), &wr, nullptr);
     DWORD werr = ok ? 0 : GetLastError();
+    if (ok) FlushFileBuffers(f);       // the rename below must publish bytes that actually reached disk
     CloseHandle(f);
-    if (!ok || wr != out.size())
-        logWarn("save PARTIAL to %s: wrote %lu of %zu bytes (err %lu)", narrow(path).c_str(), wr, out.size(), werr);
-    else
-        logInfo("save ok: %d session(s), %zu bytes -> %s", saved, out.size(), narrow(path).c_str());
+    if (!ok || wr != out.size()) {
+        logWarn("save PARTIAL to %s: wrote %lu of %zu bytes (err %lu) — previous state left intact",
+                narrow(tmp).c_str(), wr, out.size(), werr);
+        DeleteFileW(tmp.c_str());
+        return;
+    }
+    if (saved == 0) {
+        // The user emptied the window on purpose (this is the only way a zero-session save gets
+        // here). Keeping a .bak would resurrect on the next launch exactly what they just closed.
+        DeleteFileW(bak.c_str());
+    } else if (stateFileSessionCount(path) > 0 && !MoveFileExW(path.c_str(), bak.c_str(), MOVEFILE_REPLACE_EXISTING)) {
+        // Keep exactly one previous generation. Only rotate a file that actually held sessions, so a
+        // good .bak is never overwritten by an empty or absent primary.
+        logWarn("save: could not rotate %s to .bak (err %lu)", narrow(path).c_str(), GetLastError());
+    }
+    if (!MoveFileExW(tmp.c_str(), path.c_str(), MOVEFILE_REPLACE_EXISTING)) {
+        logWarn("save FAILED to publish %s (err %lu) — %d session(s) not saved; .bak holds the previous state",
+                narrow(path).c_str(), GetLastError(), saved);
+        DeleteFileW(tmp.c_str());
+        return;
+    }
+    logInfo("save ok: %d session(s), %zu bytes -> %s", saved, out.size(), narrow(path).c_str());
 }
 
 // Select a face+size, apply it, and persist the choice (used by the Properties dialog).
@@ -2096,6 +2165,12 @@ static int liteDiagnose() {
     } else {
         line("session file", narrow(state) + "  <-- DOES NOT EXIST (nothing to restore)");
     }
+    // The previous generation kept by every save; restore falls back to it when the primary is
+    // missing, empty, or parses to zero sessions.
+    WIN32_FILE_ATTRIBUTE_DATA ba{};
+    line("backup file", GetFileAttributesExW((state + L".bak").c_str(), GetFileExInfoStandard, &ba)
+                            ? narrow(state) + ".bak (" + std::to_string(ba.nFileSizeLow) + " bytes)"
+                            : narrow(state) + ".bak  (none yet)");
 
     say("\r\nlog\r\n");
     line("path", narrow(log));
@@ -5295,27 +5370,25 @@ static DWORD WINAPI ctlServerThread(void*) {
     }
 }
 
-// Rebuild the saved workspaces + sessions on launch. Returns false (caller opens a default session) if
-// there's nothing to restore. Sessions relaunch with their remembered profile + creation cwd.
-static bool restoreSessions() {
-    std::wstring path = stateFilePath();
-    HANDLE f = CreateFileW(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
-    if (f == INVALID_HANDLE_VALUE) {
-        // Exit 1 of 4. "No state file" and "state file I refused to use" look identical from
-        // outside, so each exit says which one it was.
-        logInfo("restore: no state file at %s (err %lu) — starting fresh", narrow(path).c_str(), GetLastError());
-        return false;
-    }
-    std::string data; char buf[4096]; DWORD rd;
-    while (ReadFile(f, buf, sizeof buf, &rd, nullptr) && rd) data.append(buf, rd);
-    CloseHandle(f);
-    if (data.empty()) { logWarn("restore: state file is EMPTY: %s", narrow(path).c_str()); return false; }   // exit 2 of 4
-
+// One parsed state file. `opened` separates "no file" from "a file that says nothing useful" — the
+// two used to look identical from outside, which is half of why the field report was unanswerable.
+struct RestoreSpec { int ws; std::string name, app, cwd; std::vector<std::string> args; bool flagged = false; };
+struct ParsedState {
     std::vector<std::wstring> wss;
-    struct Spec { int ws; std::string name, app, cwd; std::vector<std::string> args; bool flagged = false; };
-    std::vector<Spec> specs;
+    std::vector<RestoreSpec> specs;
     std::vector<std::string> savedIds;   // from the D line; empty for a pre-0.17.3 file
     int activeWs = 0, focusWs = -1;
+    size_t bytes = 0;
+    DWORD err = 0;
+    bool opened = false;
+};
+
+static ParsedState parseStateFile(const std::wstring& path) {
+    ParsedState ps;
+    std::string data;
+    ps.opened = readWholeFile(path, data, &ps.err);
+    if (!ps.opened) return ps;
+    ps.bytes = data.size();
     size_t i = 0;
     auto split = [](const std::string& l) {
         std::vector<std::string> ff; size_t p = 0;
@@ -5329,27 +5402,53 @@ static bool restoreSessions() {
         if (!l.empty() && l.back() == '\r') l.pop_back();
         if (l.empty()) continue;
         auto ff = split(l);
-        if (ff[0] == "W" && ff.size() >= 2) wss.push_back(widen(ff[1]));
+        if (ff[0] == "W" && ff.size() >= 2) ps.wss.push_back(widen(ff[1]));
         else if (ff[0] == "S" && ff.size() >= 5) {
-            Spec sp; sp.ws = atoi(ff[1].c_str()); sp.name = ff[2]; sp.app = ff[3]; sp.cwd = ff[4];
+            RestoreSpec sp; sp.ws = atoi(ff[1].c_str()); sp.name = ff[2]; sp.app = ff[3]; sp.cwd = ff[4];
             for (size_t k = 5; k < ff.size(); k++) sp.args.push_back(ff[k]);
-            specs.push_back(sp);
+            ps.specs.push_back(sp);
         } else if (ff[0] == "F") {   // flagged indices, in S-line order
             for (size_t k = 1; k < ff.size(); k++) {
                 int fi = atoi(ff[k].c_str());
-                if (fi >= 0 && fi < (int)specs.size()) specs[fi].flagged = true;
+                if (fi >= 0 && fi < (int)ps.specs.size()) ps.specs[fi].flagged = true;
             }
         } else if (ff[0] == "D") {   // host session ids, in S-line order (absent in 0.17.x files)
-            for (size_t k = 1; k < ff.size(); k++) savedIds.push_back(ff[k]);
-        } else if (ff[0] == "O" && ff.size() >= 2) focusWs = atoi(ff[1].c_str());
-        else if (ff[0] == "A" && ff.size() >= 2) activeWs = atoi(ff[1].c_str());
+            for (size_t k = 1; k < ff.size(); k++) ps.savedIds.push_back(ff[k]);
+        } else if (ff[0] == "O" && ff.size() >= 2) ps.focusWs = atoi(ff[1].c_str());
+        else if (ff[0] == "A" && ff.size() >= 2) ps.activeWs = atoi(ff[1].c_str());
     }
-    if (specs.empty()) {   // exit 3 of 4: the file exists and has content, but no S lines parsed
-        logWarn("restore: %s parsed to 0 session specs (%zu bytes, %zu workspace lines)",
-                narrow(path).c_str(), data.size(), wss.size());
-        return false;
+    return ps;
+}
+
+// Rebuild the saved workspaces + sessions on launch. Returns false (caller opens a default session) if
+// there's nothing to restore. Sessions relaunch with their remembered profile + creation cwd.
+static bool restoreSessions() {
+    std::wstring path = stateFilePath(), bakPath = path + L".bak", usedPath = path;
+    ParsedState ps = parseStateFile(path);
+    if (ps.specs.empty()) {
+        // Exits 1-3 of 4. "No state file", "empty state file" and "a file I could not make sense of"
+        // look identical from outside, so each one says which it was.
+        if (!ps.opened)          logInfo("restore: no state file at %s (err %lu)", narrow(path).c_str(), ps.err);
+        else if (ps.bytes == 0)  logWarn("restore: state file is EMPTY: %s", narrow(path).c_str());
+        else                     logWarn("restore: %s parsed to 0 session specs (%zu bytes, %zu workspace lines)",
+                                         narrow(path).c_str(), ps.bytes, ps.wss.size());
+        // Second chance: the previous generation kept by the save. Restore had none before, so a
+        // single bad write was permanent.
+        ParsedState bak = parseStateFile(bakPath);
+        if (bak.specs.empty()) {
+            logInfo("restore: no usable %s either — starting fresh", narrow(bakPath).c_str());
+            return false;
+        }
+        logWarn("restore: falling back to %s (%zu spec(s), %zu bytes)",
+                narrow(bakPath).c_str(), bak.specs.size(), bak.bytes);
+        ps = bak;
+        usedPath = bakPath;
     }
-    logInfo("restore: %zu spec(s) from %s (%zu bytes)", specs.size(), narrow(path).c_str(), data.size());
+    const std::vector<RestoreSpec>& specs = ps.specs;
+    const std::vector<std::string>& savedIds = ps.savedIds;
+    const std::vector<std::wstring>& wss = ps.wss;
+    int activeWs = ps.activeWs, focusWs = ps.focusWs;
+    logInfo("restore: %zu spec(s) from %s (%zu bytes)", specs.size(), narrow(usedPath).c_str(), ps.bytes);
 
     g_restoring = true;
     if (!wss.empty()) g_workspaces = wss;

--- a/lite/src/main.cpp
+++ b/lite/src/main.cpp
@@ -5389,6 +5389,7 @@ struct ParsedState {
     std::vector<RestoreSpec> specs;
     std::vector<std::string> savedIds;   // from the D line; empty for a pre-0.17.3 file
     int activeWs = 0, focusWs = -1;
+    int version = 0;                     // from the V header; 0 = there wasn't one
     size_t bytes = 0;
     DWORD err = 0;
     bool opened = false;
@@ -5413,7 +5414,12 @@ static ParsedState parseStateFile(const std::wstring& path) {
         if (!l.empty() && l.back() == '\r') l.pop_back();
         if (l.empty()) continue;
         auto ff = split(l);
-        if (ff[0] == "W" && ff.size() >= 2) ps.wss.push_back(widen(ff[1]));
+        // The format grows by ADDING line types (that is how D arrived), so a file from a newer
+        // build is read for the lines this one recognises rather than thrown away — discarding it
+        // would lose the sessions AND overwrite the newer file on the next save. Recorded so the
+        // log can say so; unknown line types are ignored by the same principle.
+        if (ff[0].size() >= 2 && ff[0][0] == 'V' && isdigit((unsigned char)ff[0][1])) ps.version = atoi(ff[0].c_str() + 1);
+        else if (ff[0] == "W" && ff.size() >= 2) ps.wss.push_back(widen(ff[1]));
         else if (ff[0] == "S" && ff.size() >= 5) {
             RestoreSpec sp; sp.ws = atoi(ff[1].c_str()); sp.name = ff[2]; sp.app = ff[3]; sp.cwd = ff[4];
             for (size_t k = 5; k < ff.size(); k++) sp.args.push_back(ff[k]);
@@ -5490,6 +5496,9 @@ static bool restoreSessions() {
     const std::vector<std::wstring>& wss = ps.wss;
     int activeWs = ps.activeWs, focusWs = ps.focusWs;
     logInfo("restore: %zu spec(s) from %s (%zu bytes)", specs.size(), narrow(usedPath).c_str(), ps.bytes);
+    if (ps.version != 1)
+        logWarn("restore: %s is format V%d, this build writes V1 — reading the line types it recognises",
+                narrow(usedPath).c_str(), ps.version);
 
     g_restoring = true;
     if (!wss.empty()) g_workspaces = wss;

--- a/lite/src/main.cpp
+++ b/lite/src/main.cpp
@@ -1303,6 +1303,15 @@ static Session* attachSession(const char* id, int cols, int rows, const char* ap
                               const std::vector<std::string>* pargs, const char* cwd,
                               bool repaint = false);   // fwd
 
+// The protocol's string fields are FIXED-SIZE arrays, and MSVC's strcpy_s does not truncate on an
+// oversize source — it invokes the CRT invalid-parameter handler, whose default terminates the
+// process outright: no window, no message box, no log line. Every value copied below can come from
+// the state file, and saveSessionState persists sessionLiveCwd(), which reads the shell's cwd out of
+// its PEB — a UNICODE_STRING with no MAX_PATH limit. So a session sitting in a deep directory could
+// be saved perfectly and then hard-kill the NEXT launch, which is exactly the unexplainable "lite
+// won't start" shape this branch exists to remove. Check before every copy.
+static bool fitsField(const char* s, size_t cap) { return s && strlen(s) < cap; }
+
 static Session* newSession(int cols, int rows, const char* app = nullptr,
                            const std::vector<std::string>* pargs = nullptr, const char* cwd = nullptr) {
     char idbuf[64];
@@ -1316,13 +1325,40 @@ static Session* newSession(int cols, int rows, const char* app = nullptr,
     req.cmd.create.cols = (uint32_t)cols;
     req.cmd.create.rows = (uint32_t)rows;
     const char* useApp = app ? app : "powershell.exe";
+    if (!fitsField(useApp, sizeof agwinterm_ptyhost_Create::app)) {
+        // Nothing could launch this anyway. Returning nullptr lets restore keep it as a named dead
+        // session (failedSpecSession) instead of losing the entry — or killing the process.
+        logWarn("session create refused: app is %zu bytes, the protocol field holds %zu",
+                strlen(useApp), sizeof agwinterm_ptyhost_Create::app - 1);
+        return nullptr;
+    }
     strcpy_s(req.cmd.create.app, useApp);
-    if (cwd && *cwd) strcpy_s(req.cmd.create.cwd, cwd);
+    if (cwd && *cwd) {
+        // An over-long cwd is not worth failing the session over — start in the inherited directory
+        // and say why, which beats both a dead pane and a terminated process.
+        if (fitsField(cwd, sizeof agwinterm_ptyhost_Create::cwd)) strcpy_s(req.cmd.create.cwd, cwd);
+        else logWarn("session create: cwd is %zu bytes and does not fit the protocol field (%zu) — "
+                     "starting in the default directory instead", strlen(cwd), sizeof agwinterm_ptyhost_Create::cwd - 1);
+    }
     std::string enc;
     if (pargs && !pargs->empty()) {                     // explicit profile args -> run app + args as-is
-        int n = (int)pargs->size(); if (n > 4) n = 4;
+        // The wire holds 16 args (proto/ptyhost.options). The old cap of 4 silently rewrote the
+        // command line of any profile with more than four — saved in full, relaunched truncated.
+        const int kMaxArgs = (int)(sizeof agwinterm_ptyhost_Create::args / sizeof agwinterm_ptyhost_Create::args[0]);
+        int n = (int)pargs->size();
+        if (n > kMaxArgs) {
+            logWarn("session create: %d args, the protocol carries %d — dropping the rest", n, kMaxArgs);
+            n = kMaxArgs;
+        }
         req.cmd.create.args_count = n;
-        for (int i = 0; i < n; i++) strcpy_s(req.cmd.create.args[i], (*pargs)[i].c_str());
+        for (int i = 0; i < n; i++) {
+            if (!fitsField((*pargs)[i].c_str(), sizeof agwinterm_ptyhost_Create::args[0])) {
+                logWarn("session create refused: arg %d is %zu bytes, the protocol field holds %zu",
+                        i, (*pargs)[i].size(), sizeof agwinterm_ptyhost_Create::args[0] - 1);
+                return nullptr;                         // a truncated arg is a DIFFERENT command
+            }
+            strcpy_s(req.cmd.create.args[i], (*pargs)[i].c_str());
+        }
     } else if (isPwshApp(useApp)) {                     // PowerShell: keep the interactive prompt wrap
         // -NoExit keeps the shell interactive after the wrap runs; -EncodedCommand runs AFTER the
         // profile so it chains (not replaces) the user's prompt.
@@ -1390,6 +1426,13 @@ static Session* attachSession(const char* id, int cols, int rows, const char* ap
     agwinterm_ptyhost_Request req = agwinterm_ptyhost_Request_init_default;
     agwinterm_ptyhost_Reply rep = agwinterm_ptyhost_Reply_init_default;
     req.which_cmd = agwinterm_ptyhost_Request_attach_tag;
+    // Adoption feeds this straight from the state file's D line, so the id is as untrusted as the
+    // rest of the file. See fitsField: an over-long one would terminate the process, not truncate.
+    if (!fitsField(id, sizeof agwinterm_ptyhost_Attach::id)) {
+        logWarn("attach refused: session id is %zu bytes, the protocol field holds %zu",
+                strlen(id ? id : ""), sizeof agwinterm_ptyhost_Attach::id - 1);
+        return nullptr;
+    }
     strcpy_s(req.cmd.attach.id, id);
     // ADOPTION only: the shell has been running without a client and has already painted its screen,
     // but the adopting side gets a brand-new empty emulator and the host forwards only NEW output.
@@ -1889,11 +1932,13 @@ static bool readWholeFile(const std::wstring& path, std::string& out, DWORD* err
     if (err) *err = 0;
     return true;
 }
-// How many session lines a state file on disk holds; -1 when it can't be read at all. Cheap enough
-// to ask before every save, and it is what "would this write throw sessions away?" actually means.
-static int stateFileSessionCount(const std::wstring& path) {
+// How many session lines a state file on disk holds; -1 when it can't be read at all. `err` tells
+// the two -1s apart: a file that ISN'T THERE has nothing to lose (every first run), while a file
+// that exists and won't open is the locked-profile case a save must not steamroll. Cheap enough to
+// ask before every save, and it is what "would this write throw sessions away?" actually means.
+static int stateFileSessionCount(const std::wstring& path, DWORD* err = nullptr) {
     std::string d;
-    if (!readWholeFile(path, d)) return -1;
+    if (!readWholeFile(path, d, err)) return -1;
     int n = 0;
     for (size_t i = 0; i < d.size();) {
         size_t e = d.find('\n', i);
@@ -1904,18 +1949,30 @@ static int stateFileSessionCount(const std::wstring& path) {
     return n;
 }
 
+// A field written into a tab-separated, newline-delimited record must not CONTAIN a tab or a
+// newline. Names reach here from the control API — session.rename takes a JSON string, and
+// jsonParseString decodes \t, \n and \uXXXX — so an unescaped name could shift every field after it
+// on its own line, or append a whole synthetic `S` line that the NEXT launch would faithfully start
+// as a real session. It also breaks the S/D pairing guard, which then disables adoption for the
+// entire file. One choke point on the way out covers every ingest path, present and future.
+static std::string tsvField(const std::string& s) {
+    std::string o = s;
+    for (char& c : o) if (c == '\t' || c == '\n' || c == '\r') c = ' ';
+    return o;
+}
+
 // session line is: S <ws> <name> <app> <cwd> <arg0> <arg1>...  Split-shells (hidden) aren't persisted.
 //
 // The write is atomic and keeps one previous generation: build the buffer, write it to
-// sessions.tsv.tmp, rotate the current file to sessions.tsv.bak, then MoveFileExW the temp over the
-// target. A crash, a full disk or a killed process can therefore never leave a truncated file where
-// a good one was — the old CREATE_ALWAYS wrote in place, so the only copy was destroyed the instant
-// the write began.
+// sessions.tsv.tmp, then publish it with ReplaceFileW, which rotates the current file to
+// sessions.tsv.bak and swaps the temp in as ONE operation. A crash, a full disk or a killed process
+// can therefore never leave a truncated file where a good one was — the old CREATE_ALWAYS wrote in
+// place, so the only copy was destroyed the instant the write began.
 static void saveSessionState() {
     std::wstring path = stateFilePath();
     if (path.empty()) return;
     std::string out = "V1\n";
-    for (const auto& w : g_workspaces) out += "W\t" + narrow(w) + "\n";
+    for (const auto& w : g_workspaces) out += "W\t" + tsvField(narrow(w)) + "\n";
     EnterCriticalSection(&g_lock);
     std::string flagLine;   // "F\t<i>..." = indices (in S-line order) of flagged sessions; old builds skip it
     // "D\t<id>..." = the host session ids, in S-line order — same in-order idiom as the F line, and
@@ -1925,8 +1982,13 @@ static void saveSessionState() {
     for (const Session* s : g_sessions) {
         if (s->hidden) continue;
         std::string cw = sessionLiveCwd(s);              // live dir (OSC 7) wins over the creation dir
-        out += "S\t" + std::to_string(s->ws) + "\t" + narrow(s->name) + "\t" + s->app + "\t" + (cw.empty() ? s->cwd : cw);
-        for (const auto& a : s->args) out += "\t" + a;
+        // Never persist a cwd the next launch cannot use: Create.cwd is a fixed 260-byte wire field,
+        // while the PEB path sessionLiveCwd() reads has no such limit. Falling back to the creation
+        // dir loses a little accuracy; writing it would lose the session (see fitsField).
+        if (cw.size() >= sizeof agwinterm_ptyhost_Create::cwd) cw.clear();
+        out += "S\t" + std::to_string(s->ws) + "\t" + tsvField(narrow(s->name)) + "\t" + tsvField(s->app)
+             + "\t" + tsvField(cw.empty() ? s->cwd : cw);
+        for (const auto& a : s->args) out += "\t" + tsvField(a);
         out += "\n";
         if (s->flagged) flagLine += "\t" + std::to_string(saved);
         idLine += "\t" + s->id;
@@ -1941,8 +2003,12 @@ static void saveSessionState() {
     // file with zero S lines — a good file replaced by a useless one, with nothing to fall back to.
     // The one legitimate zero-session save is the user closing the last session (g_userEmptied).
     if (saved == 0 && !g_userEmptied) {
-        int had = stateFileSessionCount(path);
-        DWORD hadErr = GetLastError();   // only meaningful for had == -1 (CreateFileW is the last call made)
+        DWORD hadErr = 0;
+        int had = stateFileSessionCount(path, &hadErr);
+        // No file yet is not a file that "could not be read" — that is every first run, and saying
+        // so in the log the field reports are read from sends the reader after a fault that isn't
+        // there. Nothing on disk means nothing to lose, so treat it as the empty case.
+        if (had < 0 && (hadErr == ERROR_FILE_NOT_FOUND || hadErr == ERROR_PATH_NOT_FOUND)) had = 0;
         if (had != 0) {   // -1 = the file exists but could not be read: unknown is NOT permission to overwrite
             if (had > 0)
                 logWarn("save SKIPPED: refusing to replace %s (%d saved session(s)) with a zero-session save",
@@ -1978,20 +2044,36 @@ static void saveSessionState() {
         DeleteFileW(tmp.c_str());
         return;
     }
-    if (saved == 0 && g_userEmptied) {
-        // The user emptied the window ON PURPOSE. Keeping a .bak would resurrect on the next launch
-        // exactly what they just closed. Every other zero-session save keeps its generation: the
-        // guard above lets one through only when the primary holds nothing worth keeping either, and
-        // a .bak is then the last copy of anything at all.
-        DeleteFileW(bak.c_str());
-    } else if (stateFileSessionCount(path) > 0 && !MoveFileExW(path.c_str(), bak.c_str(), MOVEFILE_REPLACE_EXISTING)) {
-        // Keep exactly one previous generation. Only rotate a file that actually held sessions, so a
-        // good .bak is never overwritten by an empty or absent primary.
-        logWarn("save: could not rotate %s to .bak (err %lu)", narrow(path).c_str(), GetLastError());
+    // Keep exactly one previous generation, but only rotate a file that actually held sessions, so a
+    // good .bak is never overwritten by an empty or absent primary. The user emptying the window ON
+    // PURPOSE is the one case that drops the .bak: keeping it would resurrect on the next launch
+    // exactly what they just closed.
+    bool rotate = !(saved == 0 && g_userEmptied) && stateFileSessionCount(path) > 0;
+    if (saved == 0 && g_userEmptied) DeleteFileW(bak.c_str());
+    // ReplaceFileW does the rotation and the publish as ONE operation, and never unlinks the target
+    // in between. Doing it as two renames leaves a window in which no primary exists at all — and a
+    // shutdown landing in that window (the OnDestroy save is exactly when Windows is killing things)
+    // costs a whole generation, which is "some of my sessions are gone" with a log line claiming the
+    // save worked. It needs an existing target, so the two-rename path stays for the first save.
+    if (rotate && ReplaceFileW(path.c_str(), tmp.c_str(), bak.c_str(),
+                               REPLACEFILE_IGNORE_MERGE_ERRORS | REPLACEFILE_WRITE_THROUGH, nullptr, nullptr)) {
+        logInfo("save ok: %d session(s), %zu bytes -> %s", saved, out.size(), narrow(path).c_str());
+        return;
     }
+    bool rotated = rotate && MoveFileExW(path.c_str(), bak.c_str(), MOVEFILE_REPLACE_EXISTING);
+    if (rotate && !rotated)
+        logWarn("save: could not rotate %s to .bak (err %lu)", narrow(path).c_str(), GetLastError());
     if (!MoveFileExW(tmp.c_str(), path.c_str(), MOVEFILE_REPLACE_EXISTING)) {
-        logWarn("save FAILED to publish %s (err %lu) — %d session(s) not saved; .bak holds the previous state",
-                narrow(path).c_str(), GetLastError(), saved);
+        DWORD perr = GetLastError();
+        // Put the primary back. Without this a failed publish leaves NO primary at all — the state
+        // lives only in a .bak nothing but the fallback path reads, and --diagnose (the first thing
+        // a reader runs) reports the session file as missing.
+        bool restored = rotated && MoveFileExW(bak.c_str(), path.c_str(), MOVEFILE_REPLACE_EXISTING);
+        logWarn("save FAILED to publish %s (err %lu) — %d session(s) not saved; %s",
+                narrow(path).c_str(), perr, saved,
+                restored  ? "the previous state was put back"
+                : rotated ? "the previous state is in the .bak"
+                          : "the previous state is untouched");
         DeleteFileW(tmp.c_str());
         return;
     }
@@ -5276,7 +5358,7 @@ static std::string ctlDispatch(const std::string& line) {
         if (!target) return ctlErr("session not found");
         std::string nm = req.get("args.name");
         if (nm.empty()) return ctlErr("rename needs a name");
-        target->name = widen(nm);
+        target->name = widen(tsvField(nm));   // JSON carries \t and \n; a name is one line (see tsvField)
         PostMessageW(g_hwnd, WM_APP_REFRESHTREE, 0, 0);
         return ctlOkStr("renamed");
     }
@@ -5386,7 +5468,7 @@ static std::string ctlDispatch(const std::string& line) {
         std::string nm = req.get("args.name");
         if (w < 0) return ctlErr("workspace not found");
         if (nm.empty()) return ctlErr("rename needs a name");
-        g_workspaces[w] = widen(nm);
+        g_workspaces[w] = widen(tsvField(nm));
         PostMessageW(g_hwnd, WM_APP_REFRESHTREE, 0, 0);
         return ctlOkStr("renamed");
     }
@@ -5714,6 +5796,25 @@ static bool restoreSessions() {
         for (const auto& hs : g_hostLive) if (hs.id == id) return hs.adoptable();
         return false;
     };
+    // A saved id the host still holds but that cannot be adopted because its shell has EXITED is a
+    // dead record only an explicit kill removes — and no other code path ever sends one for it. It
+    // would survive every future launch, and enough of them push `list` past this build's field
+    // storage (ListReply.sessions is max_count:64), at which point the whole reply stops decoding
+    // and adoption — plus the id reservation that goes with it — is off permanently. Reap it here,
+    // where we know we are about to create the replacement. An ATTACHED id is NOT touched: that one
+    // belongs to a live window, and killing it would take down someone else's shell.
+    auto reapExited = [&](const std::string& id) {
+        if (id.empty() || !fitsField(id.c_str(), sizeof agwinterm_ptyhost_SessionRef::id)) return;
+        for (const auto& hs : g_hostLive) {
+            if (hs.id != id || !hs.exited) continue;
+            agwinterm_ptyhost_Request k = agwinterm_ptyhost_Request_init_default;
+            agwinterm_ptyhost_Reply kr = agwinterm_ptyhost_Reply_init_default;
+            k.which_cmd = agwinterm_ptyhost_Request_kill_tag;
+            strcpy_s(k.cmd.kill.id, id.c_str());
+            if (request(k, &kr)) logInfo("restore: reaped exited host session '%s'", id.c_str());
+            return;
+        }
+    };
 
     for (size_t si = 0; si < specs.size(); si++) {
         const auto& sp = specs[si];
@@ -5726,6 +5827,8 @@ static bool restoreSessions() {
                               true);   // repaint: the shell already has a screen, ask it to redraw
             if (s) { adopted++; logInfo("restore: adopted live session '%s' (%s)", want.c_str(), sp.name.c_str()); }
             else logWarn("restore: adopt of live session '%s' failed — creating a fresh one", want.c_str());
+        } else {
+            reapExited(want);   // a dead record we are about to replace: don't leave it on the host
         }
         if (!s)
             s = newSession(cols, rows, sp.app.empty() ? nullptr : sp.app.c_str(),

--- a/lite/src/main.cpp
+++ b/lite/src/main.cpp
@@ -129,6 +129,27 @@ static std::string  g_idPrefix = "lite";              // session-id prefix ("<pr
 static bool g_isDefaultInstance = true;
 static const wchar_t* kInstKey = L"Software\\agwinterm-lite\\Instances";
 
+/// The instance name as it will actually be used. It becomes a FILENAME (sessions-<name>.tsv,
+/// lite-<name>.log) and is interpolated into the "Restart everything" command line, so drop the
+/// characters that make either of those mean something else: path separators (--pipe "..\..\x"
+/// would write outside the state directory), and the quoting/chaining metacharacters cmd.exe acts
+/// on. None of them are legal in a filename anyway, so no name that works today changes.
+///
+/// EVERY producer of an instance name must run it through here. `--pipe` does (parseLaunchArgs) and
+/// so does `window.new`: the child sanitizes whatever it is handed, so a caller told it got
+/// "build&test" would then find `window select build&test` answering "window not found".
+static std::wstring sanitizeInstanceName(const std::wstring& raw) {
+    std::wstring clean;
+    for (wchar_t c : raw)
+        if (c >= 32 && !wcschr(L"\\/:*?\"<>|&^%", c)) clean += c;
+    // Length matters as much as content: the name also becomes the session-id prefix, and ids are
+    // formatted into a fixed 64-byte buffer (newSession). 32 is longer than any name worth typing
+    // and leaves room for "-<n>" many times over.
+    if (clean.size() > 32) clean.resize(32);
+    while (!clean.empty() && (clean.back() == L' ' || clean.back() == L'.')) clean.pop_back();
+    return clean.empty() ? L"lite" : clean;
+}
+
 static void announceInstance(HWND hwnd) {   // name -> [pid, hwnd] (REG_BINARY, 16 bytes)
     unsigned long long v[2] = { GetCurrentProcessId(), (unsigned long long)(uintptr_t)hwnd };
     RegSetKeyValueW(HKEY_CURRENT_USER, kInstKey, g_instance.c_str(), REG_BINARY, v, sizeof v);
@@ -1279,7 +1300,8 @@ static std::vector<Profile> detectProfiles() {
 
 // cols/rows + an optional profile (app/args) and cwd. Default (no app) = PowerShell with the prompt wrap.
 static Session* attachSession(const char* id, int cols, int rows, const char* app,
-                              const std::vector<std::string>* pargs, const char* cwd);   // fwd
+                              const std::vector<std::string>* pargs, const char* cwd,
+                              bool repaint = false);   // fwd
 
 static Session* newSession(int cols, int rows, const char* app = nullptr,
                            const std::vector<std::string>* pargs = nullptr, const char* cwd = nullptr) {
@@ -1363,11 +1385,22 @@ static Session* newSession(int cols, int rows, const char* app = nullptr,
 /// the pty-host is designed to survive the UI, so after a kill/crash/sign-out its shells are still
 /// running and can simply be picked back up, scrollback and all.
 static Session* attachSession(const char* id, int cols, int rows, const char* app,
-                              const std::vector<std::string>* pargs, const char* cwd) {
+                              const std::vector<std::string>* pargs, const char* cwd,
+                              bool repaint) {
     agwinterm_ptyhost_Request req = agwinterm_ptyhost_Request_init_default;
     agwinterm_ptyhost_Reply rep = agwinterm_ptyhost_Reply_init_default;
     req.which_cmd = agwinterm_ptyhost_Request_attach_tag;
     strcpy_s(req.cmd.attach.id, id);
+    // ADOPTION only: the shell has been running without a client and has already painted its screen,
+    // but the adopting side gets a brand-new empty emulator and the host forwards only NEW output.
+    // Today the screen does come back anyway — syncPaneSizes() after restore almost always asks for
+    // a size that differs from the one the restore placeholder was built with, and ConPTY re-emits
+    // on any real resize. That is incidental, not a guarantee: restore at exactly the saved geometry
+    // and there is no resize to piggyback on. `repaint` asks the host for the redraw outright (the
+    // same thing the full app does via JiggleRepaint) so an adopted pane is never blank by luck.
+    // A create-then-attach must NOT ask for it: there is nothing on that screen yet, and the jiggle
+    // would race the shell's startup.
+    req.cmd.attach.repaint = repaint;
     if (!request(req, &rep) || rep.which_body != agwinterm_ptyhost_Reply_attach_tag) return nullptr;
 
     Session* s = new Session();
@@ -1381,8 +1414,9 @@ static Session* attachSession(const char* id, int cols, int rows, const char* ap
     s->data = openPipe(std::wstring(rep.body.attach.pipe, rep.body.attach.pipe + strlen(rep.body.attach.pipe)), 5000, true);
     if (s->data == INVALID_HANDLE_VALUE) { emu_free(s->emu); delete s; return nullptr; }
     // NOTE: AttachReply.scrollback stays callback-decoded (unbounded), so an adopted session comes
-    // back live but with an empty screen rather than its history. The shell itself — and anything
-    // running in it — survives, which is the point; seeding history is a separate improvement.
+    // back without its HISTORY — the repaint above brings back the current screen, which is what
+    // makes the pane look alive. The shell itself, and anything running in it, survives either way;
+    // seeding the scrollback is a separate improvement.
     s->reader = CreateThread(nullptr, 0, readerThread, s, 0, nullptr);
     EnterCriticalSection(&g_lock);
     g_sessions.push_back(s);
@@ -1924,9 +1958,13 @@ static void saveSessionState() {
     HANDLE f = CreateFileW(tmp.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
     if (f == INVALID_HANDLE_VALUE) {
         // The silent return that made "restore doesn't work" unanswerable in the field: if the
-        // state file can't be opened, nothing is saved and nothing says so.
-        logWarn("save FAILED to open %s (err %lu) — %d session(s) not saved",
-                narrow(tmp).c_str(), GetLastError(), saved);
+        // state file can't be opened, nothing is saved and nothing says so. Name the STATE file as
+        // well as the temp: the overwhelmingly likely cause is that the directory is not writable
+        // (a policy-locked %LOCALAPPDATA%), and a reader handed only a .tmp path they have never
+        // seen before is one indirection away from the thing they have to go fix.
+        logWarn("save FAILED to open %s (err %lu) — %d session(s) not saved to %s "
+                "(is the state directory writable?)",
+                narrow(tmp).c_str(), GetLastError(), saved, narrow(path).c_str());
         return;
     }
     DWORD wr = 0;
@@ -5405,6 +5443,10 @@ static std::string ctlDispatch(const std::string& line) {
         }
         if (cmd == "window.new") {
             std::wstring nm = widen(req.get("args.name"));
+            // Sanitize BEFORE the duplicate check and before building the command line: the child
+            // will do it anyway, so an unsanitized name here would be compared against (and
+            // returned instead of) the name the new window actually registers under.
+            if (!nm.empty()) nm = sanitizeInstanceName(nm);
             if (nm.empty()) {   // pick a free name
                 for (int n = 2;; n++) {
                     nm = L"win-" + std::to_wstring(n);
@@ -5680,7 +5722,8 @@ static bool restoreSessions() {
         Session* s = nullptr;
         if (isAdoptable(want)) {
             s = attachSession(want.c_str(), cols, rows, sp.app.empty() ? nullptr : sp.app.c_str(),
-                              sp.args.empty() ? nullptr : &sp.args, sp.cwd.empty() ? nullptr : sp.cwd.c_str());
+                              sp.args.empty() ? nullptr : &sp.args, sp.cwd.empty() ? nullptr : sp.cwd.c_str(),
+                              true);   // repaint: the shell already has a screen, ask it to redraw
             if (s) { adopted++; logInfo("restore: adopted live session '%s' (%s)", want.c_str(), sp.name.c_str()); }
             else logWarn("restore: adopt of live session '%s' failed — creating a fresh one", want.c_str());
         }
@@ -5743,26 +5786,17 @@ static void parseLaunchArgs() {
         if (at == INVALID_FILE_ATTRIBUTES || !(at & FILE_ATTRIBUTE_DIRECTORY)) g_argDir.clear();
     }
     if (!g_argPipe.empty() && g_argPipe != L"agwinterm-lite") {   // named instance
-        // The instance name becomes a FILENAME (sessions-<name>.tsv, lite-<name>.log) and is
-        // interpolated into the "Restart everything" command line, so drop the characters that make
-        // either of those mean something else: path separators (--pipe "..\..\x" would write outside
-        // the state directory), and the quoting/chaining metacharacters cmd.exe acts on. None of
-        // them are legal in a filename anyway, so no name that works today changes.
-        std::wstring clean;
-        for (wchar_t c : g_argPipe)
-            if (c >= 32 && !wcschr(L"\\/:*?\"<>|&^%", c)) clean += c;
-        // Length matters as much as content: the name also becomes the session-id prefix, and ids
-        // are formatted into a fixed 64-byte buffer (newSession). 32 is longer than any name worth
-        // typing and leaves room for "-<n>" many times over.
-        if (clean.size() > 32) clean.resize(32);
-        while (!clean.empty() && (clean.back() == L' ' || clean.back() == L'.')) clean.pop_back();
-        if (clean.empty()) clean = L"lite";
+        std::wstring clean = sanitizeInstanceName(g_argPipe);
         g_argPipe = clean;
         g_instance = clean;
         g_isDefaultInstance = false;
-        std::string p;   // sanitized session-id prefix (alnum/dash only)
+        // Session-id prefix: ASCII alnum/dash only. `(char)towlower(wchar_t)` on anything above
+        // U+007F truncates to a lone high byte, and the id travels as a protobuf STRING — the Rust
+        // host's decode rejects invalid UTF-8, so every create would come back "unknown command"
+        // and the window could never open a session. `--pipe café` was enough to do it.
+        std::string p;
         for (wchar_t c : g_argPipe)
-            if (iswalnum(c) || c == L'-' || c == L'_') p += (char)towlower(c);
+            if (c < 128 && (iswalnum(c) || c == L'-' || c == L'_')) p += (char)towlower(c);
         g_idPrefix = p.empty() ? "lite" : p;
     }
 }

--- a/lite/src/main.cpp
+++ b/lite/src/main.cpp
@@ -125,6 +125,7 @@ static HWND g_hwnd;   // main frame (declared early: the instance registry compa
 // lets any number of lite windows coexist. Instances see each other through a registry of
 // name -> {pid, hwnd} entries under HKCU, which the window.* control verbs act on.
 static std::wstring g_instance = L"agwinterm-lite";   // resolved in parseLaunchArgs
+static std::wstring g_instanceRaw;                    // --pipe as TYPED, when sanitizing changed it
 static std::string  g_idPrefix = "lite";              // session-id prefix ("<prefix>-N")
 static bool g_isDefaultInstance = true;
 static const wchar_t* kInstKey = L"Software\\agwinterm-lite\\Instances";
@@ -133,7 +134,9 @@ static const wchar_t* kInstKey = L"Software\\agwinterm-lite\\Instances";
 /// lite-<name>.log) and is interpolated into the "Restart everything" command line, so drop the
 /// characters that make either of those mean something else: path separators (--pipe "..\..\x"
 /// would write outside the state directory), and the quoting/chaining metacharacters cmd.exe acts
-/// on. None of them are legal in a filename anyway, so no name that works today changes.
+/// on. `& ^ %` and anything past 32 characters ARE legal in a filename, so a name already in use
+/// can change here — and a changed name reads its state from a different file, i.e. "my sessions
+/// are gone" with no explanation. g_instanceRaw keeps the requested name so logInit can say so.
 ///
 /// EVERY producer of an instance name must run it through here. `--pipe` does (parseLaunchArgs) and
 /// so does `window.new`: the child sanitizes whatever it is handed, so a caller told it got
@@ -967,6 +970,13 @@ static void logInit(int argc, wchar_t** argv) {
     logInfo("instance=%s exe=%s args=[%s]",
             narrow(g_isDefaultInstance ? L"(default)" : g_instance).c_str(),
             narrow(exe).c_str(), narrow(cmd).c_str());
+    // The instance name IS the state-file name, so a sanitized name reads a different file and the
+    // window comes up empty. Silently that is indistinguishable from "restore is broken".
+    if (!g_instanceRaw.empty())
+        logWarn("instance name '%s' is not usable as a filename — running as '%s' instead; state is in "
+                "sessions-%s.tsv, not sessions-%s.tsv",
+                narrow(g_instanceRaw).c_str(), narrow(g_instance).c_str(),
+                narrow(g_instance).c_str(), narrow(g_instanceRaw).c_str());
 }
 
 // ---- control pipe: protobuf frames (4-byte LE length prefix) ----
@@ -982,13 +992,21 @@ static bool request(const agwinterm_ptyhost_Request& req, agwinterm_ptyhost_Repl
     *outcome = ReqOutcome::NoReply;
     EnterCriticalSection(&g_reqLock);
     struct Unlock { ~Unlock() { LeaveCriticalSection(&g_reqLock); } } unlock;
-    uint8_t buf[4096];
-    pb_ostream_t os = pb_ostream_from_buffer(buf + 4, sizeof buf - 4);
-    if (!pb_encode(&os, agwinterm_ptyhost_Request_fields, &req)) return false;
+    // Sized from the generated worst case, not a round number: a Create carries 16 args of 2048 bytes
+    // (35572 total), and the old 4 KB buffer meant a spec whose fields each passed fitsField could
+    // still overflow the FRAME — pb_encode failed, request returned false with no log at all, and the
+    // session came back as a nameless "FAILED to start". Restore feeds these straight from the state
+    // file, so it was reachable from a file, which is exactly the silent failure this branch removes.
+    std::vector<uint8_t> buf(agwinterm_ptyhost_Request_size + 4);
+    pb_ostream_t os = pb_ostream_from_buffer(buf.data() + 4, buf.size() - 4);
+    if (!pb_encode(&os, agwinterm_ptyhost_Request_fields, &req)) {
+        logWarn("control: request (cmd %d) did not encode: %s", (int)req.which_cmd, PB_GET_ERROR(&os));
+        return false;
+    }
     uint32_t len = (uint32_t)os.bytes_written;
-    memcpy(buf, &len, 4);
+    memcpy(buf.data(), &len, 4);
     DWORD n = 0;
-    if (!WriteFile(g_control, buf, len + 4, &n, nullptr)) return false;
+    if (!WriteFile(g_control, buf.data(), len + 4, &n, nullptr)) return false;
 
     uint32_t rlen = 0;
     DWORD got = 0, need = 4;
@@ -1445,6 +1463,22 @@ static Session* attachSession(const char* id, int cols, int rows, const char* ap
     // would race the shell's startup.
     req.cmd.attach.repaint = repaint;
     if (!request(req, &rep) || rep.which_body != agwinterm_ptyhost_Reply_attach_tag) return nullptr;
+    // Adoption decides on g_hostLive, a snapshot taken before the window, the fonts, the toolbar and
+    // the update check — seconds before this call. A shell that exits in between is still "adoptable"
+    // per that snapshot, and attaching to it yields an immediate EOF: the saved session comes back as
+    // a permanently dead pane instead of being relaunched, which is the outcome the exited filter
+    // exists to prevent. The reply carries the answer first-hand, so use it and let the caller create.
+    if (repaint && rep.body.attach.has_exited) {
+        logWarn("session '%s' exited between the startup scan and restore — relaunching it instead of adopting", id);
+        // Reap it while we know first-hand that it is dead: nothing is running behind an exited
+        // session, and the record would otherwise outlive every future launch (see reapExited).
+        agwinterm_ptyhost_Request k = agwinterm_ptyhost_Request_init_default;
+        agwinterm_ptyhost_Reply kr = agwinterm_ptyhost_Reply_init_default;
+        k.which_cmd = agwinterm_ptyhost_Request_kill_tag;
+        strcpy_s(k.cmd.kill.id, id);
+        request(k, &kr);
+        return nullptr;
+    }
 
     Session* s = new Session();
     s->id = id;
@@ -1541,19 +1575,28 @@ static void closeSessionAt(int idx) {
     }
     killSession(g_sessions[idx]);
     EnterCriticalSection(&g_lock);
+    // Taken BEFORE the erase: the split pane's shell is hidden (never persisted, never in the tree)
+    // but it is on screen in this window, so it still counts against "the window is empty". After the
+    // erase the pane fixup below can repoint a pane at ANY surviving session — including a quick
+    // popup's, which lives in its own window — so the pane indices can no longer answer this.
+    const Session* splitShell = (g_pane[1] >= 0 && g_pane[1] < (int)g_sessions.size() && g_pane[1] != idx)
+                                ? g_sessions[g_pane[1]] : nullptr;
     g_sessions.erase(g_sessions.begin() + idx);
     for (int p = 0; p < 2; p++) {
         if (g_pane[p] == idx) g_pane[p] = g_sessions.empty() ? -1 : max(0, idx - 1);
         else if (g_pane[p] > idx) g_pane[p]--;
     }
     if (g_sessions.empty()) g_pane[1] = -1;   // unsplit when the last pane dies
-    // "Emptied" has to mean what the SAVE means by it: saveSessionState counts only sessions it
-    // would write, i.e. non-hidden ones. With a split pane or a quick/scratch popup open, closing
-    // the last VISIBLE session leaves g_sessions non-empty while the save sees zero — keying the
-    // flag off the raw vector would then make the guard refuse that save, and the sessions the user
-    // just closed would be read back from the untouched file on the next launch.
+    // "Emptied" means NOTHING IS LEFT ON SCREEN IN THIS WINDOW, which is neither the raw session
+    // count nor the save's count. The save writes only non-hidden sessions, so a quick/scratch popup
+    // (its own window) keeps g_sessions non-empty while the save sees zero — judged by the raw vector
+    // the guard would refuse that save and the sessions the user just closed would be read straight
+    // back out of the untouched file on the next launch. A split shell is hidden too, but it is
+    // right there in pane 1: the window is not empty, so this is not the one save allowed to write a
+    // zero-session file (and to drop the .bak). Unsplit as well and nothing writes the empty either —
+    // deliberately, because "throw away every saved session" should take an unambiguous gesture.
     bool anyVisible = false;
-    for (const Session* vs : g_sessions) if (!vs->hidden) { anyVisible = true; break; }
+    for (const Session* vs : g_sessions) if (!vs->hidden || vs == splitShell) { anyVisible = true; break; }
     bool allGone = g_sessions.empty();
     LeaveCriticalSection(&g_lock);
     // The user closed the last session, so the window goes with it. This is the ONLY path that may
@@ -2023,14 +2066,40 @@ static void saveSessionState() {
     std::wstring tmp = path + L".tmp", bak = path + L".bak";
     HANDLE f = CreateFileW(tmp.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
     if (f == INVALID_HANDLE_VALUE) {
-        // The silent return that made "restore doesn't work" unanswerable in the field: if the
-        // state file can't be opened, nothing is saved and nothing says so. Name the STATE file as
-        // well as the temp: the overwhelmingly likely cause is that the directory is not writable
-        // (a policy-locked %LOCALAPPDATA%), and a reader handed only a .tmp path they have never
-        // seen before is one indirection away from the thing they have to go fix.
-        logWarn("save FAILED to open %s (err %lu) — %d session(s) not saved to %s "
-                "(is the state directory writable?)",
-                narrow(tmp).c_str(), GetLastError(), saved, narrow(path).c_str());
+        // Writing through a temp needs a permission the old in-place save did not: creating a NEW
+        // file in the state directory. Somewhere that allows writing the existing sessions.tsv but
+        // not creating beside it (a policy-locked profile, a DLP/AV agent that blocks new files) this
+        // build would save nothing where the previous one saved fine — the atomic write turning into
+        // the very "restore doesn't work" it was added to fix. So fall back to the old route rather
+        // than give up. It is not atomic: an interrupted write leaves a truncated file. That is the
+        // right trade only because the alternative here is no file at all, and it is what every build
+        // before this one did on every save.
+        DWORD terr = GetLastError();
+        HANDLE g = CreateFileW(path.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+        if (g == INVALID_HANDLE_VALUE) {
+            // The silent return that made "restore doesn't work" unanswerable in the field: if the
+            // state file can't be opened, nothing is saved and nothing says so. Name the STATE file as
+            // well as the temp: the overwhelmingly likely cause is that the directory is not writable
+            // (a policy-locked %LOCALAPPDATA%), and a reader handed only a .tmp path they have never
+            // seen before is one indirection away from the thing they have to go fix.
+            logWarn("save FAILED to open %s (err %lu) or %s (err %lu) — %d session(s) not saved "
+                    "(is the state directory writable?)",
+                    narrow(tmp).c_str(), terr, narrow(path).c_str(), GetLastError(), saved);
+            return;
+        }
+        DWORD wr2 = 0;
+        BOOL ok2 = WriteFile(g, out.data(), (DWORD)out.size(), &wr2, nullptr);
+        DWORD werr2 = ok2 ? 0 : GetLastError();
+        if (ok2) FlushFileBuffers(g);
+        CloseHandle(g);
+        if (ok2 && wr2 == out.size())
+            logWarn("save ok (IN PLACE): %d session(s), %zu bytes -> %s — %s could not be created "
+                    "(err %lu), so this save was not atomic",
+                    saved, out.size(), narrow(path).c_str(), narrow(tmp).c_str(), terr);
+        else
+            logWarn("save FAILED in place to %s: wrote %lu of %zu bytes (err %lu) after %s could not "
+                    "be created (err %lu)", narrow(path).c_str(), wr2, out.size(), werr2,
+                    narrow(tmp).c_str(), terr);
         return;
     }
     DWORD wr = 0;
@@ -3159,7 +3228,7 @@ static UpdRelease updParse(const std::string& j) {
 }
 
 static const char kUpdHelper[] =
-    "param([int]$ProcId, [string]$Payload, [string]$Exe, [string]$RelArgs)\n"
+    "param([int]$ProcId, [string]$Payload, [string]$Exe, [string]$Instance)\n"
     "function Log([string]$m) { try { Add-Content -Path ($Payload + '.log') -Value (\"{0:HH:mm:ss.fff} {1}\" -f (Get-Date), $m) } catch { } }\n"
     "Log \"wait pid=$ProcId\"\n"
     "try { Wait-Process -Id $ProcId -Timeout 120 -ErrorAction SilentlyContinue } catch { }\n"
@@ -3168,7 +3237,11 @@ static const char kUpdHelper[] =
     "Log 'applying'\n"
     "Start-Process $Payload -ArgumentList '/VERYSILENT','/NORESTART','/SUPPRESSMSGBOXES' -Wait\n"
     "Log 'setup finished'\n"
-    "if ($RelArgs) { Start-Process $Exe -ArgumentList $RelArgs } else { Start-Process $Exe }\n"
+    // The instance name is passed as its OWN element, not baked into one argument string: a name with
+    // a space ("--pipe my win") came back through CommandLineToArgvW as instance "my", which is a
+    // different pipe AND a different state file — the "my sessions are gone" shape, self-inflicted by
+    // the update. Start-Process quotes an element that needs it.
+    "if ($Instance) { Start-Process $Exe -ArgumentList '--pipe', $Instance } else { Start-Process $Exe }\n"
     "Log 'relaunched'\n";
 
 static std::wstring* updHeapStr(const std::wstring& s) { return new std::wstring(s); }   // freed by the UI handler
@@ -4907,7 +4980,7 @@ public:
                                        L" -File \"" + a->helper + L"\" -ProcId " + std::to_wstring(GetCurrentProcessId()) +
                                        L" -Payload \"" + a->payload + L"\" -Exe \"" + exe + L"\"";
                     if (!g_isDefaultInstance)   // named instances come back under their own pipe
-                        cmd += L" -RelArgs \"--pipe " + g_instance + L"\"";
+                        cmd += L" -Instance \"" + g_instance + L"\"";
                     STARTUPINFOW si{ sizeof si }; PROCESS_INFORMATION pi{};
                     if (CreateProcessW(nullptr, &cmd[0], nullptr, nullptr, FALSE, CREATE_NO_WINDOW,
                                        nullptr, nullptr, &si, &pi)) {
@@ -5293,8 +5366,17 @@ static std::string ctlDispatch(const std::string& line) {
     }
     if (cmd == "session.close") {
         if (!target) return ctlErr("session not found");
+        // Close the session that was ASKED for, by index. The old form pointed the focused pane at it
+        // and called closeFocused(), which with the split pane focused reroutes into toggleSplit() —
+        // so it killed the repointed target through the unsplit path, ORPHANING the hidden split
+        // shell (a live process with no pane, no tree entry and no kill until exit) and skipping
+        // everything closeSessionAt does: the reopen stack, the deliberate-empty mark, the teardown.
         for (int i2 = 0; i2 < (int)g_sessions.size(); i2++)
-            if (g_sessions[i2] == target) { g_pane[g_focus] = i2; closeFocused(); break; }
+            if (g_sessions[i2] == target) {
+                if (g_pane[1] == i2) toggleSplit();   // it IS the split pane's shell: closing it unsplits
+                else closeSessionAt(i2);
+                break;
+            }
         return ctlOkStr("closed");
     }
     if (cmd == "session.overlay") {   // run a command in an overlay popup over the active session
@@ -5791,29 +5873,17 @@ static bool restoreSessions() {
     // an attached session supersedes its current client — a second window on the same instance would
     // silently steal the first one's shells — and attaching to an exited one yields an immediate EOF,
     // i.e. a dead pane where a relaunched shell belongs.
+    // Ids already taken by this restore. g_hostLive is a snapshot and nothing marks it as adoption
+    // proceeds, so without this a D line carrying the same id twice — a hand-edited or damaged file,
+    // which is the case the .bak fallback exists for — adopts one host session into TWO panes: the
+    // second attach supersedes the first, the first goes dead on EOF, and closing either kills the
+    // shell out from under the other.
+    std::vector<std::string> taken;
     auto isAdoptable = [&](const std::string& id) {
         if (id.empty()) return false;
+        for (const auto& t : taken) if (t == id) return false;
         for (const auto& hs : g_hostLive) if (hs.id == id) return hs.adoptable();
         return false;
-    };
-    // A saved id the host still holds but that cannot be adopted because its shell has EXITED is a
-    // dead record only an explicit kill removes — and no other code path ever sends one for it. It
-    // would survive every future launch, and enough of them push `list` past this build's field
-    // storage (ListReply.sessions is max_count:64), at which point the whole reply stops decoding
-    // and adoption — plus the id reservation that goes with it — is off permanently. Reap it here,
-    // where we know we are about to create the replacement. An ATTACHED id is NOT touched: that one
-    // belongs to a live window, and killing it would take down someone else's shell.
-    auto reapExited = [&](const std::string& id) {
-        if (id.empty() || !fitsField(id.c_str(), sizeof agwinterm_ptyhost_SessionRef::id)) return;
-        for (const auto& hs : g_hostLive) {
-            if (hs.id != id || !hs.exited) continue;
-            agwinterm_ptyhost_Request k = agwinterm_ptyhost_Request_init_default;
-            agwinterm_ptyhost_Reply kr = agwinterm_ptyhost_Reply_init_default;
-            k.which_cmd = agwinterm_ptyhost_Request_kill_tag;
-            strcpy_s(k.cmd.kill.id, id.c_str());
-            if (request(k, &kr)) logInfo("restore: reaped exited host session '%s'", id.c_str());
-            return;
-        }
     };
 
     for (size_t si = 0; si < specs.size(); si++) {
@@ -5825,10 +5895,8 @@ static bool restoreSessions() {
             s = attachSession(want.c_str(), cols, rows, sp.app.empty() ? nullptr : sp.app.c_str(),
                               sp.args.empty() ? nullptr : &sp.args, sp.cwd.empty() ? nullptr : sp.cwd.c_str(),
                               true);   // repaint: the shell already has a screen, ask it to redraw
-            if (s) { adopted++; logInfo("restore: adopted live session '%s' (%s)", want.c_str(), sp.name.c_str()); }
+            if (s) { adopted++; taken.push_back(want); logInfo("restore: adopted live session '%s' (%s)", want.c_str(), sp.name.c_str()); }
             else logWarn("restore: adopt of live session '%s' failed — creating a fresh one", want.c_str());
-        } else {
-            reapExited(want);   // a dead record we are about to replace: don't leave it on the host
         }
         if (!s)
             s = newSession(cols, rows, sp.app.empty() ? nullptr : sp.app.c_str(),
@@ -5847,6 +5915,28 @@ static bool restoreSessions() {
         }
     }
     g_restoring = false;
+    // Host records whose shell has EXITED are tombstones only an explicit kill removes, and no other
+    // code path ever sends one: nothing here closed them, so nothing here killed them. They survive
+    // every future launch, and enough of them push `list` past this build's field storage
+    // (ListReply.sessions is max_count:64), at which point the whole reply stops decoding and
+    // adoption — plus the id reservation that rides along with it — is off PERMANENTLY. Sweep them
+    // now that adoption is done. Deliberately narrow: only this instance's id prefix (another
+    // window's sessions are not ours to touch), only entries the host reported exited, never one it
+    // reported attached, and never one this run just adopted.
+    for (const auto& hs : g_hostLive) {
+        if (!hs.exited || hs.attached) continue;
+        size_t dash = hs.id.rfind('-');
+        if (dash == std::string::npos || hs.id.compare(0, dash, g_idPrefix) != 0) continue;
+        if (!fitsField(hs.id.c_str(), sizeof agwinterm_ptyhost_SessionRef::id)) continue;
+        bool mine = false;
+        for (const auto& t : taken) if (t == hs.id) { mine = true; break; }
+        if (mine) continue;
+        agwinterm_ptyhost_Request k = agwinterm_ptyhost_Request_init_default;
+        agwinterm_ptyhost_Reply kr = agwinterm_ptyhost_Reply_init_default;
+        k.which_cmd = agwinterm_ptyhost_Request_kill_tag;
+        strcpy_s(k.cmd.kill.id, hs.id.c_str());
+        if (request(k, &kr)) logInfo("restore: reaped exited host session '%s'", hs.id.c_str());
+    }
     logInfo("restore: %d of %zu session(s) built (%d adopted live from the pty-host, %d kept as dead)",
             built, specs.size(), adopted, dead);
     if (firstIdx < 0) {   // exit 4 of 4: specs parsed but nothing could be started
@@ -5890,6 +5980,7 @@ static void parseLaunchArgs() {
     }
     if (!g_argPipe.empty() && g_argPipe != L"agwinterm-lite") {   // named instance
         std::wstring clean = sanitizeInstanceName(g_argPipe);
+        if (clean != g_argPipe) g_instanceRaw = g_argPipe;   // logInit reports it; see sanitizeInstanceName
         g_argPipe = clean;
         g_instance = clean;
         g_isDefaultInstance = false;
@@ -6072,7 +6163,12 @@ int WINAPI wWinMain(HINSTANCE inst, HINSTANCE, PWSTR, int show) {
         Session* s = newSession(cols, rows, haveProf ? argApp.c_str() : nullptr,
                                 (haveProf && !argAppArgs.empty()) ? &argAppArgs : nullptr,
                                 g_argDir.empty() ? nullptr : g_argDir.c_str());
-        if (!s && !restored) fatal(L"could not create the first session");
+        // Only when there is NOTHING to show. restoreSessions() returns false while still having kept
+        // the specs it could not start as dead "(failed to start)" entries — the whole point of
+        // failedSpecSession — and a window listing them, with the log line naming each one, is far
+        // better than a message box that throws them away. Judged by `restored` alone this killed
+        // exactly the launch it was built to explain.
+        if (!s && g_sessions.empty()) fatal(L"could not create the first session");
         if (s) { g_pane[0] = (int)g_sessions.size() - 1; g_focus = 0; syncPaneSizes(); }
         refreshTree();
     }

--- a/lite/src/main.cpp
+++ b/lite/src/main.cpp
@@ -194,6 +194,10 @@ struct Session {
     int cols = 0, rows = 0;     // geometry last pushed to the host (0 = never sized yet)
     int scrollOff = 0;          // rows scrolled up into history (0 = live)
     bool exited = false;
+    // Restore placeholder: this spec's app would not start on THIS machine, so there is no shell
+    // behind it. The entry is kept anyway (empty id, exited) so the name/workspace/cwd/args survive
+    // instead of vanishing — a failed spec used to be dropped, and the user was never told.
+    bool failed = false;
     std::vector<FfiCell> grid;  // paint snapshot buffer
     std::vector<FfiCell> hrow;
 };
@@ -1110,13 +1114,15 @@ static void hostResize(Session* s, int cols, int rows) {
     if (s->cols == cols && s->rows == rows) return;
     s->cols = cols;
     s->rows = rows;
-    agwinterm_ptyhost_Request req = agwinterm_ptyhost_Request_init_default;
-    agwinterm_ptyhost_Reply rep = agwinterm_ptyhost_Reply_init_default;
-    req.which_cmd = agwinterm_ptyhost_Request_resize_tag;
-    strcpy_s(req.cmd.resize.id, s->id.c_str());
-    req.cmd.resize.cols = (uint32_t)cols;
-    req.cmd.resize.rows = (uint32_t)rows;
-    request(req, &rep);
+    if (!s->id.empty()) {   // a restore placeholder has no host session — only its emulator resizes
+        agwinterm_ptyhost_Request req = agwinterm_ptyhost_Request_init_default;
+        agwinterm_ptyhost_Reply rep = agwinterm_ptyhost_Reply_init_default;
+        req.which_cmd = agwinterm_ptyhost_Request_resize_tag;
+        strcpy_s(req.cmd.resize.id, s->id.c_str());
+        req.cmd.resize.cols = (uint32_t)cols;
+        req.cmd.resize.rows = (uint32_t)rows;
+        request(req, &rep);
+    }
     EnterCriticalSection(&g_lock);
     emu_resize(s->emu, cols, rows);
     LeaveCriticalSection(&g_lock);
@@ -1328,6 +1334,7 @@ static std::vector<std::string> hostSessionIds() {
 
 static void killSession(Session* s) {
     if (g_sel.sess == s) g_sel.clear();   // the selection is keyed by session: don't outlive it
+    if (s->id.empty()) return;            // restore placeholder: nothing on the host to kill
     agwinterm_ptyhost_Request req = agwinterm_ptyhost_Request_init_default;
     agwinterm_ptyhost_Reply rep = agwinterm_ptyhost_Reply_init_default;
     req.which_cmd = agwinterm_ptyhost_Request_kill_tag;
@@ -3206,7 +3213,8 @@ static void refreshTree() {
             // while it's busy (italic applied in the tree's NM_CUSTOMDRAW). Others show plain.
             int cls = s->exited ? AGST_NONE : statusClass(s->status);
             std::wstring label = s->name.empty() ? (L"session " + std::to_wstring(vis)) : s->name;
-            if (s->exited) label += L"  (exited)";
+            if (s->failed) label += L"  (failed to start)";   // restored spec whose app won't run here
+            else if (s->exited) label += L"  (exited)";
             else if (cls == AGST_WORKING) label += L"  (working…)";
             TVINSERTSTRUCTW tis{};
             tis.hParent = wh;
@@ -4984,6 +4992,9 @@ static std::string ctlDispatch(const std::string& line) {
                         "\",\"active\":" + (g_pane[g_focus] == i2 ? "true" : "false") +
                         ",\"status\":\"" + jsonEscape(s->status) + "\"" +
                         ",\"flagged\":" + (s->flagged ? "true" : "false") +
+                        ",\"exited\":" + (s->exited ? "true" : "false") +
+                        // a spec that could not be relaunched on this machine: kept, not dropped
+                        ",\"failed\":" + (s->failed ? "true" : "false") +
                         ",\"unread\":" + std::to_string(s->unread) + "}";
             }
             wss += "{\"id\":\"" + std::to_string(w) + "\",\"name\":\"" + jsonEscape(narrow(g_workspaces[w])) +
@@ -5420,6 +5431,36 @@ static ParsedState parseStateFile(const std::wstring& path) {
     return ps;
 }
 
+// A spec that would not start on THIS machine (a profile whose exe only exists on the other one, a
+// cwd on a drive that isn't mounted). Dropping it silently loses the name, workspace, cwd and args —
+// which is precisely why "restore doesn't work" was unreportable in the field. Keep a dead session
+// instead: no shell behind it, marked "(failed to start)" the way an exited one is marked, and still
+// persisted by the next save so the entry can be retried where the app does exist.
+static Session* failedSpecSession(const RestoreSpec& sp, int cols, int rows) {
+    Session* s = new Session();
+    s->name = widen(sp.name);
+    s->flagged = sp.flagged;
+    s->app = sp.app;
+    s->args = sp.args;
+    s->cwd = sp.cwd;
+    s->ws = (g_activeWs >= 0 && g_activeWs < (int)g_workspaces.size()) ? g_activeWs : 0;
+    s->exited = true;
+    s->failed = true;
+    s->cols = cols; s->rows = rows;
+    s->emu = emu_new(cols, rows);
+    // Say it in the pane as well as the tree: the terminal is where the user looks first, and "why
+    // is this session dead?" has to be answerable without opening the log.
+    std::string msg = "\r\n  [agwinterm-lite] this session could not be restored on this machine.\r\n"
+                      "  app: " + (sp.app.empty() ? std::string("(default shell)") : sp.app) + "\r\n";
+    if (!sp.cwd.empty()) msg += "  cwd: " + sp.cwd + "\r\n";
+    msg += "  The entry is kept so its name and settings are not lost.\r\n";
+    EnterCriticalSection(&g_lock);
+    if (s->emu) emu_feed(s->emu, (const uint8_t*)msg.data(), (uint32_t)msg.size());
+    g_sessions.push_back(s);
+    LeaveCriticalSection(&g_lock);
+    return s;
+}
+
 // Rebuild the saved workspaces + sessions on launch. Returns false (caller opens a default session) if
 // there's nothing to restore. Sessions relaunch with their remembered profile + creation cwd.
 static bool restoreSessions() {
@@ -5453,7 +5494,7 @@ static bool restoreSessions() {
     g_restoring = true;
     if (!wss.empty()) g_workspaces = wss;
     int cols, rows; paneGridSize(0, &cols, &rows);
-    int firstIdx = -1, built = 0, adopted = 0;
+    int firstIdx = -1, built = 0, adopted = 0, dead = 0;
 
     // Sessions the host still holds. lite was killed rather than closed if this is non-empty: the
     // pty-host outlives the UI by design, so those shells are STILL RUNNING. Adopt them instead of
@@ -5495,17 +5536,23 @@ static bool restoreSessions() {
             if (firstIdx < 0) firstIdx = (int)g_sessions.size() - 1;
             built++;
         } else {
-            // A spec that won't start is invisible otherwise — the session simply doesn't come back.
-            // Name it, so a shell that no longer exists on that machine is obvious from the log.
-            logWarn("restore: session '%s' FAILED to start (app='%s' cwd='%s')",
+            // A spec that won't start used to be invisible AND gone: the session didn't come back and
+            // the next save rewrote the file without it. Keep it as a dead entry and name it in the log.
+            logWarn("restore: session '%s' FAILED to start (app='%s' cwd='%s') — kept as a dead session",
                     sp.name.c_str(), sp.app.c_str(), sp.cwd.c_str());
+            failedSpecSession(sp, cols, rows);
+            dead++;
         }
     }
     g_restoring = false;
-    logInfo("restore: %d of %zu session(s) built (%d adopted live from the pty-host)",
-            built, specs.size(), adopted);
+    logInfo("restore: %d of %zu session(s) built (%d adopted live from the pty-host, %d kept as dead)",
+            built, specs.size(), adopted, dead);
     if (firstIdx < 0) {   // exit 4 of 4: specs parsed but nothing could be started
-        logWarn("restore: no session could be started from %zu spec(s) — starting fresh", specs.size());
+        // The dead entries stay in the tree; the caller opens a working session beside them, so the
+        // window is usable and the specs are still there to look at (and still saved).
+        logWarn("restore: no session could be started from %zu spec(s) — starting fresh (%d dead entr%s kept)",
+                specs.size(), dead, dead == 1 ? "y" : "ies");
+        if (dead) refreshTree();
         return false;
     }
     g_pane[0] = firstIdx; g_pane[1] = -1; g_focus = 0;

--- a/lite/src/main.cpp
+++ b/lite/src/main.cpp
@@ -1047,23 +1047,25 @@ static void loadCore() {
 /// field storage can't hold is still proof the host is alive and serving, and refusing to launch
 /// over one is far worse than the fault it was guarding against (lite has to start; adoption is a
 /// bonus). Decode failures are logged where they matter — in hostSessions().
-static bool controlHandshake() {
+enum class HostHealth { Dead, HelloOnly, Healthy };
+static HostHealth controlHandshake() {
     agwinterm_ptyhost_Request req = agwinterm_ptyhost_Request_init_default;
     agwinterm_ptyhost_Reply rep = agwinterm_ptyhost_Reply_init_default;
     req.which_cmd = agwinterm_ptyhost_Request_hello_tag;
     req.cmd.hello.protocol = kProtocolVersion;
-    if (!request(req, &rep) || rep.which_body != agwinterm_ptyhost_Reply_hello_tag) return false;
+    if (!request(req, &rep) || rep.which_body != agwinterm_ptyhost_Reply_hello_tag) return HostHealth::Dead;
     req = agwinterm_ptyhost_Request_init_default;
     rep = agwinterm_ptyhost_Reply_init_default;
     req.which_cmd = agwinterm_ptyhost_Request_list_tag;
     ReqOutcome out = ReqOutcome::NoReply;
-    if (request(req, &rep, &out)) return rep.which_body == agwinterm_ptyhost_Reply_list_tag;
+    if (request(req, &rep, &out))
+        return rep.which_body == agwinterm_ptyhost_Reply_list_tag ? HostHealth::Healthy : HostHealth::HelloOnly;
     if (out == ReqOutcome::Undecodable) {
         logWarn("pty-host: list replied with something this build cannot decode — the host is alive, "
                 "so lite starts; adoption of live sessions is unavailable this run");
-        return true;
+        return HostHealth::Healthy;
     }
-    return false;
+    return HostHealth::HelloOnly;
 }
 
 static void connectControl() {
@@ -1074,7 +1076,8 @@ static void connectControl() {
     // against host A are invisible to a client that lands on host B. Retrying is for waiting out a
     // dying host, not for stacking up replacements.
     bool spawned = false;
-    for (int attempt = 0; attempt < 4; attempt++) {
+    const int kAttempts = 4;
+    for (int attempt = 0; attempt < kAttempts; attempt++) {
         g_control = openPipe(control, 0, false);
         if (g_control == INVALID_HANDLE_VALUE && !spawned) {   // no host yet: start one
             spawned = true;
@@ -1088,8 +1091,19 @@ static void connectControl() {
             CloseHandle(pi.hProcess);
             g_control = openPipe(control, 5000, false);
         }
-        if (g_control != INVALID_HANDLE_VALUE && controlHandshake()) {
+        HostHealth health = g_control != INVALID_HANDLE_VALUE ? controlHandshake() : HostHealth::Dead;
+        if (health == HostHealth::Healthy) {
             if (attempt) logInfo("pty-host: healthy on attempt %d", attempt + 1);
+            return;
+        }
+        // A host that answers hello but refuses `list` is usually on its way out — the retries are
+        // there to wait for it to release the pipe name so a fresh one can take over. But it can
+        // also be a host that is alive and serving other windows and simply cannot answer this one
+        // command. Never refuse to launch over that: a terminal with no adoption beats no terminal
+        // at all, which is the whole reason the probe returns Healthy for an undecodable reply too.
+        if (health == HostHealth::HelloOnly && attempt == kAttempts - 1) {
+            logWarn("pty-host: answers hello but not list after %d attempts — starting anyway; live "
+                    "sessions cannot be adopted this run", attempt + 1);
             return;
         }
         // Either nothing answered, or what answered is on its way out. Drop it and give the dying
@@ -1270,7 +1284,9 @@ static Session* attachSession(const char* id, int cols, int rows, const char* ap
 static Session* newSession(int cols, int rows, const char* app = nullptr,
                            const std::vector<std::string>* pargs = nullptr, const char* cwd = nullptr) {
     char idbuf[64];
-    wsprintfA(idbuf, "%s-%d", g_idPrefix.c_str(), g_seq++);
+    // _snprintf_s, not wsprintfA: wsprintfA does not bound its output to the destination, and the
+    // prefix comes from --pipe (see parseLaunchArgs, which caps it — this is the second lock).
+    _snprintf_s(idbuf, _TRUNCATE, "%s-%d", g_idPrefix.c_str(), g_seq++);
     agwinterm_ptyhost_Request req = agwinterm_ptyhost_Request_init_default;
     agwinterm_ptyhost_Reply rep = agwinterm_ptyhost_Reply_init_default;
     req.which_cmd = agwinterm_ptyhost_Request_create_tag;
@@ -1311,7 +1327,22 @@ static Session* newSession(int cols, int rows, const char* app = nullptr,
     setEnv(3, "AGWINTERM_SESSION_ID", idbuf);
     setEnv(4, "AGWINTERM_PANE_ID", idbuf);
     setEnv(5, "TERM_PROGRAM", "agwinterm-lite");
-    if (!request(req, &rep)) return nullptr;
+    // An id the host already holds is REFUSED, and that single rejection is what used to sink every
+    // spec of a restore at once. scanHostSessions() reserves the ids it can see, but it only sees
+    // what `list` returns: a reply this build cannot decode (more sessions than its field storage
+    // holds), a refused or unanswered list, or a host that gained sessions since startup all leave
+    // g_seq pointing at an id already in use. So don't depend on the scan — take the host's "already
+    // exists" at face value and step over it. Any other refusal is a real failure and returns.
+    ReqOutcome oc = ReqOutcome::NoReply;
+    for (int tries = 0; !request(req, &rep, &oc); tries++) {
+        if (oc != ReqOutcome::Refused || !strstr(rep.error, "already exists") || tries >= 64) return nullptr;
+        _snprintf_s(idbuf, _TRUNCATE, "%s-%d", g_idPrefix.c_str(), g_seq++);
+        strcpy_s(req.cmd.create.id, idbuf);
+        strcpy_s(req.cmd.create.env[3].value, idbuf);   // AGWINTERM_SESSION_ID
+        strcpy_s(req.cmd.create.env[4].value, idbuf);   // AGWINTERM_PANE_ID
+        rep = agwinterm_ptyhost_Reply_init_default;
+        logWarn("session create refused (id in use) — retrying as '%s'", idbuf);
+    }
     Session* s = attachSession(idbuf, cols, rows, app, pargs, cwd);
     if (!s) {
         // The create SUCCEEDED and only the attach failed, so the host is now holding a shell
@@ -1439,13 +1470,22 @@ static void closeSessionAt(int idx) {
         else if (g_pane[p] > idx) g_pane[p]--;
     }
     if (g_sessions.empty()) g_pane[1] = -1;   // unsplit when the last pane dies
+    // "Emptied" has to mean what the SAVE means by it: saveSessionState counts only sessions it
+    // would write, i.e. non-hidden ones. With a split pane or a quick/scratch popup open, closing
+    // the last VISIBLE session leaves g_sessions non-empty while the save sees zero — keying the
+    // flag off the raw vector would then make the guard refuse that save, and the sessions the user
+    // just closed would be read back from the untouched file on the next launch.
+    bool anyVisible = false;
+    for (const Session* vs : g_sessions) if (!vs->hidden) { anyVisible = true; break; }
+    bool allGone = g_sessions.empty();
     LeaveCriticalSection(&g_lock);
     // The user closed the last session, so the window goes with it. This is the ONLY path that may
     // legitimately write a zero-session state file; every other empty list is transient and the save
     // refuses it (see saveSessionState). The flag describes THIS empty, not the process: driven over
     // the control pipe the DestroyWindow below is a no-op (wrong thread) and the window lives on, so
     // adding a session clears it again — otherwise the guard would stay off for good.
-    if (g_sessions.empty()) { g_userEmptied = true; DestroyWindow(g_hwnd); return; }
+    if (!anyVisible) g_userEmptied = true;
+    if (allGone) { DestroyWindow(g_hwnd); return; }
     syncPaneSizes();
     InvalidateRect(g_hwnd, nullptr, FALSE);
     PostMessageW(g_hwnd, WM_APP_REFRESHTREE, 0, 0);   // drop the session from the tree
@@ -5373,7 +5413,9 @@ static std::string ctlDispatch(const std::string& line) {
             } else if (findInstance(insts, nm)) return ctlErr("window '" + narrow(nm) + "' already exists");
             wchar_t exe[MAX_PATH];
             GetModuleFileNameW(nullptr, exe, MAX_PATH);
-            std::wstring cl = L"\"" + std::wstring(exe) + L"\" --pipe " + nm;
+            // Quote the name: unquoted, "my win" would reach the child as two args and it would come
+            // up as instance "my" while the caller is told it got "my win".
+            std::wstring cl = L"\"" + std::wstring(exe) + L"\" --pipe \"" + nm + L"\"";
             STARTUPINFOW si{ sizeof si }; PROCESS_INFORMATION pi{};
             std::vector<wchar_t> buf(cl.begin(), cl.end()); buf.push_back(0);
             if (!CreateProcessW(nullptr, buf.data(), nullptr, nullptr, FALSE, 0, nullptr, nullptr, &si, &pi))
@@ -5525,6 +5567,17 @@ static ParsedState parseStateFile(const std::wstring& path) {
             for (size_t k = 1; k < ff.size(); k++) ps.savedIds.push_back(ff[k]);
         } else if (ff[0] == "O" && ff.size() >= 2) ps.focusWs = atoi(ff[1].c_str());
         else if (ff[0] == "A" && ff.size() >= 2) ps.activeWs = atoi(ff[1].c_str());
+    }
+    // The D line pairs POSITIONALLY with the S lines: id k belongs to spec k. A malformed S line is
+    // dropped by the >= 5 check above, which slides every later id onto the wrong spec — and restore
+    // would then adopt a live shell belonging to a different session, relabel it with this spec's
+    // name/app/cwd, and save that wrong pairing back. Damaged files are exactly what the .bak
+    // fallback exists to read, so refuse the ids rather than misapply them; the specs still restore,
+    // just as fresh sessions.
+    if (!ps.savedIds.empty() && ps.savedIds.size() != ps.specs.size()) {
+        logWarn("state: %zu saved id(s) for %zu session line(s) — the file is inconsistent, so live "
+                "sessions will not be adopted from it", ps.savedIds.size(), ps.specs.size());
+        ps.savedIds.clear();
     }
     return ps;
 }
@@ -5698,6 +5751,10 @@ static void parseLaunchArgs() {
         std::wstring clean;
         for (wchar_t c : g_argPipe)
             if (c >= 32 && !wcschr(L"\\/:*?\"<>|&^%", c)) clean += c;
+        // Length matters as much as content: the name also becomes the session-id prefix, and ids
+        // are formatted into a fixed 64-byte buffer (newSession). 32 is longer than any name worth
+        // typing and leaves room for "-<n>" many times over.
+        if (clean.size() > 32) clean.resize(32);
         while (!clean.empty() && (clean.back() == L' ' || clean.back() == L'.')) clean.pop_back();
         if (clean.empty()) clean = L"lite";
         g_argPipe = clean;

--- a/lite/src/main.cpp
+++ b/lite/src/main.cpp
@@ -1021,28 +1021,50 @@ static void loadCore() {
     if (core_abi() != kRequiredAbi) fatal(L"agwinterm_core.dll: ABI mismatch (need v15)");
 }
 
-static void connectControl() {
-    std::wstring control = std::wstring(kAppId) + L"-ptyhost";
-    g_control = openPipe(control, 0, false);
-    if (g_control == INVALID_HANDLE_VALUE) {
-        std::wstring cmd = L"\"" + exeDir() + L"\\agwinterm-ptyhost.exe\" --pipe " + kAppId;
-        STARTUPINFOW si{ sizeof(si) };
-        PROCESS_INFORMATION pi{};
-        std::vector<wchar_t> buf(cmd.begin(), cmd.end());
-        buf.push_back(0);
-        if (!CreateProcessW(nullptr, buf.data(), nullptr, nullptr, FALSE, CREATE_NO_WINDOW, nullptr, nullptr, &si, &pi))
-            fatal(L"could not start agwinterm-ptyhost.exe");
-        CloseHandle(pi.hThread);
-        CloseHandle(pi.hProcess);
-        g_control = openPipe(control, 5000, false);
-        if (g_control == INVALID_HANDLE_VALUE) fatal(L"pty-host control pipe never appeared");
-    }
+/// Handshake + liveness probe. `hello` alone is NOT enough: a pty-host whose client was killed is
+/// tearing down but still accepts a connection and answers hello for a moment, while refusing every
+/// real command. Believing that host is what made restore fail wholesale after lite was killed —
+/// every create came back false in the same millisecond and the sessions were simply gone. `list`
+/// is the cheapest request that actually touches the session table, so it is the real probe.
+static bool controlHandshake() {
     agwinterm_ptyhost_Request req = agwinterm_ptyhost_Request_init_default;
     agwinterm_ptyhost_Reply rep = agwinterm_ptyhost_Reply_init_default;
     req.which_cmd = agwinterm_ptyhost_Request_hello_tag;
     req.cmd.hello.protocol = kProtocolVersion;
-    if (!request(req, &rep) || rep.which_body != agwinterm_ptyhost_Reply_hello_tag)
-        fatal(L"pty-host hello failed (protocol mismatch?)");
+    if (!request(req, &rep) || rep.which_body != agwinterm_ptyhost_Reply_hello_tag) return false;
+    req = agwinterm_ptyhost_Request_init_default;
+    rep = agwinterm_ptyhost_Reply_init_default;
+    req.which_cmd = agwinterm_ptyhost_Request_list_tag;
+    return request(req, &rep) && rep.which_body == agwinterm_ptyhost_Reply_list_tag;
+}
+
+static void connectControl() {
+    std::wstring control = std::wstring(kAppId) + L"-ptyhost";
+    std::wstring cmd = L"\"" + exeDir() + L"\\agwinterm-ptyhost.exe\" --pipe " + kAppId;
+    for (int attempt = 0; attempt < 4; attempt++) {
+        g_control = openPipe(control, 0, false);
+        if (g_control == INVALID_HANDLE_VALUE) {   // no host yet: start one
+            STARTUPINFOW si{ sizeof(si) };
+            PROCESS_INFORMATION pi{};
+            std::vector<wchar_t> buf(cmd.begin(), cmd.end());
+            buf.push_back(0);
+            if (!CreateProcessW(nullptr, buf.data(), nullptr, nullptr, FALSE, CREATE_NO_WINDOW, nullptr, nullptr, &si, &pi))
+                fatal(L"could not start agwinterm-ptyhost.exe");
+            CloseHandle(pi.hThread);
+            CloseHandle(pi.hProcess);
+            g_control = openPipe(control, 5000, false);
+        }
+        if (g_control != INVALID_HANDLE_VALUE && controlHandshake()) {
+            if (attempt) logInfo("pty-host: healthy on attempt %d", attempt + 1);
+            return;
+        }
+        // Either nothing answered, or what answered is on its way out. Drop it and give the dying
+        // host time to release the pipe name so the next attempt can spawn a fresh one.
+        logWarn("pty-host: connection unusable (attempt %d) — retrying with a fresh host", attempt + 1);
+        if (g_control != INVALID_HANDLE_VALUE) { CloseHandle(g_control); g_control = INVALID_HANDLE_VALUE; }
+        Sleep(400);
+    }
+    fatal(L"pty-host did not become usable (protocol mismatch, or a previous host is stuck)");
 }
 
 // ---- pane geometry ----
@@ -1205,6 +1227,9 @@ static std::vector<Profile> detectProfiles() {
 }
 
 // cols/rows + an optional profile (app/args) and cwd. Default (no app) = PowerShell with the prompt wrap.
+static Session* attachSession(const char* id, int cols, int rows, const char* app,
+                              const std::vector<std::string>* pargs, const char* cwd);   // fwd
+
 static Session* newSession(int cols, int rows, const char* app = nullptr,
                            const std::vector<std::string>* pargs = nullptr, const char* cwd = nullptr) {
     char idbuf[64];
@@ -1250,14 +1275,23 @@ static Session* newSession(int cols, int rows, const char* app = nullptr,
     setEnv(4, "AGWINTERM_PANE_ID", idbuf);
     setEnv(5, "TERM_PROGRAM", "agwinterm-lite");
     if (!request(req, &rep)) return nullptr;
+    return attachSession(idbuf, cols, rows, app, pargs, cwd);
+}
 
-    req = agwinterm_ptyhost_Request_init_default;
+/// Attach to a session the host already has and wire it into the UI. Used for both halves of a
+/// normal create (create-then-attach) and for ADOPTING a session that outlived a previous lite:
+/// the pty-host is designed to survive the UI, so after a kill/crash/sign-out its shells are still
+/// running and can simply be picked back up, scrollback and all.
+static Session* attachSession(const char* id, int cols, int rows, const char* app,
+                              const std::vector<std::string>* pargs, const char* cwd) {
+    agwinterm_ptyhost_Request req = agwinterm_ptyhost_Request_init_default;
+    agwinterm_ptyhost_Reply rep = agwinterm_ptyhost_Reply_init_default;
     req.which_cmd = agwinterm_ptyhost_Request_attach_tag;
-    strcpy_s(req.cmd.attach.id, idbuf);
+    strcpy_s(req.cmd.attach.id, id);
     if (!request(req, &rep) || rep.which_body != agwinterm_ptyhost_Reply_attach_tag) return nullptr;
 
     Session* s = new Session();
-    s->id = idbuf;
+    s->id = id;
     s->app = app ? app : "";        // remember the launch spec for session restore
     if (pargs) s->args = *pargs;
     s->cwd = cwd ? cwd : "";
@@ -1266,12 +1300,29 @@ static Session* newSession(int cols, int rows, const char* app = nullptr,
     s->childPid = rep.body.attach.child_pid;
     s->data = openPipe(std::wstring(rep.body.attach.pipe, rep.body.attach.pipe + strlen(rep.body.attach.pipe)), 5000, true);
     if (s->data == INVALID_HANDLE_VALUE) { emu_free(s->emu); delete s; return nullptr; }
+    // NOTE: AttachReply.scrollback stays callback-decoded (unbounded), so an adopted session comes
+    // back live but with an empty screen rather than its history. The shell itself — and anything
+    // running in it — survives, which is the point; seeding history is a separate improvement.
     s->reader = CreateThread(nullptr, 0, readerThread, s, 0, nullptr);
     EnterCriticalSection(&g_lock);
     g_sessions.push_back(s);
     LeaveCriticalSection(&g_lock);
     PostMessageW(g_hwnd, WM_APP_REFRESHTREE, 0, 0);   // add the session to the tree (UI thread)
     return s;
+}
+
+/// Ids of the sessions the host currently holds. On a normal start this is empty; after lite was
+/// killed it still lists the shells from the previous run, which is what makes adoption possible
+/// (and what made every restore create collide with `session '<id>' already exists`).
+static std::vector<std::string> hostSessionIds() {
+    std::vector<std::string> ids;
+    agwinterm_ptyhost_Request req = agwinterm_ptyhost_Request_init_default;
+    agwinterm_ptyhost_Reply rep = agwinterm_ptyhost_Reply_init_default;
+    req.which_cmd = agwinterm_ptyhost_Request_list_tag;
+    if (!request(req, &rep) || rep.which_body != agwinterm_ptyhost_Reply_list_tag) return ids;
+    for (pb_size_t i = 0; i < rep.body.list.sessions_count; i++)
+        ids.push_back(rep.body.list.sessions[i].id);
+    return ids;
 }
 
 static void killSession(Session* s) {
@@ -1669,6 +1720,9 @@ static void saveSessionState() {
     for (const auto& w : g_workspaces) out += "W\t" + narrow(w) + "\n";
     EnterCriticalSection(&g_lock);
     std::string flagLine;   // "F\t<i>..." = indices (in S-line order) of flagged sessions; old builds skip it
+    // "D\t<id>..." = the host session ids, in S-line order — same in-order idiom as the F line, and
+    // additive so a 0.17.x file (which has no D line) still restores, just without adoption.
+    std::string idLine;
     int saved = 0;
     for (const Session* s : g_sessions) {
         if (s->hidden) continue;
@@ -1677,10 +1731,12 @@ static void saveSessionState() {
         for (const auto& a : s->args) out += "\t" + a;
         out += "\n";
         if (s->flagged) flagLine += "\t" + std::to_string(saved);
+        idLine += "\t" + s->id;
         saved++;
     }
     LeaveCriticalSection(&g_lock);
     if (!flagLine.empty()) out += "F" + flagLine + "\n";
+    if (!idLine.empty()) out += "D" + idLine + "\n";
     out += "A\t" + std::to_string(g_activeWs) + "\n";
     HANDLE f = CreateFileW(path.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
     if (f == INVALID_HANDLE_VALUE) {
@@ -5245,6 +5301,7 @@ static bool restoreSessions() {
     std::vector<std::wstring> wss;
     struct Spec { int ws; std::string name, app, cwd; std::vector<std::string> args; bool flagged = false; };
     std::vector<Spec> specs;
+    std::vector<std::string> savedIds;   // from the D line; empty for a pre-0.17.3 file
     int activeWs = 0, focusWs = -1;
     size_t i = 0;
     auto split = [](const std::string& l) {
@@ -5269,6 +5326,8 @@ static bool restoreSessions() {
                 int fi = atoi(ff[k].c_str());
                 if (fi >= 0 && fi < (int)specs.size()) specs[fi].flagged = true;
             }
+        } else if (ff[0] == "D") {   // host session ids, in S-line order (absent in 0.17.x files)
+            for (size_t k = 1; k < ff.size(); k++) savedIds.push_back(ff[k]);
         } else if (ff[0] == "O" && ff.size() >= 2) focusWs = atoi(ff[1].c_str());
         else if (ff[0] == "A" && ff.size() >= 2) activeWs = atoi(ff[1].c_str());
     }
@@ -5282,11 +5341,43 @@ static bool restoreSessions() {
     g_restoring = true;
     if (!wss.empty()) g_workspaces = wss;
     int cols, rows; paneGridSize(0, &cols, &rows);
-    int firstIdx = -1, built = 0;
-    for (const auto& sp : specs) {
+    int firstIdx = -1, built = 0, adopted = 0;
+
+    // Sessions the host still holds. lite was killed rather than closed if this is non-empty: the
+    // pty-host outlives the UI by design, so those shells are STILL RUNNING. Adopt them instead of
+    // creating new ones — which also fixes the wholesale restore failure, because a create against
+    // an id the host already has is rejected ("session '<id>' already exists") and used to sink
+    // every single spec.
+    std::vector<std::string> live = hostSessionIds();
+    logInfo("restore: %zu saved id(s) in the file, host holds %zu live session(s)%s%s",
+            savedIds.size(), live.size(), live.empty() ? "" : ": ",
+            live.empty() ? "" : live[0].c_str());
+    auto isLive = [&](const std::string& id) {
+        return !id.empty() && std::find(live.begin(), live.end(), id) != live.end();
+    };
+    // Never hand out an id the host is already using, for the sessions we do have to create.
+    for (const auto& id : live) {
+        size_t dash = id.rfind('-');
+        if (dash != std::string::npos && id.compare(0, dash, g_idPrefix) == 0) {
+            int n = atoi(id.c_str() + dash + 1);
+            if (n >= g_seq) g_seq = n + 1;
+        }
+    }
+
+    for (size_t si = 0; si < specs.size(); si++) {
+        const auto& sp = specs[si];
         g_activeWs = (sp.ws >= 0 && sp.ws < (int)g_workspaces.size()) ? sp.ws : 0;
-        Session* s = newSession(cols, rows, sp.app.empty() ? nullptr : sp.app.c_str(),
-                                sp.args.empty() ? nullptr : &sp.args, sp.cwd.empty() ? nullptr : sp.cwd.c_str());
+        std::string want = si < savedIds.size() ? savedIds[si] : std::string();
+        Session* s = nullptr;
+        if (isLive(want)) {
+            s = attachSession(want.c_str(), cols, rows, sp.app.empty() ? nullptr : sp.app.c_str(),
+                              sp.args.empty() ? nullptr : &sp.args, sp.cwd.empty() ? nullptr : sp.cwd.c_str());
+            if (s) { adopted++; logInfo("restore: adopted live session '%s' (%s)", want.c_str(), sp.name.c_str()); }
+            else logWarn("restore: adopt of live session '%s' failed — creating a fresh one", want.c_str());
+        }
+        if (!s)
+            s = newSession(cols, rows, sp.app.empty() ? nullptr : sp.app.c_str(),
+                           sp.args.empty() ? nullptr : &sp.args, sp.cwd.empty() ? nullptr : sp.cwd.c_str());
         if (s) {
             s->name = widen(sp.name); s->flagged = sp.flagged;
             if (firstIdx < 0) firstIdx = (int)g_sessions.size() - 1;
@@ -5299,7 +5390,8 @@ static bool restoreSessions() {
         }
     }
     g_restoring = false;
-    logInfo("restore: %d of %zu session(s) built", built, specs.size());
+    logInfo("restore: %d of %zu session(s) built (%d adopted live from the pty-host)",
+            built, specs.size(), adopted);
     if (firstIdx < 0) {   // exit 4 of 4: specs parsed but nothing could be started
         logWarn("restore: no session could be started from %zu spec(s) — starting fresh", specs.size());
         return false;

--- a/lite/src/proto/ptyhost.pb.c
+++ b/lite/src/proto/ptyhost.pb.c
@@ -33,7 +33,7 @@ PB_BIND(agwinterm_ptyhost_List, agwinterm_ptyhost_List, AUTO)
 PB_BIND(agwinterm_ptyhost_Shutdown, agwinterm_ptyhost_Shutdown, AUTO)
 
 
-PB_BIND(agwinterm_ptyhost_Reply, agwinterm_ptyhost_Reply, 2)
+PB_BIND(agwinterm_ptyhost_Reply, agwinterm_ptyhost_Reply, 4)
 
 
 PB_BIND(agwinterm_ptyhost_HelloReply, agwinterm_ptyhost_HelloReply, AUTO)
@@ -45,10 +45,10 @@ PB_BIND(agwinterm_ptyhost_CreateReply, agwinterm_ptyhost_CreateReply, AUTO)
 PB_BIND(agwinterm_ptyhost_AttachReply, agwinterm_ptyhost_AttachReply, 2)
 
 
-PB_BIND(agwinterm_ptyhost_SessionInfo, agwinterm_ptyhost_SessionInfo, AUTO)
+PB_BIND(agwinterm_ptyhost_SessionInfo, agwinterm_ptyhost_SessionInfo, 2)
 
 
-PB_BIND(agwinterm_ptyhost_ListReply, agwinterm_ptyhost_ListReply, AUTO)
+PB_BIND(agwinterm_ptyhost_ListReply, agwinterm_ptyhost_ListReply, 4)
 
 
 

--- a/lite/src/proto/ptyhost.pb.c
+++ b/lite/src/proto/ptyhost.pb.c
@@ -45,7 +45,7 @@ PB_BIND(agwinterm_ptyhost_CreateReply, agwinterm_ptyhost_CreateReply, AUTO)
 PB_BIND(agwinterm_ptyhost_AttachReply, agwinterm_ptyhost_AttachReply, 2)
 
 
-PB_BIND(agwinterm_ptyhost_SessionInfo, agwinterm_ptyhost_SessionInfo, 2)
+PB_BIND(agwinterm_ptyhost_SessionInfo, agwinterm_ptyhost_SessionInfo, AUTO)
 
 
 PB_BIND(agwinterm_ptyhost_ListReply, agwinterm_ptyhost_ListReply, 4)

--- a/lite/src/proto/ptyhost.pb.h
+++ b/lite/src/proto/ptyhost.pb.h
@@ -103,7 +103,7 @@ typedef struct _agwinterm_ptyhost_SessionInfo {
     uint32_t child_pid;
     bool has_exited;
     int32_t exit_code;
-    char title[256];
+    pb_callback_t title;
     bool attached;
 } agwinterm_ptyhost_SessionInfo;
 
@@ -143,7 +143,7 @@ extern "C" {
 #define agwinterm_ptyhost_HelloReply_init_default {0, 0}
 #define agwinterm_ptyhost_CreateReply_init_default {""}
 #define agwinterm_ptyhost_AttachReply_init_default {"", 0, 0, 0, 0, 0, "", {{NULL}, NULL}, {{NULL}, NULL}}
-#define agwinterm_ptyhost_SessionInfo_init_default {"", 0, 0, 0, 0, 0, "", 0}
+#define agwinterm_ptyhost_SessionInfo_init_default {"", 0, 0, 0, 0, 0, {{NULL}, NULL}, 0}
 #define agwinterm_ptyhost_ListReply_init_default {0, {agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default}}
 #define agwinterm_ptyhost_Request_init_zero      {0, {agwinterm_ptyhost_Hello_init_zero}}
 #define agwinterm_ptyhost_Hello_init_zero        {0}
@@ -158,7 +158,7 @@ extern "C" {
 #define agwinterm_ptyhost_HelloReply_init_zero   {0, 0}
 #define agwinterm_ptyhost_CreateReply_init_zero  {""}
 #define agwinterm_ptyhost_AttachReply_init_zero  {"", 0, 0, 0, 0, 0, "", {{NULL}, NULL}, {{NULL}, NULL}}
-#define agwinterm_ptyhost_SessionInfo_init_zero  {"", 0, 0, 0, 0, 0, "", 0}
+#define agwinterm_ptyhost_SessionInfo_init_zero  {"", 0, 0, 0, 0, 0, {{NULL}, NULL}, 0}
 #define agwinterm_ptyhost_ListReply_init_zero    {0, {agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero}}
 
 /* Field tags (for use in manual encoding/decoding) */
@@ -337,9 +337,9 @@ X(a, STATIC,   SINGULAR, UINT32,   rows,              3) \
 X(a, STATIC,   SINGULAR, UINT32,   child_pid,         4) \
 X(a, STATIC,   SINGULAR, BOOL,     has_exited,        5) \
 X(a, STATIC,   SINGULAR, INT32,    exit_code,         6) \
-X(a, STATIC,   SINGULAR, STRING,   title,             7) \
+X(a, CALLBACK, SINGULAR, STRING,   title,             7) \
 X(a, STATIC,   SINGULAR, BOOL,     attached,          8)
-#define agwinterm_ptyhost_SessionInfo_CALLBACK NULL
+#define agwinterm_ptyhost_SessionInfo_CALLBACK pb_default_field_callback
 #define agwinterm_ptyhost_SessionInfo_DEFAULT NULL
 
 #define agwinterm_ptyhost_ListReply_FIELDLIST(X, a) \
@@ -384,6 +384,8 @@ extern const pb_msgdesc_t agwinterm_ptyhost_ListReply_msg;
 /* Maximum encoded size of messages (where known) */
 /* agwinterm_ptyhost_Reply_size depends on runtime parameters */
 /* agwinterm_ptyhost_AttachReply_size depends on runtime parameters */
+/* agwinterm_ptyhost_SessionInfo_size depends on runtime parameters */
+/* agwinterm_ptyhost_ListReply_size depends on runtime parameters */
 #define AGWINTERM_PTYHOST_PTYHOST_PB_H_MAX_SIZE  agwinterm_ptyhost_Request_size
 #define agwinterm_ptyhost_Attach_size            132
 #define agwinterm_ptyhost_CreateReply_size       130
@@ -391,11 +393,9 @@ extern const pb_msgdesc_t agwinterm_ptyhost_ListReply_msg;
 #define agwinterm_ptyhost_Create_size            35568
 #define agwinterm_ptyhost_HelloReply_size        12
 #define agwinterm_ptyhost_Hello_size             6
-#define agwinterm_ptyhost_ListReply_size         27136
 #define agwinterm_ptyhost_List_size              0
 #define agwinterm_ptyhost_Request_size           35572
 #define agwinterm_ptyhost_Resize_size            142
-#define agwinterm_ptyhost_SessionInfo_size       421
 #define agwinterm_ptyhost_SessionRef_size        130
 #define agwinterm_ptyhost_Shutdown_size          0
 

--- a/lite/src/proto/ptyhost.pb.h
+++ b/lite/src/proto/ptyhost.pb.h
@@ -88,22 +88,28 @@ typedef struct _agwinterm_ptyhost_AttachReply {
     bool has_exited;
     int32_t exit_code;
     char modes[1024]; /* synthesized VT reproducing mode state (DumpModes) */
-    pb_callback_t scrollback; /* plain-text history rows, oldest first */
+    pb_callback_t scrollback; /* plain-text history rows, oldest first (back-compat / lite) */
+    /* Full-fidelity attributed scrollback: a serialized agwinterm.persist.PBuffer of the HISTORY
+ rows (colours + styles). When present the client seeds from this instead of the plain text,
+ so a reattached view is not dim-until-repaint. Empty when the host can't produce it (a Rust
+ host without persist support yet); the client falls back to `scrollback`. */
+    pb_callback_t scrollback_blob;
 } agwinterm_ptyhost_AttachReply;
 
 typedef struct _agwinterm_ptyhost_SessionInfo {
-    pb_callback_t id;
+    char id[128];
     uint32_t cols;
     uint32_t rows;
     uint32_t child_pid;
     bool has_exited;
     int32_t exit_code;
-    pb_callback_t title;
+    char title[256];
     bool attached;
 } agwinterm_ptyhost_SessionInfo;
 
 typedef struct _agwinterm_ptyhost_ListReply {
-    pb_callback_t sessions;
+    pb_size_t sessions_count;
+    agwinterm_ptyhost_SessionInfo sessions[64];
 } agwinterm_ptyhost_ListReply;
 
 typedef struct _agwinterm_ptyhost_Reply {
@@ -136,9 +142,9 @@ extern "C" {
 #define agwinterm_ptyhost_Reply_init_default     {0, "", 0, {agwinterm_ptyhost_HelloReply_init_default}}
 #define agwinterm_ptyhost_HelloReply_init_default {0, 0}
 #define agwinterm_ptyhost_CreateReply_init_default {""}
-#define agwinterm_ptyhost_AttachReply_init_default {"", 0, 0, 0, 0, 0, "", {{NULL}, NULL}}
-#define agwinterm_ptyhost_SessionInfo_init_default {{{NULL}, NULL}, 0, 0, 0, 0, 0, {{NULL}, NULL}, 0}
-#define agwinterm_ptyhost_ListReply_init_default {{{NULL}, NULL}}
+#define agwinterm_ptyhost_AttachReply_init_default {"", 0, 0, 0, 0, 0, "", {{NULL}, NULL}, {{NULL}, NULL}}
+#define agwinterm_ptyhost_SessionInfo_init_default {"", 0, 0, 0, 0, 0, "", 0}
+#define agwinterm_ptyhost_ListReply_init_default {0, {agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default, agwinterm_ptyhost_SessionInfo_init_default}}
 #define agwinterm_ptyhost_Request_init_zero      {0, {agwinterm_ptyhost_Hello_init_zero}}
 #define agwinterm_ptyhost_Hello_init_zero        {0}
 #define agwinterm_ptyhost_Create_init_zero       {"", 0, 0, "", 0, {"", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""}, "", 0, 0, 0, 0, {agwinterm_ptyhost_Create_EnvEntry_init_zero, agwinterm_ptyhost_Create_EnvEntry_init_zero, agwinterm_ptyhost_Create_EnvEntry_init_zero, agwinterm_ptyhost_Create_EnvEntry_init_zero, agwinterm_ptyhost_Create_EnvEntry_init_zero, agwinterm_ptyhost_Create_EnvEntry_init_zero, agwinterm_ptyhost_Create_EnvEntry_init_zero, agwinterm_ptyhost_Create_EnvEntry_init_zero}}
@@ -151,9 +157,9 @@ extern "C" {
 #define agwinterm_ptyhost_Reply_init_zero        {0, "", 0, {agwinterm_ptyhost_HelloReply_init_zero}}
 #define agwinterm_ptyhost_HelloReply_init_zero   {0, 0}
 #define agwinterm_ptyhost_CreateReply_init_zero  {""}
-#define agwinterm_ptyhost_AttachReply_init_zero  {"", 0, 0, 0, 0, 0, "", {{NULL}, NULL}}
-#define agwinterm_ptyhost_SessionInfo_init_zero  {{{NULL}, NULL}, 0, 0, 0, 0, 0, {{NULL}, NULL}, 0}
-#define agwinterm_ptyhost_ListReply_init_zero    {{{NULL}, NULL}}
+#define agwinterm_ptyhost_AttachReply_init_zero  {"", 0, 0, 0, 0, 0, "", {{NULL}, NULL}, {{NULL}, NULL}}
+#define agwinterm_ptyhost_SessionInfo_init_zero  {"", 0, 0, 0, 0, 0, "", 0}
+#define agwinterm_ptyhost_ListReply_init_zero    {0, {agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero, agwinterm_ptyhost_SessionInfo_init_zero}}
 
 /* Field tags (for use in manual encoding/decoding) */
 #define agwinterm_ptyhost_Hello_protocol_tag     1
@@ -194,6 +200,7 @@ extern "C" {
 #define agwinterm_ptyhost_AttachReply_exit_code_tag 6
 #define agwinterm_ptyhost_AttachReply_modes_tag  7
 #define agwinterm_ptyhost_AttachReply_scrollback_tag 8
+#define agwinterm_ptyhost_AttachReply_scrollback_blob_tag 9
 #define agwinterm_ptyhost_SessionInfo_id_tag     1
 #define agwinterm_ptyhost_SessionInfo_cols_tag   2
 #define agwinterm_ptyhost_SessionInfo_rows_tag   3
@@ -318,25 +325,26 @@ X(a, STATIC,   SINGULAR, UINT32,   child_pid,         4) \
 X(a, STATIC,   SINGULAR, BOOL,     has_exited,        5) \
 X(a, STATIC,   SINGULAR, INT32,    exit_code,         6) \
 X(a, STATIC,   SINGULAR, STRING,   modes,             7) \
-X(a, CALLBACK, REPEATED, STRING,   scrollback,        8)
+X(a, CALLBACK, REPEATED, STRING,   scrollback,        8) \
+X(a, CALLBACK, SINGULAR, BYTES,    scrollback_blob,   9)
 #define agwinterm_ptyhost_AttachReply_CALLBACK pb_default_field_callback
 #define agwinterm_ptyhost_AttachReply_DEFAULT NULL
 
 #define agwinterm_ptyhost_SessionInfo_FIELDLIST(X, a) \
-X(a, CALLBACK, SINGULAR, STRING,   id,                1) \
+X(a, STATIC,   SINGULAR, STRING,   id,                1) \
 X(a, STATIC,   SINGULAR, UINT32,   cols,              2) \
 X(a, STATIC,   SINGULAR, UINT32,   rows,              3) \
 X(a, STATIC,   SINGULAR, UINT32,   child_pid,         4) \
 X(a, STATIC,   SINGULAR, BOOL,     has_exited,        5) \
 X(a, STATIC,   SINGULAR, INT32,    exit_code,         6) \
-X(a, CALLBACK, SINGULAR, STRING,   title,             7) \
+X(a, STATIC,   SINGULAR, STRING,   title,             7) \
 X(a, STATIC,   SINGULAR, BOOL,     attached,          8)
-#define agwinterm_ptyhost_SessionInfo_CALLBACK pb_default_field_callback
+#define agwinterm_ptyhost_SessionInfo_CALLBACK NULL
 #define agwinterm_ptyhost_SessionInfo_DEFAULT NULL
 
 #define agwinterm_ptyhost_ListReply_FIELDLIST(X, a) \
-X(a, CALLBACK, REPEATED, MESSAGE,  sessions,          1)
-#define agwinterm_ptyhost_ListReply_CALLBACK pb_default_field_callback
+X(a, STATIC,   REPEATED, MESSAGE,  sessions,          1)
+#define agwinterm_ptyhost_ListReply_CALLBACK NULL
 #define agwinterm_ptyhost_ListReply_DEFAULT NULL
 #define agwinterm_ptyhost_ListReply_sessions_MSGTYPE agwinterm_ptyhost_SessionInfo
 
@@ -376,8 +384,6 @@ extern const pb_msgdesc_t agwinterm_ptyhost_ListReply_msg;
 /* Maximum encoded size of messages (where known) */
 /* agwinterm_ptyhost_Reply_size depends on runtime parameters */
 /* agwinterm_ptyhost_AttachReply_size depends on runtime parameters */
-/* agwinterm_ptyhost_SessionInfo_size depends on runtime parameters */
-/* agwinterm_ptyhost_ListReply_size depends on runtime parameters */
 #define AGWINTERM_PTYHOST_PTYHOST_PB_H_MAX_SIZE  agwinterm_ptyhost_Request_size
 #define agwinterm_ptyhost_Attach_size            132
 #define agwinterm_ptyhost_CreateReply_size       130
@@ -385,9 +391,11 @@ extern const pb_msgdesc_t agwinterm_ptyhost_ListReply_msg;
 #define agwinterm_ptyhost_Create_size            35568
 #define agwinterm_ptyhost_HelloReply_size        12
 #define agwinterm_ptyhost_Hello_size             6
+#define agwinterm_ptyhost_ListReply_size         27136
 #define agwinterm_ptyhost_List_size              0
 #define agwinterm_ptyhost_Request_size           35572
 #define agwinterm_ptyhost_Resize_size            142
+#define agwinterm_ptyhost_SessionInfo_size       421
 #define agwinterm_ptyhost_SessionRef_size        130
 #define agwinterm_ptyhost_Shutdown_size          0
 

--- a/lite/test/log-restore.ps1
+++ b/lite/test/log-restore.ps1
@@ -17,7 +17,9 @@ $dir   = "$env:LOCALAPPDATA\agwinterm-lite"
 $log   = "$dir\lite-$pipe.log"
 $state = "$dir\sessions-$pipe.tsv"
 $ctl   = "$env:LOCALAPPDATA\Programs\agwinterm\agwintermctl.exe"
-Remove-Item $log, "$log.old", $state -ErrorAction SilentlyContinue
+# The .bak and .tmp go too: since the save keeps a previous generation, leaving one behind means
+# run 1 is NOT a first run — it falls back to the last suite run's sessions and every count is off.
+Remove-Item $log, "$log.old", $state, "$state.bak", "$state.tmp" -ErrorAction SilentlyContinue
 
 "== log-restore =="
 
@@ -46,9 +48,14 @@ if ($save.Success) {
 $p2 = Start-Process $Exe -ArgumentList @('--pipe', $pipe) -PassThru
 Start-Sleep -Seconds 8
 $text2 = Get-Content $log -Raw
-$spec = [regex]::Match($text2, 'restore: (\d+) spec\(s\) from')
+# The log accumulates across runs, so read the LAST restore — the first one belongs to run 1.
+function LastMatch([string]$text, [string]$pattern) {
+    $m = [regex]::Matches($text, $pattern)
+    if ($m.Count) { $m[$m.Count - 1] } else { [regex]::Match('', 'x') }
+}
+$spec = LastMatch $text2 'restore: (\d+) spec\(s\) from'
 Check 'restore reports the spec count' $spec.Success
-$built = [regex]::Match($text2, 'restore: (\d+) of (\d+) session\(s\) built')
+$built = LastMatch $text2 'restore: (\d+) of (\d+) session\(s\) built'
 Check 'restore reports how many were built' $built.Success
 if ($built.Success -and $save.Success) {
     Check 'built count matches what was saved' ($built.Groups[1].Value -eq $save.Groups[1].Value) `

--- a/lite/test/log-restore.ps1
+++ b/lite/test/log-restore.ps1
@@ -67,12 +67,18 @@ if (-not $p2.HasExited) { Stop-Process -Id $p2.Id -Force }
 Start-Sleep -Seconds 1
 
 # --- error case: a zero-byte state file must be NAMED, not silently ignored --------------------
-Remove-Item $log -ErrorAction SilentlyContinue
+# The .bak goes too. Run 2's save left one behind, and with it there restore takes the FALLBACK path
+# instead of the empty-file one — the check would still pass while testing something else entirely.
+Remove-Item $log, "$state.bak" -ErrorAction SilentlyContinue
 Set-Content -Path $state -Value '' -NoNewline
 $p3 = Start-Process $Exe -ArgumentList @('--pipe', $pipe) -PassThru
 Start-Sleep -Seconds 8
 $text3 = Get-Content $log -Raw
 Check 'empty state file is reported as EMPTY' ($text3 -match 'restore: state file is EMPTY')
+Check 'with no .bak either, it starts fresh' ($text3 -match 'starting fresh')
+# ...and the window is actually usable: a log line proves nothing if lite died right after writing it.
+$alive = ((& $ctl tree --json --pipe $pipe 2>&1) -join '') -match '"ok":true'
+Check 'lite still answers after an empty state file' $alive
 $p3.CloseMainWindow() | Out-Null
 Start-Sleep -Seconds 4
 if (-not $p3.HasExited) { Stop-Process -Id $p3.Id -Force }

--- a/lite/test/restore-matrix.ps1
+++ b/lite/test/restore-matrix.ps1
@@ -202,6 +202,89 @@ Cell -Name 'shell-exited' -Setup {
     Start-Sleep -Seconds 3
 } -Assert { param($b, $a) $a -eq $b }
 
+# --- "Restart everything" must come back as the SAME instance ----------------------------------
+# restartApp() used to relaunch the bare exe, so a named window restarted as the DEFAULT instance
+# and read a different sessions file. Nothing crashed; the sessions were simply someone else's.
+
+function Find-Lite($inst) {
+    Get-CimInstance Win32_Process -Filter "Name='agwinterm-lite.exe'" |
+        Where-Object { $_.CommandLine -match [regex]::Escape($inst) } |
+        ForEach-Object { Get-Process -Id $_.ProcessId -ErrorAction SilentlyContinue }
+}
+
+function Restart-Cell {
+    param([string]$Name)
+    if ($Only -and $Only -ne $Name) { return }
+    $inst = "rm-$Name"
+    Reset-Cell $inst
+    $before = ''; $after = ''; $err = ''
+    try {
+        $p = Start-Lite $inst
+        & $ctl session new --pipe $inst 2>&1 | Out-Null
+        Start-Sleep -Seconds 2
+        $before = Signature $inst
+        $oldId = $p.Id
+
+        # File > Restart everything (IDM_RESTART = 103), posted — never injected globally.
+        $p.Refresh()
+        if (-not $p.MainWindowHandle -or $p.MainWindowHandle -eq 0) { throw "no main window for $inst" }
+        [void][Win32Post]::PostMessageW($p.MainWindowHandle, 0x0111, [IntPtr]103, [IntPtr]::Zero)
+
+        for ($i = 0; $i -lt 25; $i++) { Start-Sleep -Milliseconds 400; $p.Refresh(); if ($p.HasExited) { break } }
+        if (-not $p.HasExited) { throw 'the old instance never exited after Restart everything' }
+
+        # The relaunch is a detached grandchild (cmd /c ping & start), so wait for its pipe.
+        $p2 = $null
+        for ($i = 0; $i -lt 40; $i++) {
+            Start-Sleep -Milliseconds 500
+            $r = (& $ctl tree --json --pipe $inst 2>&1) -join ''
+            if ($r -match '"ok":true') { $p2 = @(Find-Lite $inst | Where-Object { $_.Id -ne $oldId })[0]; break }
+        }
+        if (-not $p2) { throw 'the restarted instance never answered its control pipe' }
+        Start-Sleep -Seconds 2
+        $after = Signature $inst
+        Stop-Lite $p2
+    } catch { $err = $_.Exception.Message }
+
+    if (-not $err -and $after -eq $before -and ($before -split '\|').Count -ge 2) {
+        "  PASS  {0,-22} [{1}]" -f $Name, $after
+    } else {
+        $script:failed += $Name
+        "  FAIL  {0,-22}" -f $Name
+        if ($err) { "        error:  $err" }
+        "        before: [$before]"
+        "        after:  [$after]"
+        "        log:    $(Restore-Verdict $inst)"
+    }
+}
+
+if (-not ('Win32Post' -as [type])) {
+    Add-Type -Namespace '' -Name Win32Post -MemberDefinition @'
+[DllImport("user32.dll", SetLastError=true, CharSet=CharSet.Unicode)]
+public static extern bool PostMessageW(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+'@
+}
+
+Restart-Cell -Name 'restart-named'
+
+# The no-regression half: the DEFAULT instance must still relaunch as the default (no stray --pipe).
+# Checked through --diagnose's "restart cmdline", which is the exact string restartApp() launches —
+# the default instance owns real user state and this suite never starts it.
+if (-not $Only -or $Only -eq 'restart-cmdline') {
+    $named = (& $Exe --pipe rm-restart-cmdline --diagnose 2>&1 | Out-String)
+    $plain = (& $Exe --diagnose 2>&1 | Out-String)
+    $nOk = $named -match '(?m)^\s*restart cmdline: .*agwinterm-lite\.exe" --pipe "rm-restart-cmdline"'
+    $dOk = ($plain -match '(?m)^\s*restart cmdline: .*agwinterm-lite\.exe"\s*$') -and ($plain -notmatch 'restart cmdline: .*--pipe')
+    if ($nOk -and $dOk) {
+        "  PASS  {0,-22} (named keeps --pipe; default stays bare)" -f 'restart-cmdline'
+    } else {
+        $script:failed += 'restart-cmdline'
+        "  FAIL  restart-cmdline"
+        "        named:   $(($named -split "`n" | Where-Object { $_ -match 'restart cmdline' }) -join '')"
+        "        default: $(($plain -split "`n" | Where-Object { $_ -match 'restart cmdline' }) -join '')"
+    }
+}
+
 # --- harness self-check: a deliberately corrupted state file MUST fail a cell -------------------
 # Without this, a harness that silently passes everything would be indistinguishable from a
 # working restore — which is exactly the trap this whole exercise exists to avoid.

--- a/lite/test/restore-matrix.ps1
+++ b/lite/test/restore-matrix.ps1
@@ -238,8 +238,17 @@ function Seeded {
 }
 
 $cwd = (Resolve-Path "$PSScriptRoot\..").Path
-Seeded -Name 'app-spec' -Tsv "V1`nW`tws-a`nS`t0`tprofile-session`tpowershell.exe`t$cwd`nA`t0`n" -Assert {
-    param($a) $a -match 'profile-session'
+# The name coming back is only half of it: a build that dropped app/args from the S line on re-save,
+# or restored the spec as a plain default shell, would pass a name-only assertion. Check the re-saved
+# S line still carries the app AND its args — that is the shape a shell profile actually produces.
+Seeded -Name 'app-spec' `
+    -Tsv "V1`nW`tws-a`nS`t0`tprofile-session`tpowershell.exe`t$cwd`t-NoLogo`t-NoExit`nA`t0`n" -Assert {
+    param($a, $i)
+    if ($a -notmatch 'profile-session') { return $false }
+    $line = @(Get-Content (State $i) | Where-Object { $_ -match 'profile-session' })[0]
+    $f = $line -split "`t"
+    # S <ws> <name> <app> <cwd> <arg0> <arg1>
+    ($f[3] -eq 'powershell.exe') -and ($f[5] -eq '-NoLogo') -and ($f[6] -eq '-NoExit')
 }
 
 # A spec whose app does not exist on this machine — the shape of "a profile that doesn't resolve
@@ -418,6 +427,22 @@ function Find-Lite($inst) {
         ForEach-Object { Get-Process -Id $_.ProcessId -ErrorAction SilentlyContinue }
 }
 
+# Every agwinterm-lite.exe alive right now, by pid. Snapshotted before the restart so anything the
+# restart itself produces can be told apart from the user's own running lite.
+function Lite-Pids { @(Get-CimInstance Win32_Process -Filter "Name='agwinterm-lite.exe'" | ForEach-Object { $_.ProcessId }) }
+
+# The regression this cell exists to catch is also the regression that makes it dangerous: if
+# restartCommandLine() ever drops the --pipe, "Restart everything" relaunches as the DEFAULT
+# instance, which owns the user's REAL sessions.tsv and would overwrite it on its next save. The
+# cell's own $p2 lookup finds nothing in that case and throws, so nothing else would ever stop it.
+function Stop-Stray-Lite($known) {
+    Get-CimInstance Win32_Process -Filter "Name='agwinterm-lite.exe'" |
+        Where-Object { $known -notcontains $_.ProcessId } | ForEach-Object {
+            "        (stopping stray lite pid $($_.ProcessId): $($_.CommandLine))"
+            Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue
+        }
+}
+
 function Restart-Cell {
     param([string]$Name)
     if ($Only -and $Only -ne $Name) { return }
@@ -425,8 +450,10 @@ function Restart-Cell {
     Reset-Cell $inst
     $before = ''; $after = ''; $err = ''
     $p = $null; $p2 = $null
+    $known = Lite-Pids                        # includes the user's own lite, which must NOT be touched
     try {
         $p = Start-Lite $inst
+        $known += $p.Id
         & $ctl session new --pipe $inst 2>&1 | Out-Null
         Start-Sleep -Seconds 2
         $before = Signature $inst
@@ -448,12 +475,13 @@ function Restart-Cell {
             if ($r -match '"ok":true') { $p2 = @(Find-Lite $inst | Where-Object { $_.Id -ne $oldId })[0]; break }
         }
         if (-not $p2) { throw 'the restarted instance never answered its control pipe' }
+        $known += $p2.Id
         Start-Sleep -Seconds 2
         $after = Signature $inst
         Stop-Lite $p2; $p2 = $null
         $p = $null   # already exited: that is what this cell just asserted
     } catch { $err = $_.Exception.Message }
-    finally { Stop-Leftover $p; Stop-Leftover $p2 }
+    finally { Stop-Leftover $p; Stop-Leftover $p2; Stop-Stray-Lite $known }
 
     if (-not $err -and $after -eq $before -and (SessionCount $before) -ge 2) {
         "  PASS  {0,-22} [{1}]" -f $Name, $after
@@ -784,6 +812,65 @@ Seeded -Name 'no-workspaces' `
 Seeded -Name 'stray-ws-index' `
     -Tsv "V1`nW`tonly-ws`nS`t7`tstray-session`t`t$cwd`nS`t0`thome-session`t`t$cwd`nF`t9`nA`t9`n" -Assert {
     param($a, $i) ($a -match 'stray-session') -and ($a -match 'home-session') -and ($a -match 'only-ws')
+}
+
+# Fields longer than the protocol's fixed-size wire storage. This is NOT a hand-edit-only case: the
+# save persists the shell's live cwd read straight out of its PEB, which has no MAX_PATH limit, so a
+# session sitting in a deep directory (long paths enabled, nested node_modules) writes a cwd lite
+# then has to read back. strcpy_s does not truncate on overflow — it terminates the process — so
+# before the fix this file killed lite at launch with no window and no log line. Both sessions must
+# come back: the long cwd is dropped (the session starts in the default dir), the long ARG cannot be
+# truncated without changing the command, so that spec is kept as a dead entry instead.
+$longCwd = 'C:\' + ('deep-directory-name\' * 25)
+$longArg = '-x' + ('y' * 3000)
+Seeded -Name 'oversize-fields' `
+    -Tsv "V1`nW`tws-o`nS`t0`tlong-cwd-session`t`t$longCwd`nS`t0`tlong-arg-session`tpowershell.exe`t$cwd`t$longArg`nA`t0`n" -Assert {
+    param($a, $i)
+    ($a -match 'long-cwd-session') -and ($a -match 'long-arg-session') -and
+    (Log-Has $i 'does not fit the protocol field') -and (Log-Has $i 'arg 0 is')
+}
+
+# A session NAME carrying the state file's own delimiters. session.rename takes a JSON string, and
+# jsonParseString decodes \t and \n, so the name arrives with real control characters in it — and the
+# file is tab-separated and newline-delimited. Unescaped, the name below appends a whole second `S`
+# line, which the next launch starts as a real session running whatever app it names. (It also puts
+# the S count out of step with the D line, which switches adoption off for the entire file.) The
+# state file must come back with exactly ONE session line and no trace of the injected one.
+if (-not $Only -or $Only -eq 'name-injection') {
+    $inst = 'rm-name-injection'
+    Reset-Cell $inst
+    $err = ''; $lines = 0; $after = ''; $renamed = ''; $count = 0; $forged = 0
+    $p = $null; $p2 = $null
+    try {
+        $p = Start-Lite $inst
+        $id = LastSessionId $inst
+        $evil = 'pwn' + [char]10 + 'S' + [char]9 + '0' + [char]9 + 'injected' + [char]9 + 'notepad.exe' + [char]9
+        $renamed = (& $ctl session rename $evil --target $id --pipe $inst 2>&1) -join ''
+        Start-Sleep -Seconds 2
+        Stop-Lite $p; $p = $null
+        $lines = @(Get-Content (State $inst) | Where-Object { $_ -match "^S`t" }).Count
+        $p2 = Start-Lite $inst
+        Start-Sleep -Seconds 3
+        # Count sessions, don't grep the signature: the payload survives as ordinary TEXT inside the
+        # one session's name (that is the fix working), so 'injected' appearing there is expected.
+        $count = @(SessionsOf $inst).Count
+        $forged = @(SessionsOf $inst | Where-Object { $_.name -eq 'injected' }).Count
+        $after = Signature $inst
+        Stop-Lite $p2; $p2 = $null
+    } catch { $err = $_.Exception.Message }
+    finally { Stop-Leftover $p; Stop-Leftover $p2 }
+    if (-not $err -and $renamed -match 'renamed' -and $lines -eq 1 -and $count -eq 1 -and $forged -eq 0) {
+        "  PASS  {0,-22} (a name cannot forge a session line)" -f 'name-injection'
+    } else {
+        $script:failed += 'name-injection'
+        "  FAIL  name-injection"
+        if ($err) { "        error:  $err" }
+        "        rename said: $renamed"
+        "        S lines in the saved file: $lines (expected 1)"
+        "        sessions restored: $count (expected 1), forged 'injected' session(s): $forged"
+        "        after:  [$after]"
+        "        log:    $(Restore-Verdict $inst)"
+    }
 }
 
 # --- harness self-check: a deliberately corrupted state file MUST fail a cell -------------------

--- a/lite/test/restore-matrix.ps1
+++ b/lite/test/restore-matrix.ps1
@@ -1,0 +1,230 @@
+# lite session restore — scenario matrix.
+#
+# "restore sessions doesn't work at all" (work laptop, 2026-07-31) has never reproduced on the dev
+# machine, so this walks the real-world combinations one cell at a time until one fails. Each cell:
+#
+#     clean state+log -> launch -> set up sessions -> close (or kill) -> relaunch -> compare
+#
+# and reads lite.log for WHICH of restoreSessions()'s four exits ran, so a failing cell explains
+# itself instead of just saying "sessions missing".
+#
+# House rules: sandbox instances only (never the default, which owns real user state), no global
+# input injection, and every cell gets its own instance name so cells cannot contaminate each other.
+param(
+    [string]$Exe = "$PSScriptRoot\..\bin\agwinterm-lite.exe",
+    [string]$Only = ''          # run a single cell by name
+)
+
+$ErrorActionPreference = 'Stop'
+$ctl = "$env:LOCALAPPDATA\Programs\agwinterm\agwintermctl.exe"
+$dir = "$env:LOCALAPPDATA\agwinterm-lite"
+$script:failed = @()
+
+function State($inst) { "$dir\sessions-$inst.tsv" }
+function Log($inst)   { "$dir\lite-$inst.log" }
+
+function Reset-Cell($inst) {
+    Remove-Item (State $inst), (Log $inst), "$(Log $inst).old", "$(State $inst).bak" -ErrorAction SilentlyContinue
+}
+
+function Start-Lite($inst) {
+    $p = Start-Process $Exe -ArgumentList @('--pipe', $inst) -PassThru
+    for ($i = 0; $i -lt 40; $i++) {
+        Start-Sleep -Milliseconds 400
+        $r = (& $ctl tree --json --pipe $inst 2>&1) -join ''
+        if ($r -match '"ok":true') { return $p }
+    }
+    throw "lite ($inst) did not answer its control pipe"
+}
+
+function Stop-Lite($p, [switch]$Kill) {
+    if ($Kill) { Stop-Process -Id $p.Id -Force; Start-Sleep -Seconds 2; return }
+    $p.CloseMainWindow() | Out-Null
+    for ($i = 0; $i -lt 25; $i++) { Start-Sleep -Milliseconds 400; $p.Refresh(); if ($p.HasExited) { break } }
+    if (-not $p.HasExited) { Stop-Process -Id $p.Id -Force }
+    Start-Sleep -Seconds 1
+}
+
+# A cell's fingerprint: the session names in tree order. Names are what the user actually notices.
+function Signature($inst) {
+    $j = (& $ctl tree --json --pipe $inst 2>&1) -join ''
+    $names = [regex]::Matches($j, '"name"\s*:\s*"([^"]*)"') | ForEach-Object { $_.Groups[1].Value }
+    ($names -join '|')
+}
+
+function Restore-Verdict($inst) {
+    $l = Log $inst
+    if (-not (Test-Path $l)) { return '(no log)' }
+    $lines = Get-Content $l | Where-Object { $_ -match 'restore:|save ok|save FAILED|save PARTIAL' }
+    if (-not $lines) { return '(no save/restore lines)' }
+    ($lines | Select-Object -Last 4) -join "`n        "
+}
+
+function Cell {
+    param(
+        [string]$Name,
+        [scriptblock]$Setup,          # receives the instance name; creates the state to be restored
+        [switch]$Kill,                # forced kill instead of a graceful close
+        [scriptblock]$Assert          # receives (before, after, instance); returns $true when the cell passes
+    )
+    if ($Only -and $Only -ne $Name) { return }
+    $inst = "rm-$Name"
+    Reset-Cell $inst
+    $before = ''; $after = ''; $err = ''
+    try {
+        $p = Start-Lite $inst
+        & $Setup $inst
+        Start-Sleep -Seconds 2
+        $before = Signature $inst
+        Stop-Lite $p -Kill:$Kill
+
+        $p2 = Start-Lite $inst
+        Start-Sleep -Seconds 2
+        $after = Signature $inst
+        Stop-Lite $p2
+    } catch { $err = $_.Exception.Message }
+
+    $ok = $false
+    if (-not $err) { $ok = & $Assert $before $after $inst }
+    if ($ok) {
+        "  PASS  {0,-22} [{1}]" -f $Name, $after
+    } else {
+        $script:failed += $Name
+        "  FAIL  {0,-22}" -f $Name
+        if ($err) { "        error:  $err" }
+        "        before: [$before]"
+        "        after:  [$after]"
+        "        log:    $(Restore-Verdict $inst)"
+    }
+}
+
+"== restore matrix =="
+
+# --- baseline cells ---------------------------------------------------------------------------
+
+Cell -Name 'single' -Setup {
+    param($i)   # the instance starts with one session already
+} -Assert { param($b, $a) $a -eq $b -and $b -ne '' }
+
+Cell -Name 'several' -Setup {
+    param($i)
+    & $ctl session new --pipe $i 2>&1 | Out-Null; Start-Sleep -Seconds 2
+    & $ctl session new --pipe $i 2>&1 | Out-Null; Start-Sleep -Seconds 2
+} -Assert { param($b, $a) $a -eq $b -and ($b -split '\|').Count -ge 3 }
+
+Cell -Name 'renamed' -Setup {
+    param($i)
+    $id = @(([regex]::Matches(((& $ctl tree --json --pipe $i 2>&1) -join ''), '"id"\s*:\s*"([^"]+)"') |
+             ForEach-Object { $_.Groups[1].Value }) | Where-Object { $_ -notmatch '^\d+$' })[-1]
+    & $ctl session rename my-renamed-session --target $id --pipe $i 2>&1 | Out-Null
+    Start-Sleep -Seconds 2
+} -Assert { param($b, $a) $a -eq $b -and $a -match 'my-renamed-session' }
+
+Cell -Name 'workspaces' -Setup {
+    param($i)
+    & $ctl workspace new second-ws --pipe $i 2>&1 | Out-Null; Start-Sleep -Seconds 2
+    & $ctl session new --pipe $i 2>&1 | Out-Null; Start-Sleep -Seconds 2
+} -Assert { param($b, $a) $a -eq $b -and $a -match 'second-ws' }
+
+Cell -Name 'flagged' -Setup {
+    param($i)
+    $id = @(([regex]::Matches(((& $ctl tree --json --pipe $i 2>&1) -join ''), '"id"\s*:\s*"([^"]+)"') |
+             ForEach-Object { $_.Groups[1].Value }) | Where-Object { $_ -notmatch '^\d+$' })[-1]
+    & $ctl session flag on --target $id --pipe $i 2>&1 | Out-Null
+    Start-Sleep -Seconds 2
+} -Assert {
+    param($b, $a, $i)
+    if ($a -ne $b) { return $false }
+    (Get-Content (State $i) -Raw) -match '(?m)^F\t'      # the flagged line survived the round trip
+}
+
+# --- cells that differ from a clean dev run ----------------------------------------------------
+# These are the ones that could plausibly explain the work-laptop report.
+
+# A spec carrying an explicit app + args — what a shell profile produces. ctl's session.new always
+# makes a DEFAULT session, so the state file is seeded directly: that is also the exact shape
+# restoreSessions() has to cope with, and it keeps the cell deterministic.
+function Seeded {
+    param([string]$Name, [string]$Tsv, [scriptblock]$Assert)
+    if ($Only -and $Only -ne $Name) { return }
+    $inst = "rm-$Name"
+    Reset-Cell $inst
+    Set-Content -Path (State $inst) -Value $Tsv -NoNewline -Encoding utf8
+    $after = ''; $err = ''
+    try {
+        $p = Start-Lite $inst
+        Start-Sleep -Seconds 3
+        $after = Signature $inst
+        Stop-Lite $p
+    } catch { $err = $_.Exception.Message }
+    $ok = $false
+    if (-not $err) { $ok = & $Assert $after $inst }
+    if ($ok) { "  PASS  {0,-22} [{1}]" -f $Name, $after }
+    else {
+        $script:failed += $Name
+        "  FAIL  {0,-22}" -f $Name
+        if ($err) { "        error:  $err" }
+        "        after:  [$after]"
+        "        log:    $(Restore-Verdict $inst)"
+    }
+}
+
+$cwd = (Resolve-Path "$PSScriptRoot\..").Path
+Seeded -Name 'app-spec' -Tsv "V1`nW`tws-a`nS`t0`tprofile-session`tpowershell.exe`t$cwd`n A`t0`n".Replace(' A', 'A') -Assert {
+    param($a) $a -match 'profile-session'
+}
+
+# A spec whose app does not exist on this machine — the shape of "a profile that doesn't resolve
+# on the laptop". Pins current behaviour so Task 5 can change it deliberately.
+Seeded -Name 'bogus-app' -Tsv "V1`nW`tws-b`nS`t0`tdead-session`tno-such-program-xyz.exe`t$cwd`nA`t0`n" -Assert {
+    param($a, $i)
+    $log = Restore-Verdict $i
+    # Either it comes back (host tolerates the bad app) or the log names the failure. Silence is the
+    # only unacceptable outcome, because that is what made this unreportable in the field.
+    ($a -match 'dead-session') -or ($log -match 'FAILED to start' -or $log -match 'no session could be started')
+}
+
+# Forced kill: no OnDestroy, so restore depends entirely on the refreshTree() save. If a laptop
+# shutdown or crash explains the report, this is the cell that shows it.
+Cell -Name 'killed' -Setup {
+    param($i)
+    & $ctl session new --pipe $i 2>&1 | Out-Null; Start-Sleep -Seconds 2
+} -Kill -Assert { param($b, $a) $a -eq $b -and ($b -split '\|').Count -ge 2 }
+
+# A session whose shell has already exited: its spec must still be saved and relaunched, otherwise
+# a day's worth of sessions quietly evaporates the moment their shells end.
+Cell -Name 'shell-exited' -Setup {
+    param($i)
+    $id = @(([regex]::Matches(((& $ctl tree --json --pipe $i 2>&1) -join ''), '"id"\s*:\s*"([^"]+)"') |
+             ForEach-Object { $_.Groups[1].Value }) | Where-Object { $_ -notmatch '^\d+$' })[-1]
+    & $ctl session new --pipe $i 2>&1 | Out-Null; Start-Sleep -Seconds 2
+    & $ctl session type "exit`n" --target $id --pipe $i 2>&1 | Out-Null
+    Start-Sleep -Seconds 3
+} -Assert { param($b, $a) $a -eq $b }
+
+# --- harness self-check: a deliberately corrupted state file MUST fail a cell -------------------
+# Without this, a harness that silently passes everything would be indistinguishable from a
+# working restore — which is exactly the trap this whole exercise exists to avoid.
+$selfInst = 'rm-selfcheck'
+Reset-Cell $selfInst
+$sp = Start-Lite $selfInst
+& $ctl session new --pipe $selfInst 2>&1 | Out-Null
+Start-Sleep -Seconds 2
+$sigBefore = Signature $selfInst
+Stop-Lite $sp
+Set-Content -Path (State $selfInst) -Value '' -NoNewline      # wipe it: restore must not match
+$sp2 = Start-Lite $selfInst
+Start-Sleep -Seconds 2
+$sigAfter = Signature $selfInst
+Stop-Lite $sp2
+if ($sigAfter -ne $sigBefore) {
+    "  PASS  {0,-22} (corrupted state correctly fails to restore)" -f 'harness-selfcheck'
+} else {
+    $script:failed += 'harness-selfcheck'
+    "  FAIL  harness-selfcheck    — a wiped state file still 'restored'; the harness proves nothing"
+}
+
+""
+if ($script:failed.Count) { "restore-matrix: FAILED cells: $($script:failed -join ', ')"; exit 1 }
+"restore-matrix: all cells passed"
+exit 0

--- a/lite/test/restore-matrix.ps1
+++ b/lite/test/restore-matrix.ps1
@@ -747,6 +747,56 @@ if (-not $Only -or $Only -eq 'bak-rotation') {
     }
 }
 
+# The publish half of the atomic write, forced to fail. Nothing else in the suite reaches it: every
+# other cell publishes successfully, so the rollback, the "previous state is untouched" message and
+# — the point — the promise that a FAILED save never costs the saved sessions were all untested.
+# Holding the primary open with no sharing is the one deterministic way to deny the rename without
+# touching the state directory (which every other cell writes into at the same time).
+if (-not $Only -or $Only -eq 'publish-blocked') {
+    $inst = 'rm-publish-blocked'
+    Reset-Cell $inst
+    $err = ''; $logged = $false; $intact = $false; $after = ''
+    $p = $null; $p2 = $null; $fs = $null
+    try {
+        $p = Start-Lite $inst
+        $id = LastSessionId $inst
+        & $ctl session rename survives-blocked-publish --target $id --pipe $inst 2>&1 | Out-Null
+        Start-Sleep -Seconds 3                       # the good save this cell must not lose
+        if ((Get-Content (State $inst) -Raw) -notmatch 'survives-blocked-publish') { throw 'setup save never landed' }
+        # FileShare.None: lite can create and write the .tmp, but neither ReplaceFileW nor MoveFileExW
+        # can touch the primary.
+        $fs = [System.IO.File]::Open((State $inst), 'Open', 'ReadWrite', 'None')
+        & $ctl session rename must-not-land --target $id --pipe $inst 2>&1 | Out-Null
+        Start-Sleep -Seconds 3
+        $logged = Log-Has $inst 'save FAILED to publish'
+        # Read through the handle that holds the lock — nothing else can open the file right now.
+        $fs.Position = 0
+        $buf = New-Object byte[] $fs.Length
+        [void]$fs.Read($buf, 0, $buf.Length)
+        $held = [System.Text.Encoding]::UTF8.GetString($buf)
+        $intact = ($held -match 'survives-blocked-publish') -and ($held -notmatch 'must-not-land')
+        $fs.Close(); $fs = $null
+        # Hard kill: a graceful stop saves again (with the lock gone) and would overwrite the very
+        # file this cell is asserting survived.
+        Stop-Lite $p -Kill; $p = $null
+        $p2 = Start-Lite $inst
+        Start-Sleep -Seconds 2
+        $after = Signature $inst
+        Stop-Lite $p2 -Kill; $p2 = $null
+    } catch { $err = $_.Exception.Message }
+    finally { if ($fs) { try { $fs.Close() } catch { } }; Stop-Leftover $p; Stop-Leftover $p2 }
+    if (-not $err -and $logged -and $intact -and $after -match 'survives-blocked-publish') {
+        "  PASS  {0,-22} (a failed publish leaves the saved state readable)" -f 'publish-blocked'
+    } else {
+        $script:failed += 'publish-blocked'
+        "  FAIL  publish-blocked"
+        if ($err) { "        error:  $err" }
+        "        log named the failed publish: $logged ; primary still held the old state: $intact"
+        "        after: [$after]"
+        "        log:   $(Restore-Verdict $inst)"
+    }
+}
+
 # Backward compatibility: a plain 0.17.x file — no D line, no .bak anywhere — must still restore.
 Seeded -Name 'compat-0.17' `
     -Tsv "V1`nW`tws-c`nS`t0`told-one`t`t$cwd`nS`t0`told-two`t`t$cwd`nF`t1`nA`t0`n" -Assert {

--- a/lite/test/restore-matrix.ps1
+++ b/lite/test/restore-matrix.ps1
@@ -191,13 +191,62 @@ Seeded -Name 'app-spec' -Tsv "V1`nW`tws-a`nS`t0`tprofile-session`tpowershell.exe
 }
 
 # A spec whose app does not exist on this machine — the shape of "a profile that doesn't resolve
-# on the laptop". Pins current behaviour so Task 5 can change it deliberately.
+# on the laptop". It must stay VISIBLE (a dead session, not a hole) and the log must name it.
 Seeded -Name 'bogus-app' -Tsv "V1`nW`tws-b`nS`t0`tdead-session`tno-such-program-xyz.exe`t$cwd`nA`t0`n" -Assert {
     param($a, $i)
-    $log = Restore-Verdict $i
-    # Either it comes back (host tolerates the bad app) or the log names the failure. Silence is the
-    # only unacceptable outcome, because that is what made this unreportable in the field.
-    ($a -match 'dead-session') -or ($log -match 'FAILED to start' -or $log -match 'no session could be started')
+    # Silence is the one unacceptable outcome — that is what made this unreportable in the field.
+    ($a -match 'dead-session') -and (Log-Has $i "session 'dead-session' FAILED to start")
+}
+
+# The session object the control API reports for a given name ('' when there is none). Session
+# objects carry no nested braces, so one flat match per session is exact.
+function Session-Obj($json, $name) {
+    foreach ($m in [regex]::Matches($json, '\{"id":[^}]*\}')) {
+        if ($m.Value -match ('"name"\s*:\s*"' + [regex]::Escape($name) + '"')) { return $m.Value }
+    }
+    ''
+}
+
+# The full round trip for a spec that cannot start here: it must come back as a DEAD session rather
+# than a hole, keep its name/workspace, be saved again (so it is recoverable on a machine where the
+# app exists), and it must not disturb the good spec beside it.
+if (-not $Only -or $Only -eq 'failed-spec') {
+    $inst = 'rm-failed-spec'
+    Reset-Cell $inst
+    Set-Content -Path (State $inst) -NoNewline -Encoding utf8 -Value `
+        "V1`nW`tws-f`nS`t0`tghost-session`tno-such-program-xyz.exe`t$cwd`nS`t0`tlive-session`tpowershell.exe`t$cwd`nA`t0`n"
+    $err = ''; $ghost = ''; $live = ''; $named = $false; $resaved = $false; $after = ''
+    try {
+        $p = Start-Lite $inst
+        Start-Sleep -Seconds 3
+        $j = (& $ctl tree --json --pipe $inst 2>&1) -join ''
+        $ghost = Session-Obj $j 'ghost-session'
+        $live  = Session-Obj $j 'live-session'
+        $named = Log-Has $inst "session 'ghost-session' FAILED to start"
+        Stop-Lite $p
+        # Kept in the state file: the entry survives, so it can start on a machine that has the app.
+        $resaved = (Get-Content (State $inst) -Raw) -match 'ghost-session'
+        $p2 = Start-Lite $inst
+        Start-Sleep -Seconds 3
+        $after = Signature $inst
+        Stop-Lite $p2
+    } catch { $err = $_.Exception.Message }
+
+    $ghostOk = $ghost -match '"failed"\s*:\s*true'
+    $liveOk  = $live -match '"failed"\s*:\s*false' -and $live -match '"exited"\s*:\s*false'
+    if (-not $err -and $ghostOk -and $liveOk -and $named -and $resaved -and
+        $after -match 'ghost-session' -and $after -match 'live-session') {
+        "  PASS  {0,-22} [{1}]" -f 'failed-spec', $after
+    } else {
+        $script:failed += 'failed-spec'
+        "  FAIL  failed-spec"
+        if ($err) { "        error:  $err" }
+        "        ghost:  [$ghost] (dead entry kept: $ghostOk)"
+        "        live:   [$live] (good spec unaffected: $liveOk)"
+        "        log named it: $named ; re-saved: $resaved"
+        "        after:  [$after]"
+        "        log:    $(Restore-Verdict $inst)"
+    }
 }
 
 # Forced kill: no OnDestroy, so restore depends entirely on the refreshTree() save. If a laptop

--- a/lite/test/restore-matrix.ps1
+++ b/lite/test/restore-matrix.ps1
@@ -10,12 +10,20 @@
 #
 # House rules: sandbox instances only (never the default, which owns real user state), no global
 # input injection, and every cell gets its own instance name so cells cannot contaminate each other.
+#
+# One shared resource remains: the pty-host control pipe is keyed on the APP id, not the instance, so
+# every cell (and any lite window already open) talks to the same agwinterm-ptyhost.exe. Don't run
+# the suite with a real lite window open — the last instance out shuts the host down.
 param(
     [string]$Exe = "$PSScriptRoot\..\bin\agwinterm-lite.exe",
     [string]$Only = ''          # run a single cell by name
 )
 
 $ErrorActionPreference = 'Stop'
+# agwintermctl exits nonzero while a pipe is still coming up, and Start-Lite polls it on purpose.
+# Pinned rather than assumed: with the native-command mapping on, that poll throws on its first
+# iteration and every cell fails for a reason that has nothing to do with restore.
+$PSNativeCommandUseErrorActionPreference = $false
 $ctl = "$env:LOCALAPPDATA\Programs\agwinterm\agwintermctl.exe"
 $dir = "$env:LOCALAPPDATA\agwinterm-lite"
 $script:failed = @()
@@ -28,11 +36,25 @@ function Reset-Cell($inst) {
         -ErrorAction SilentlyContinue
 }
 
-# The newest real session id in the tree (workspace rows carry numeric ids).
-function LastSessionId($inst) {
-    @(([regex]::Matches(((& $ctl tree --json --pipe $inst 2>&1) -join ''), '"id"\s*:\s*"([^"]+)"') |
-       ForEach-Object { $_.Groups[1].Value }) | Where-Object { $_ -notmatch '^\d+$' })[-1]
+# The tree as objects. Regexing this JSON is what let a workspace object and the first session
+# inside it be read as one blob, so every reader below goes through here.
+function Tree($inst) {
+    $raw = (& $ctl tree --json --pipe $inst 2>&1) -join ''
+    try { $j = $raw | ConvertFrom-Json } catch { return $null }
+    if ($j.PSObject.Properties.Name -contains 'result') { $j = $j.result }
+    if ($j -and ($j.PSObject.Properties.Name -contains 'workspaces')) { return @($j.workspaces) }
+    $null
 }
+
+# Every session in the window, in tree order (workspace rows are not sessions).
+function SessionsOf($inst) {
+    $ws = Tree $inst
+    if ($null -eq $ws) { return @() }
+    @($ws | ForEach-Object { $_.sessions })
+}
+
+# The newest real session id in the tree.
+function LastSessionId($inst) { @(SessionsOf $inst | ForEach-Object { $_.id })[-1] }
 
 function Start-Lite($inst) {
     $p = Start-Process $Exe -ArgumentList @('--pipe', $inst) -PassThru
@@ -52,12 +74,30 @@ function Stop-Lite($p, [switch]$Kill) {
     Start-Sleep -Seconds 1
 }
 
-# A cell's fingerprint: the session names in tree order. Names are what the user actually notices.
-function Signature($inst) {
-    $j = (& $ctl tree --json --pipe $inst 2>&1) -join ''
-    $names = [regex]::Matches($j, '"name"\s*:\s*"([^"]*)"') | ForEach-Object { $_.Groups[1].Value }
-    ($names -join '|')
+# Best-effort teardown for a cell that threw part-way. A leaked instance keeps the pipe name, so the
+# NEXT run of that cell would connect to the stale process and test nothing.
+function Stop-Leftover($p) {
+    if (-not $p) { return }
+    try { $p.Refresh(); if (-not $p.HasExited) { Stop-Process -Id $p.Id -Force; Start-Sleep -Seconds 1 } } catch { }
 }
+
+# A cell's fingerprint: workspace names (prefixed '#') and the session names inside them, in tree
+# order. Names are what the user actually notices; the prefix keeps a workspace row from being
+# counted as a session (which let a "restored 2 sessions" assertion pass on one session + one
+# workspace, i.e. on a setup that had silently failed).
+function Signature($inst) {
+    $ws = Tree $inst
+    if ($null -eq $ws) { return '' }
+    $parts = @()
+    foreach ($w in $ws) {
+        $parts += "#$($w.name)"
+        foreach ($s in @($w.sessions)) { $parts += $s.name }
+    }
+    ($parts -join '|')
+}
+
+# How many real sessions a signature holds.
+function SessionCount($sig) { @($sig -split '\|' | Where-Object { $_ -and $_ -notlike '#*' }).Count }
 
 # Does the whole log say this? (Restore-Verdict only shows the last few lines, so a decision made
 # early in a run — like the .bak fallback — is not visible there.)
@@ -84,22 +124,26 @@ function Cell {
     if ($Only -and $Only -ne $Name) { return }
     $inst = "rm-$Name"
     Reset-Cell $inst
-    $before = ''; $after = ''; $err = ''
+    $before = ''; $after = ''; $err = ''; $ok = $false
+    $p = $null; $p2 = $null
     try {
         $p = Start-Lite $inst
         & $Setup $inst
         Start-Sleep -Seconds 2
         $before = Signature $inst
-        Stop-Lite $p -Kill:$Kill
+        Stop-Lite $p -Kill:$Kill; $p = $null
 
         $p2 = Start-Lite $inst
         Start-Sleep -Seconds 2
         $after = Signature $inst
-        Stop-Lite $p2
-    } catch { $err = $_.Exception.Message }
+        Stop-Lite $p2; $p2 = $null
+        # The assert runs INSIDE the try. $ErrorActionPreference is Stop, and several asserts read
+        # files that a genuine regression would have removed — outside, one such cell terminated the
+        # whole suite (skipping every cell after it, and the exit code with them).
+        $ok = [bool](& $Assert $before $after $inst)
+    } catch { $err = $_.Exception.Message; $ok = $false }
+    finally { Stop-Leftover $p; Stop-Leftover $p2 }
 
-    $ok = $false
-    if (-not $err) { $ok = & $Assert $before $after $inst }
     if ($ok) {
         "  PASS  {0,-22} [{1}]" -f $Name, $after
     } else {
@@ -124,12 +168,11 @@ Cell -Name 'several' -Setup {
     param($i)
     & $ctl session new --pipe $i 2>&1 | Out-Null; Start-Sleep -Seconds 2
     & $ctl session new --pipe $i 2>&1 | Out-Null; Start-Sleep -Seconds 2
-} -Assert { param($b, $a) $a -eq $b -and ($b -split '\|').Count -ge 3 }
+} -Assert { param($b, $a) $a -eq $b -and (SessionCount $b) -ge 3 }
 
 Cell -Name 'renamed' -Setup {
     param($i)
-    $id = @(([regex]::Matches(((& $ctl tree --json --pipe $i 2>&1) -join ''), '"id"\s*:\s*"([^"]+)"') |
-             ForEach-Object { $_.Groups[1].Value }) | Where-Object { $_ -notmatch '^\d+$' })[-1]
+    $id = LastSessionId $i
     & $ctl session rename my-renamed-session --target $id --pipe $i 2>&1 | Out-Null
     Start-Sleep -Seconds 2
 } -Assert { param($b, $a) $a -eq $b -and $a -match 'my-renamed-session' }
@@ -142,14 +185,13 @@ Cell -Name 'workspaces' -Setup {
 
 Cell -Name 'flagged' -Setup {
     param($i)
-    $id = @(([regex]::Matches(((& $ctl tree --json --pipe $i 2>&1) -join ''), '"id"\s*:\s*"([^"]+)"') |
-             ForEach-Object { $_.Groups[1].Value }) | Where-Object { $_ -notmatch '^\d+$' })[-1]
+    $id = LastSessionId $i
     & $ctl session flag on --target $id --pipe $i 2>&1 | Out-Null
     Start-Sleep -Seconds 2
 } -Assert {
     param($b, $a, $i)
     if ($a -ne $b) { return $false }
-    (Get-Content (State $i) -Raw) -match '(?m)^F\t'      # the flagged line survived the round trip
+    (Test-Path (State $i)) -and ((Get-Content (State $i) -Raw) -match '(?m)^F\t')   # the F line survived
 }
 
 # --- cells that differ from a clean dev run ----------------------------------------------------
@@ -166,15 +208,16 @@ function Seeded {
     if ($null -ne $Tsv) { Set-Content -Path (State $inst) -Value $Tsv -NoNewline -Encoding utf8 }
     if ($Bak) { Set-Content -Path "$(State $inst).bak" -Value $Bak -NoNewline -Encoding utf8 }
     if ($Tmp) { Set-Content -Path "$(State $inst).tmp" -Value $Tmp -NoNewline -Encoding utf8 }
-    $after = ''; $err = ''
+    $after = ''; $err = ''; $ok = $false
+    $p = $null
     try {
         $p = Start-Lite $inst
         Start-Sleep -Seconds 3
         $after = Signature $inst
-        Stop-Lite $p
-    } catch { $err = $_.Exception.Message }
-    $ok = $false
-    if (-not $err) { $ok = & $Assert $after $inst }
+        Stop-Lite $p; $p = $null
+        $ok = [bool](& $Assert $after $inst)   # inside the try — see Cell
+    } catch { $err = $_.Exception.Message; $ok = $false }
+    finally { Stop-Leftover $p }
     if ($ok) { "  PASS  {0,-22} [{1}]" -f $Name, $after }
     else {
         $script:failed += $Name
@@ -186,7 +229,7 @@ function Seeded {
 }
 
 $cwd = (Resolve-Path "$PSScriptRoot\..").Path
-Seeded -Name 'app-spec' -Tsv "V1`nW`tws-a`nS`t0`tprofile-session`tpowershell.exe`t$cwd`n A`t0`n".Replace(' A', 'A') -Assert {
+Seeded -Name 'app-spec' -Tsv "V1`nW`tws-a`nS`t0`tprofile-session`tpowershell.exe`t$cwd`nA`t0`n" -Assert {
     param($a) $a -match 'profile-session'
 }
 
@@ -198,14 +241,8 @@ Seeded -Name 'bogus-app' -Tsv "V1`nW`tws-b`nS`t0`tdead-session`tno-such-program-
     ($a -match 'dead-session') -and (Log-Has $i "session 'dead-session' FAILED to start")
 }
 
-# The session object the control API reports for a given name ('' when there is none). Session
-# objects carry no nested braces, so one flat match per session is exact.
-function Session-Obj($json, $name) {
-    foreach ($m in [regex]::Matches($json, '\{"id":[^}]*\}')) {
-        if ($m.Value -match ('"name"\s*:\s*"' + [regex]::Escape($name) + '"')) { return $m.Value }
-    }
-    ''
-}
+# The session the control API reports for a given name ($null when there is none).
+function Session-Named($inst, $name) { @(SessionsOf $inst | Where-Object { $_.name -eq $name })[0] }
 
 # The full round trip for a spec that cannot start here: it must come back as a DEAD session rather
 # than a hole, keep its name/workspace, be saved again (so it is recoverable on a machine where the
@@ -215,25 +252,27 @@ if (-not $Only -or $Only -eq 'failed-spec') {
     Reset-Cell $inst
     Set-Content -Path (State $inst) -NoNewline -Encoding utf8 -Value `
         "V1`nW`tws-f`nS`t0`tghost-session`tno-such-program-xyz.exe`t$cwd`nS`t0`tlive-session`tpowershell.exe`t$cwd`nA`t0`n"
-    $err = ''; $ghost = ''; $live = ''; $named = $false; $resaved = $false; $after = ''
+    $err = ''; $ghost = $null; $live = $null; $named = $false; $resaved = $false; $after = ''
+    $ghostOk = $false; $liveOk = $false
+    $p = $null; $p2 = $null
     try {
         $p = Start-Lite $inst
         Start-Sleep -Seconds 3
-        $j = (& $ctl tree --json --pipe $inst 2>&1) -join ''
-        $ghost = Session-Obj $j 'ghost-session'
-        $live  = Session-Obj $j 'live-session'
+        $ghost = Session-Named $inst 'ghost-session'
+        $live  = Session-Named $inst 'live-session'
+        $ghostOk = [bool]($ghost -and $ghost.failed -and $ghost.exited)
+        $liveOk  = [bool]($live -and -not $live.failed -and -not $live.exited)
         $named = Log-Has $inst "session 'ghost-session' FAILED to start"
-        Stop-Lite $p
+        Stop-Lite $p; $p = $null
         # Kept in the state file: the entry survives, so it can start on a machine that has the app.
-        $resaved = (Get-Content (State $inst) -Raw) -match 'ghost-session'
+        $resaved = (Test-Path (State $inst)) -and ((Get-Content (State $inst) -Raw) -match 'ghost-session')
         $p2 = Start-Lite $inst
         Start-Sleep -Seconds 3
         $after = Signature $inst
-        Stop-Lite $p2
+        Stop-Lite $p2; $p2 = $null
     } catch { $err = $_.Exception.Message }
+    finally { Stop-Leftover $p; Stop-Leftover $p2 }
 
-    $ghostOk = $ghost -match '"failed"\s*:\s*true'
-    $liveOk  = $live -match '"failed"\s*:\s*false' -and $live -match '"exited"\s*:\s*false'
     if (-not $err -and $ghostOk -and $liveOk -and $named -and $resaved -and
         $after -match 'ghost-session' -and $after -match 'live-session') {
         "  PASS  {0,-22} [{1}]" -f 'failed-spec', $after
@@ -241,8 +280,8 @@ if (-not $Only -or $Only -eq 'failed-spec') {
         $script:failed += 'failed-spec'
         "  FAIL  failed-spec"
         if ($err) { "        error:  $err" }
-        "        ghost:  [$ghost] (dead entry kept: $ghostOk)"
-        "        live:   [$live] (good spec unaffected: $liveOk)"
+        "        ghost:  [$($ghost | ConvertTo-Json -Compress)] (dead entry kept: $ghostOk)"
+        "        live:   [$($live | ConvertTo-Json -Compress)] (good spec unaffected: $liveOk)"
         "        log named it: $named ; re-saved: $resaved"
         "        after:  [$after]"
         "        log:    $(Restore-Verdict $inst)"
@@ -251,20 +290,31 @@ if (-not $Only -or $Only -eq 'failed-spec') {
 
 # Forced kill: no OnDestroy, so restore depends entirely on the refreshTree() save. If a laptop
 # shutdown or crash explains the report, this is the cell that shows it.
+# Also the ONLY cell where adoption can fire: the pty-host outlives a killed UI, so its shells are
+# still running and must be picked back up rather than re-created. The log assertion is what tells
+# those two apart — the names come back identically either way, so without it this cell passes just
+# as happily when adoption is broken (which is how it shipped unverified).
 Cell -Name 'killed' -Setup {
     param($i)
     & $ctl session new --pipe $i 2>&1 | Out-Null; Start-Sleep -Seconds 2
-} -Kill -Assert { param($b, $a) $a -eq $b -and ($b -split '\|').Count -ge 2 }
+} -Kill -Assert {
+    param($b, $a, $i)
+    $a -eq $b -and (SessionCount $b) -ge 2 -and (Log-Has $i 'adopted live session')
+}
 
 # A session whose shell has already exited: its spec must still be saved and relaunched, otherwise
 # a day's worth of sessions quietly evaporates the moment their shells end.
 Cell -Name 'shell-exited' -Setup {
     param($i)
-    $id = @(([regex]::Matches(((& $ctl tree --json --pipe $i 2>&1) -join ''), '"id"\s*:\s*"([^"]+)"') |
-             ForEach-Object { $_.Groups[1].Value }) | Where-Object { $_ -notmatch '^\d+$' })[-1]
+    $id = LastSessionId $i
     & $ctl session new --pipe $i 2>&1 | Out-Null; Start-Sleep -Seconds 2
     & $ctl session type "exit`n" --target $id --pipe $i 2>&1 | Out-Null
     Start-Sleep -Seconds 3
+    # Prove the premise. Without this the cell is a duplicate of 'several': a `type` that silently
+    # failed, or a shell that ignored `exit`, would leave it asserting nothing at all.
+    $s = @(SessionsOf $i | Where-Object { $_.id -eq $id })[0]
+    if (-not $s) { throw "session $id vanished instead of exiting" }
+    if (-not $s.exited) { throw "the shell in $id never exited, so this cell would prove nothing" }
 } -Assert { param($b, $a) $a -eq $b }
 
 # Two windows open at once. Multi-window lite is one PROCESS per window, each with its own
@@ -274,19 +324,23 @@ if (-not $Only -or $Only -eq 'two-windows') {
     $ia = 'rm-two-windows-a'; $ib = 'rm-two-windows-b'
     Reset-Cell $ia; Reset-Cell $ib
     $afterA = ''; $afterB = ''; $err = ''
+    $pa = $null; $pb = $null; $pa2 = $null; $pb2 = $null
     try {
         $pa = Start-Lite $ia
         $pb = Start-Lite $ib
         & $ctl session rename win-a-session --target (LastSessionId $ia) --pipe $ia 2>&1 | Out-Null
         & $ctl session rename win-b-session --target (LastSessionId $ib) --pipe $ib 2>&1 | Out-Null
         Start-Sleep -Seconds 2
-        Stop-Lite $pa; Stop-Lite $pb
+        Stop-Lite $pa; $pa = $null
+        Stop-Lite $pb; $pb = $null
 
         $pa2 = Start-Lite $ia; $pb2 = Start-Lite $ib
         Start-Sleep -Seconds 2
         $afterA = Signature $ia; $afterB = Signature $ib
-        Stop-Lite $pa2; Stop-Lite $pb2
+        Stop-Lite $pa2; $pa2 = $null
+        Stop-Lite $pb2; $pb2 = $null
     } catch { $err = $_.Exception.Message }
+    finally { Stop-Leftover $pa; Stop-Leftover $pb; Stop-Leftover $pa2; Stop-Leftover $pb2 }
     $ok = (-not $err) -and ($afterA -match 'win-a-session') -and ($afterA -notmatch 'win-b-session') `
                        -and ($afterB -match 'win-b-session') -and ($afterB -notmatch 'win-a-session')
     if ($ok) { "  PASS  {0,-22} (each window restores only its own)" -f 'two-windows' }
@@ -315,6 +369,7 @@ function Restart-Cell {
     $inst = "rm-$Name"
     Reset-Cell $inst
     $before = ''; $after = ''; $err = ''
+    $p = $null; $p2 = $null
     try {
         $p = Start-Lite $inst
         & $ctl session new --pipe $inst 2>&1 | Out-Null
@@ -340,10 +395,12 @@ function Restart-Cell {
         if (-not $p2) { throw 'the restarted instance never answered its control pipe' }
         Start-Sleep -Seconds 2
         $after = Signature $inst
-        Stop-Lite $p2
+        Stop-Lite $p2; $p2 = $null
+        $p = $null   # already exited: that is what this cell just asserted
     } catch { $err = $_.Exception.Message }
+    finally { Stop-Leftover $p; Stop-Leftover $p2 }
 
-    if (-not $err -and $after -eq $before -and ($before -split '\|').Count -ge 2) {
+    if (-not $err -and $after -eq $before -and (SessionCount $before) -ge 2) {
         "  PASS  {0,-22} [{1}]" -f $Name, $after
     } else {
         $script:failed += $Name
@@ -393,6 +450,7 @@ if (-not $Only -or $Only -eq 'zero-guard') {
     $inst = 'rm-zero-guard'
     Reset-Cell $inst
     $err = ''; $kept = $false; $skipped = $false; $after = ''
+    $p = $null; $p2 = $null
     try {
         $p = Start-Lite $inst
         $id = LastSessionId $inst
@@ -402,14 +460,15 @@ if (-not $Only -or $Only -eq 'zero-guard') {
         Start-Sleep -Seconds 2
         & $ctl session close $id --pipe $inst 2>&1 | Out-Null
         Start-Sleep -Seconds 3
-        $kept = (Get-Content (State $inst) -Raw) -match 'keep-me'
-        $skipped = (Get-Content (Log $inst) -Raw) -match 'save SKIPPED'
-        Stop-Lite $p
+        $kept = (Test-Path (State $inst)) -and ((Get-Content (State $inst) -Raw) -match 'keep-me')
+        $skipped = Log-Has $inst 'save SKIPPED'
+        Stop-Lite $p; $p = $null
         $p2 = Start-Lite $inst
         Start-Sleep -Seconds 2
         $after = Signature $inst
-        Stop-Lite $p2
+        Stop-Lite $p2; $p2 = $null
     } catch { $err = $_.Exception.Message }
+    finally { Stop-Leftover $p; Stop-Leftover $p2 }
     if (-not $err -and $kept -and $skipped -and $after -match 'keep-me') {
         "  PASS  {0,-22} [{1}]" -f 'zero-guard', $after
     } else {
@@ -429,6 +488,7 @@ if (-not $Only -or $Only -eq 'closed-last') {
     $inst = 'rm-closed-last'
     Reset-Cell $inst
     $err = ''; $tsv = 'x'; $after = ''; $bak = $true
+    $p = $null; $p2 = $null
     try {
         $p = Start-Lite $inst
         $id = LastSessionId $inst
@@ -442,12 +502,13 @@ if (-not $Only -or $Only -eq 'closed-last') {
         $tsv = if (Test-Path (State $inst)) { (Get-Content (State $inst) -Raw) } else { '' }
         $bak = Test-Path "$(State $inst).bak"
         if (-not (Log-Has $inst 'save ok: 0 session')) { throw 'the deliberate empty save never happened' }
-        Stop-Lite $p
+        Stop-Lite $p; $p = $null
         $p2 = Start-Lite $inst
         Start-Sleep -Seconds 2
         $after = Signature $inst
-        Stop-Lite $p2
+        Stop-Lite $p2; $p2 = $null
     } catch { $err = $_.Exception.Message }
+    finally { Stop-Leftover $p; Stop-Leftover $p2 }
     if (-not $err -and $tsv -notmatch 'gone-for-good' -and -not $bak -and $after -notmatch 'gone-for-good') {
         "  PASS  {0,-22} (deliberate empty is honoured)" -f 'closed-last'
     } else {
@@ -456,6 +517,52 @@ if (-not $Only -or $Only -eq 'closed-last') {
         if ($err) { "        error:  $err" }
         "        state: [$($tsv -replace "`r?`n", '\n')] ; .bak left behind: $bak"
         "        after: [$after]"
+    }
+}
+
+# The guard must survive being used. Closing the last session marks the empty as DELIBERATE, and
+# driven over the control pipe the window does not actually go away (DestroyWindow is a no-op off the
+# UI thread) — so a window keeps running with that mark set. If it is a one-way latch rather than a
+# statement about one save, every later transient empty is waved straight through and the good file
+# is overwritten with a zero-session one, which is exactly what 'zero-guard' exists to prevent.
+if (-not $Only -or $Only -eq 'guard-after-empty') {
+    $inst = 'rm-guard-after-empty'
+    Reset-Cell $inst
+    $err = ''; $kept = $false; $skipped = $false; $after = ''
+    $p = $null; $p2 = $null
+    try {
+        $p = Start-Lite $inst
+        & $ctl session close (LastSessionId $inst) --pipe $inst 2>&1 | Out-Null   # window is now empty
+        Start-Sleep -Seconds 3
+        if (-not (Log-Has $inst 'save ok: 0 session')) { throw 'the window never reached the deliberate-empty save' }
+        # Re-fill it, then drive a TRANSIENT empty exactly as zero-guard does.
+        & $ctl session new --pipe $inst 2>&1 | Out-Null
+        Start-Sleep -Seconds 2
+        $id = LastSessionId $inst
+        & $ctl session rename kept-after-empty --target $id --pipe $inst 2>&1 | Out-Null
+        Start-Sleep -Seconds 2
+        & $ctl session split on --pipe $inst 2>&1 | Out-Null
+        Start-Sleep -Seconds 2
+        & $ctl session close $id --pipe $inst 2>&1 | Out-Null
+        Start-Sleep -Seconds 3
+        $kept = (Test-Path (State $inst)) -and ((Get-Content (State $inst) -Raw) -match 'kept-after-empty')
+        $skipped = Log-Has $inst 'save SKIPPED'
+        Stop-Lite $p; $p = $null
+        $p2 = Start-Lite $inst
+        Start-Sleep -Seconds 2
+        $after = Signature $inst
+        Stop-Lite $p2; $p2 = $null
+    } catch { $err = $_.Exception.Message }
+    finally { Stop-Leftover $p; Stop-Leftover $p2 }
+    if (-not $err -and $kept -and $skipped -and $after -match 'kept-after-empty') {
+        "  PASS  {0,-22} [{1}]" -f 'guard-after-empty', $after
+    } else {
+        $script:failed += 'guard-after-empty'
+        "  FAIL  guard-after-empty"
+        if ($err) { "        error:  $err" }
+        "        state kept the session: $kept ; log said SKIPPED: $skipped"
+        "        after: [$after]"
+        "        log:   $(Restore-Verdict $inst)"
     }
 }
 
@@ -482,6 +589,23 @@ Seeded -Name 'compat-0.17' `
     -Tsv "V1`nW`tws-c`nS`t0`told-one`t`t$cwd`nS`t0`told-two`t`t$cwd`nF`t1`nA`t0`n" -Assert {
     param($a, $i)
     ($a -match 'old-one') -and ($a -match 'old-two')
+}
+
+# The D line's ordinary case, which only 'killed' covers non-deterministically: ids the host does
+# NOT have. That is every graceful restart (the host kills those sessions on the way out), so the
+# specs must be created fresh — an id that isn't live must never make a spec vanish.
+Seeded -Name 'stale-ids' `
+    -Tsv "V1`nW`tws-s`nS`t0`tstale-one`t`t$cwd`nS`t0`tstale-two`t`t$cwd`nD`tnobody-1`tnobody-2`nA`t0`n" -Assert {
+    param($a, $i)
+    ($a -match 'stale-one') -and ($a -match 'stale-two') -and -not (Log-Has $i 'adopted live session')
+}
+
+# A D line SHORTER than the S list (hand-edited, or written while a session had no host id yet).
+# The pairing is by index, so the specs past the end of the D line must still restore rather than
+# read off the end of it.
+Seeded -Name 'short-id-line' `
+    -Tsv "V1`nW`tws-d`nS`t0`tpaired-one`t`t$cwd`nS`t0`tunpaired-two`t`t$cwd`nD`tnobody-1`nA`t0`n" -Assert {
+    param($a, $i) ($a -match 'paired-one') -and ($a -match 'unpaired-two')
 }
 
 # --- malformed / future state files: degrade, never crash and never take the window down -------
@@ -530,24 +654,34 @@ Seeded -Name 'stray-ws-index' `
 # --- harness self-check: a deliberately corrupted state file MUST fail a cell -------------------
 # Without this, a harness that silently passes everything would be indistinguishable from a
 # working restore — which is exactly the trap this whole exercise exists to avoid.
-$selfInst = 'rm-selfcheck'
-Reset-Cell $selfInst
-$sp = Start-Lite $selfInst
-& $ctl session new --pipe $selfInst 2>&1 | Out-Null
-Start-Sleep -Seconds 2
-$sigBefore = Signature $selfInst
-Stop-Lite $sp
-Set-Content -Path (State $selfInst) -Value '' -NoNewline      # wipe it: restore must not match
-Remove-Item "$(State $selfInst).bak" -ErrorAction SilentlyContinue   # ...and the generation it would fall back to
-$sp2 = Start-Lite $selfInst
-Start-Sleep -Seconds 2
-$sigAfter = Signature $selfInst
-Stop-Lite $sp2
-if ($sigAfter -ne $sigBefore) {
-    "  PASS  {0,-22} (corrupted state correctly fails to restore)" -f 'harness-selfcheck'
-} else {
-    $script:failed += 'harness-selfcheck'
-    "  FAIL  harness-selfcheck    — a wiped state file still 'restored'; the harness proves nothing"
+if (-not $Only -or $Only -eq 'harness-selfcheck') {
+    $selfInst = 'rm-selfcheck'
+    Reset-Cell $selfInst
+    $sigBefore = ''; $sigAfter = ''; $err = ''
+    $sp = $null; $sp2 = $null
+    try {
+        $sp = Start-Lite $selfInst
+        & $ctl session new --pipe $selfInst 2>&1 | Out-Null
+        Start-Sleep -Seconds 2
+        $sigBefore = Signature $selfInst
+        Stop-Lite $sp; $sp = $null
+        Set-Content -Path (State $selfInst) -Value '' -NoNewline      # wipe it: restore must not match
+        Remove-Item "$(State $selfInst).bak" -ErrorAction SilentlyContinue   # ...and the generation it would fall back to
+        $sp2 = Start-Lite $selfInst
+        Start-Sleep -Seconds 2
+        $sigAfter = Signature $selfInst
+        Stop-Lite $sp2; $sp2 = $null
+    } catch { $err = $_.Exception.Message }
+    finally { Stop-Leftover $sp; Stop-Leftover $sp2 }
+    if (-not $err -and $sigBefore -ne '' -and $sigAfter -ne $sigBefore) {
+        "  PASS  {0,-22} (corrupted state correctly fails to restore)" -f 'harness-selfcheck'
+    } else {
+        $script:failed += 'harness-selfcheck'
+        "  FAIL  harness-selfcheck    — a wiped state file still 'restored'; the harness proves nothing"
+        if ($err) { "        error:  $err" }
+        "        before: [$sigBefore]"
+        "        after:  [$sigAfter]"
+    }
 }
 
 ""

--- a/lite/test/restore-matrix.ps1
+++ b/lite/test/restore-matrix.ps1
@@ -24,7 +24,14 @@ function State($inst) { "$dir\sessions-$inst.tsv" }
 function Log($inst)   { "$dir\lite-$inst.log" }
 
 function Reset-Cell($inst) {
-    Remove-Item (State $inst), (Log $inst), "$(Log $inst).old", "$(State $inst).bak" -ErrorAction SilentlyContinue
+    Remove-Item (State $inst), (Log $inst), "$(Log $inst).old", "$(State $inst).bak", "$(State $inst).tmp" `
+        -ErrorAction SilentlyContinue
+}
+
+# The newest real session id in the tree (workspace rows carry numeric ids).
+function LastSessionId($inst) {
+    @(([regex]::Matches(((& $ctl tree --json --pipe $inst 2>&1) -join ''), '"id"\s*:\s*"([^"]+)"') |
+       ForEach-Object { $_.Groups[1].Value }) | Where-Object { $_ -notmatch '^\d+$' })[-1]
 }
 
 function Start-Lite($inst) {
@@ -50,6 +57,13 @@ function Signature($inst) {
     $j = (& $ctl tree --json --pipe $inst 2>&1) -join ''
     $names = [regex]::Matches($j, '"name"\s*:\s*"([^"]*)"') | ForEach-Object { $_.Groups[1].Value }
     ($names -join '|')
+}
+
+# Does the whole log say this? (Restore-Verdict only shows the last few lines, so a decision made
+# early in a run — like the .bak fallback — is not visible there.)
+function Log-Has($inst, [string]$pattern) {
+    $l = Log $inst
+    (Test-Path $l) -and ((Get-Content $l -Raw) -match $pattern)
 }
 
 function Restore-Verdict($inst) {
@@ -145,11 +159,13 @@ Cell -Name 'flagged' -Setup {
 # makes a DEFAULT session, so the state file is seeded directly: that is also the exact shape
 # restoreSessions() has to cope with, and it keeps the cell deterministic.
 function Seeded {
-    param([string]$Name, [string]$Tsv, [scriptblock]$Assert)
+    param([string]$Name, [string]$Tsv, [string]$Bak, [string]$Tmp, [scriptblock]$Assert)
     if ($Only -and $Only -ne $Name) { return }
     $inst = "rm-$Name"
     Reset-Cell $inst
-    Set-Content -Path (State $inst) -Value $Tsv -NoNewline -Encoding utf8
+    if ($null -ne $Tsv) { Set-Content -Path (State $inst) -Value $Tsv -NoNewline -Encoding utf8 }
+    if ($Bak) { Set-Content -Path "$(State $inst).bak" -Value $Bak -NoNewline -Encoding utf8 }
+    if ($Tmp) { Set-Content -Path "$(State $inst).tmp" -Value $Tmp -NoNewline -Encoding utf8 }
     $after = ''; $err = ''
     try {
         $p = Start-Lite $inst
@@ -285,6 +301,108 @@ if (-not $Only -or $Only -eq 'restart-cmdline') {
     }
 }
 
+# --- a good state file must never be replaced by an empty or truncated one ----------------------
+# The save is atomic (tmp + rename) and keeps one .bak generation; restore falls back to the .bak.
+
+# The transient-empty save, driven for real. Split shells are hidden and deliberately not persisted,
+# so with a split open, closing the only VISIBLE session leaves lite running with zero persistable
+# sessions. That save used to write a 0-session file over a good one — and with CREATE_ALWAYS there
+# was nothing left to fall back to.
+if (-not $Only -or $Only -eq 'zero-guard') {
+    $inst = 'rm-zero-guard'
+    Reset-Cell $inst
+    $err = ''; $kept = $false; $skipped = $false; $after = ''
+    try {
+        $p = Start-Lite $inst
+        $id = LastSessionId $inst
+        & $ctl session rename keep-me --target $id --pipe $inst 2>&1 | Out-Null
+        Start-Sleep -Seconds 2
+        & $ctl session split on --pipe $inst 2>&1 | Out-Null
+        Start-Sleep -Seconds 2
+        & $ctl session close $id --pipe $inst 2>&1 | Out-Null
+        Start-Sleep -Seconds 3
+        $kept = (Get-Content (State $inst) -Raw) -match 'keep-me'
+        $skipped = (Get-Content (Log $inst) -Raw) -match 'save SKIPPED'
+        Stop-Lite $p
+        $p2 = Start-Lite $inst
+        Start-Sleep -Seconds 2
+        $after = Signature $inst
+        Stop-Lite $p2
+    } catch { $err = $_.Exception.Message }
+    if (-not $err -and $kept -and $skipped -and $after -match 'keep-me') {
+        "  PASS  {0,-22} [{1}]" -f 'zero-guard', $after
+    } else {
+        $script:failed += 'zero-guard'
+        "  FAIL  zero-guard"
+        if ($err) { "        error:  $err" }
+        "        state kept the session: $kept ; log said SKIPPED: $skipped"
+        "        after:  [$after]"
+        "        log:    $(Restore-Verdict $inst)"
+    }
+}
+
+# The other side of that guard: closing the LAST session is a deliberate empty, so it must be
+# written (and must not be undone by the .bak on the next launch). A guard that over-refuses would
+# resurrect sessions the user closed on purpose.
+if (-not $Only -or $Only -eq 'closed-last') {
+    $inst = 'rm-closed-last'
+    Reset-Cell $inst
+    $err = ''; $tsv = 'x'; $after = ''; $bak = $true
+    try {
+        $p = Start-Lite $inst
+        $id = LastSessionId $inst
+        & $ctl session rename gone-for-good --target $id --pipe $inst 2>&1 | Out-Null
+        Start-Sleep -Seconds 2
+        # Closing the last session empties the window. (Driven over the control pipe it does not tear
+        # the window down — DestroyWindow only works from the UI thread — but the save is the same
+        # one, and the save is what this cell is about.)
+        & $ctl session close $id --pipe $inst 2>&1 | Out-Null
+        Start-Sleep -Seconds 3
+        $tsv = if (Test-Path (State $inst)) { (Get-Content (State $inst) -Raw) } else { '' }
+        $bak = Test-Path "$(State $inst).bak"
+        if (-not (Log-Has $inst 'save ok: 0 session')) { throw 'the deliberate empty save never happened' }
+        Stop-Lite $p
+        $p2 = Start-Lite $inst
+        Start-Sleep -Seconds 2
+        $after = Signature $inst
+        Stop-Lite $p2
+    } catch { $err = $_.Exception.Message }
+    if (-not $err -and $tsv -notmatch 'gone-for-good' -and -not $bak -and $after -notmatch 'gone-for-good') {
+        "  PASS  {0,-22} (deliberate empty is honoured)" -f 'closed-last'
+    } else {
+        $script:failed += 'closed-last'
+        "  FAIL  closed-last"
+        if ($err) { "        error:  $err" }
+        "        state: [$($tsv -replace "`r?`n", '\n')] ; .bak left behind: $bak"
+        "        after: [$after]"
+    }
+}
+
+# An interrupted write can only ever leave a stray .tmp: the previous file is replaced by a rename,
+# which either happened or didn't. Seed the wreckage of a half-finished save and assert both
+# sessions still come back.
+Seeded -Name 'interrupted-write' `
+    -Tsv "V1`nW`tws-i`nS`t0`tsurvivor-one`t`t$cwd`nS`t0`tsurvivor-two`t`t$cwd`nA`t0`n" `
+    -Tmp "V1`nW`tws-i`nS`t0`tsurviv" -Assert {
+    param($a, $i)
+    ($a -match 'survivor-one') -and ($a -match 'survivor-two')
+}
+
+# The second chance restore never had: a primary that parses to nothing, with a good previous
+# generation beside it.
+Seeded -Name 'bak-fallback' -Tsv '' `
+    -Bak "V1`nW`tws-k`nS`t0`tfrom-the-bak`t`t$cwd`nA`t0`n" -Assert {
+    param($a, $i)
+    ($a -match 'from-the-bak') -and (Log-Has $i 'falling back')
+}
+
+# Backward compatibility: a plain 0.17.x file — no D line, no .bak anywhere — must still restore.
+Seeded -Name 'compat-0.17' `
+    -Tsv "V1`nW`tws-c`nS`t0`told-one`t`t$cwd`nS`t0`told-two`t`t$cwd`nF`t1`nA`t0`n" -Assert {
+    param($a, $i)
+    ($a -match 'old-one') -and ($a -match 'old-two')
+}
+
 # --- harness self-check: a deliberately corrupted state file MUST fail a cell -------------------
 # Without this, a harness that silently passes everything would be indistinguishable from a
 # working restore — which is exactly the trap this whole exercise exists to avoid.
@@ -296,6 +414,7 @@ Start-Sleep -Seconds 2
 $sigBefore = Signature $selfInst
 Stop-Lite $sp
 Set-Content -Path (State $selfInst) -Value '' -NoNewline      # wipe it: restore must not match
+Remove-Item "$(State $selfInst).bak" -ErrorAction SilentlyContinue   # ...and the generation it would fall back to
 $sp2 = Start-Lite $selfInst
 Start-Sleep -Seconds 2
 $sigAfter = Signature $selfInst

--- a/lite/test/restore-matrix.ps1
+++ b/lite/test/restore-matrix.ps1
@@ -566,6 +566,47 @@ if (-not $Only -or $Only -eq 'guard-after-empty') {
     }
 }
 
+# The guard's counting has to agree with the save's. The save writes only VISIBLE sessions, but a
+# hidden one (the quick terminal here, or a split shell) keeps the session list non-empty — so
+# closing the last visible session while one is open is still a deliberate empty, and the file must
+# be rewritten. Judged by the raw list instead, the save is refused and the sessions the user just
+# closed are read straight back out of the untouched file on the next launch.
+if (-not $Only -or $Only -eq 'closed-last-with-hidden') {
+    $inst = 'rm-hidden-empty'
+    Reset-Cell $inst
+    $err = ''; $tsv = 'x'; $after = ''; $wrote = $false
+    $p = $null; $p2 = $null
+    try {
+        $p = Start-Lite $inst
+        $id = LastSessionId $inst
+        & $ctl session rename closed-with-quick --target $id --pipe $inst 2>&1 | Out-Null
+        Start-Sleep -Seconds 2
+        & $ctl quick on --pipe $inst 2>&1 | Out-Null       # a hidden session the save never writes
+        Start-Sleep -Seconds 2
+        & $ctl session close $id --pipe $inst 2>&1 | Out-Null
+        Start-Sleep -Seconds 3
+        $wrote = Log-Has $inst 'save ok: 0 session'
+        $tsv = if (Test-Path (State $inst)) { (Get-Content (State $inst) -Raw) } else { '' }
+        Stop-Lite $p; $p = $null
+        $p2 = Start-Lite $inst
+        Start-Sleep -Seconds 2
+        $after = Signature $inst
+        Stop-Lite $p2; $p2 = $null
+    } catch { $err = $_.Exception.Message }
+    finally { Stop-Leftover $p; Stop-Leftover $p2 }
+    if (-not $err -and $wrote -and $tsv -notmatch 'closed-with-quick' -and $after -notmatch 'closed-with-quick') {
+        "  PASS  {0,-22} (hidden shells don't block the deliberate empty)" -f 'closed-last-with-hidden'
+    } else {
+        $script:failed += 'closed-last-with-hidden'
+        "  FAIL  closed-last-with-hidden"
+        if ($err) { "        error:  $err" }
+        "        empty save happened: $wrote"
+        "        state: [$($tsv -replace "`r?`n", '\n')]"
+        "        after: [$after]"
+        "        log:   $(Restore-Verdict $inst)"
+    }
+}
+
 # An interrupted write can only ever leave a stray .tmp: the previous file is replaced by a rename,
 # which either happened or didn't. Seed the wreckage of a half-finished save and assert both
 # sessions still come back.

--- a/lite/test/restore-matrix.ps1
+++ b/lite/test/restore-matrix.ps1
@@ -267,6 +267,38 @@ Cell -Name 'shell-exited' -Setup {
     Start-Sleep -Seconds 3
 } -Assert { param($b, $a) $a -eq $b }
 
+# Two windows open at once. Multi-window lite is one PROCESS per window, each with its own
+# sessions-<instance>.tsv, so each window restores ITS OWN sessions and never the other's. Pinned
+# because "my sessions are gone" has this mundane reading: they came back in the other window.
+if (-not $Only -or $Only -eq 'two-windows') {
+    $ia = 'rm-two-windows-a'; $ib = 'rm-two-windows-b'
+    Reset-Cell $ia; Reset-Cell $ib
+    $afterA = ''; $afterB = ''; $err = ''
+    try {
+        $pa = Start-Lite $ia
+        $pb = Start-Lite $ib
+        & $ctl session rename win-a-session --target (LastSessionId $ia) --pipe $ia 2>&1 | Out-Null
+        & $ctl session rename win-b-session --target (LastSessionId $ib) --pipe $ib 2>&1 | Out-Null
+        Start-Sleep -Seconds 2
+        Stop-Lite $pa; Stop-Lite $pb
+
+        $pa2 = Start-Lite $ia; $pb2 = Start-Lite $ib
+        Start-Sleep -Seconds 2
+        $afterA = Signature $ia; $afterB = Signature $ib
+        Stop-Lite $pa2; Stop-Lite $pb2
+    } catch { $err = $_.Exception.Message }
+    $ok = (-not $err) -and ($afterA -match 'win-a-session') -and ($afterA -notmatch 'win-b-session') `
+                       -and ($afterB -match 'win-b-session') -and ($afterB -notmatch 'win-a-session')
+    if ($ok) { "  PASS  {0,-22} (each window restores only its own)" -f 'two-windows' }
+    else {
+        $script:failed += 'two-windows'
+        "  FAIL  two-windows"
+        if ($err) { "        error:  $err" }
+        "        window A: [$afterA]"
+        "        window B: [$afterB]"
+    }
+}
+
 # --- "Restart everything" must come back as the SAME instance ----------------------------------
 # restartApp() used to relaunch the bare exe, so a named window restarted as the DEFAULT instance
 # and read a different sessions file. Nothing crashed; the sessions were simply someone else's.
@@ -450,6 +482,49 @@ Seeded -Name 'compat-0.17' `
     -Tsv "V1`nW`tws-c`nS`t0`told-one`t`t$cwd`nS`t0`told-two`t`t$cwd`nF`t1`nA`t0`n" -Assert {
     param($a, $i)
     ($a -match 'old-one') -and ($a -match 'old-two')
+}
+
+# --- malformed / future state files: degrade, never crash and never take the window down -------
+# Every one of these is a file the user can genuinely end up with: a save that never got any bytes,
+# a disk that filled mid-write, a downgrade after running a newer build, a hand-edited file.
+
+# An empty primary with NO generation to fall back to: lite must start fresh, with a usable window,
+# and the log must say which of the two empties it was (no file vs. a file with nothing in it).
+Seeded -Name 'empty-file' -Tsv '' -Assert {
+    param($a, $i)
+    ($a -ne '') -and (Log-Has $i 'state file is EMPTY') -and (Log-Has $i 'starting fresh')
+}
+
+# Cut mid-record, the shape a full disk used to leave behind. The complete specs above the cut must
+# restore; the partial one is dropped rather than restored as a spec with empty fields.
+Seeded -Name 'truncated' `
+    -Tsv "V1`nW`tws-t`nS`t0`twhole-one`t`t$cwd`nS`t0`twhole-two`t`t$cwd`nS`t0`tcut-o" -Assert {
+    param($a, $i)
+    ($a -match 'whole-one') -and ($a -match 'whole-two') -and ($a -notmatch 'cut-o')
+}
+
+# A file written by a FUTURE build (downgrade, or a roaming profile shared between versions). The
+# format grows by adding line types, so the right answer is to read what this build understands and
+# say so — refusing would lose the sessions and then overwrite the newer file with a V1 one.
+Seeded -Name 'future-v2' `
+    -Tsv "V2`nW`tws-v`nS`t0`tfrom-the-future`t`t$cwd`nZ`tsomething-new`t42`nA`t0`n" -Assert {
+    param($a, $i)
+    ($a -match 'from-the-future') -and (Log-Has $i 'is format V2')
+}
+
+# S lines with no W lines at all: the workspace list stays whatever the build defaults to, and every
+# spec lands in it rather than vanishing with its workspace.
+Seeded -Name 'no-workspaces' `
+    -Tsv "V1`nS`t0`tno-ws-session`t`t$cwd`nA`t0`n" -Assert {
+    param($a, $i) $a -match 'no-ws-session'
+}
+
+# A spec pointing at a workspace that no longer exists (workspace deleted by an older build, or the
+# file hand-edited), plus an out-of-range active workspace: both clamp to 0, so the session is
+# visible instead of being filed under a workspace nobody can reach.
+Seeded -Name 'stray-ws-index' `
+    -Tsv "V1`nW`tonly-ws`nS`t7`tstray-session`t`t$cwd`nS`t0`thome-session`t`t$cwd`nF`t9`nA`t9`n" -Assert {
+    param($a, $i) ($a -match 'stray-session') -and ($a -match 'home-session') -and ($a -match 'only-ws')
 }
 
 # --- harness self-check: a deliberately corrupted state file MUST fail a cell -------------------

--- a/lite/test/restore-matrix.ps1
+++ b/lite/test/restore-matrix.ps1
@@ -31,6 +31,15 @@ $script:failed = @()
 function State($inst) { "$dir\sessions-$inst.tsv" }
 function Log($inst)   { "$dir\lite-$inst.log" }
 
+# Seed a state file with EXACTLY these bytes. Not Set-Content -Encoding utf8: that means "UTF-8 with
+# BOM" on Windows PowerShell 5.1 and "UTF-8 without BOM" on pwsh 7, so under 5.1 every seeded file
+# would start with EF BB BF and the "V1"/"V2" header would never be recognised — cells like
+# future-v2 would fail for a reason that has nothing to do with lite. run-all.ps1 does not pin the
+# host, so the suite has to write the same bytes on either one.
+function Write-State([string]$Path, [string]$Text) {
+    [System.IO.File]::WriteAllText($Path, $Text, (New-Object System.Text.UTF8Encoding $false))
+}
+
 function Reset-Cell($inst) {
     Remove-Item (State $inst), (Log $inst), "$(Log $inst).old", "$(State $inst).bak", "$(State $inst).tmp" `
         -ErrorAction SilentlyContinue
@@ -205,9 +214,9 @@ function Seeded {
     if ($Only -and $Only -ne $Name) { return }
     $inst = "rm-$Name"
     Reset-Cell $inst
-    if ($null -ne $Tsv) { Set-Content -Path (State $inst) -Value $Tsv -NoNewline -Encoding utf8 }
-    if ($Bak) { Set-Content -Path "$(State $inst).bak" -Value $Bak -NoNewline -Encoding utf8 }
-    if ($Tmp) { Set-Content -Path "$(State $inst).tmp" -Value $Tmp -NoNewline -Encoding utf8 }
+    if ($null -ne $Tsv) { Write-State (State $inst) $Tsv }
+    if ($Bak) { Write-State "$(State $inst).bak" $Bak }
+    if ($Tmp) { Write-State "$(State $inst).tmp" $Tmp }
     $after = ''; $err = ''; $ok = $false
     $p = $null
     try {
@@ -250,7 +259,7 @@ function Session-Named($inst, $name) { @(SessionsOf $inst | Where-Object { $_.na
 if (-not $Only -or $Only -eq 'failed-spec') {
     $inst = 'rm-failed-spec'
     Reset-Cell $inst
-    Set-Content -Path (State $inst) -NoNewline -Encoding utf8 -Value `
+    Write-State (State $inst) `
         "V1`nW`tws-f`nS`t0`tghost-session`tno-such-program-xyz.exe`t$cwd`nS`t0`tlive-session`tpowershell.exe`t$cwd`nA`t0`n"
     $err = ''; $ghost = $null; $live = $null; $named = $false; $resaved = $false; $after = ''
     $ghostOk = $false; $liveOk = $false
@@ -300,6 +309,52 @@ Cell -Name 'killed' -Setup {
 } -Kill -Assert {
     param($b, $a, $i)
     $a -eq $b -and (SessionCount $b) -ge 2 -and (Log-Has $i 'adopted live session')
+}
+
+# Adoption's user-visible half, which 'killed' cannot see: it compares NAMES, and a name comes back
+# from the state file whether the pane behind it has any content or not. An adopted session gets a
+# brand-new empty emulator and the host forwards only NEW output, so "the shells are alive" and "the
+# user can see anything" are separate claims. Put a marker on the screen, kill, adopt, demand it back.
+#
+# Honest about what this does and does not pin: it passes both with and without Attach.repaint,
+# because the post-restore resize already makes ConPTY re-emit. It is a guard on the PROPERTY (an
+# adopted pane has its screen), not a discriminator for the mechanism that provides it.
+if (-not $Only -or $Only -eq 'killed-repaint') {
+    $inst = 'rm-killed-repaint'
+    Reset-Cell $inst
+    $err = ''; $seenBefore = $false; $adopted = $false; $seenAfter = $false; $textAfter = ''
+    $p = $null; $p2 = $null
+    try {
+        $p = Start-Lite $inst
+        $id = LastSessionId $inst
+        & $ctl session type "echo ADOPTME-MARKER`n" --target $id --pipe $inst 2>&1 | Out-Null
+        Start-Sleep -Seconds 3
+        # Prove the premise: without this, a `type` that never landed would make the cell assert
+        # nothing and "fail" for a reason that has nothing to do with repaint.
+        $seenBefore = ((& $ctl session text --target $id --pipe $inst 2>&1) -join "`n") -match 'ADOPTME-MARKER'
+        Stop-Lite $p -Kill; $p = $null
+
+        $p2 = Start-Lite $inst
+        Start-Sleep -Seconds 4                       # the repaint jiggle is async in the host
+        $adopted = Log-Has $inst 'adopted live session'
+        $id2 = LastSessionId $inst
+        $textAfter = (& $ctl session text --target $id2 --pipe $inst 2>&1) -join "`n"
+        $seenAfter = $textAfter -match 'ADOPTME-MARKER'
+        Stop-Lite $p2; $p2 = $null
+    } catch { $err = $_.Exception.Message }
+    finally { Stop-Leftover $p; Stop-Leftover $p2 }
+    if (-not $err -and $seenBefore -and $adopted -and $seenAfter) {
+        "  PASS  {0,-22} (an adopted pane comes back with its screen)" -f 'killed-repaint'
+    } else {
+        $script:failed += 'killed-repaint'
+        "  FAIL  killed-repaint"
+        if ($err) { "        error:  $err" }
+        "        marker on screen before the kill: $seenBefore"
+        "        session was adopted:              $adopted"
+        "        marker back after adoption:       $seenAfter"
+        "        after: [$(($textAfter -replace '\s+', ' ').Trim())]"
+        "        log:   $(Restore-Verdict $inst)"
+    }
 }
 
 # A session whose shell has already exited: its spec must still be saved and relaunched, otherwise
@@ -625,6 +680,45 @@ Seeded -Name 'bak-fallback' -Tsv '' `
     ($a -match 'from-the-bak') -and (Log-Has $i 'falling back')
 }
 
+# The other half of Task 4, and the half bak-fallback cannot reach: bak-fallback SEEDS a .bak by
+# hand, so it would pass unchanged against a build that never writes one. This asserts lite itself
+# rotates — that after a second save the .bak holds the PREVIOUS generation while the primary holds
+# the current one. On the pre-fix in-place write there is no .bak at all and this fails outright.
+if (-not $Only -or $Only -eq 'bak-rotation') {
+    $inst = 'rm-bak-rotation'
+    Reset-Cell $inst
+    $err = ''; $bakExists = $false; $bakIsPrev = $false; $tsvIsCurrent = $false; $orig = ''
+    $p = $null
+    try {
+        $p = Start-Lite $inst
+        $id = LastSessionId $inst
+        $orig = @(SessionsOf $inst | Where-Object { $_.id -eq $id })[0].name
+        Start-Sleep -Seconds 2                                  # save #1: primary written, nothing to rotate yet
+        & $ctl session rename rotated-generation --target $id --pipe $inst 2>&1 | Out-Null
+        Start-Sleep -Seconds 3                                  # save #2: primary -> .bak, new primary published
+        # Read both WHILE lite runs: the shutdown save rotates again, which would put the current
+        # name in the .bak too and make the "previous generation" half of this untestable.
+        $bakExists = Test-Path "$(State $inst).bak"
+        if ($bakExists) {
+            $bak = Get-Content "$(State $inst).bak" -Raw
+            $bakIsPrev = ($bak -match [regex]::Escape($orig)) -and ($bak -notmatch 'rotated-generation')
+        }
+        $tsvIsCurrent = (Test-Path (State $inst)) -and ((Get-Content (State $inst) -Raw) -match 'rotated-generation')
+        Stop-Lite $p; $p = $null
+    } catch { $err = $_.Exception.Message }
+    finally { Stop-Leftover $p }
+    if (-not $err -and $bakExists -and $bakIsPrev -and $tsvIsCurrent) {
+        "  PASS  {0,-22} (.bak holds the previous generation)" -f 'bak-rotation'
+    } else {
+        $script:failed += 'bak-rotation'
+        "  FAIL  bak-rotation"
+        if ($err) { "        error:  $err" }
+        "        .bak exists: $bakExists / holds '$orig' and not the new name: $bakIsPrev"
+        "        primary holds the new name: $tsvIsCurrent"
+        "        log:   $(Restore-Verdict $inst)"
+    }
+}
+
 # Backward compatibility: a plain 0.17.x file — no D line, no .bak anywhere — must still restore.
 Seeded -Name 'compat-0.17' `
     -Tsv "V1`nW`tws-c`nS`t0`told-one`t`t$cwd`nS`t0`told-two`t`t$cwd`nF`t1`nA`t0`n" -Assert {
@@ -706,7 +800,7 @@ if (-not $Only -or $Only -eq 'harness-selfcheck') {
         Start-Sleep -Seconds 2
         $sigBefore = Signature $selfInst
         Stop-Lite $sp; $sp = $null
-        Set-Content -Path (State $selfInst) -Value '' -NoNewline      # wipe it: restore must not match
+        Write-State (State $selfInst) ''                              # wipe it: restore must not match
         Remove-Item "$(State $selfInst).bak" -ErrorAction SilentlyContinue   # ...and the generation it would fall back to
         $sp2 = Start-Lite $selfInst
         Start-Sleep -Seconds 2

--- a/lite/test/run-all.ps1
+++ b/lite/test/run-all.ps1
@@ -4,7 +4,7 @@ param([string]$Exe = "$PSScriptRoot\..\bin\agwinterm-lite.exe")
 
 $ErrorActionPreference = 'Continue'
 $failed = @()
-foreach ($t in 'log-basics', 'log-restore', 'log-focus-font', 'log-rotation', 'diagnose') {
+foreach ($t in 'log-basics', 'log-restore', 'log-focus-font', 'log-rotation', 'diagnose', 'restore-matrix') {
     $script = Join-Path $PSScriptRoot "$t.ps1"
     if (-not (Test-Path $script)) { continue }
     & $script -Exe $Exe

--- a/lite/test/run-all.ps1
+++ b/lite/test/run-all.ps1
@@ -7,7 +7,12 @@ $failed = @()
 foreach ($t in 'log-basics', 'log-restore', 'log-focus-font', 'log-rotation', 'diagnose', 'restore-matrix') {
     $script = Join-Path $PSScriptRoot "$t.ps1"
     if (-not (Test-Path $script)) { continue }
-    & $script -Exe $Exe
+    # Each child sets $ErrorActionPreference = 'Stop', so it can die before reaching its own exit
+    # statement. Without the reset + catch, $LASTEXITCODE would still hold the PREVIOUS script's 0
+    # and a script that crashed would be reported as passing.
+    $global:LASTEXITCODE = 0
+    try { & $script -Exe $Exe }
+    catch { "  ERROR  $t terminated: $($_.Exception.Message)"; $global:LASTEXITCODE = 1 }
     if ($LASTEXITCODE -ne 0) { $failed += $t }
     ""
 }

--- a/proto/ptyhost.options
+++ b/proto/ptyhost.options
@@ -14,13 +14,15 @@ agwinterm.ptyhost.CreateReply.id       max_size:128
 agwinterm.ptyhost.AttachReply.pipe     max_size:128
 agwinterm.ptyhost.AttachReply.modes    max_size:1024
 # list: lite reads the host's live session ids at startup to ADOPT sessions that outlived a killed
-# UI (the pty-host survives the UI by design). Only `id` needs storage; the rest stay callbacks and
-# are skipped on decode. 64 is far past any realistic window's session count.
+# UI (the pty-host survives the UI by design). 64 is far past any realistic window's session count.
 agwinterm.ptyhost.ListReply.sessions   max_count:64
+# Only id/has_exited/attached get storage — the three fields adoption decides on. `title` must NOT:
+# nanopb fails the WHOLE ListReply decode on string overflow, and a title is whatever OSC 0/2 the
+# shell emitted (a prompt with a long path, an ssh banner), so any fixed size is a size a real title
+# can exceed. As a callback with no decoder it is skipped instead, which cannot overflow. This
+# matters far beyond adoption: `list` is also the startup liveness probe, so a title nobody reads
+# used to be able to stop lite from launching at all.
 agwinterm.ptyhost.SessionInfo.id       max_size:128
-# title must hold a REAL title: nanopb fails the whole ListReply decode on string overflow, so
-# truncating this silently broke `list` for any host that had a titled session.
-agwinterm.ptyhost.SessionInfo.title    max_size:256
 agwinterm.ptyhost.Create.env           max_count:8
 agwinterm.ptyhost.Create.EnvEntry.key    max_size:64
 agwinterm.ptyhost.Create.EnvEntry.value  max_size:192

--- a/proto/ptyhost.options
+++ b/proto/ptyhost.options
@@ -13,6 +13,14 @@ agwinterm.ptyhost.HelloReply.protocol  int_size:IS_32
 agwinterm.ptyhost.CreateReply.id       max_size:128
 agwinterm.ptyhost.AttachReply.pipe     max_size:128
 agwinterm.ptyhost.AttachReply.modes    max_size:1024
+# list: lite reads the host's live session ids at startup to ADOPT sessions that outlived a killed
+# UI (the pty-host survives the UI by design). Only `id` needs storage; the rest stay callbacks and
+# are skipped on decode. 64 is far past any realistic window's session count.
+agwinterm.ptyhost.ListReply.sessions   max_count:64
+agwinterm.ptyhost.SessionInfo.id       max_size:128
+# title must hold a REAL title: nanopb fails the whole ListReply decode on string overflow, so
+# truncating this silently broke `list` for any host that had a titled session.
+agwinterm.ptyhost.SessionInfo.title    max_size:256
 agwinterm.ptyhost.Create.env           max_count:8
 agwinterm.ptyhost.Create.EnvEntry.key    max_size:64
 agwinterm.ptyhost.Create.EnvEntry.value  max_size:192


### PR DESCRIPTION
Implements `docs/plans/2026-07-31-lite-restore-scenario-matrix.md`. **Found and fixed the reported break.**

## How it was found

The matrix walks real-world scenarios until one fails. It failed on `killed` — force-kill lite, relaunch:

```
FAIL  killed
      before: [workspace 1|rm-killed-1|rm-killed-2]
      after:  [workspace 1|rm-killed-3]
      log:    restore: no session could be started from 2 spec(s) — starting fresh
```

The state file was written and parsed correctly (**2 specs**), every create failed **in the same millisecond**, and the file was then rewritten with the single fresh session — destroying the evidence. That is why this never survived long enough to diagnose in the field.

## My first diagnosis was wrong, and the log said so

Id collision fit beautifully: `newSession()` numbers ids `<prefix>-<seq>` from 1 each launch, the pty-host outlives the UI by design, the host rejects duplicates with `session '<id>' already exists`, and the next fresh session came back as `-3`. Then the log answered:

```
restore: 2 saved id(s) in the file, host holds 0 live session(s)
```

Nothing to collide with. The diagnostics from #183 are the difference between a fix and a guess.

## Actual cause

`connectControl()` opened the existing control pipe with **timeout 0** and treated a `hello` reply as proof of life. After a force-kill, the old pty-host is tearing down but still accepts a connection and answers hello for a moment, while refusing every real command. lite restored against a corpse.

On a machine that gets shut down or signed out rather than closed cleanly, that is "doesn't work **at all**" — and it repeats every single time.

**Fix:**
- `controlHandshake()` probes with `list` as well — the cheapest request that actually touches the session table, so a host that cannot serve sessions isn't mistaken for one that can.
- `connectControl()` retries with a freshly spawned host (4 attempts, 400 ms apart), giving a dying host time to release the pipe name.

## Also here, deliberately

- **Session adoption.** When the host genuinely survives (another lite window keeps it alive), restore now *attaches* to the live shells instead of creating new ones — so a crash no longer costs you a running claude. Ids persist in a new `D` line, additive: a 0.17.x file without one still restores, just without adoption.
- **`SessionInfo.title` needed real storage** (`max_size:256`). nanopb fails an entire `ListReply` decode on string overflow, so a truncated title silently broke `list` for any host holding a titled session — it made the new health probe fail on *healthy* hosts.

## Tests

`lite/test/restore-matrix.ps1` — 9 cells, each isolated, each printing the `lite.log` verdict on failure:

```
PASS  single      PASS  app-spec        PASS  killed
PASS  several     PASS  bogus-app       PASS  shell-exited
PASS  renamed     PASS  workspaces      PASS  flagged
PASS  harness-selfcheck  (corrupted state correctly fails to restore)
```

The self-check matters: it wipes a state file and asserts the cell **fails**, so the harness cannot pass vacuously — which is the trap this whole exercise existed to avoid. Full lite suite, .NET 316 and Rust 27 all unchanged.

## Still open

`restartApp()` dropping `--pipe` (plan Task 3b) and the atomic-write/`.bak` hardening (Task 4) are not in this PR — the reported bug is fixed and worth shipping on its own.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)