### PR TITLE
fix(core): a variation selector is not a character — give it no cell

### DIFF
--- a/docs/plans/20260821-image-frameshm-command.md
+++ b/docs/plans/20260821-image-frameshm-command.md
@@ -1,0 +1,339 @@
+# Host-side support for winterm-browser (`image.frameshm`, cell metrics, `?1016`)
+
+> **Revision 2**, after a revmux triage panel run against the consuming plan
+> (`winterm-browser/.revmux/tasks/plan-windows-port/01-initial`). Three changes: the two-slot
+> tear-proof claim was wrong as argued and the real invariant is now stated and tested; two further
+> host capabilities the consumer cannot work around were found, and one of them **blocks** it.
+> Findings cited inline as `[triage: …]`.
+
+## Overview
+
+Add a control-pipe command that accepts browser-rate BGRA frames through a shared memory mapping
+instead of through files, so a producer can drive a pane at video rates without a PNG encode or a
+disk round-trip on every frame.
+
+The consumer is [winterm-browser](file:///C:/Users/boris/source/winterm-browser), a Windows-native
+port of terminal-browser that renders Chromium into an agwinterm pane. Its design brief is
+`C:\Users\boris\source\winterm-browser\docs\design\00-port-brief.md`. That project is blocked on
+this command, and this plan defines the contract it codes against — so the wire shape here is the
+deliverable, not just the implementation.
+
+**Problem it solves.** `image.frame` (`ControlServer.cs:249`) is already a frame path: it takes an
+`images[]` array, content-signature-caches each id to skip re-transmits, reads pixel bytes off the
+render lock, and swaps placements under a microsecond-scale lock. But every image arrives as a
+`path`, so a 30fps full-pane producer must PNG-encode and write a file 30 times a second and
+agwinterm must read it back. For a document viewer like docxy that is fine. For a browser it is not.
+
+**Why this is worth doing beyond the browser.** The expensive part of `image.frame` is not the
+placement machinery, which is already good — it is the format and the transport. Anything that
+generates pixels rather than loading them (a video preview, a plot that animates, a remote frame
+buffer) hits the same wall.
+
+## Three deliverables, and only one of them blocks the consumer
+
+Revision 1 had one. The triage panel found two more, and correctly separated them by urgency:
+
+| task | what | consumer impact if absent |
+|---|---|---|
+| 1–6 | `image.frameshm` | **none.** winterm-browser's Tasks 1–10 have zero dependency on this plan; the file-based `image.frame` already ships every capability its milestone needs. This is an optimisation with a self-guarding precondition and an automatic fallback. |
+| **6b** | **cell pixel metrics** | **blocking.** The consumer has no other source, and its own fallback is a hardcoded `(16, 32)` guess that silently produces wrong click targets. |
+| 6c | `?1016` SGR-Pixels mouse | degrades. The browser works with pointer resolution quantised to one character cell. |
+
+That ordering is worth holding onto: the piece that looked like the critical path is the one nothing
+waits on, and the blocking piece was not in the plan at all.
+
+## Context (from discovery)
+
+- `src/Agwinterm.Pty/ControlServer.cs:249` — `image.frame` dispatch; `HandleImageFrame` at ~line 425
+  is the model to follow: phase 1 resolves placements and owns pixel bytes **off** the render lock,
+  phase 2 takes a brief lock for dictionary/list swaps only.
+- `src/Agwinterm.Core/KittyGraphics.cs` — `KittyFormat { Rgb = 24, Rgba = 32, Png = 100 }`,
+  `KittyImage(Id, Format, Width, Height, Data)`, `ImagePlacement(ImageId, Row, Col, Cols, Rows,
+  SrcX, SrcY, SrcW, SrcH)`.
+- `src/Agwinterm.Pty/ISession.cs:64,66` — `Inject(ReadOnlySpan<byte>)` and
+  `MutateLocked(Action<ITerminalCore>)`; both take the render lock internally.
+- `tests/Agwinterm.Pty.Tests/ControlServerTests.cs` and `ControlApiTests.cs` — where control-verb
+  tests live.
+- `tests/conformance/control-api.json` — **shared with agliteterm**; the same spec runs in both
+  repositories' CI. See the constraint below.
+
+## Constraints
+
+- **Do not add `image.frameshm` to `tests/conformance/control-api.json`.** That file is a contract
+  agliteterm must also satisfy, and adding a verb there fails agliteterm's build for a command it
+  does not implement. Test this verb in agwinterm's own xunit suites only. If it should later become
+  part of the shared dialect, that is a separate decision made with agliteterm in hand.
+- **Frames must never tear.** A producer writing while the renderer reads is the default failure
+  mode of any shared buffer; the design must make a torn read impossible, not unlikely.
+- **A dead or lying producer must not take the terminal down.** The name, dimensions, stride and
+  offsets all arrive from another process and every one of them is untrusted input into a pointer
+  computation. Validate against the actual mapped view length before any copy.
+- **`ControlServer` int args must be JSON numbers, not strings** — `GetInt` throws
+  `"requires an element of type 'Number'"` otherwise. The ctl serializes `cargs` by type, so parse
+  with `int.TryParse` on the CLI side.
+- Backward compatibility: `image.frame` keeps working unchanged. This is an additional verb.
+- Build discipline (these have cost hours before): close the running dev instance before building;
+  build `src/Agwinterm.Win32` **explicitly** so its copy of `Agwinterm.Pty.dll` is not stale;
+  a plain solution build outputs to a *different* directory than a project build.
+- Test against an isolated instance: a Debug build auto-uses instance id `agwinterm-dev` with its own
+  data dir and pipe. Drive it with `agwintermctl --pipe agwinterm-dev`. **Never** run against the
+  real `agwinterm` pipe or data dir.
+
+## Development Approach
+
+- **Testing approach**: Regular (code first, then tests).
+- Complete each task fully before moving to the next.
+- Make small, focused changes.
+- **CRITICAL: every task MUST include new/updated tests** for the code changes in that task.
+  - unit tests for new and modified methods, listed as separate checklist items
+  - both success and error scenarios — for this plan the error scenarios are the point, since
+    most of the risk is malformed input from another process
+- **CRITICAL: all tests must pass before starting the next task.**
+- **CRITICAL: update this plan file when scope changes during implementation.**
+- Maintain backward compatibility with `image.frame`.
+
+## Testing Strategy
+
+- **Unit tests**: required in every task. `tests/Agwinterm.Pty.Tests/` for the control verb and its
+  validation; `tests/Agwinterm.Core.Tests/` for any `KittyGraphics` change.
+- **Integration test**: a test that creates a real `MemoryMappedFile`, publishes a frame through the
+  control server, and asserts the emulator holds the expected `KittyImage` and `ImagePlacement`.
+- **No e2e/UI test in this plan.** Visual confirmation arrives with the winterm-browser plan, which
+  is the real consumer. Do not build a throwaway pixel producer just to look at it.
+
+## Progress Tracking
+
+- Mark completed items with `[x]` immediately when done.
+- Add newly discovered tasks with ➕ prefix.
+- Document issues/blockers with ⚠️ prefix.
+- Update the plan if implementation deviates from the original scope.
+
+## Implementation Steps
+
+### Task 1: Define the shared-frame wire format and header
+
+- [ ] add `docs/specs/image-frameshm.md` documenting the mapping layout and the JSON args, so the
+      consuming project has a written contract rather than a reading of the source
+- [ ] define the mapping layout in `src/Agwinterm.Pty/ShmFrameLayout.cs`: a fixed-size header
+      followed by two pixel slots, so the producer writes one slot while the renderer reads the other
+- [ ] header carries at minimum: a magic value, a layout version, slot count, slot byte stride,
+      per-slot `(width, height, stride, format)` and a monotonically increasing `ready` sequence
+      number identifying the slot that is complete
+- [ ] define the JSON args shape: `{"images":[{"id":N,"name":"Local\\...","slot":N,"seq":N,
+      "width":N,"height":N,"stride":N,"format":N,"row":N,"col":N,"cols":N,"rows":N}]}` — every
+      numeric a JSON number, `name` the mapping name, ids reusing `image.frame` semantics
+- [ ] **write the literal `Local\` name prefix into the spec.** Task 3 restricts accepted names to a
+      fixed prefix; if the string is not in the spec, the producer picks its own and is rejected at
+      runtime with a validation error that reads like a bug. Neither document currently contains the
+      string a producer must actually use. [triage: major]
+- [ ] **state the producer slot-reuse invariant explicitly**: a producer must not begin filling a
+      slot until the reply for the frame two back has returned. This is what actually makes two slots
+      sufficient — see Technical Details. Without it in the spec, a producer that pipelines requests
+      to hide pipe latency tears, and nothing forbids that. [triage: major]
+- [ ] write tests for header encode/decode round-trip
+- [ ] write tests for rejecting a bad magic, an unknown version and an out-of-range slot index
+- [ ] run tests — must pass before Task 2
+
+### Task 2: Add BGRA as an internal pixel format
+
+- [ ] add `Bgra` to `KittyFormat` in `src/Agwinterm.Core/KittyGraphics.cs` with a value **outside**
+      the Kitty wire range (24/32/100 are the protocol's; pick e.g. 132) so it can never be produced
+      by parsing a real APC sequence
+- [ ] document in the enum why it exists: Direct2D wants `B8G8R8A8_UNORM` and Electron hands out
+      BGRA, so carrying BGRA end to end removes a full-frame channel swizzle per frame
+- [ ] handle the new format in the renderer's texture upload path, taking the no-swizzle route
+- [ ] verify the emulator's APC parser cannot yield the new value — add a guard if it can
+- [ ] write tests for the renderer path selecting no-swizzle for `Bgra` and swizzle for `Rgba`
+- [ ] write a test asserting a crafted APC sequence declaring `f=132` does not produce `Bgra`
+- [ ] run tests — must pass before Task 3
+
+### Task 3: Open and validate a producer's mapping safely
+
+- [ ] add `src/Agwinterm.Pty/ShmFrameReader.cs` that opens a named mapping with
+      `MemoryMappedFile.OpenExisting(name, MemoryMappedFileRights.Read)`
+- [ ] validate before any copy: view length is at least header size; `stride >= width * 4`;
+      `height * stride` fits within the slot; the slot's byte range lies inside the view; `width`
+      and `height` are positive and within a sane maximum
+- [ ] restrict accepted names to a fixed prefix in the `Local\` namespace so a request cannot name
+      an arbitrary existing object
+- [ ] return a typed failure rather than throwing for every rejection, so the control server answers
+      `{"ok":false,...}` instead of tearing down the connection
+- [ ] treat a vanished mapping (producer died) as an ordinary failure, not an exception path
+- [ ] write tests for each rejection: short view, `stride < width*4`, slot out of range, negative and
+      overflowing dimensions, name outside the allowed prefix, nonexistent mapping
+- [ ] write a test for the success case reading known bytes out of a real `MemoryMappedFile`
+- [ ] run tests — must pass before Task 4
+
+### Task 4: Wire `image.frameshm` into the control server
+
+- [ ] add `"image.frameshm" => HandleImageFrameShm(s, args)` to the session-targeted dispatch in
+      `src/Agwinterm.Pty/ControlServer.cs`
+- [ ] implement `HandleImageFrameShm` mirroring `HandleImageFrame`'s two-phase structure: resolve
+      placements and copy pixel bytes out of the mapping **off** the render lock, then take the
+      brief lock for `ClearPlacements` and the placement/image swap
+- [ ] skip re-transmitting a slot whose `(id, seq)` matches what was last accepted, the shm analogue
+      of `image.frame`'s content-signature cache
+- [ ] return the same result shape as `image.frame` (count, transmits, bytes read) so a caller can
+      tell whether a frame actually moved
+- [ ] write tests for a single frame producing the expected `KittyImage` and `ImagePlacement`
+- [ ] write tests for the `(id, seq)` cache skipping a repeat and accepting a bumped seq
+- [ ] write tests for malformed args: missing `images`, missing `name`, a string where a number
+      belongs, an id that is not an int
+- [ ] **write a test where the producer publishes frames faster than the consumer drains them** —
+      the case the two-slot scheme does not cover on its own. No test in revision 1 exercised a
+      producer running ahead; every test was argument validation or cache behaviour. [triage: major]
+- [ ] run tests — must pass before Task 5
+
+### Task 5: Expose the verb on `agwintermctl`
+
+- [ ] add the CLI surface in `src/Agwinterm.Ctl` alongside the existing `image` verbs
+- [ ] parse numeric options with `int.TryParse` and place **ints** into `cargs`, never strings
+- [ ] keep the CLI shape close to `image frame` so the two read as siblings
+- [ ] write tests for arg parsing, especially that numerics serialize as JSON numbers
+- [ ] run tests — must pass before Task 6
+
+### Task 6: Prove it end to end against a live dev instance
+
+- [ ] close any running dev instance, then `dotnet build src/Agwinterm.Win32` explicitly
+- [ ] launch the Debug build (instance id `agwinterm-dev`, its own pipe and data dir)
+- [ ] write an integration test that creates a mapping, fills a slot with a recognisable pattern,
+      publishes it via the control pipe and asserts the emulator's image and placement state
+- [ ] confirm `--pipe agwinterm-dev tree` shows the fresh dev tree, not the real sessions, before
+      trusting any result
+- [ ] measure and record: frames per second sustained, and bytes copied per frame, for a full-pane
+      1920x1080 BGRA frame — the winterm-browser plan needs this number to size its frame budget
+- [ ] write the measurement into `docs/specs/image-frameshm.md`
+- [ ] run tests — must pass before Task 7
+
+### Task 6b: Publish cell pixel metrics — **blocking for winterm-browser**
+
+A revmux triage panel on the consuming plan found that nothing in agwinterm publishes cell metrics,
+and that the consumer has no other way to get them. This is a second cross-repo dependency, and
+unlike `image.frameshm` it is not an optimisation — the port stalls without an answer.
+[triage: major, verified exhaustively against the full verb dispatch]
+
+Established by that review, so do not re-derive it: the global switch (`ControlServer.cs:140-234`)
+and the session-targeted switch (`:241-250`) contain no verb reporting pane geometry, pixel size or
+cell metrics. `csi_dispatch` (`native/agwinterm-core/src/emulator.rs:964-1045`) matches
+`H f A B C D G d J K X m r L M @ P S T q` and, under `?`, only `h`, `l` and DECRQM `?2026$p` —
+there is no `t` arm, so `CSI 14t`/`16t`/`18t` fall to `Unhandled`. The session env dictionary
+(`MainWindow.xaml.cs:227-234`) exports `AGWINTERM`, `AGWINTERM_ENABLED`, `AGWINTERM_PIPE`,
+`AGWINTERM_SESSION_ID`, `AGWINTERM_WORKSPACE_ID`, `AGWINTERM_WINDOW_ID` — nothing dimensional.
+
+The metrics **exist**: `Agwinterm.Win32/Program.cs:336` computes them, `Program.Render.cs:356` pushes
+them into the emulator as `CellPixelWidth`/`CellPixelHeight` (`ITerminalCore.cs:66`,
+`TerminalEmulator.cs:479`), and they are used for sixel cell-span at `TerminalEmulator.cs:502`. They
+are simply not published.
+
+- [ ] choose one: add `CSI 16 t` (and probably `14t`/`18t`) to `csi_dispatch`, or add cell metrics to
+      a control-pipe response. XTWINOPS is the standard answer and costs the consumer nothing to
+      adopt, since `pixel-core` already queries it at `terminal.rs:880`; a control verb is easier to
+      version. Record the reasoning either way.
+- [ ] implement the chosen mechanism, reading the live `_cellW`/`_cellH`, not a constant
+- [ ] note that `Agwinterm.App/MainWindow.xaml.cs` is **dead code** — absent from `Agwinterm.slnx`.
+      The live values are in `Agwinterm.Win32`. Do not implement against the dead project.
+- [ ] write tests for the response carrying the live metrics, and for it tracking a font-size change
+- [ ] if XTWINOPS: write tests that the new `t` arm does not swallow sequences previously `Unhandled`
+- [ ] document the mechanism in `docs/specs/image-frameshm.md` or its own spec, and tell
+      winterm-browser's Task 6, which is where it is consumed
+- [ ] run tests — must pass before Task 7
+
+### Task 6c: `?1016` SGR-Pixels mouse — optional, lifts a product ceiling
+
+Not blocking: without it the browser works, with pointer resolution quantised to one character cell.
+Worth doing because that ceiling lands on the headline feature. [triage: major, confirmed]
+
+`Program.Input.cs:442-453` computes `col = (pxX - ox) / cw` and `row = (pxY - oy) / ch` as integers
+and emits `\x1b[<btn;col+1;row+1M` — the sub-cell offset is discarded at the encode site and is
+unrecoverable downstream. `?1016` appears nowhere in `src` or `native`; both cores handle
+1000/1002/1003/1006 only (`TerminalEmulator.cs:402-405`, `emulator.rs:620-623`). The consumer
+already probes for it — `pixel-core` requests `\x1b[?1016h` at `terminal.rs:361` and sends the DECRQM
+`\x1b[?1016$p` at `:945-948` — and agwinterm's DECRQM handler (`emulator.rs:768-774`) answers only
+for mode 2026, so the probe times out and `reports_pixel_mouse()` is false. That flag gates real
+behaviour in the consumer: hover and pairing get no position at all (`engine/pointer.rs:61`).
+
+- [ ] add `1016` to the mode handlers in **both** cores, keeping them in agreement
+- [ ] answer DECRQM for `?1016$p` so a client can discover support instead of timing out
+- [ ] add a pixel-coordinate branch to `SendMouse` that emits pixel values when `?1016` is active,
+      leaving the cell path untouched when it is not
+- [ ] write tests for mode set/reset, the DECRQM reply, and the encoder emitting pixel coordinates
+      only when the mode is on
+- [ ] write a test that sub-cell movement produces distinct reports under `?1016` and identical ones
+      without it — the whole point of the change
+- [ ] run tests — must pass before Task 7
+
+### Task 7: Verify acceptance criteria
+
+- [ ] verify `image.frame` still behaves exactly as before (no regression in the file path)
+- [ ] verify every rejection in Task 3 answers `{"ok":false,...}` and leaves the session usable
+- [ ] verify a producer killed mid-frame does not wedge or crash the terminal
+- [ ] verify a producer running ahead of the consumer either cannot tear or is rejected — whichever
+      the Task 1 invariant chose — and that the spec says which
+- [ ] verify the cell metrics from Task 6b track a live font-size change rather than being sampled once
+- [ ] verify `?1016` off is byte-identical to today's mouse encoding, so existing apps see no change
+- [ ] confirm `tests/conformance/control-api.json` is **unchanged** — note this now covers three new
+      capabilities, none of which agliteterm implements
+- [ ] run the full unit test suite
+- [ ] run the linter — all issues fixed
+- [ ] verify test coverage meets the project standard
+
+### Task 8: [Final] Update documentation
+
+- [ ] update `docs/agterm-gap-analysis.md:41`, whose "Image protocols / graphics" line currently
+      reads *Partial* and describes only the out-of-band file path
+- [ ] update the agent skill's image section (`src/Agwinterm.Pty/AgentSkill.cs`) if the verb should
+      be discoverable to agents
+- [ ] cross-link `docs/specs/image-frameshm.md` from the winterm-browser brief
+
+## Technical Details
+
+**Why two slots and a sequence number.** The producer fills a slot completely, then publishes by
+writing `ready = seq` with a release barrier; the renderer reads `ready` with an acquire barrier and
+copies from the slot it names. No lock is shared across the process boundary, and a producer that
+dies mid-write leaves a half-written slot that is simply never published.
+
+**What that alternation does and does not guarantee** — an earlier draft of this paragraph claimed
+"a frame in flight is therefore never the frame being read", and that does not follow.
+[triage: major, two findings] What two slots plus the barrier guarantee is narrower: *a half-written
+slot is never published*. With only two slots, a producer running two frames ahead of the consumer
+wraps back onto the slot being copied, and the barrier orders the producer's publish, not the
+consumer's copy. An 8 MB copy for a 1920×1080 BGRA frame is not a narrow window.
+
+What actually closes it is the control pipe being **request/response**: `HandleImageFrame` returns
+`Ok($"frame:{count}/{transmits}")` at `ControlServer.cs:481`, after the phase-1 copy at `:457` and
+the locked swap at `:467-478`. A producer that serializes on the reply can never have two
+unacknowledged frames outstanding, so for that producer two slots are sufficient and tearing is
+genuinely impossible.
+
+That makes the invariant a **property of the producer, not of the layout** — which is exactly why it
+has to be written into the spec rather than left implicit. The verb is advertised here as
+general-purpose beyond the browser; a future producer that pipelines to hide pipe latency is doing
+something no document forbids, and it tears. If the verb should be safe for pipelining producers,
+that is a larger design: an in-use word per slot that the reader sets and clears, or more slots plus
+a consumer-published released-sequence. Decide which before the layout is a published contract.
+
+The consequence of getting it wrong is a visibly torn frame, not a crash — Task 3's bounds validation
+keeps the copy inside the view either way.
+
+**Why copy at all.** The renderer could map the producer's pixels directly, but then a producer that
+exits invalidates a view the renderer is still using. Copying under a brief lock costs one memcpy and
+removes an entire class of lifetime bug. A genuine zero-copy path — Electron's D3D11 shared texture
+handle opened directly by Direct2D — is a later, separate piece of work and is explicitly out of
+scope here.
+
+**Format.** BGRA end to end. Electron's `paint` gives BGRA, Direct2D wants `B8G8R8A8_UNORM`, so a
+swizzle would be pure loss at both ends.
+
+## Post-Completion
+
+**Manual verification**:
+- Sustained-load behaviour: leave a producer running at full rate for a long stretch and watch for
+  drift in memory and handles.
+- Behaviour when the pane is not visible — agwinterm gates repaint on visibility, so a background
+  pane should stop costing anything.
+
+**External system updates**:
+- winterm-browser codes against `docs/specs/image-frameshm.md`; a change to the layout after that
+  project starts is a breaking change for it.
+- agliteterm speaks the agwintermctl dialect via the shared conformance contract. This verb is
+  deliberately outside it; revisit only with agliteterm in hand.

--- a/native/agwinterm-core/src/wcwidth.rs
+++ b/native/agwinterm-core/src/wcwidth.rs
@@ -30,6 +30,8 @@ const ZERO_WIDTH: &[(u32, u32)] = &[
     (0x0670, 0x0670),
     (0x06D6, 0x06DC),
     (0x200B, 0x200F),  // zero-width space / joiners / marks
+    (0xFE00, 0xFE0F),  // variation selectors: VS16 selects emoji presentation of the
+                       // PRECEDING character, it is not a character of its own
     (0xFE20, 0xFE2F),  // combining half marks
 ];
 
@@ -95,6 +97,15 @@ mod tests {
     fn combining_is_zero() {
         assert_eq!(of(0x0301), 0); // combining acute
         assert_eq!(of(0x200D), 0); // ZWJ
+    }
+
+    #[test]
+    fn variation_selectors_are_zero() {
+        // Claude Code prints the snowflake as U+2744 U+FE0F. Giving VS16 a column of its own
+        // cost a cell and drew a hex-box glyph over the row.
+        assert_eq!(of(0xFE0F), 0); // VS16 — emoji presentation
+        assert_eq!(of(0xFE0E), 0); // VS15 — text presentation
+        assert_eq!(of(0x2744), 1); // the base character keeps its width
     }
 
     #[test]

--- a/src/Agwinterm.Core/Wcwidth.cs
+++ b/src/Agwinterm.Core/Wcwidth.cs
@@ -37,6 +37,8 @@ public static class Wcwidth
         (0x0670, 0x0670),
         (0x06D6, 0x06DC),
         (0x200B, 0x200F), // zero-width space / joiners / marks
+        (0xFE00, 0xFE0F), // variation selectors: VS16 selects emoji presentation of the
+                          // PRECEDING character, it is not a character of its own
         (0xFE20, 0xFE2F), // combining half marks
     };
 

--- a/tests/Agwinterm.Core.Tests/WideCharTests.cs
+++ b/tests/Agwinterm.Core.Tests/WideCharTests.cs
@@ -28,6 +28,22 @@ public class WideCharTests
     }
 
     [Fact]
+    public void VariationSelector_TakesNoCell()
+    {
+        // Claude Code prints the snowflake as U+2744 U+FE0F. VS16 asks for the emoji
+        // presentation of the character BEFORE it; treating it as a character of its own
+        // cost a column and painted a hex-box glyph across the row.
+        Assert.Equal(0, Wcwidth.Of(0xFE0F));   // VS16 - emoji presentation
+        Assert.Equal(0, Wcwidth.Of(0xFE0E));   // VS15 - text presentation
+        Assert.Equal(1, Wcwidth.Of(0x2744));   // the base character is unaffected
+
+        var t = Feed(10, 2, "\u2744\uFE0F!");
+        Assert.Equal(0x2744, t.Screen[0, 0].Rune);
+        Assert.Equal((int)'!', t.Screen[0, 1].Rune);   // the '!' lands in column 1, not 2
+        Assert.Equal(2, t.CursorCol);
+    }
+
+    [Fact]
     public void WideChar_OccupiesTwoCells()
     {
         var t = Feed(10, 2, Zhong);


### PR DESCRIPTION
Boris reported the snowflake in Claude Code rendering half-drawn in agliteterm. It is not the font packs this time — it is the width table, and it affects **both** terminals.

## What is actually happening

Claude Code prints that glyph as **U+2744 U+FE0F** — the snowflake, then VS16 asking for its *emoji* presentation. VS16 is not a character; it modifies the one before it.

`Wcwidth` gave it a column of its own. So every such sequence cost an extra cell, and the selector was handed to the renderer as a rune to draw — with no glyph anywhere, GDI drew its **hex-box fallback**, which is taller than the cell. Clipped at the row boundary and spilling into the lines above and below, that reads on screen as a glyph cut in half.

The table already carried U+FE20..U+FE2F (combining half marks) and stopped just short of the selectors sitting immediately below them.

## The fix

`U+FE00..U+FE0F` join the zero-width ranges — all sixteen selectors, not only the emoji one.

Both implementations change together, because `RustParityTests.Wcwidth_AgreesForEveryCodepoint` diffs the Rust core against the C# oracle over every codepoint: fixing one alone turns that test red.

## Verified

Direct query of the shipped export, before → after:

```
agwcore_wcwidth(0xFE0F)   1  ->  0
agwcore_wcwidth(0xFE0E)   1  ->  0
agwcore_wcwidth(0x2744)   1  ->  1     (base character unaffected)
```

On screen, printing `❄️ ✳️ ⭐ ✨` in a sandbox agliteterm built against this core:

- **before** — snowflake, then a tall `FE0F` hex box overhanging the row; same again for the asterisk
- **after** — the four glyphs, correctly spaced, nothing overhanging

Confirmed on both render paths — the `.agbf` bitmap packs and a TrueType face (Consolas via GDI font-linking).

Tests: `cargo test -p agwinterm-core` 28 passed; `dotnet test Agwinterm.Core.Tests` **185 passed**, including the every-codepoint parity diff. New cases: `wcwidth::tests::variation_selectors_are_zero` and `WideCharTests.VariationSelector_TakesNoCell` (which also asserts the `!` after `❄️` lands in column 1, not 2).

## Note for agliteterm

agliteterm consumes the core as a published release asset (`native/pinned.json` tracks `latest`), so it only picks this up once agwinterm cuts a release with the rebuilt `agwinterm_core.dll`.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
