### PR TITLE
fix(render): a regrid can no longer collapse a pane's PTY to one column

### DIFF
--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -473,12 +473,26 @@ internal partial class Program
         if (_cover is not null) RegridCover();
     }
 
-    /// <summary>Resize every pane's PTY grid to fit its column using the pane's own font metrics.</summary>
+    /// <summary>Resize every pane's PTY grid to fit its column using the pane's own font metrics.
+    /// Does nothing while the window has no usable client area — see the guard.</summary>
     private void RegridSession(Ses ses)
     {
+        // A minimized window's client rect is 0x0, and ContentArea() floors that with
+        // MathF.Max(1f, ...) — so the layout comes back as a 1-PIXEL column that looks valid.
+        // Regridding from it resized the PTY to 1x1 and ConPTY reflowed every line to a single
+        // character: that is the "Claude Code renders 1 char per line after I come back and switch
+        // sessions" report, and the blank PowerShell prompt that needed an Enter to redraw. Two
+        // defensive clamps (1px, then 1 col) combining into a destructive-but-"valid" size.
+        // Skipping leaves each PTY at its last good size; WM_SIZE regrids everything (RegridAll)
+        // the moment the window is real again, so nothing is lost by waiting.
+        if (_hwnd != IntPtr.Zero && IsIconic(_hwnd)) return;
+
         foreach (var (pane, _, _, w, h) in PaneLayout(ses))
         {
             var (_, cw, ch) = Metrics(pane.FontSize);
+            // Not even one cell fits: the layout is degenerate (mid-teardown, or a sidebar wider
+            // than the window). Leave this pane's PTY alone rather than telling it it's 1x1.
+            if (w < cw || h < ch) continue;
             int cols = Math.Max(1, (int)(w / cw)), rows = Math.Max(1, (int)(h / ch));
             if (pane.S.Cols != cols || pane.S.Rows != rows) pane.S.Resize(cols, rows);
             pane.ScrollOffset = Math.Clamp(pane.ScrollOffset, 0, pane.S.Emulator.HistoryCount);
@@ -661,8 +675,10 @@ internal partial class Program
     private void RegridCover()
     {
         if (_cover is null) return;
+        if (_hwnd != IntPtr.Zero && IsIconic(_hwnd)) return;   // same 1x1 trap as RegridSession
         var (_, _, w, h) = CoverRect();
         var (_, cw, ch) = Metrics(_cover.FontSize);
+        if (w < cw || h < ch) return;
         int cols = Math.Max(1, (int)(w / cw)), rows = Math.Max(1, (int)(h / ch));
         if (_cover.S.Cols != cols || _cover.S.Rows != rows) _cover.S.Resize(cols, rows);
         _cover.ScrollOffset = Math.Clamp(_cover.ScrollOffset, 0, _cover.S.Emulator.HistoryCount);

--- a/tests/Agwinterm.Core.Tests/Agwinterm.Core.Tests.csproj
+++ b/tests/Agwinterm.Core.Tests/Agwinterm.Core.Tests.csproj
@@ -14,5 +14,14 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../src/Agwinterm.Core/Agwinterm.Core.csproj" />
+    <!-- PInvokeCharSetTests reflects over the BUILT Agwinterm.Win32 assembly (it can't reference it:
+         that's a net10.0-windows WinExe and this is net10.0). Build-order only — no assembly
+         reference, TFM check skipped. Without this the test fails with "build Agwinterm.Win32 first"
+         in any fresh clone or worktree, and only passed in CI because the workflow happens to run a
+         full solution build in an earlier step. -->
+    <ProjectReference Include="../../src/Agwinterm.Win32/Agwinterm.Win32.csproj"
+                      ReferenceOutputAssembly="false"
+                      SkipGetTargetFrameworkProperties="true"
+                      Private="false" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Report: coming back to the main app and switching sessions renders Claude Code **one character per line**, and a PowerShell pane sits **black until you press Enter**. lite doesn't do it.

## Why "one char per line" pins the cause

That is not a paint bug. It means the PTY really was told it is ~1 column wide, and the program inside reflowed to match. Exactly one place can say that — two defensive clamps stacking into a destructive-but-"valid" size:

```csharp
// ContentArea()
float w = MathF.Max(1f, ClientW() - _sidebarW - 2 * PadX);   // 0 -> 1 PIXEL

// RegridSession()
int cols = Math.Max(1, (int)(w / cw));                        // 1px -> 1 COLUMN
```

A minimized window's client rect is `0x0`. Any regrid running then resizes **every** pane to 1x1 — `RegridAllSessions()` exists precisely to regrid inactive sessions too, so one bad call reaches all of them. ConPTY reflows, alt-screen content is destroyed, and the pane stays wrong until something forces a real resize. That is "I need to force refresh it", and the blank PowerShell prompt is the same event from the other side.

## Fix

`RegridSession` and `RegridCover` bail while the window is iconic, and skip any pane whose rect can't fit a single cell. Skipping leaves each PTY at its last good size, and `WM_SIZE` regrids everything the moment the window is real again — nothing is lost by waiting.

## What I could NOT do

**Reproduce it.** An isolated Debug instance (`agwinterm-dev`, own data dir and pipe) driven through minimize → restore → switch sessions held at **83 columns**, with and without the change. The probe asks the shell itself (`[Console]::WindowWidth`), so it measures the PTY the way the program inside sees it.

So this is not a confirmed fix for the report — it closes a path that provably produces the exact symptom and should never have existed. If it still happens on 0.17.3+, the trigger is a different degenerate input to the same clamp, and the next step is making the main app self-reporting the way lite now is (log the regrid inputs when they'd yield ≤2 columns).

Not a regression: a real resize still reaches the PTY, **83 → 131 columns** at 1500px.

## Noticed while here, not fixed

The app calls `SetProcessDpiAwarenessContext` but has **no `WM_DPICHANGED` handler and no `_dpi` anywhere**. Per-monitor DPI awareness means Windows won't rescale it — so docking/undocking a laptop leaves `_sidebarW` and the DirectWrite font metrics at the old scale. That fits "when I come back" on a docked machine and deserves its own issue.

## Drive-by

`PInvokeCharSetTests` (mine, from #178) reflects over the **built** `Agwinterm.Win32` assembly, so in a fresh clone or worktree it failed with `build Agwinterm.Win32 first`. It only passed in CI because the workflow runs a full solution build in an earlier step. Added a build-order-only `ProjectReference` (`ReferenceOutputAssembly=false`, `SkipGetTargetFrameworkProperties=true`).

Tests: **200 Core + 116 Pty** green in a clean worktree.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)