### PR TITLE
feat(control): resolve a session target by name, not just by id

### DIFF
--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -1604,13 +1604,27 @@ internal partial class Program
         RequestRedraw(); SaveState();
     }
 
+    /// <summary>
+    /// Resolve a control-API target: id (exact), then id prefix, then NAME.
+    /// </summary>
+    /// <remarks>
+    /// The name is what a person says and therefore what an agent is told — "run it in the build
+    /// session" — and an id-only lookup made that the one phrasing that could not work, while every
+    /// verb reported the same flat "session not found".
+    ///
+    /// An ambiguous name resolves to NOTHING rather than to the first match: sessions can share a
+    /// name, and silently typing into the wrong terminal is worse than refusing.
+    /// </remarks>
     private Ses? Find(string? target)
     {
         lock (_workspaces)
         {
             if (string.IsNullOrEmpty(target) || target == "active") return _active;
             var all = _workspaces.SelectMany(w => w.Sessions).ToList();
-            return all.FirstOrDefault(x => x.Id == target) ?? all.FirstOrDefault(x => x.Id.StartsWith(target));
+            var byId = all.FirstOrDefault(x => x.Id == target) ?? all.FirstOrDefault(x => x.Id.StartsWith(target));
+            if (byId is not null) return byId;
+            var named = all.Where(x => string.Equals(x.Name, target, StringComparison.OrdinalIgnoreCase)).ToList();
+            return named.Count == 1 ? named[0] : null;
         }
     }
 

--- a/tests/conformance/control-api.json
+++ b/tests/conformance/control-api.json
@@ -59,7 +59,7 @@
       "result": "string",
       "capture": "alpha",
       "settle": 3,
-      "note": "returns the new session's id, which the rest of the run targets. The settle is not politeness: the full app posts the creation to its UI thread and returns the id first, so a verb aimed at it a millisecond later legitimately cannot find it."
+      "note": "returns the new session's id, and MUST honour --name: agliteterm ignored it and handed back a session called \"<pipe>-<n>\", so an agent could not find what it had just created, by name or in the tree. The settle is not politeness — the full app posts the creation to its UI thread and answers first, so a verb aimed at that id a millisecond later legitimately cannot find it."
     },
     {
       "verb": "session.select",
@@ -80,6 +80,16 @@
         "{alpha}"
       ],
       "result": "string"
+    },
+    {
+      "verb": "session.select",
+      "args": [
+        "session",
+        "select",
+        "conf-renamed"
+      ],
+      "result": "string",
+      "note": "targeted BY NAME, not by id. This is the phrasing an agent is given — \"run it in the build session\" — and it used to be the one that could not work: both products resolved ids only and answered a flat \"session not found\". An ambiguous name still resolves to nothing, because typing into the wrong terminal is worse than refusing."
     },
     {
       "verb": "session.status",


### PR DESCRIPTION
*"Run it in the ralphex02 session"* is how a person says it, and therefore how an agent is told. It was the one phrasing that could not work:

```
$ agwintermctl session select ralphex02 --json
{"ok":false,"error":"session not found"}      # the session exists; only its NAME was used
```

`Find()` matched an id or an id prefix, so a name came back as a flat *session not found* with nothing to suggest the name was the problem.

Resolution is now **id → id prefix → name**. An **ambiguous name resolves to nothing** rather than to the first match: sessions can share a name, and silently typing into the wrong terminal is worse than refusing.

## Why it lands here too

agliteterm had the identical limitation. Fixing it there alone would mean a script that works against one product breaks against the other — exactly the divergence the split was meant to prevent. So both change together, and the **control-API contract gains a target-by-name step** ([agliteterm side](https://github.com/yeroo/agliteterm/pull/1)), which is what keeps it true rather than merely true today.

That step earns its place twice over. agliteterm was also ignoring `session.new --name`, and a **shape-only conformance check cannot see an ignored argument** — a string came back, so it passed. A later verb that targets the session *by that name* does catch it.

## Verification

Both suites green on the 40-step contract, run against the built app (the runner prints which binary it used, so a pass is attributable).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)