### PR TITLE
fix(control): events returns an object, not a string of JSON

### DIFF
--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -205,7 +205,11 @@ public sealed class ControlServer : IDisposable
                     return host.SessionBind(target, GetString(args, "agent") ?? "claude") ? Ok("bound") : Err("session not found");
                 case "session.restore":
                     return host.SessionRestore(target, GetString(args, "command") ?? "") ? Ok("pinned") : Err("session not found");
-                case "events": return Ok(host.Events(GetInt(args, "since", 0), GetInt(args, "limit", 0)));
+                // OkRaw, not Ok: Events() already returns JSON. Ok() would serialize it AGAIN, so
+                // .result arrived as a STRING of JSON and a caller had to parse it a second time —
+                // while tree and window.list, built the same way, return objects. The conformance
+                // contract caught it as a divergence from agliteterm, which had it right.
+                case "events": return OkRaw(host.Events(GetInt(args, "since", 0), GetInt(args, "limit", 0)));
                 case "claude.adopt":
                     return Ok(host.AdoptClaude());
                 case "claude.yolo":

--- a/tests/conformance/control-api.json
+++ b/tests/conformance/control-api.json
@@ -49,6 +49,18 @@
       "note": "the whole structure in one call — what every script reads first."
     },
     {
+      "verb": "events",
+      "args": [
+        "events"
+      ],
+      "result": "object",
+      "fields": [
+        "cursor",
+        "events"
+      ],
+      "note": "cursor-polled change log. The reply carries the current cursor even when nothing happened, so polling a quiet terminal still moves the caller forward instead of re-reading history. Types: session / status / tree."
+    },
+    {
       "verb": "session.new",
       "args": [
         "session",
@@ -134,6 +146,17 @@
       ],
       "result": "string",
       "note": "the visible buffer. A string even when the pane is empty."
+    },
+    {
+      "verb": "session.output",
+      "args": [
+        "session",
+        "output",
+        "--target",
+        "{alpha}"
+      ],
+      "result": "string",
+      "note": "the last COMPLETED command's output, delimited by FTCS (OSC 133) marks. A string either way: with no shell integration it says so, rather than returning \"\" — which an agent would read as \"the command printed nothing\"."
     },
     {
       "verb": "session.copy",


### PR DESCRIPTION
`Events()` already builds JSON, and the case arm wrapped it in `Ok()`, which serializes it **again**:

```
"result":"{\"cursor\":3,\"events\":[...]}"     before — a string the caller must parse twice
"result":{"cursor":3,"events":[...]}           after
```

Meanwhile `tree` and `window.list`, built the same way from a `StringBuilder`, return objects via `OkRaw`. So `events` was the odd one out.

## How it was found

The control-API conformance contract. agliteterm implemented `events` as an object, so `.result.cursor` worked against one product and failed against the other — and the suite reported the divergence rather than either side noticing on its own.

**This is the first time it caught the full app being the wrong side**, which is precisely what it was built for. Until now it had only ever corrected agliteterm.

## Breaking?

Yes, for anything that was double-parsing `.result` — realistically nothing outside this repo, since the shape was inconsistent with every neighbouring verb and the verb is recent. The alternative was to write the accident into the contract and make it permanent.

## Also

The contract gains `session.output`, which both products implement — agliteterm's arrives in [its PR](https://github.com/yeroo/agliteterm/pulls).

## Verification

Both suites green on **42 steps**. The full app was rebuilt and re-run to confirm the fix, not just the contract edited.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)