### PR TITLE
ci(release): publish agwintermctl as a release asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,23 @@ jobs:
           Copy-Item native/target/release/agwinterm_core.dll     "installer/Output/agwinterm_core-abi$abi.dll"
           Copy-Item native/target/release/agwinterm-ptyhost.exe  "installer/Output/agwinterm-ptyhost-abi$abi.exe"
 
+      # agliteterm ships from its own repository but is driven by the SAME control client — which
+      # is what "speaks the agwintermctl dialect" has to mean if it is to be tested rather than
+      # asserted. Its CI cannot install agwinterm to get one, so the client ships as a release
+      # asset: SELF-CONTAINED single file, so the consuming repo pins no .NET version and the
+      # contract is one URL rather than a runtime handshake.
+      # Compressed (73 MB -> 37 MB); NOT trimmed — trimming a reflection-using JSON path to save
+      # another 20 MB would be a poor trade for the tool that verifies the API contract.
+      - name: Publish agwintermctl for other repositories
+        shell: pwsh
+        run: |
+          $v = '${{ github.ref_name }}'
+          $v = if ($v -match '^v\d') { $v.TrimStart('v') } else { '0.0.0' }
+          dotnet publish src/Agwinterm.Ctl/Agwinterm.Ctl.csproj -c Release -r win-x64 `
+            --self-contained true -p:PublishSingleFile=true -p:EnableCompressionInSingleFile=true -p:Version=$v `
+            -o ctl-publish
+          Copy-Item ctl-publish/agwintermctl.exe installer/Output/agwintermctl.exe
+
       # Free, certless supply-chain signing: a Sigstore-backed attestation binding each artifact to
       # this commit + workflow. Verify with:  gh attestation verify <file> --repo yeroo/agwinterm
       # (Doesn't remove SmartScreen — that needs Authenticode, e.g. a SignPath Foundation OSS cert.)
@@ -58,6 +75,7 @@ jobs:
             installer/Output/agwinterm-setup-*.exe
             installer/Output/agliteterm-setup-*.exe
             installer/Output/agwinterm-portable-*.exe
+            installer/Output/agwintermctl.exe
             installer/Output/agwinterm_core-abi*.dll
             installer/Output/agwinterm-ptyhost-abi*.exe
             installer/Output/agwinterm-core-abi.json
@@ -69,11 +87,12 @@ jobs:
             installer/Output/agwinterm-setup-*.exe
             installer/Output/agliteterm-setup-*.exe
             installer/Output/agwinterm-portable-*.exe
+            installer/Output/agwintermctl.exe
             installer/Output/agwinterm_core-abi*.dll
             installer/Output/agwinterm-ptyhost-abi*.exe
             installer/Output/agwinterm-core-abi.json
           generate_release_notes: true
-          fail_on_unmatched_files: true    # all three are hard build products now — a missing one is a broken release
+          fail_on_unmatched_files: true    # every one is a hard build product now — a missing one is a broken release
 
   # Opens the version-bump PR to microsoft/winget-pkgs for each release. Runs as a job here
   # (not a `release:` workflow) because releases published with GITHUB_TOKEN don't trigger


### PR DESCRIPTION
Task 5 groundwork. agliteterm now lives in its own repository, and its checks drive it through the control pipe **with the same client the full app uses** — which is what "speaks the agwintermctl dialect" has to mean if it is going to be tested rather than asserted.

Its CI cannot install agwinterm to get one. So the client ships as a release asset.

- **Self-contained single file**, so the consuming repository pins no .NET version — the contract is one URL, not a runtime handshake.
- **Compressed**: 73 MB → 37 MB. Verified locally that the compressed exe still runs (`agwintermctl tree --pipe …` reaches its "is agwinterm running?" error, i.e. it parsed, loaded and tried to connect).
- **Not trimmed.** Another ~20 MB is available by trimming, but trimming a reflection-using JSON path on the tool whose whole job is verifying the API contract is a poor trade.

Also attested alongside the other artifacts, so a consumer can `gh attestation verify` the client it is about to trust.

The manual-run guard matters: `workflow_dispatch` has no tag, so `github.ref_name` is a branch name and `-p:Version=main` would fail the publish. It falls back to `0.0.0`.

## Why now

Six of the seven agliteterm checks need this binary — they hardcoded `%LOCALAPPDATA%\Programs\agwinterm\agwintermctl.exe`, a dependency on the *other product being installed* that was invisible while both lived in one tree. In the new repo they resolve it (explicit env var → fetched `bin\` copy → installed agwinterm) and skip with a message when it is absent.

It is also what unblocks **Task 6**, the control-API conformance suite meant to run in both repos: without a fetchable client, agliteterm's side of that gate cannot exist.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)