### PR TITLE
fix(input): typing works again in the action palette, settings filter and search bar

### DIFF
--- a/src/Agwinterm.Win32/Program.WndProc.cs
+++ b/src/Agwinterm.Win32/Program.WndProc.cs
@@ -268,9 +268,6 @@ internal partial class Program
                 {
                     char c = (char)wParam;
                     if (_kittyAteChar) { _kittyAteChar = false; return IntPtr.Zero; }   // OnKeyDown already CSI-u-encoded this key
-                    // win32-input-mode encodes the char in the key-down sequence's Uc field, so the
-                    // normal WM_CHAR for this pane is redundant — drop it.
-                    if (ActiveSurface()?.S.Emulator.Win32InputMode == true) return IntPtr.Zero;
                     if (_coverKind == 3 && _ovlOwner is { OverlayExited: true }) { CloseActiveOverlay(); return IntPtr.Zero; }
                     if (_setOpen)
                     {
@@ -287,6 +284,15 @@ internal partial class Program
                         if (c >= 0x20 && c != 0x7f) { _searchQuery += c; RecomputeSearch(); _searchCur = 0; ScrollToMatch(); RequestRedraw(); }
                         return IntPtr.Zero;
                     }
+                    // win32-input-mode encodes the char in the key-down sequence's Uc field, so
+                    // sending it again here would duplicate it for this pane. Checked HERE, below the
+                    // overlay handlers, not above them: while the action palette / settings dropdown /
+                    // search bar is up it owns the keyboard, and dropping its characters made all
+                    // three impossible to type into whenever the pane's program had ?9001 on — which
+                    // ConPTY enables, so any pane running Claude Code did it. The overlay opened,
+                    // arrows and Enter worked (those are handled in OnKeyDown, above this path), but
+                    // no text ever arrived.
+                    if (ActiveSurface()?.S.Emulator.Win32InputMode == true) return IntPtr.Zero;
                     if (c >= 0x20 && c != 0x7f) Send(c.ToString());
                     return IntPtr.Zero;
                 }


### PR DESCRIPTION
Report: **"I can't type in the actions popup (Ctrl+Shift+P) any more."**

## Cause

`WM_CHAR` dropped every character whenever the **active pane's** program had win32-input-mode (`DECSET ?9001`) on — and the check sat at the very top of the handler, above every overlay:

```csharp
if (ActiveSurface()?.S.Emulator.Win32InputMode == true) return IntPtr.Zero;   // <-- swallows all
...
if (_setOpen)                     { _ddQuery     += c; ... }   // settings dropdown filter
if (_palette != PaletteKind.None) { _palQuery    += c; ... }   // action / session palette
if (_searchActive)                { _searchQuery += c; ... }   // in-terminal search
```

ConPTY turns `?9001` on, so **any pane running Claude Code put the whole window in this state**.

The overlays' *keys* still worked — arrows, Enter and Escape are handled in `OnKeyDown`, which dispatches them at line ~936, well before its own `?9001` branch at ~1051. So the palette opened and responded to navigation, but no text ever reached the query. That mismatch is precisely what "the popup is there but I can't type in it" looks like, and it's why this reads as a UI bug rather than an input-routing one.

**"Any more" dates it**: win32-input-mode shipped in **0.15.0**, and the jump was 0.14.x → 0.17.x.

## Fix

The drop itself is right — the character already rode out in the key-down sequence's `Uc` field, so sending it again would duplicate it for that pane. It just belongs on the path that would `Send()` to the pane, not ahead of the overlays that own the keyboard while they're up. Moved to immediately above the `Send()`.

## Verification

End to end on an isolated dev instance (`agwinterm-dev`), driven only with **posted** messages — no global input injection. `?9001` enabled from inside the pane, palette bound to a bare `F9` via `keymap.conf` (modifier chords can't be posted: the app reads real modifier state), then `WM_CHAR` posted for `session`.

| build | result |
|---|---|
| before | palette open, **query empty**, list unfiltered |
| after | **query reads `session`**, list filtered to Next Session / Flag Session / Make Claude Sessions Resumable / … |

Captured with `PrintWindow`. Tests: **200 Core + 116 Pty** green.

## Scope

Fixes the same swallow for the settings dropdown filter and the in-terminal search bar, which were broken identically and for the same reason.

Related but separate: #185 (regrid collapsing a pane to one column).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)