### PR TITLE
fix(lite): state-save hardening — locking, torn records, .bak rotation, name sanitising

### DIFF
--- a/lite/src/main.cpp
+++ b/lite/src/main.cpp
@@ -1537,6 +1537,7 @@ static std::vector<HostSession> hostSessions() {
 // What the host held when this lite connected, read ONCE at startup (the list is also the handshake
 // probe, so asking twice was a wasted round trip). Filled by scanHostSessions().
 static std::vector<HostSession> g_hostLive;
+static std::vector<std::string> g_adoptedIds;   // ids this launch picked back up (never reaped)
 
 /// Read the host's sessions and make sure this window can never mint an id the host already has.
 /// Must run for EVERY launch, not just a restoring one: with --no-restore (or a state file that
@@ -1598,13 +1599,16 @@ static void closeSessionAt(int idx) {
     bool anyVisible = false;
     for (const Session* vs : g_sessions) if (!vs->hidden || vs == splitShell) { anyVisible = true; break; }
     bool allGone = g_sessions.empty();
+    // Set under the lock, with the session list it was judged from: this runs on the control-pipe
+    // thread as well as the UI one, and saveSessionState reads the flag to decide whether it may
+    // write a zero-session file and drop the .bak.
+    if (!anyVisible) g_userEmptied = true;
     LeaveCriticalSection(&g_lock);
     // The user closed the last session, so the window goes with it. This is the ONLY path that may
     // legitimately write a zero-session state file; every other empty list is transient and the save
     // refuses it (see saveSessionState). The flag describes THIS empty, not the process: driven over
     // the control pipe the DestroyWindow below is a no-op (wrong thread) and the window lives on, so
     // adding a session clears it again — otherwise the guard would stay off for good.
-    if (!anyVisible) g_userEmptied = true;
     if (allGone) { DestroyWindow(g_hwnd); return; }
     syncPaneSizes();
     InvalidateRect(g_hwnd, nullptr, FALSE);
@@ -1985,7 +1989,13 @@ static int stateFileSessionCount(const std::wstring& path, DWORD* err = nullptr)
     int n = 0;
     for (size_t i = 0; i < d.size();) {
         size_t e = d.find('\n', i);
-        if (d.compare(i, 2, "S\t") == 0) n++;
+        size_t len = (e == std::string::npos) ? d.size() - i : e - i;
+        // Count what parseStateFile would actually RESTORE, not every line that merely starts "S\t".
+        // A record cut mid-write (what an interrupted in-place save leaves) parses to nothing, so
+        // counting it as a session would let the save rotate that wreckage into the .bak — over the
+        // one generation that still held the sessions — and let it call a good file "not empty".
+        if (d.compare(i, 2, "S\t") == 0 &&
+            std::count(d.begin() + i, d.begin() + i + len, '\t') >= 4) n++;
         if (e == std::string::npos) break;
         i = e + 1;
     }
@@ -2013,7 +2023,13 @@ static std::string tsvField(const std::string& s) {
 // place, so the only copy was destroyed the instant the write began.
 static void saveSessionState() {
     std::wstring path = stateFilePath();
-    if (path.empty()) return;
+    if (path.empty()) {
+        // The last silent save failure left: no state directory means nothing is written and, before
+        // this line, nothing said so — "restore doesn't work" with an empty log, on exactly the kind
+        // of redirected/policy-locked profile the field reports come from.
+        logWarn("save FAILED: no state directory (%%LOCALAPPDATA%% is not set) — nothing was saved");
+        return;
+    }
     std::string out = "V1\n";
     for (const auto& w : g_workspaces) out += "W\t" + tsvField(narrow(w)) + "\n";
     EnterCriticalSection(&g_lock);
@@ -2037,6 +2053,10 @@ static void saveSessionState() {
         idLine += "\t" + s->id;
         saved++;
     }
+    // Read under the lock, with the session list it describes: the flag is written from the
+    // control-pipe thread (closeSessionAt) while this can run on the UI one, and it gates both the
+    // zero-session refusal and the .bak delete — the two decisions that can cost saved sessions.
+    bool userEmptied = g_userEmptied;
     LeaveCriticalSection(&g_lock);
     if (!flagLine.empty()) out += "F" + flagLine + "\n";
     if (!idLine.empty()) out += "D" + idLine + "\n";
@@ -2045,7 +2065,7 @@ static void saveSessionState() {
     // Anything that rebuilds the tree while the session list is momentarily empty used to rewrite the
     // file with zero S lines — a good file replaced by a useless one, with nothing to fall back to.
     // The one legitimate zero-session save is the user closing the last session (g_userEmptied).
-    if (saved == 0 && !g_userEmptied) {
+    if (saved == 0 && !userEmptied) {
         DWORD hadErr = 0;
         int had = stateFileSessionCount(path, &hadErr);
         // No file yet is not a file that "could not be read" — that is every first run, and saying
@@ -2075,6 +2095,14 @@ static void saveSessionState() {
         // right trade only because the alternative here is no file at all, and it is what every build
         // before this one did on every save.
         DWORD terr = GetLastError();
+        // Keep the generation by hand, because CREATE_ALWAYS below truncates the only copy the
+        // instant it opens — the atomic path's rotation (ReplaceFileW) is exactly what this path
+        // does not get. Copying first is best effort: if it fails the in-place write still has to
+        // happen, since the alternative here is no file at all.
+        if (!(saved == 0 && userEmptied) && stateFileSessionCount(path) > 0 &&
+            !CopyFileW(path.c_str(), bak.c_str(), FALSE))
+            logWarn("save: could not keep a .bak generation of %s (err %lu) before writing in place",
+                    narrow(path).c_str(), GetLastError());
         HANDLE g = CreateFileW(path.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
         if (g == INVALID_HANDLE_VALUE) {
             // The silent return that made "restore doesn't work" unanswerable in the field: if the
@@ -2092,11 +2120,15 @@ static void saveSessionState() {
         DWORD werr2 = ok2 ? 0 : GetLastError();
         if (ok2) FlushFileBuffers(g);
         CloseHandle(g);
-        if (ok2 && wr2 == out.size())
+        if (ok2 && wr2 == out.size()) {
+            // The same rule the atomic path applies: the user emptying the window on purpose drops
+            // the previous generation. Left behind, restore's fallback reads it on the next launch
+            // and brings back exactly the sessions they just closed.
+            if (saved == 0 && userEmptied) DeleteFileW(bak.c_str());
             logWarn("save ok (IN PLACE): %d session(s), %zu bytes -> %s — %s could not be created "
                     "(err %lu), so this save was not atomic",
                     saved, out.size(), narrow(path).c_str(), narrow(tmp).c_str(), terr);
-        else
+        } else
             logWarn("save FAILED in place to %s: wrote %lu of %zu bytes (err %lu) after %s could not "
                     "be created (err %lu)", narrow(path).c_str(), wr2, out.size(), werr2,
                     narrow(tmp).c_str(), terr);
@@ -2113,12 +2145,19 @@ static void saveSessionState() {
         DeleteFileW(tmp.c_str());
         return;
     }
-    // Keep exactly one previous generation, but only rotate a file that actually held sessions, so a
-    // good .bak is never overwritten by an empty or absent primary. The user emptying the window ON
-    // PURPOSE is the one case that drops the .bak: keeping it would resurrect on the next launch
-    // exactly what they just closed.
-    bool rotate = !(saved == 0 && g_userEmptied) && stateFileSessionCount(path) > 0;
-    if (saved == 0 && g_userEmptied) DeleteFileW(bak.c_str());
+    // Keep exactly one previous generation, but only rotate a file that is actually worth keeping, so
+    // a good .bak is never overwritten by an empty primary. The user emptying the window ON PURPOSE is
+    // the one case that drops the .bak: keeping it would resurrect on the next launch exactly what
+    // they just closed. A primary that exists but cannot be READ right now (an AV scan, a transient
+    // lock) still holds the saved sessions, so it counts as worth keeping — publishing over it with no
+    // .bak is the one outcome that loses them. Only "there is no file at all" — every first save —
+    // means there is nothing to preserve, and that is also the case ReplaceFileW cannot serve (it
+    // needs an existing target).
+    DWORD prevErr = 0;
+    int prev = stateFileSessionCount(path, &prevErr);
+    bool havePrev = prev > 0 || (prev < 0 && prevErr != ERROR_FILE_NOT_FOUND && prevErr != ERROR_PATH_NOT_FOUND);
+    bool rotate = !(saved == 0 && userEmptied) && havePrev;
+    if (saved == 0 && userEmptied) DeleteFileW(bak.c_str());
     // ReplaceFileW does the rotation and the publish as ONE operation, and never unlinks the target
     // in between. Doing it as two renames leaves a window in which no primary exists at all — and a
     // shutdown landing in that window (the OnDestroy save is exactly when Windows is killing things)
@@ -5640,6 +5679,13 @@ static std::string ctlDispatch(const std::string& line) {
             std::wstring nm = w->name;   // copy before the instance dies
             PostMessageW(w->hwnd, WM_CLOSE, 0, 0);
             if (cmd == "window.delete" && lstrcmpiW(nm.c_str(), L"agwinterm-lite") != 0) {
+                // The name becomes a FILENAME here, and it arrives from the HKCU instance registry —
+                // which an older build, or a hand edit, can have written unsanitized. "..\..\x" would
+                // then delete outside the state directory. Only ever delete state belonging to a name
+                // this build would itself have registered; the window is closed either way.
+                if (sanitizeInstanceName(nm) != nm)
+                    return ctlErr("window '" + narrow(nm) + "' was closed, but its name is not one "
+                                  "this build would create, so its state file was left alone");
                 Sleep(800);   // let it finish its teardown writes, then drop its saved state
                 wchar_t base[MAX_PATH];
                 if (GetEnvironmentVariableW(L"LOCALAPPDATA", base, MAX_PATH)) {
@@ -5819,6 +5865,33 @@ static Session* failedSpecSession(const RestoreSpec& sp, int cols, int rows) {
     return s;
 }
 
+// Host records whose shell has EXITED are tombstones only an explicit kill removes, and no other code
+// path ever sends one: nothing here closed them, so nothing here killed them. They survive every
+// future launch, and enough of them push `list` past this build's field storage (ListReply.sessions
+// is max_count:64), at which point the whole reply stops decoding and adoption — plus the id
+// reservation that rides along with it — is off PERMANENTLY. Sweep them once adoption has had its
+// chance. Runs on EVERY launch, not just a restoring one: --no-restore, a missing state file and a
+// file that parsed to nothing all leave the host holding the same tombstones, and those are exactly
+// the launches after which nobody ever comes back to clear them. Deliberately narrow: only this
+// instance's id prefix (another window's sessions are not ours to touch), only entries the host
+// reported exited, never one it reported attached, and never one this run just adopted.
+static void reapExitedHostSessions() {
+    for (const auto& hs : g_hostLive) {
+        if (!hs.exited || hs.attached) continue;
+        size_t dash = hs.id.rfind('-');
+        if (dash == std::string::npos || hs.id.compare(0, dash, g_idPrefix) != 0) continue;
+        if (!fitsField(hs.id.c_str(), sizeof agwinterm_ptyhost_SessionRef::id)) continue;
+        bool mine = false;
+        for (const auto& t : g_adoptedIds) if (t == hs.id) { mine = true; break; }
+        if (mine) continue;
+        agwinterm_ptyhost_Request k = agwinterm_ptyhost_Request_init_default;
+        agwinterm_ptyhost_Reply kr = agwinterm_ptyhost_Reply_init_default;
+        k.which_cmd = agwinterm_ptyhost_Request_kill_tag;
+        strcpy_s(k.cmd.kill.id, hs.id.c_str());
+        if (request(k, &kr)) logInfo("restore: reaped exited host session '%s'", hs.id.c_str());
+    }
+}
+
 // Rebuild the saved workspaces + sessions on launch. Returns false (caller opens a default session) if
 // there's nothing to restore. Sessions relaunch with their remembered profile + creation cwd.
 static bool restoreSessions() {
@@ -5878,7 +5951,8 @@ static bool restoreSessions() {
     // which is the case the .bak fallback exists for — adopts one host session into TWO panes: the
     // second attach supersedes the first, the first goes dead on EOF, and closing either kills the
     // shell out from under the other.
-    std::vector<std::string> taken;
+    std::vector<std::string>& taken = g_adoptedIds;   // the reap below must never touch these
+    taken.clear();
     auto isAdoptable = [&](const std::string& id) {
         if (id.empty()) return false;
         for (const auto& t : taken) if (t == id) return false;
@@ -5896,7 +5970,12 @@ static bool restoreSessions() {
                               sp.args.empty() ? nullptr : &sp.args, sp.cwd.empty() ? nullptr : sp.cwd.c_str(),
                               true);   // repaint: the shell already has a screen, ask it to redraw
             if (s) { adopted++; taken.push_back(want); logInfo("restore: adopted live session '%s' (%s)", want.c_str(), sp.name.c_str()); }
-            else logWarn("restore: adopt of live session '%s' failed — creating a fresh one", want.c_str());
+            // The shell itself is untouched by a failed adopt (attach may well have succeeded and
+            // only the data pipe refused), so it keeps running under an id nothing points at any
+            // more — a duplicate for the same spec is created beside it. Name the id: that orphan is
+            // otherwise invisible, and it is the reader's only handle on "why are there two?".
+            else logWarn("restore: adopt of live session '%s' failed — creating a fresh one; the "
+                         "host may still be running the old shell under that id", want.c_str());
         }
         if (!s)
             s = newSession(cols, rows, sp.app.empty() ? nullptr : sp.app.c_str(),
@@ -5915,28 +5994,6 @@ static bool restoreSessions() {
         }
     }
     g_restoring = false;
-    // Host records whose shell has EXITED are tombstones only an explicit kill removes, and no other
-    // code path ever sends one: nothing here closed them, so nothing here killed them. They survive
-    // every future launch, and enough of them push `list` past this build's field storage
-    // (ListReply.sessions is max_count:64), at which point the whole reply stops decoding and
-    // adoption — plus the id reservation that rides along with it — is off PERMANENTLY. Sweep them
-    // now that adoption is done. Deliberately narrow: only this instance's id prefix (another
-    // window's sessions are not ours to touch), only entries the host reported exited, never one it
-    // reported attached, and never one this run just adopted.
-    for (const auto& hs : g_hostLive) {
-        if (!hs.exited || hs.attached) continue;
-        size_t dash = hs.id.rfind('-');
-        if (dash == std::string::npos || hs.id.compare(0, dash, g_idPrefix) != 0) continue;
-        if (!fitsField(hs.id.c_str(), sizeof agwinterm_ptyhost_SessionRef::id)) continue;
-        bool mine = false;
-        for (const auto& t : taken) if (t == hs.id) { mine = true; break; }
-        if (mine) continue;
-        agwinterm_ptyhost_Request k = agwinterm_ptyhost_Request_init_default;
-        agwinterm_ptyhost_Reply kr = agwinterm_ptyhost_Reply_init_default;
-        k.which_cmd = agwinterm_ptyhost_Request_kill_tag;
-        strcpy_s(k.cmd.kill.id, hs.id.c_str());
-        if (request(k, &kr)) logInfo("restore: reaped exited host session '%s'", hs.id.c_str());
-    }
     logInfo("restore: %d of %zu session(s) built (%d adopted live from the pty-host, %d kept as dead)",
             built, specs.size(), adopted, dead);
     if (firstIdx < 0) {   // exit 4 of 4: specs parsed but nothing could be started
@@ -6157,6 +6214,7 @@ int WINAPI wWinMain(HINSTANCE inst, HINSTANCE, PWSTR, int show) {
     bool haveProf = resolveLaunchProfile(argApp, argAppArgs);
     bool wantLaunch = haveProf || !g_argDir.empty();   // -p/-d ask for a specific session
     bool restored = !g_argNoRestore && restoreSessions();
+    reapExitedHostSessions();   // after adoption has had its chance, on every launch path
     if (!restored || wantLaunch) {   // fresh first session, or an EXTRA one for the launch args
         int cols, rows;
         paneGridSize(0, &cols, &rows);

--- a/lite/test/restore-matrix.ps1
+++ b/lite/test/restore-matrix.ps1
@@ -797,6 +797,60 @@ if (-not $Only -or $Only -eq 'publish-blocked') {
     }
 }
 
+# The OTHER half of the atomic write, and the one no other cell reaches: the temp file cannot be
+# CREATED at all (a policy-locked profile, a DLP/AV agent that blocks new files), so the save falls
+# back to writing sessions.tsv in place. publish-blocked locks the PRIMARY, which forces a failed
+# publish, not a failed create — so this fallback shipped untested. It has to keep both promises the
+# atomic path makes: a generation in the .bak (copied by hand here, since nothing rotates), and the
+# .bak dropped when the user deliberately empties the window, or the next launch reads it and brings
+# back exactly what they just closed.
+if (-not $Only -or $Only -eq 'inplace-fallback') {
+    $inst = 'rm-inplace-fallback'
+    Reset-Cell $inst
+    $err = ''; $inPlace = $false; $current = $false; $bakIsPrev = $false; $bakGone = $false; $after = ''
+    $p = $null; $p2 = $null; $fs = $null
+    try {
+        $p = Start-Lite $inst
+        $id = LastSessionId $inst
+        & $ctl session rename inplace-one --target $id --pipe $inst 2>&1 | Out-Null
+        Start-Sleep -Seconds 3                       # the generation the fallback must preserve
+        if ((Get-Content (State $inst) -Raw) -notmatch 'inplace-one') { throw 'setup save never landed' }
+        # FileShare.None on the .tmp path: lite's CREATE_ALWAYS on it fails with a sharing violation,
+        # which is the same door-slam a profile that forbids creating new files gives it.
+        $fs = [System.IO.File]::Open("$(State $inst).tmp", 'Create', 'ReadWrite', 'None')
+        & $ctl session rename inplace-two --target $id --pipe $inst 2>&1 | Out-Null
+        Start-Sleep -Seconds 3
+        $inPlace = Log-Has $inst 'save ok \(IN PLACE\)'
+        $current = (Get-Content (State $inst) -Raw) -match 'inplace-two'
+        if (Test-Path "$(State $inst).bak") {
+            $bak = Get-Content "$(State $inst).bak" -Raw
+            $bakIsPrev = ($bak -match 'inplace-one') -and ($bak -notmatch 'inplace-two')
+        }
+        # Now the deliberate empty, still on the in-place path: the .bak must go with it.
+        & $ctl session close $id --pipe $inst 2>&1 | Out-Null
+        Start-Sleep -Seconds 3
+        $bakGone = -not (Test-Path "$(State $inst).bak")
+        $fs.Close(); $fs = $null
+        Stop-Lite $p -Kill; $p = $null               # a graceful stop would save again, atomically
+        $p2 = Start-Lite $inst
+        Start-Sleep -Seconds 2
+        $after = Signature $inst
+        Stop-Lite $p2 -Kill; $p2 = $null
+    } catch { $err = $_.Exception.Message }
+    finally { if ($fs) { try { $fs.Close() } catch { } }; Stop-Leftover $p; Stop-Leftover $p2 }
+    if (-not $err -and $inPlace -and $current -and $bakIsPrev -and $bakGone -and $after -notmatch 'inplace-two') {
+        "  PASS  {0,-22} (in-place save keeps a generation, and drops it on a deliberate empty)" -f 'inplace-fallback'
+    } else {
+        $script:failed += 'inplace-fallback'
+        "  FAIL  inplace-fallback"
+        if ($err) { "        error:  $err" }
+        "        wrote in place: $inPlace ; primary holds the new state: $current"
+        "        .bak held the previous generation: $bakIsPrev ; dropped on the deliberate empty: $bakGone"
+        "        after:  [$after]"
+        "        log:    $(Restore-Verdict $inst)"
+    }
+}
+
 # Backward compatibility: a plain 0.17.x file — no D line, no .bak anywhere — must still restore.
 Seeded -Name 'compat-0.17' `
     -Tsv "V1`nW`tws-c`nS`t0`told-one`t`t$cwd`nS`t0`told-two`t`t$cwd`nF`t1`nA`t0`n" -Assert {


### PR DESCRIPTION
Four fixes to the save/restore path, all in the class the restore matrix exists to guard: **losing saved sessions quietly**.

- **`g_userEmptied` is set and read under the lock**, with the session list it was judged from. It's written from the control-pipe thread (`closeSessionAt`) and read on the UI thread, and it gates *both* the zero-session refusal and the `.bak` delete — the two decisions that can cost saved sessions.
- **`stateFileSessionCount` counts only records that would actually restore** (≥4 tabs), not every line beginning `S\t`. A record cut mid-write parses to nothing, so counting it would let the save rotate that wreckage into the `.bak` — over the one generation still holding the sessions — and call a good file "not empty".
- **Rotation keeps a generation only when the primary is worth keeping**, and drops the `.bak` only when the user emptied the window on purpose. Otherwise the next launch reads the fallback and brings back exactly the sessions they just closed. A primary that exists but can't be *read* right now (AV scan, transient lock) still counts as worth keeping.
- **Instance names from the HKCU registry are sanitised before becoming filenames.** An older build or a hand edit could hold `..\..\x`, which would delete state outside the state directory.

Also: `saveSessionState` now logs when it returns on an empty path. That was the last remaining way to get "restore doesn't work" with **nothing in the log** — on exactly the redirected or policy-locked profile the field reports come from.

## New coverage

`inplace-fallback` covers the half of the atomic write nothing else reached: the temp file can't be **created** at all (policy-locked profile, DLP/AV agent blocking new files), so the save falls back to writing in place. `publish-blocked` locks the *primary*, which forces a failed publish rather than a failed create — so this path shipped untested. It must still keep both promises: a generation in the `.bak`, and that `.bak` dropped on a deliberate empty.

## Verification

Full lite suite green — 30 matrix cells plus the log and diagnose suites:

```
PASS  inplace-fallback  (in-place save keeps a generation, and drops it on a deliberate empty)
restore-matrix: all cells passed
all lite checks passed
```

Authored by Boris; landed as-is.