### PR TITLE
ci(release): sync the winget fork before submitting the manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,18 @@ jobs:
           WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
         run: |
           if (-not $env:WINGET_TOKEN) { Write-Warning 'WINGET_TOKEN secret not set - skipping winget publish'; exit 0 }
+          # Sync the fork FIRST. wingetcreate refuses to open a PR from a fork that has drifted
+          # ("The forked repository could not be synced with the upstream commits. Sync your fork
+          # manually and try again."), and upstream touches .github/workflows often enough that this
+          # recurs — it blocked 0.17.3 until the fork was synced by hand. merge-upstream is
+          # server-side, so it needs no checkout; the PAT carries the scope that a plain OAuth token
+          # lacks. Best-effort: a fresh fork (or none yet) must not fail the release.
+          $owner = '${{ github.repository_owner }}'
+          try {
+            $h = @{ Authorization = "token $env:WINGET_TOKEN"; 'User-Agent' = 'agwinterm-release'; Accept = 'application/vnd.github+json' }
+            $r = Invoke-RestMethod -Method Post -Headers $h -Uri "https://api.github.com/repos/$owner/winget-pkgs/merge-upstream" -Body (@{ branch = 'master' } | ConvertTo-Json)
+            Write-Host "fork sync: $($r.message)"
+          } catch { Write-Warning "fork sync skipped: $($_.Exception.Message)" }
           $version = '${{ github.ref_name }}'.TrimStart('v')
           $url = "https://github.com/${{ github.repository }}/releases/download/v$version/agwinterm-setup-$version.exe"
           Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe


### PR DESCRIPTION
`wingetcreate` refuses to open a PR from a fork that has drifted from upstream:

> The forked repository could not be synced with the upstream commits. Sync your fork manually and try again.

That blocked winget for **0.17.3** — the manifest built and validated, then failed at submission — and it recurs whenever `microsoft/winget-pkgs` touches `.github/workflows`, because syncing a fork that carries workflow files needs the `workflow` scope a plain OAuth token lacks:

```
refusing to allow an OAuth App to create or update workflow
`.github/workflows/manifest-validation-diagnosis.lock.yml` without `workflow` scope
```

Clearing it by hand costs a manual round trip plus a job re-run each time.

## Change

The release job calls the server-side `merge-upstream` endpoint before `wingetcreate`, using `WINGET_TOKEN` (a PAT, which has the scope). No checkout needed — the sync happens entirely on GitHub's side.

Best-effort and wrapped in `try/catch`: a fresh fork, or none at all, must not fail the release. The submit step keeps its own `continue-on-error` for the moderation cases it already tolerated.

Owner comes from `github.repository_owner` rather than being hardcoded, matching how the rest of the workflow addresses the repo.

## Verified by hand today

After `gh auth refresh -s workflow`, syncing the fork moved it to upstream's head (`91fdec2e1` on both) and the re-run submitted **microsoft/winget-pkgs#417355** — "New version: yeroo.agwinterm version 0.17.3". This change makes that automatic.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)