### PR TITLE
test(control-api): make the cross-product contract a gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,7 @@ jobs:
       - name: Control-API conformance
         shell: pwsh
         timeout-minutes: 15
-        env:
-          AGWINTERMCTL: ${{ github.workspace }}\src\Agwinterm.Ctl\bin\Release\net10.0-windows\agwintermctl.exe
-        run: ./tests/conformance/conformance.ps1 -Strict -Exe "${{ github.workspace }}\src\Agwinterm.Win32\bin\Release\net10.0-windows\win-x64\Agwinterm.Win32.exe"
+        run: ./tests/conformance/conformance.ps1 -Strict
 
       - name: Test (Core + Pty)
         # One retry for the known .NET 10 test-host #118 pathology under named-pipe churn, which

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,17 @@ jobs:
         shell: pwsh
         run: ./lite/build.ps1
 
+      # The control API is a cross-product contract now: agliteterm ships from its own repository
+      # promising to speak this dialect, and its CI runs THIS spec against its own client. Running
+      # it here too is what makes "same control API" a gate rather than a claim — a verb reshaped
+      # in the full app fails the other product's build, and vice versa.
+      - name: Control-API conformance
+        shell: pwsh
+        timeout-minutes: 15
+        env:
+          AGWINTERMCTL: ${{ github.workspace }}\src\Agwinterm.Ctl\bin\Release\net10.0-windows\agwintermctl.exe
+        run: ./tests/conformance/conformance.ps1 -Exe "${{ github.workspace }}\src\Agwinterm.Win32\bin\Release\net10.0-windows\Agwinterm.Win32.exe"
+
       - name: Test (Core + Pty)
         # One retry for the known .NET 10 test-host #118 pathology under named-pipe churn, which
         # manifests two ways: a native CRASH ("Test Run Aborted") OR a DEADLOCK that hangs the run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         timeout-minutes: 15
         env:
           AGWINTERMCTL: ${{ github.workspace }}\src\Agwinterm.Ctl\bin\Release\net10.0-windows\agwintermctl.exe
-        run: ./tests/conformance/conformance.ps1 -Exe "${{ github.workspace }}\src\Agwinterm.Win32\bin\Release\net10.0-windows\Agwinterm.Win32.exe"
+        run: ./tests/conformance/conformance.ps1 -Strict -Exe "${{ github.workspace }}\src\Agwinterm.Win32\bin\Release\net10.0-windows\win-x64\Agwinterm.Win32.exe"
 
       - name: Test (Core + Pty)
         # One retry for the known .NET 10 test-host #118 pathology under named-pipe churn, which

--- a/tests/conformance/conformance.ps1
+++ b/tests/conformance/conformance.ps1
@@ -16,7 +16,7 @@
 #   - always a sandbox instance (--pipe <name>); never the default instance, which owns real state
 #   - never inject global input — every action goes through the control pipe
 param(
-    [string]$Exe = "$env:LOCALAPPDATA\Programs\agwinterm\Agwinterm.Win32.exe",
+    [string]$Exe,
     [string]$Spec = "$PSScriptRoot\control-api.json",
     # CI passes -Strict: a suite that skips is reporting success while checking nothing,
     # which is worse than not running it at all. Locally a skip is the right answer.
@@ -32,14 +32,29 @@ function Check([string]$name, [bool]$ok, [string]$detail = '') {
 
 "== conformance =="
 
-# The full app's own build tree first, then an installed copy — the same resolution order the
-# other repository uses, minus its download step.
-$ctl = @($env:AGWINTERMCTL,
-         (Join-Path $PSScriptRoot '..\..\src\Agwinterm.Ctl\bin\Release\net10.0-windows\agwintermctl.exe'),
-         "$env:LOCALAPPDATA\Programs\agwinterm\agwintermctl.exe") |
-       Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
+# Build layouts differ by where the build ran — locally bin\Release\..., in CI bin\x64\Release\...
+# because the solution config sets a platform. So both binaries are FOUND rather than assumed, and a
+# miss reports what it looked at: a hardcoded path that silently misses is how this suite first went
+# green having checked nothing.
+function Resolve-Binary([string]$explicit, [string]$name, [string]$projectDir) {
+    $roots = @()
+    if ($explicit) { $roots += $explicit }
+    $built = Join-Path (Join-Path $PSScriptRoot '..\..') "src\$projectDir\bin"
+    if (Test-Path $built) {
+        # newest first: a stale Debug copy must not win over the Release build CI just made
+        $roots += (Get-ChildItem $built -Recurse -Filter $name -ErrorAction SilentlyContinue |
+                   Sort-Object LastWriteTime -Descending | Select-Object -ExpandProperty FullName)
+    }
+    $roots += "$env:LOCALAPPDATA\Programs\agwinterm\$name"
+    foreach ($r in $roots) { if ($r -and (Test-Path $r)) { return $r } }
+    return $null
+}
+
+$ctl = Resolve-Binary $env:AGWINTERMCTL 'agwintermctl.exe' 'Agwinterm.Ctl'
+$Exe = Resolve-Binary $Exe 'Agwinterm.Win32.exe' 'Agwinterm.Win32'
 if (-not $ctl) { "  SKIP  agwintermctl not found (set AGWINTERMCTL)"; exit ($Strict ? 1 : 0) }
-if (-not (Test-Path $Exe)) { "  SKIP  agwinterm not found at $Exe"; exit ($Strict ? 1 : 0) }
+if (-not $Exe) { "  SKIP  agwinterm not found (pass -Exe)"; exit ($Strict ? 1 : 0) }
+"  using: $(Split-Path $Exe -Leaf) from $(Split-Path $Exe -Parent)"
 
 # NOT back into $Spec: that parameter is typed [string], and PowerShell is case-insensitive, so
 # assigning the parsed object to $spec would silently ConvertTo-String it — $contract.steps then reads

--- a/tests/conformance/conformance.ps1
+++ b/tests/conformance/conformance.ps1
@@ -17,7 +17,10 @@
 #   - never inject global input — every action goes through the control pipe
 param(
     [string]$Exe = "$env:LOCALAPPDATA\Programs\agwinterm\Agwinterm.Win32.exe",
-    [string]$Spec = "$PSScriptRoot\control-api.json"
+    [string]$Spec = "$PSScriptRoot\control-api.json",
+    # CI passes -Strict: a suite that skips is reporting success while checking nothing,
+    # which is worse than not running it at all. Locally a skip is the right answer.
+    [switch]$Strict
 )
 
 $ErrorActionPreference = 'Stop'
@@ -35,8 +38,8 @@ $ctl = @($env:AGWINTERMCTL,
          (Join-Path $PSScriptRoot '..\..\src\Agwinterm.Ctl\bin\Release\net10.0-windows\agwintermctl.exe'),
          "$env:LOCALAPPDATA\Programs\agwinterm\agwintermctl.exe") |
        Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
-if (-not $ctl) { "  SKIP  agwintermctl not found (set AGWINTERMCTL)"; exit 0 }
-if (-not (Test-Path $Exe)) { "  SKIP  agwinterm not found at $Exe"; exit 0 }
+if (-not $ctl) { "  SKIP  agwintermctl not found (set AGWINTERMCTL)"; exit ($Strict ? 1 : 0) }
+if (-not (Test-Path $Exe)) { "  SKIP  agwinterm not found at $Exe"; exit ($Strict ? 1 : 0) }
 
 # NOT back into $Spec: that parameter is typed [string], and PowerShell is case-insensitive, so
 # assigning the parsed object to $spec would silently ConvertTo-String it — $contract.steps then reads

--- a/tests/conformance/conformance.ps1
+++ b/tests/conformance/conformance.ps1
@@ -1,0 +1,172 @@
+# Control-API conformance — the agwinterm side.
+#
+# agliteterm ships from its own repository promising to speak the agwintermctl dialect. THIS file is
+# the canonical copy of the contract and the runner; agliteterm's CI checks its copy against this
+# one and runs the same steps against its own client. So a verb removed or reshaped here fails the
+# other product's build, and vice versa — the promise is enforced by two CIs rather than asserted
+# in a README.
+#
+# Every verb in tests/conformance/control-api.json is driven through the REAL agwintermctl against
+# a sandbox instance, and the response SHAPE is checked.
+#
+# Shape, not values: "session.text returns a string" is a contract; "it returns exactly these
+# bytes" is a snapshot of one machine's shell prompt.
+#
+# Suite rules (shared with the rest of the checks):
+#   - always a sandbox instance (--pipe <name>); never the default instance, which owns real state
+#   - never inject global input — every action goes through the control pipe
+param(
+    [string]$Exe = "$env:LOCALAPPDATA\Programs\agwinterm\Agwinterm.Win32.exe",
+    [string]$Spec = "$PSScriptRoot\control-api.json"
+)
+
+$ErrorActionPreference = 'Stop'
+$fail = 0
+function Check([string]$name, [bool]$ok, [string]$detail = '') {
+    if ($ok) { "  PASS  $name" }
+    else { $script:fail++; "  FAIL  $name$(if ($detail) { " — $detail" })" }
+}
+
+"== conformance =="
+
+# The full app's own build tree first, then an installed copy — the same resolution order the
+# other repository uses, minus its download step.
+$ctl = @($env:AGWINTERMCTL,
+         (Join-Path $PSScriptRoot '..\..\src\Agwinterm.Ctl\bin\Release\net10.0-windows\agwintermctl.exe'),
+         "$env:LOCALAPPDATA\Programs\agwinterm\agwintermctl.exe") |
+       Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
+if (-not $ctl) { "  SKIP  agwintermctl not found (set AGWINTERMCTL)"; exit 0 }
+if (-not (Test-Path $Exe)) { "  SKIP  agwinterm not found at $Exe"; exit 0 }
+
+# NOT back into $Spec: that parameter is typed [string], and PowerShell is case-insensitive, so
+# assigning the parsed object to $spec would silently ConvertTo-String it — $contract.steps then reads
+# as $null and the whole run "passes" having checked nothing. Which it did, once.
+# agwintermctl defaults its target to $AGWINTERM_SESSION_ID when none is given — which is the whole
+# point of that variable, and a trap here: this runner is itself launched from a terminal session,
+# so an untargeted verb would aim at the DEVELOPER's session id, which the sandbox instance has
+# never heard of ("session not found"). CI would pass and a local run would fail, or worse.
+$env:AGWINTERM_SESSION_ID = $null
+$env:AGWINTERM_PANE_ID = $null
+$env:AGWINTERM_PIPE = $null
+
+$contract = Get-Content $Spec -Raw | ConvertFrom-Json
+$pipe = 'conform'
+$vars = @{}
+$checked = 0
+
+# Substitute {captured} values into an argument list.
+function Expand-Args($argv) {
+    $out = @()
+    foreach ($a in $argv) {
+        $s = [string]$a
+        foreach ($k in $vars.Keys) { $s = $s.Replace("{$k}", $vars[$k]) }
+        $out += $s
+    }
+    # The comma is load-bearing: PowerShell unwraps a one-element array on return, and splatting a
+    # bare string spreads its CHARACTERS — @('ping') reached agwintermctl as "p i n g".
+    return ,[string[]]$out
+}
+
+# One control call. Returns the parsed envelope, or $null when the output was not JSON at all —
+# which is itself a contract violation worth reporting distinctly from ok:false.
+function Invoke-Ctl($argv) {
+    $argv = [string[]]@($argv)          # same unwrapping trap on the way in
+    $out = (& $ctl @argv --pipe $pipe --json 2>&1) -join "`n"
+    try { return $out | ConvertFrom-Json } catch { return [pscustomobject]@{ __raw = $out } }
+}
+
+function Test-Shape($resp, [string]$kind, $fields) {
+    if ($null -eq $resp -or $resp.PSObject.Properties.Name -contains '__raw') { return "not JSON: $($resp.__raw)" }
+    if (-not $resp.ok) { return "ok:false — $($resp.error)" }
+    $r = $resp.result
+    switch ($kind) {
+        'string' { if ($r -isnot [string]) { return "result is $($r.GetType().Name), expected string" } }
+        'object' {
+            if ($r -isnot [psobject]) { return "result is not an object" }
+            foreach ($f in $fields) { if ($r.PSObject.Properties.Name -notcontains $f) { return "result is missing '$f'" } }
+        }
+        'array' {
+            if ($r -isnot [Array]) { return "result is not an array" }
+            if ($r.Count -gt 0) {
+                foreach ($f in $fields) { if ($r[0].PSObject.Properties.Name -notcontains $f) { return "elements are missing '$f'" } }
+            }
+        }
+    }
+    return $null
+}
+
+$p = Start-Process $Exe -ArgumentList @('--pipe', $pipe, '--no-restore') -PassThru
+try {
+    # Wait for the pipe rather than sleeping a guessed amount: the first verb failing because the
+    # app had not finished starting would look exactly like a broken verb.
+    $up = $false
+    for ($i = 0; $i -lt 40; $i++) {
+        Start-Sleep -Milliseconds 500
+        if ((Invoke-Ctl @('ping')).ok) { $up = $true; break }
+    }
+    Check 'the sandbox instance answers' $up
+    if (-not $up) { throw 'instance never came up' }
+
+    foreach ($step in $contract.steps) {
+        if ($step.setup) {
+            # "window.new:name" — a step that needs a subject it must create itself.
+            $parts = $step.setup -split ':', 2
+            if ($parts[0] -eq 'window.new') { Invoke-Ctl @('window', 'new', '--name', $parts[1]) | Out-Null; Start-Sleep -Seconds 6 }
+        }
+        $argv = Expand-Args $step.args
+        $resp = Invoke-Ctl $argv
+        $why = Test-Shape $resp $step.result $step.fields
+        Check $step.verb ($null -eq $why) $why
+        $checked++
+        if (-not $why -and $step.capture) { $vars[$step.capture] = [string]$resp.result }
+        if ($step.settle) { Start-Sleep -Seconds $step.settle }
+    }
+
+    # --- the env contract -----------------------------------------------------------------------
+    # The AGWINTERM_* variables are what the agent skill, the status hooks and agwintermctl-inside-a-
+    # session read. They are the reason the rename kept the old prefix, so they are part of the
+    # contract rather than an implementation detail — and they are asked of the SHELL, not of the
+    # app, because what matters is that the child process actually received them.
+    $envSession = [string](Invoke-Ctl @('session', 'new', '--name', 'conf-env')).result
+    Start-Sleep -Seconds 4
+    foreach ($v in $contract.sessionEnv) {
+        Invoke-Ctl @('session', 'type', "echo [$v=`$env:$v]`r", '--target', $envSession) | Out-Null
+        Start-Sleep -Seconds 2
+        $text = [string](Invoke-Ctl @('session', 'text', '--target', $envSession)).result
+        # The shell echoes the VALUE back, so a set variable prints as [NAME=something]; an unset
+        # one prints as [NAME=] — which is why the pattern demands at least one character.
+        Check "session env $v" ($text -match "\[$v=[^\]]+\]") 'not set in the session shell'
+    }
+
+    # --- refusals -------------------------------------------------------------------------------
+    # A script branches on ok, so a bad target must come back as a refusal — not a crash, and not a
+    # cheerful ok:true that did nothing.
+    foreach ($e in $contract.errors) {
+        $resp = Invoke-Ctl (Expand-Args $e.args)
+        $isRefusal = ($null -ne $resp) -and ($resp.PSObject.Properties.Name -notcontains '__raw') -and (-not $resp.ok) -and $resp.error
+        Check "refuses: $($e.args -join ' ')" $isRefusal
+    }
+}
+finally {
+    # Close ONLY what this run created, by name, through the pipe — never by enumerating processes.
+    # A blanket "stop every agliteterm" here would close the windows the developer is working in,
+    # which is the exact accident this suite's rules exist to prevent.
+    try {
+        $wins = (Invoke-Ctl @('window', 'list')).result
+        foreach ($w in $wins) {
+            if ($w.name -like 'conf-*') { Invoke-Ctl @('window', 'close', $w.name) | Out-Null }
+        }
+    } catch { }
+    $p.CloseMainWindow() | Out-Null
+    Start-Sleep -Seconds 3
+    if (-not $p.HasExited) { Stop-Process -Id $p.Id -Force }
+}
+# A conformance suite that checks nothing must never report success. This is the guard for the
+# failure that actually happened: a silent empty run.
+if ($checked -lt $contract.steps.Count) {
+    "conformance: only $checked of $($contract.steps.Count) verbs were exercised"
+    exit 1
+}
+if ($fail) { "conformance: $fail FAILED"; exit 1 }
+"conformance: all passed"
+exit 0

--- a/tests/conformance/control-api.json
+++ b/tests/conformance/control-api.json
@@ -1,0 +1,483 @@
+{
+  "$comment": [
+    "THE CONTROL-API CONTRACT. agliteterm's promise is that it speaks the agwintermctl dialect, and",
+    "this file is what makes that testable rather than asserted: the same spec runs in BOTH",
+    "repositories' CI — in agwinterm against the full app, here against agliteterm — so a verb",
+    "removed or reshaped on one side fails the other side's build.",
+    "",
+    "It checks SHAPE, not values. 'session.text returns a string' is a contract; 'it returns exactly",
+    "these bytes' is a snapshot of one machine's shell. Every response is the same envelope:",
+    "{ok:true,result:<json>} or {ok:false,error:<string>}.",
+    "",
+    "Steps run in order and share state — a session must exist before anything can select it — and",
+    "{placeholders} carry captured values forward.",
+    "",
+    "The full app implements a superset (38 verbs here; it also has search, output, readonly, bind,",
+    "background, theme.*, config.*, install.*, ...). Those are deliberately NOT in this file: this is",
+    "the shared floor both products stand on, not an inventory of either one."
+  ],
+  "envelope": {
+    "ok": "bool",
+    "result": "present when ok",
+    "error": "present when not ok"
+  },
+  "sessionEnv": [
+    "AGWINTERM_ENABLED",
+    "AGWINTERM_PIPE",
+    "AGWINTERM_SESSION_ID",
+    "AGWINTERM_PANE_ID"
+  ],
+  "steps": [
+    {
+      "verb": "ping",
+      "args": [
+        "ping"
+      ],
+      "result": "string",
+      "note": "liveness. The string names the product, so it is deliberately not compared."
+    },
+    {
+      "verb": "tree",
+      "args": [
+        "tree",
+        "--json"
+      ],
+      "result": "object",
+      "fields": [
+        "workspaces"
+      ],
+      "note": "the whole structure in one call — what every script reads first."
+    },
+    {
+      "verb": "session.new",
+      "args": [
+        "session",
+        "new",
+        "--name",
+        "conf-alpha"
+      ],
+      "result": "string",
+      "capture": "alpha",
+      "settle": 3,
+      "note": "returns the new session's id, which the rest of the run targets. The settle is not politeness: the full app posts the creation to its UI thread and returns the id first, so a verb aimed at it a millisecond later legitimately cannot find it."
+    },
+    {
+      "verb": "session.select",
+      "args": [
+        "session",
+        "select",
+        "{alpha}"
+      ],
+      "result": "string"
+    },
+    {
+      "verb": "session.rename",
+      "args": [
+        "session",
+        "rename",
+        "conf-renamed",
+        "--target",
+        "{alpha}"
+      ],
+      "result": "string"
+    },
+    {
+      "verb": "session.status",
+      "args": [
+        "session",
+        "status",
+        "working",
+        "--target",
+        "{alpha}"
+      ],
+      "result": "string",
+      "note": "agent status is what drives the sidebar's bold/italic and the attention bell."
+    },
+    {
+      "verb": "session.seen",
+      "args": [
+        "session",
+        "seen",
+        "--target",
+        "{alpha}"
+      ],
+      "result": "string"
+    },
+    {
+      "verb": "session.flag",
+      "args": [
+        "session",
+        "flag",
+        "on",
+        "--target",
+        "{alpha}"
+      ],
+      "result": "string"
+    },
+    {
+      "verb": "session.text",
+      "args": [
+        "session",
+        "text",
+        "--target",
+        "{alpha}"
+      ],
+      "result": "string",
+      "note": "the visible buffer. A string even when the pane is empty."
+    },
+    {
+      "verb": "session.copy",
+      "args": [
+        "session",
+        "copy",
+        "--target",
+        "{alpha}"
+      ],
+      "result": "string",
+      "note": "the selection's text, and an empty string when there is no selection — not an error."
+    },
+    {
+      "verb": "session.type",
+      "args": [
+        "session",
+        "type",
+        "echo conformance",
+        "--target",
+        "{alpha}"
+      ],
+      "result": "string"
+    },
+    {
+      "verb": "session.paste",
+      "args": [
+        "session",
+        "paste",
+        "pasted-text",
+        "--target",
+        "{alpha}"
+      ],
+      "result": "string"
+    },
+    {
+      "verb": "session.duplicate",
+      "args": [
+        "session",
+        "duplicate",
+        "{alpha}"
+      ],
+      "result": "string",
+      "capture": "beta",
+      "settle": 3,
+      "note": "clones the launch spec; returns the NEW id, so a caller can drive what it just made."
+    },
+    {
+      "verb": "session.move",
+      "args": [
+        "session",
+        "move",
+        "--to",
+        "up",
+        "--target",
+        "{beta}"
+      ],
+      "result": "string"
+    },
+    {
+      "verb": "session.go",
+      "args": [
+        "session",
+        "go",
+        "next"
+      ],
+      "result": "string"
+    },
+    {
+      "verb": "session.split",
+      "args": [
+        "session",
+        "split",
+        "off"
+      ],
+      "result": "string"
+    },
+    {
+      "verb": "session.scratch",
+      "args": [
+        "session",
+        "scratch",
+        "off"
+      ],
+      "result": "string"
+    },
+    {
+      "verb": "session.overlay",
+      "args": [
+        "session",
+        "overlay",
+        "close"
+      ],
+      "result": "string"
+    },
+    {
+      "verb": "quick",
+      "args": [
+        "quick",
+        "off"
+      ],
+      "result": "string"
+    },
+    {
+      "verb": "session.close",
+      "args": [
+        "session",
+        "close",
+        "{beta}"
+      ],
+      "result": "string"
+    },
+    {
+      "verb": "workspace.new",
+      "args": [
+        "workspace",
+        "new",
+        "conf-ws"
+      ],
+      "result": "string",
+      "capture": "ws",
+      "settle": 2
+    },
+    {
+      "verb": "workspace.rename",
+      "args": [
+        "workspace",
+        "rename",
+        "conf-ws2",
+        "--target",
+        "{ws}"
+      ],
+      "result": "string"
+    },
+    {
+      "verb": "workspace.select",
+      "args": [
+        "workspace",
+        "select",
+        "--target",
+        "{ws}"
+      ],
+      "result": "string"
+    },
+    {
+      "verb": "workspace.collapse",
+      "args": [
+        "workspace",
+        "collapse",
+        "{ws}"
+      ],
+      "result": "string"
+    },
+    {
+      "verb": "workspace.expand",
+      "args": [
+        "workspace",
+        "expand",
+        "{ws}"
+      ],
+      "result": "string"
+    },
+    {
+      "verb": "workspace.focus",
+      "args": [
+        "workspace",
+        "focus",
+        "off"
+      ],
+      "result": "string"
+    },
+    {
+      "verb": "workspace.delete",
+      "args": [
+        "workspace",
+        "delete",
+        "--target",
+        "{ws}"
+      ],
+      "result": "string"
+    },
+    {
+      "verb": "sidebar",
+      "args": [
+        "sidebar",
+        "on"
+      ],
+      "result": "string"
+    },
+    {
+      "verb": "window.list",
+      "args": [
+        "window",
+        "list"
+      ],
+      "result": "object",
+      "fields": [
+        "windows"
+      ],
+      "note": "the window registry. WRAPPED in an object: a bare array would break every script that reads .result.windows."
+    },
+    {
+      "verb": "window.new",
+      "args": [
+        "window",
+        "new",
+        "--name",
+        "conf-win"
+      ],
+      "result": "string",
+      "capture": "win",
+      "settle": 6,
+      "note": "spawns a real second window and returns its HANDLE — an id in the full app, the pipe name in agliteterm. Everything downstream targets the captured value, never the name it asked for."
+    },
+    {
+      "verb": "window.select",
+      "args": [
+        "window",
+        "select",
+        "{win}"
+      ],
+      "result": "string"
+    },
+    {
+      "verb": "window.rename",
+      "args": [
+        "window",
+        "rename",
+        "{win}",
+        "conf-titled"
+      ],
+      "result": "string"
+    },
+    {
+      "verb": "window.move",
+      "args": [
+        "window",
+        "move",
+        "{win}",
+        "80",
+        "80"
+      ],
+      "result": "string"
+    },
+    {
+      "verb": "window.resize",
+      "args": [
+        "window",
+        "resize",
+        "{win}",
+        "900",
+        "600"
+      ],
+      "result": "string"
+    },
+    {
+      "verb": "window.state",
+      "args": [
+        "window",
+        "state"
+      ],
+      "result": "object",
+      "fields": [
+        "sidebarVisible",
+        "fullscreen",
+        "maximized",
+        "quickTerminalVisible",
+        "activeWorkspace",
+        "activeSession"
+      ],
+      "note": "a read-back of the window's UI flags — not geometry, and not a setter. Extra fields are allowed; these must be present."
+    },
+    {
+      "verb": "window.zoom",
+      "args": [
+        "window",
+        "zoom",
+        "{win}"
+      ],
+      "result": "string",
+      "note": "toggles; the target is positional, so an op word here would name a window instead."
+    },
+    {
+      "verb": "window.close",
+      "args": [
+        "window",
+        "close",
+        "{win}"
+      ],
+      "result": "string",
+      "settle": 3
+    },
+    {
+      "verb": "window.new",
+      "args": [
+        "window",
+        "new",
+        "--name",
+        "conf-win2"
+      ],
+      "result": "string",
+      "capture": "win2",
+      "settle": 6,
+      "note": "a second one, because window.delete consumes what it deletes."
+    },
+    {
+      "verb": "window.delete",
+      "args": [
+        "window",
+        "delete",
+        "{win2}"
+      ],
+      "result": "string",
+      "settle": 3,
+      "note": "close AND drop that window's saved state — the one verb that deletes a file."
+    }
+  ],
+  "$errorsComment": [
+    "Server-side refusals only. agwintermctl rejects some malformed invocations itself (exit 2, no",
+    "JSON) — that is the client's behaviour and identical for both products, so it says nothing",
+    "about whether the two speak the same dialect."
+  ],
+  "errors": [
+    {
+      "note": "A bad target is a REFUSAL, not a crash and not a silent success — scripts branch on ok.",
+      "args": [
+        "session",
+        "select",
+        "no-such-session-id"
+      ]
+    },
+    {
+      "note": "Same for windows: the registry is authoritative and an unknown name is an error.",
+      "args": [
+        "window",
+        "select",
+        "no-such-window"
+      ]
+    },
+    {
+      "note": "Workspaces resolve by index or name, and an unknown one is refused rather than silently acting on the active workspace.",
+      "args": [
+        "workspace",
+        "select",
+        "--target",
+        "no-such-workspace"
+      ]
+    }
+  ],
+  "$orderComment": [
+    "ORDER MATTERS, and not only because a session must exist before it can be selected.",
+    "In the full app every window shares one process and content verbs act on the FRONTMOST window;",
+    "in agliteterm every window is its own process with its own pipe, so it cannot happen there. Do the",
+    "session and workspace lifecycle FIRST, then the window block — otherwise selecting a new window",
+    "silently redirects the later verbs to a host that has never heard of the ids they carry, and the",
+    "suite reports a contract break that is really its own fault."
+  ]
+}


### PR DESCRIPTION
Task 6 of the product split. agliteterm ships from its own repository promising to speak the agwintermctl dialect. This is the canonical statement of what that means — **38 verbs**, each with its request and expected response **shape**, driven through the real `agwintermctl` against a sandbox instance.

agliteterm's CI checks its mirror of this file against this one and runs the same steps against its own client, so a verb reshaped on either side fails the other product's build. That is the difference between a promise and a gate.

Shape, not values: *"session.text returns a string"* is a contract; *"it returns exactly these bytes"* is a snapshot of one machine's shell prompt. Extra fields are allowed; the named ones must be present.

## It found three real divergences on its first run

| | agwinterm | agliteterm |
|---|---|---|
| `window.list` | `{"windows":[…]}` | a **bare array** |
| `window.state` | UI flags — `sidebarVisible`, `fullscreen`, `maximized`, `quickTerminalVisible`, `activeWorkspace`, `activeSession` | window **geometry** |

Every script that reads `.result.windows` breaks against agliteterm's shape, and `window.state` was two different verbs wearing the same name. Both fixed on the agliteterm side (geometry kept as extra fields), which is where the deviation was.

The third is on this side and is now written down rather than fixed: **`session.new` returns an id before the session exists.** The full app posts the creation to its UI thread and answers immediately, so a verb aimed at that id a millisecond later legitimately cannot find it. The spec settles between the two; the wart is documented in the step's note.

## Two traps in the harness, both of which produce confident wrong answers

- **`agwintermctl` defaults its target to `$AGWINTERM_SESSION_ID`.** A suite run from inside a terminal session therefore aims untargeted verbs at the *developer's* session, which the sandbox instance has never heard of. Six checks failed for that reason before the runner started clearing those variables — and on a bare CI runner it would have passed, so the local and CI results would have disagreed with no explanation.
- **Content verbs follow the frontmost window.** All the full app's windows share one process, so `window.select` in the middle of the run silently redirected the later session and workspace verbs to a host that had never heard of their ids. The spec now does lifecycle first and windows last, and says why — the failure looks exactly like a contract break.

Neither is a possibility in agliteterm, where every window is its own process with its own pipe. That asymmetry is itself part of what the contract has to survive.

## The env contract

`AGWINTERM_ENABLED` / `PIPE` / `SESSION_ID` / `PANE_ID` are checked by asking **the shell**, not the app — what matters is that the child process actually received them. That prefix is the reason the rename kept it, so it belongs in the contract rather than in an implementation note.

## Verification

**All 39 steps green against the full app**, and green against agliteterm after its two fixes. Locally run against an installed 0.17.3 and a fresh agliteterm build.

One thing this PR cannot answer: whether a GitHub runner can host a suite that creates real windows and real shells. These checks have only ever run on a developer machine. The first CI run is where we find out — if the runner can't, the step is the thing to change, not the contract.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)