### PR TITLE
feat(lite): hand existing installs over to agliteterm

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,13 @@ Run `agwintermctl install skill` (or the palette entry) to teach Claude Code / C
 
 ## agwinterm-lite — the tiny client
 
+> **lite is becoming its own product, `agliteterm`.** This release is the handover: its
+> *Help → Check for Updates* points at the agliteterm feed, so an existing install finds the
+> successor by the mechanism it already trusts. agliteterm installs **alongside** rather than
+> replacing this one and adopts your sessions, settings and fonts on first run, so nothing is
+> lost and you can go back. Scripts that use `--pipe agwinterm-lite` keep working; the
+> `AGWINTERM_*` session variables are unchanged.
+
 **`agwinterm-lite`** is a second, minimal client for old or low-RAM machines: a single small
 C++ exe (Win32/WTL, no .NET) over the same Rust emulator core and pty-host. It trades the
 custom-drawn chrome for **real native controls** — menu bar, toolbar, TreeView sidebar,

--- a/lite/src/main.cpp
+++ b/lite/src/main.cpp
@@ -3077,6 +3077,19 @@ static void scrollFocused(int deltaRows) {
     InvalidateRect(g_hwnd, nullptr, FALSE);
 }
 
+// ---- HANDOVER BUILD ---------------------------------------------------------------------------
+// This is the LAST agwinterm-lite. The product is now agliteterm, in its own repository
+// (docs/plans/2026-08-17-agliteterm-product-split.md), and the updater below points at ITS releases
+// so existing installs discover the successor through the mechanism they already trust.
+//
+// Without this build, agwinterm would simply stop publishing an agwinterm-lite-setup asset and every
+// install would go quiet: the check succeeds, finds no matching asset, and reports nothing. No error,
+// no notice, no route to the new product. That is why the handover ships BEFORE the rename.
+//
+// agliteterm installs ALONGSIDE (new AppId, new directory) and adopts this profile's sessions and
+// settings on first run, so the hand-off is reversible: agwinterm-lite stays installed and working
+// until the user removes it.
+//
 // ---- self-update (parity with the full app's app-update): GitHub releases/latest -> pick the
 // lite setup asset -> SHA-256-verified download (the release API's per-asset digest is the
 // integrity gate; we have no Authenticode cert) -> detached helper waits for exit, runs the
@@ -3216,7 +3229,7 @@ static UpdRelease updParse(const std::string& j) {
     if (!tag.empty() && (tag[0] == 'v' || tag[0] == 'V')) tag.erase(0, 1);
     if (tag.empty()) return r;
     for (char c : tag) r.ver += (wchar_t)c;
-    size_t a = j.find("\"name\":\"agwinterm-lite-setup-");
+    size_t a = j.find("\"name\":\"agliteterm-setup-");
     if (a == std::string::npos) return r;
     size_t end = j.find("\"name\":\"", a + 8);
     if (end == std::string::npos) end = j.size();
@@ -3228,7 +3241,7 @@ static UpdRelease updParse(const std::string& j) {
 }
 
 static const char kUpdHelper[] =
-    "param([int]$ProcId, [string]$Payload, [string]$Exe, [string]$Instance)\n"
+    "param([int]$ProcId, [string]$Payload, [string]$Exe, [string]$Instance, [string]$Successor)\n"
     "function Log([string]$m) { try { Add-Content -Path ($Payload + '.log') -Value (\"{0:HH:mm:ss.fff} {1}\" -f (Get-Date), $m) } catch { } }\n"
     "Log \"wait pid=$ProcId\"\n"
     "try { Wait-Process -Id $ProcId -Timeout 120 -ErrorAction SilentlyContinue } catch { }\n"
@@ -3237,12 +3250,34 @@ static const char kUpdHelper[] =
     "Log 'applying'\n"
     "Start-Process $Payload -ArgumentList '/VERYSILENT','/NORESTART','/SUPPRESSMSGBOXES' -Wait\n"
     "Log 'setup finished'\n"
-    // The instance name is passed as its OWN element, not baked into one argument string: a name with
-    // a space ("--pipe my win") came back through CommandLineToArgvW as instance "my", which is a
-    // different pipe AND a different state file — the "my sessions are gone" shape, self-inflicted by
-    // the update. Start-Process quotes an element that needs it.
-    "if ($Instance) { Start-Process $Exe -ArgumentList '--pipe', $Instance } else { Start-Process $Exe }\n"
+    // The instance name has to survive the round trip intact: a name with a space
+    // ("--pipe my win") came back through CommandLineToArgvW as instance "my", which is a different
+    // pipe AND a different state file — the "my sessions are gone" shape, self-inflicted by the
+    // update. Passing it as its own -ArgumentList element is NOT enough: Start-Process joins the
+    // list with spaces and quotes nothing, so the quotes have to be part of the value. The app
+    // parses its own command line with CommandLineToArgvW, which strips them again.
+    //
+    // The handover installs a DIFFERENT product alongside this one, so the exe to start after
+    // setup is not the one that launched the helper. Falls back to $Exe when the successor is
+    // not where we expect: relaunching the old build is a no-op the user can retry, while not
+    // relaunching at all looks like the update killed their terminal.
+    "$start = $Exe\n"
+    "if ($Successor) {\n"
+    "  if (Test-Path -LiteralPath $Successor) { $start = $Successor; Log 'relaunching the successor' }\n"
+    "  else { Log 'successor missing - relaunching this build' }\n"
+    "}\n"
+    "if ($Instance) { Start-Process $start -ArgumentList '--pipe', ('\"' + $Instance + '\"') } else { Start-Process $start }\n"
     "Log 'relaunched'\n";
+
+// The successor's installed exe. agliteterm ships under its OWN AppId and directory, so it lands
+// ALONGSIDE this build rather than replacing it — which is what makes the move reversible, and
+// also what makes relaunching GetModuleFileNameW() wrong here: it would start agwinterm lite
+// again and the user would see the update "do nothing". Mirrors installer/agliteterm.iss.
+static std::wstring updSuccessorExe() {
+    wchar_t base[MAX_PATH];
+    if (!GetEnvironmentVariableW(L"LOCALAPPDATA", base, MAX_PATH)) return {};
+    return std::wstring(base) + L"\\Programs\\agliteterm\\agliteterm.exe";
+}
 
 static std::wstring* updHeapStr(const std::wstring& s) { return new std::wstring(s); }   // freed by the UI handler
 
@@ -3253,7 +3288,7 @@ static DWORD WINAPI updWorker(LPVOID p) {
     std::wstring cur = updVersion();
     wchar_t apiw[512];
     std::wstring api = GetEnvironmentVariableW(L"AGWINTERM_UPDATE_API", apiw, 512) > 0
-                     ? apiw : L"https://api.github.com/repos/yeroo/agwinterm/releases/latest";
+                     ? apiw : L"https://api.github.com/repos/yeroo/agliteterm/releases/latest";
     std::vector<uint8_t> buf;
     if (!updFetch(api, buf)) {
         if (interactive) post(UPD_MSG, updHeapStr(L"update check failed (offline or rate-limited) — try again later"));
@@ -3265,7 +3300,7 @@ static DWORD WINAPI updWorker(LPVOID p) {
         return 0;
     }
     if (updCmpVer(rel.ver, cur) <= 0) {
-        if (interactive) post(UPD_MSG, updHeapStr(L"agwinterm lite " + cur + L" is already the latest"));
+        if (interactive) post(UPD_MSG, updHeapStr(L"no agliteterm release yet — agwinterm lite " + cur + L" stays as it is"));
         return 0;
     }
     if (!interactive) { post(UPD_BALLOON, updHeapStr(rel.ver)); return 0; }
@@ -3295,7 +3330,7 @@ static DWORD WINAPI updWorker(LPVOID p) {
     };
     UpdApply* a = new UpdApply;
     a->ver = rel.ver;
-    a->payload = dir + L"\\agwinterm-lite-setup-" + rel.ver + L".exe";
+    a->payload = dir + L"\\agliteterm-setup-" + rel.ver + L".exe";
     a->helper = dir + L"\\apply-update.ps1";
     if (!writeAll(a->payload, payload.data(), (DWORD)payload.size()) ||
         !writeAll(a->helper, kUpdHelper, (DWORD)(sizeof kUpdHelper - 1))) {
@@ -3313,7 +3348,7 @@ static void updCheck(bool interactive) {
         if (!updChannelInstalled()) {
             MessageBoxW(g_hwnd,
                 L"This copy of agwinterm lite is not the installed one, so it does not self-update.\n"
-                L"Get releases at github.com/yeroo/agwinterm/releases.",
+                L"Get agliteterm at github.com/yeroo/agliteterm/releases.",
                 L"agwinterm lite update", MB_OK | MB_ICONINFORMATION);
             return;
         }
@@ -4951,8 +4986,8 @@ public:
         if (wp == UPD_BALLOON) {   // background check: one tray balloon, no interruption
             std::wstring* v = (std::wstring*)lp;
             g_nid.uFlags |= NIF_INFO;
-            wcscpy_s(g_nid.szInfoTitle, L"agwinterm lite");
-            swprintf_s(g_nid.szInfo, L"%s is out (you have %s) — Help → Check for Updates",
+            wcscpy_s(g_nid.szInfoTitle, L"agwinterm lite is now agliteterm");
+            swprintf_s(g_nid.szInfo, L"agliteterm %s succeeds lite %s — Help → Check for Updates",
                        v->c_str(), updVersion().c_str());
             g_nid.dwInfoFlags = NIIF_INFO;
             Shell_NotifyIconW(NIM_MODIFY, &g_nid);
@@ -4970,15 +5005,22 @@ public:
                 MessageBoxW(L"Close the other agwinterm lite windows first — the installer can't "
                             L"replace a running exe.", L"agwinterm lite update", MB_OK | MB_ICONWARNING);
             } else {
-                std::wstring msg = L"agwinterm lite " + updVersion() + L" → " + a->ver +
-                                   L"\n\nDownload verified (SHA-256). Update and restart now?\n"
-                                   L"Sessions are saved and restored.";
-                if (MessageBoxW(msg.c_str(), L"agwinterm lite update", MB_OKCANCEL | MB_ICONQUESTION) == IDOK) {
+                std::wstring msg = L"agwinterm lite " + updVersion() + L"  →  agliteterm " + a->ver +
+                                   L"\n\nlite is now its own product, agliteterm. This is that move, "
+                                   L"not a routine update.\n\n"
+                                   L"•  Your sessions, settings and fonts come across on first run.\n"
+                                   L"•  agwinterm lite stays installed until you remove it, so you can go back.\n"
+                                   L"•  Scripts using --pipe agwinterm-lite keep working.\n\n"
+                                   L"Download verified (SHA-256). Install agliteterm and restart now?";
+                if (MessageBoxW(msg.c_str(), L"agwinterm lite is now agliteterm", MB_OKCANCEL | MB_ICONQUESTION) == IDOK) {
                     wchar_t exe[MAX_PATH];
                     GetModuleFileNameW(nullptr, exe, MAX_PATH);
+                    std::wstring succ = updSuccessorExe();
                     std::wstring cmd = L"powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden"
                                        L" -File \"" + a->helper + L"\" -ProcId " + std::to_wstring(GetCurrentProcessId()) +
                                        L" -Payload \"" + a->payload + L"\" -Exe \"" + exe + L"\"";
+                    if (!succ.empty())          // hand the session to agliteterm, not back to us
+                        cmd += L" -Successor \"" + succ + L"\"";
                     if (!g_isDefaultInstance)   // named instances come back under their own pipe
                         cmd += L" -Instance \"" + g_instance + L"\"";
                     STARTUPINFOW si{ sizeof si }; PROCESS_INFORMATION pi{};

--- a/lite/test/handover.ps1
+++ b/lite/test/handover.ps1
@@ -1,0 +1,237 @@
+# handover to agliteterm — Task 4 checks.
+#
+# This build is the LAST agwinterm-lite: its updater points at the agliteterm feed so existing
+# installs discover the successor through the mechanism they already trust. What that has to get
+# right, and what this file asserts:
+#   - it picks the agliteterm-setup asset, NOT a lite-setup asset sitting in the same release
+#   - the prompt says this is a rename, not a routine update
+#   - the relaunch starts agliteterm, not this exe — the successor installs ALONGSIDE under its own
+#     AppId, so relaunching GetModuleFileNameW() would leave the user staring at the old build,
+#     concluding the update did nothing
+#   - a missing successor falls back to relaunching this build, never to no terminal at all
+#   - an unreachable feed changes nothing and nags nobody
+#
+# Suite rules (learned the hard way, same as the other lite checks):
+#   - always a sandbox instance (--pipe <name>); never the default instance, which owns real state
+#   - never inject global input (keybd_event/SendInput) — it lands wherever focus happens to be
+#   - drive the app with PostMessage to ITS OWN window handles only
+#
+# Runs against a throwaway %LOCALAPPDATA%: the update path is gated on the exe living in
+# <LOCALAPPDATA>\Programs\agwinterm-lite (updChannelInstalled), so the check needs an install
+# layout it can build and delete — and pointing the updater at a real profile would write payloads
+# into it.
+param([string]$Exe = "$PSScriptRoot\..\bin\agwinterm-lite.exe")
+
+$ErrorActionPreference = 'Stop'
+$fail = 0
+function Check([string]$name, [bool]$ok, [string]$detail = '') {
+    if ($ok) { "  PASS  $name" }
+    else { $script:fail++; "  FAIL  $name$(if ($detail) { " — $detail" })" }
+}
+
+"== handover =="
+
+# EnumWindows, not a FindWindowEx walk: FindWindowExW(NULL, prev, NULL, NULL) returns nothing on
+# Windows 11 with a null class, so the walk silently enumerated zero windows and every dialog check
+# "passed" as absent. Compiled as a type so the callback delegate stays alive for the call.
+Add-Type -TypeDefinition @'
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+public static class HoWin {
+    delegate bool EnumProc(IntPtr h, IntPtr l);
+    [DllImport("user32.dll")] static extern bool EnumWindows(EnumProc cb, IntPtr l);
+    [DllImport("user32.dll")] static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)] static extern int GetClassNameW(IntPtr h, StringBuilder s, int n);
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)] static extern int GetWindowTextW(IntPtr h, StringBuilder s, int n);
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)] static extern int GetDlgItemTextW(IntPtr d, int id, StringBuilder s, int n);
+    [DllImport("user32.dll")] public static extern bool PostMessageW(IntPtr h, uint m, IntPtr w, IntPtr l);
+    static string Text(IntPtr h) { var b = new StringBuilder(512); GetWindowTextW(h, b, b.Capacity); return b.ToString(); }
+    // A MessageBox is class #32770. Returns "<hwnd>|<title>|<body>" for the first one this pid owns.
+    public static string Dialog(int pid) {
+        string found = null;
+        EnumWindows((h, l) => {
+            uint owner; GetWindowThreadProcessId(h, out owner);
+            if (owner != (uint)pid) return true;
+            var c = new StringBuilder(64); GetClassNameW(h, c, c.Capacity);
+            if (c.ToString() != "#32770") return true;
+            var body = new StringBuilder(4096); GetDlgItemTextW(h, 0xFFFF, body, body.Capacity);
+            found = h.ToInt64() + "|" + Text(h) + "|" + body.ToString();
+            return false;
+        }, IntPtr.Zero);
+        return found;
+    }
+}
+'@
+
+function Get-Dialog([int]$ownerPid) {
+    $raw = [HoWin]::Dialog($ownerPid)
+    if (-not $raw) { return $null }
+    $parts = $raw -split '\|', 3
+    return [pscustomobject]@{ Handle = [IntPtr][int64]$parts[0]; Title = $parts[1]; Body = $parts[2] }
+}
+function Wait-Dialog([int]$ownerPid, [int]$seconds = 25) {
+    for ($i = 0; $i -lt $seconds * 4; $i++) {
+        $d = Get-Dialog $ownerPid
+        if ($d) { return $d }
+        Start-Sleep -Milliseconds 250
+    }
+    return $null
+}
+# Start-Process returns before the window exists, and the cached MainWindowHandle stays 0 until the
+# object is refreshed — posting to IntPtr.Zero is a silent no-op, which reads exactly like "the app
+# ignored the menu command".
+function Wait-Window($proc, [int]$seconds = 30) {
+    for ($i = 0; $i -lt $seconds * 4; $i++) {
+        $proc.Refresh()
+        if ($proc.MainWindowHandle -ne [IntPtr]::Zero) { return $proc.MainWindowHandle }
+        Start-Sleep -Milliseconds 250
+    }
+    return [IntPtr]::Zero
+}
+function Close-Dialog($dlg, [int]$button) { [void][HoWin]::PostMessageW($dlg.Handle, 0x0111, [IntPtr]$button, [IntPtr]::Zero) }
+
+$root = Join-Path ([IO.Path]::GetTempPath()) ("lite-handover-" + [Guid]::NewGuid().ToString('N'))
+$installed = Join-Path $root 'Programs\agwinterm-lite'
+New-Item -ItemType Directory -Path $installed -Force | Out-Null
+# The whole payload, not just the exes: lite refuses to start without agwinterm_core.dll beside
+# it, and a half-populated install directory produces a startup error box that a naive dialog
+# check happily mistakes for the update prompt.
+Get-ChildItem (Split-Path $Exe) -File |
+    Where-Object { $_.Extension -in '.exe', '.dll', '.ttf', '.otf' } |
+    Copy-Item -Destination $installed
+$app = Join-Path $installed 'agwinterm-lite.exe'
+$updates = Join-Path $root 'agwinterm-lite\updates'
+
+# The release the successor repo will actually publish: an agliteterm-setup asset. The DECOY comes
+# first on purpose — a lite-setup asset in the same feed must not be what this build downloads,
+# which is the whole point of retargeting the asset name alongside the URL.
+$payload = Join-Path $root 'agliteterm-setup-0.17.5.exe'
+Set-Content -Path $payload -Value 'pretend this is the agliteterm installer' -NoNewline
+$sha = (Get-FileHash $payload -Algorithm SHA256).Hash.ToLower()
+$decoy = Join-Path $root 'agwinterm-lite-setup-0.17.5.exe'
+Set-Content -Path $decoy -Value 'the wrong asset' -NoNewline
+$feed = Join-Path $root 'feed.json'
+# Forward slashes: the payload URL is read as a literal path by updFetch's local-file seam, and a
+# backslash in a JSON string would have to be escaped — which this substring parser does not undo.
+@"
+{"tag_name":"v0.17.5","assets":[
+ {"name":"agwinterm-lite-setup-0.17.5.exe","browser_download_url":"$($decoy -replace '\\','/')","digest":"sha256:0000"},
+ {"name":"agliteterm-setup-0.17.5.exe","browser_download_url":"$($payload -replace '\\','/')","digest":"sha256:$sha"}]}
+"@ | Set-Content -Path $feed -Encoding utf8
+
+$env0 = @{ LOCALAPPDATA = $root; AGWINTERM_VERSION_OVERRIDE = '0.17.4'; AGWINTERM_UPDATE_API = $feed }
+
+# --- 1. an install of today's 0.17.x finds, downloads and offers the successor -----------------
+$p = Start-Process $app -ArgumentList @('--pipe', 'handover') -PassThru -Environment $env0
+Start-Sleep -Seconds 7
+$hwnd = Wait-Window $p
+Check 'the sandbox instance came up' ($hwnd -ne [IntPtr]::Zero)
+[void][HoWin]::PostMessageW($hwnd, 0x0111, [IntPtr]131, [IntPtr]::Zero)   # Help -> Check for Updates
+$dlg = Wait-Dialog $p.Id
+Check 'the successor release is offered' ($null -ne $dlg) 'no dialog appeared'
+
+if ($dlg) {
+    # The prompt has to say what is happening. A user who reads "0.17.4 -> 0.17.5" and then finds a
+    # differently-named app in their Start menu has been surprised by their terminal, which is the
+    # one thing a terminal must never do.
+    Check 'the prompt names the rename' ($dlg.Title -match 'now agliteterm')
+    Check 'it says this is not a routine update' ($dlg.Body -match 'own product' -and $dlg.Body -match 'not a routine update')
+    Check 'it promises the profile comes across' ($dlg.Body -match 'sessions, settings and fonts')
+    Check 'it says the old build stays' ($dlg.Body -match 'stays installed')
+    Check 'it still reports the verification' ($dlg.Body -match 'SHA-256')
+
+    Check 'the agliteterm asset was downloaded' (Test-Path (Join-Path $updates 'agliteterm-setup-0.17.5.exe'))
+    Check 'the lite-setup decoy was ignored' (-not (Test-Path (Join-Path $updates 'agwinterm-lite-setup-0.17.5.exe')))
+
+    Close-Dialog $dlg 2   # IDCANCEL — declining must leave the install exactly as it was
+    Start-Sleep -Seconds 2
+    $p.Refresh()
+    Check 'declining leaves lite running' (-not $p.HasExited)
+}
+
+$helper = Join-Path $updates 'apply-update.ps1'
+Check 'the apply helper was written' (Test-Path $helper)
+
+$p.CloseMainWindow() | Out-Null
+Start-Sleep -Seconds 3
+if (-not $p.HasExited) { Stop-Process -Id $p.Id -Force }
+
+# --- 2. the relaunch starts agliteterm, not this build -----------------------------------------
+# Drives the helper the app just wrote — the real script, extracted from the real exe — with stand-in
+# executables, so the assertion is about which one it starts rather than about Inno Setup.
+if (Test-Path $helper) {
+    $marker = Join-Path $root 'relaunched.txt'
+    $setup = Join-Path $root 'setup.cmd'
+    $old   = Join-Path $root 'old.cmd'
+    $succ  = Join-Path $root 'successor.cmd'
+    # %1/%2/%3 rather than %*: the interesting question is where the argument BOUNDARIES fall,
+    # and a flat tail cannot tell "--pipe" "my win" from "--pipe" "my" "win".
+    Set-Content $setup "@echo setup 1=[%1] 2=[%2] 3=[%3] >> `"$marker`"" -Encoding ascii
+    Set-Content $old   "@echo old 1=[%1] 2=[%2] 3=[%3] >> `"$marker`"" -Encoding ascii
+    Set-Content $succ  "@echo successor 1=[%1] 2=[%2] 3=[%3] >> `"$marker`"" -Encoding ascii
+
+    function Run-Helper([string]$successor, [string]$instance) {
+        Remove-Item $marker, "$setup.log" -ErrorAction SilentlyContinue
+        $dead = Start-Process cmd.exe -ArgumentList '/c', 'exit' -PassThru -WindowStyle Hidden
+        $dead.WaitForExit()
+        $a = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $helper,
+               '-ProcId', $dead.Id, '-Payload', $setup, '-Exe', $old)
+        if ($successor) { $a += @('-Successor', $successor) }
+        if ($instance)  { $a += @('-Instance', $instance) }
+        # The call operator quotes each argument; Start-Process joins the list with spaces and quotes
+        # nothing, which would split '-Instance my win' here and measure the harness, not the helper.
+        & powershell.exe @a | Out-Null
+        Start-Sleep -Seconds 2
+        return @{
+            Marker = $(if (Test-Path $marker) { Get-Content $marker -Raw } else { '' })
+            Log    = $(if (Test-Path "$setup.log") { Get-Content "$setup.log" -Raw } else { '' })
+        }
+    }
+
+    $r = Run-Helper $succ 'my win'
+    Check 'the installer ran' ($r.Marker -match 'setup 1=\[/VERYSILENT\]') $r.Marker
+    Check 'the successor is what gets relaunched' ($r.Marker -match '(?m)^successor ') $r.Marker
+    Check 'this build is NOT relaunched' ($r.Marker -notmatch '(?m)^old ')
+    # Long-standing behaviour worth keeping honest through the rename: a name with a space must
+    # survive as ONE argument, or the app comes back on a different pipe AND a different state file.
+    # Regression: passing the name as its own -ArgumentList element does NOT quote it, so the
+    # relaunch used to arrive as --pipe my win — a different pipe and a different state file, i.e.
+    # "the update ate my sessions" caused by the update itself.
+    Check 'a spaced instance name survives' ($r.Marker -match '2=\["?my win"?\]') $r.Marker
+
+    # --- 3. error case: the successor is not where we expect ----------------------------------
+    $r2 = Run-Helper (Join-Path $root 'nope\agliteterm.exe') ''
+    Check 'a missing successor falls back to this build' ($r2.Marker -match '(?m)^old ')
+    Check 'and says so in the update log' ($r2.Log -match 'successor missing')
+}
+
+# --- 4. error case: the successor feed is unreachable -------------------------------------------
+# Nothing to download, nothing to say. The check must not nag on startup and must not leave a
+# half-written payload behind — an install that never sees the handover keeps working as it is.
+Remove-Item (Join-Path $updates '*') -Recurse -ErrorAction SilentlyContinue
+$envDown = @{ LOCALAPPDATA = $root; AGWINTERM_VERSION_OVERRIDE = '0.17.4'
+              AGWINTERM_UPDATE_API = (Join-Path $root 'no-such-feed.json') }
+$p2 = Start-Process $app -ArgumentList @('--pipe', 'handover-down') -PassThru -Environment $envDown
+Start-Sleep -Seconds 12        # past the background check's 8s startup delay
+$p2.Refresh()
+Check 'an unreachable feed does not stop lite' (-not $p2.HasExited)
+Check 'and does not nag on startup' ($null -eq (Get-Dialog $p2.Id))
+
+[void][HoWin]::PostMessageW((Wait-Window $p2), 0x0111, [IntPtr]131, [IntPtr]::Zero)
+$dlg2 = Wait-Dialog $p2.Id 15
+Check 'an explicit check reports the failure' ($null -ne $dlg2 -and $dlg2.Body -match 'update check failed')
+Check 'nothing was downloaded' (-not (Test-Path (Join-Path $updates '*setup*')))
+if ($dlg2) { Close-Dialog $dlg2 1 }
+Start-Sleep -Seconds 2
+
+$p2.CloseMainWindow() | Out-Null
+Start-Sleep -Seconds 3
+if (-not $p2.HasExited) { Stop-Process -Id $p2.Id -Force }
+
+Remove-Item $root -Recurse -Force -ErrorAction SilentlyContinue
+
+if ($fail) { "handover: $fail FAILED"; exit 1 }
+"handover: all passed"
+exit 0

--- a/lite/test/run-all.ps1
+++ b/lite/test/run-all.ps1
@@ -4,7 +4,7 @@ param([string]$Exe = "$PSScriptRoot\..\bin\agwinterm-lite.exe")
 
 $ErrorActionPreference = 'Continue'
 $failed = @()
-foreach ($t in 'log-basics', 'log-restore', 'log-focus-font', 'log-rotation', 'diagnose', 'restore-matrix') {
+foreach ($t in 'log-basics', 'log-restore', 'log-focus-font', 'log-rotation', 'diagnose', 'restore-matrix', 'handover') {
     $script = Join-Path $PSScriptRoot "$t.ps1"
     if (-not (Test-Path $script)) { continue }
     # Each child sets $ErrorActionPreference = 'Stop', so it can die before reaching its own exit


### PR DESCRIPTION
Task 4 of the product split. This is the **last agwinterm-lite**: old name, old AppId, old install directory, with only its updater repointed at the agliteterm feed. It branches off `main`, not off the rename (#192) — the build that hands over has to be the identity users already have.

## Without this, every install goes quiet

The moment agwinterm stops publishing an `agwinterm-lite-setup` asset, the existing updater still *succeeds*: it fetches the release, finds no asset whose name matches, and reports nothing. No error, no notice, no route to the successor. So the handover ships **before** the rename, not after.

- **The feed and the asset name both move.** Retargeting the URL alone would have downloaded a `agwinterm-lite-setup` asset that happened to sit in the same release. The test seeds exactly that decoy, listed *first*, and asserts it is ignored.
- **The prompt says what is happening** — titled *"agwinterm lite is now agliteterm"*, and explaining what the user actually needs to know: the profile comes across on first run, the old build stays installed so they can go back, and `--pipe agwinterm-lite` keeps working. A user who reads "0.17.4 → 0.17.5" and then finds a differently-named app in their Start menu has been surprised by their terminal.
- **The relaunch starts the successor.** This is the part that would have silently broken it: the apply helper takes `-Exe` from `GetModuleFileNameW`, and because agliteterm installs **alongside** under its own AppId, the old exe still runs after setup. A naive handover installs agliteterm and then relaunches agwinterm-lite — the user watches an update do nothing and concludes it failed. The helper now takes a `-Successor`, and falls back to `-Exe` when it isn't there: relaunching the old build is a no-op they can retry, while relaunching nothing looks like the update killed their terminal.

## A bug this check surfaced, already shipping in 0.17.x

The helper relaunched a named instance with:

```powershell
Start-Process $Exe -ArgumentList '--pipe', $Instance
```

with a comment claiming the separate array element protects a name containing a space. It does not — `Start-Process` joins the list with spaces and quotes nothing:

```
1=[--pipe] 2=[my] 3=[win]        # as its own element
1=[--pipe] 2=["my win"] 3=[]     # with the quotes in the value
```

So an instance named `my win` came back as instance `my` — **a different pipe and a different state file**. That is the "my sessions are gone" shape, caused by the update itself, on exactly the path this PR touches. The quotes are now part of the value; the app parses its own command line with `CommandLineToArgvW`, which strips them again.

## Verification

`lite/test/handover.ps1` — **21 checks** — drives the built exe against a local feed through the seams the updater already has (`AGWINTERM_UPDATE_API` takes a path, `updFetch` reads local files, `AGWINTERM_VERSION_OVERRIDE` sets the current version), then runs **the apply helper the app itself wrote to disk**, with stand-in executables, so the assertion is about which one gets started rather than about Inno Setup:

```
PASS  the successor release is offered      PASS  the installer ran
PASS  the prompt names the rename           PASS  the successor is what gets relaunched
PASS  it says this is not a routine update  PASS  this build is NOT relaunched
PASS  it promises the profile comes across  PASS  a spaced instance name survives
PASS  it says the old build stays           PASS  a missing successor falls back to this build
PASS  it still reports the verification     PASS  and says so in the update log
PASS  the agliteterm asset was downloaded   PASS  an unreachable feed does not stop lite
PASS  the lite-setup decoy was ignored      PASS  and does not nag on startup
PASS  declining leaves lite running         PASS  an explicit check reports the failure
PASS  the apply helper was written          PASS  nothing was downloaded
```

Error cases are first-class here: **feed unreachable** must change nothing and nag nobody (asserted at startup, not just on an explicit check), and **successor missing** must still leave the user with a terminal.

Runs against a throwaway `%LOCALAPPDATA%` with a real install layout, because the update path is gated on the exe living in `<LOCALAPPDATA>\Programs\agwinterm-lite` — and pointing a live updater at a real profile would write payloads into it. Full lite suite green: 34 matrix cells plus log/diagnose/rotation/handover.

Two harness notes worth keeping, both of which produced *passing-looking* wrong results first: `FindWindowExW(NULL, prev, NULL, NULL)` enumerates zero windows on Windows 11, so the dialog checks all "passed" as absent until they moved to `EnumWindows`; and copying only `*.exe` into the sandbox install produced a startup error box that the dialog check happily mistook for the update prompt.

## Sequencing

1. this PR merges, and **0.17.4 ships as a normal agwinterm release** — the lite asset is still built and published exactly as today
2. #192 (rename) merges, and agliteterm publishes **0.17.5** from its own repo
3. only then does agwinterm stop publishing a lite asset

Step 2 must not happen before an 0.17.4 is in users' hands, or the handover has nobody to hand over to.

The same helper text exists on #192, so the instance-quoting fix is ported there separately.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)