### PR TITLE
fix(selection): a selection survives output, and scrollback-lines reaches the core

### DIFF
--- a/native/agwinterm-core/src/emulator.rs
+++ b/native/agwinterm-core/src/emulator.rs
@@ -399,16 +399,35 @@ impl Emulator {
         self.history.push(row);
         self.scroll_generation += 1;
         if self.history.len() > self.scrollback_max + TRIM_SLACK {
-            let trim = (self.history.len() - self.scrollback_max) as i64;
-            self.history.drain(0..trim as usize);
-            self.marks.retain_mut(|m| {
-                m.prompt_line -= trim;
-                if m.command_line >= 0 { m.command_line -= trim; }
-                if m.output_line >= 0 { m.output_line -= trim; }
-                if m.end_line >= 0 { m.end_line -= trim; }
-                m.prompt_line >= 0
-            });
+            self.trim_history();
         }
+    }
+
+    /// Drop the oldest history down to the cap, moving every stored line number with it.
+    ///
+    /// Absolute line numbers are history-relative, so trimming renumbers them: the marks are
+    /// shifted here, and a host tracking anything else by absolute line (a text selection) works
+    /// the shift out from `scroll_generation` against `history.len()`.
+    fn trim_history(&mut self) {
+        if self.history.len() <= self.scrollback_max {
+            return;
+        }
+        let trim = (self.history.len() - self.scrollback_max) as i64;
+        self.history.drain(0..trim as usize);
+        self.marks.retain_mut(|m| {
+            m.prompt_line -= trim;
+            if m.command_line >= 0 { m.command_line -= trim; }
+            if m.output_line >= 0 { m.output_line -= trim; }
+            if m.end_line >= 0 { m.end_line -= trim; }
+            m.prompt_line >= 0
+        });
+    }
+
+    /// Set the scrollback cap. 0 disables history entirely — nothing is pushed and what is already
+    /// stored is dropped, so the setting means the same thing whenever it is applied.
+    pub fn set_scrollback_max(&mut self, max: usize) {
+        self.scrollback_max = max;
+        self.trim_history();   // a LOWER cap must take effect now, not at the next scroll
     }
 
     fn index(&mut self) {

--- a/native/agwinterm-core/src/lib.rs
+++ b/native/agwinterm-core/src/lib.rs
@@ -27,7 +27,7 @@ use screen::ScreenBuffer;
 /// Bumped whenever the exported C surface changes shape. The C# loader
 /// refuses a mismatch loudly (same hard-handshake philosophy as the
 /// pty-host protocol).
-pub const ABI_VERSION: u32 = 15;
+pub const ABI_VERSION: u32 = 16;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn agwcore_abi_version() -> u32 {
@@ -583,6 +583,26 @@ pub unsafe extern "C" fn agwcore_emu_marks(p: *mut Terminal, out: *mut FfiMark, 
         };
     }
     n as u32
+}
+
+/// Set the scrollback cap for this emulator. 0 disables history entirely.
+///
+/// Until this existed the cap was whatever the core defaulted to, and `scrollback-lines` in the
+/// host's config set a field on the host side that never reached here — the knob was documented,
+/// read, and then silently ignored.
+///
+/// # Safety
+/// `p` must be a live `Terminal` from `agwcore_emu_new` that has not been freed, and no other
+/// thread may be inside this emulator for the duration of the call. A null pointer returns false.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn agwcore_emu_set_scrollback(p: *mut Terminal, max: u32) -> bool {
+    match unsafe { p.as_mut() } {
+        Some(t) => {
+            t.emu.set_scrollback_max(max as usize);
+            true
+        }
+        None => false,
+    }
 }
 
 /// Seed the scrollback with plain-text lines ('\n'-separated UTF-8) — the restore path.

--- a/src/Agwinterm.Core/RustEmulatorCore.cs
+++ b/src/Agwinterm.Core/RustEmulatorCore.cs
@@ -16,7 +16,7 @@ namespace Agwinterm.Core;
 /// </summary>
 public sealed unsafe class RustEmulatorCore : IDisposable
 {
-    public const uint RequiredAbi = 15;
+    public const uint RequiredAbi = 16;
 
     [StructLayout(LayoutKind.Sequential)]
     public struct Info
@@ -100,7 +100,8 @@ public sealed unsafe class RustEmulatorCore : IDisposable
             _takeHostActions = Get<EmuTakeHostActionsFn>("agwcore_emu_take_host_actions");
             _freeBuf = Get<FreeBufFn>("agwcore_free_buf");
             _marks = Get<EmuMarksFn>("agwcore_emu_marks");
-            _seed = Get<EmuSeedFn>("agwcore_emu_seed_scrollback");
+            _seed = Get<EmuSeedFn>("agwcore_emu_seed_scrollback");
+            _setScrollback = Get<EmuSetScrollbackFn>("agwcore_emu_set_scrollback");   // ABI v16
             _placementCount = Get<EmuPlacementCountFn>("agwcore_emu_placement_count");
             _copyPlacements = Get<EmuCopyPlacementsFn>("agwcore_emu_copy_placements");
             _imageMetas = Get<EmuImageMetasFn>("agwcore_emu_image_metas");
@@ -175,9 +176,11 @@ public sealed unsafe class RustEmulatorCore : IDisposable
     }
 
     private delegate uint EmuMarksFn(nint p, NativeMark* marks, uint cap);
-    private delegate bool EmuSeedFn(nint p, byte* text, uint len);
+    private delegate bool EmuSeedFn(nint p, byte* text, uint len);
+    private delegate bool EmuSetScrollbackFn(nint p, uint max);
     private static EmuMarksFn _marks = null!;
     private static EmuSeedFn _seed = null!;
+    private static EmuSetScrollbackFn _setScrollback = null!;
 
     /// <summary>All FTCS marks, converted to the managed mark type.</summary>
     public TerminalEmulator.ShellMark[] GetMarks()
@@ -199,6 +202,11 @@ public sealed unsafe class RustEmulatorCore : IDisposable
             };
         return result;
     }
+
+    /// <summary>Set the scrollback cap (0 disables history). Before ABI v16 there was no way to
+    /// tell the core this at all, so <c>scrollback-lines</c> was read from the config and then
+    /// silently dropped.</summary>
+    public void SetScrollbackMax(int max) => _setScrollback(_handle, (uint)Math.Max(0, max));
 
     public void SeedScrollback(string joinedLines)
     {

--- a/src/Agwinterm.Core/RustTerminalCore.cs
+++ b/src/Agwinterm.Core/RustTerminalCore.cs
@@ -97,7 +97,20 @@ public sealed class RustTerminalCore : ITerminalCore, IDisposable
     public int KeyboardFlags => _info.KeyboardFlags;
 
     // ---- scrollback ----
-    public int ScrollbackMax { get; set; } = 5000;   // native side owns the real cap (same default)
+    // The cap lives in the core; this mirrors it so the getter is free. Before ABI v16 the setter
+    // went nowhere and the core kept its own default, which made `scrollback-lines` a dead knob.
+    private int _scrollbackMax = 5000;
+    public int ScrollbackMax
+    {
+        get => _scrollbackMax;
+        set
+        {
+            _scrollbackMax = Math.Max(0, value);
+            _rust.SetScrollbackMax(_scrollbackMax);
+            Sync();   // a LOWER cap trims the core at once; the mirror must not keep claiming
+                      // rows the core no longer has, or reads of them return stale text
+        }
+    }
     public int HistoryCount => _histMirror.Count;
     public long ScrollGeneration => _info.ScrollGeneration;
 

--- a/src/Agwinterm.Win32/Program.Chrome.cs
+++ b/src/Agwinterm.Win32/Program.Chrome.cs
@@ -800,7 +800,7 @@ internal partial class Program
                 A("Focus Workspace", "", () => WorkspaceFocusOp("toggle"));
                 A("Toggle Sidebar", "", ToggleSidebar);
                 A("Select All", "Ctrl+Shift+A", () => { if (ActiveSurface() is { } p) SelectAll(p); });
-                A("Copy Selection", "Ctrl+C", () => { if (ActiveSurface() is { } p && p.HasSel) CopySelection(p); });
+                A("Copy Selection", "Ctrl+C", () => { if (ActiveSurface() is { } p && HasLiveSel(p)) CopySelection(p); });
                 A("Paste", "Ctrl+V", () => { if (ActiveSurface() is { } p) PasteInto(p); });
                 A("Next Session", "Ctrl+Tab", () => CycleSession(1));
                 A("Previous Session", "Ctrl+Shift+Tab", () => CycleSession(-1));

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -438,7 +438,7 @@ internal partial class Program
             return from > m.EndLine - 1 ? "" : RowsText(pane, from, m.EndLine - 1);
         }
 
-        public string SessionCopy(string? target)
+        public string SessionCopy(string? target) => InvokeOnUi(() =>
         {
             var s = Resolve(target);
             if (s is null) return "";
@@ -446,20 +446,22 @@ internal partial class Program
             lock (_workspaces)
                 pane = _workspaces.SelectMany(w => w.Sessions).SelectMany(x => x.Panes)
                                   .FirstOrDefault(p => ReferenceEquals(p.S, s));
-            return pane is not null ? SelectionText(pane) : ""; // reads under the session lock; safe off-UI-thread
-        }
+            // On the UI thread: reading a selection RECONCILES it (eviction may have renumbered or
+            // invalidated it), and selection state belongs to this thread.
+            return pane is not null ? SelectionText(pane) : "";
+        });
 
         // Selection/clipboard control API. Clipboard + selection are UI-thread concepts, so hop on-thread.
         public string SelectionAll(string? target) => InvokeOnUi(() =>
         {
             var p = PaneForTarget(target); if (p is null) return "no session";
-            SelectAll(p); return p.HasSel ? "selected all" : "empty";
+            SelectAll(p); return HasLiveSel(p) ? "selected all" : "empty";
         });
 
         public string SelectionCopy(string? target) => InvokeOnUi(() =>
         {
             var p = PaneForTarget(target); if (p is null) return "no session";
-            if (!p.HasSel) return "no selection";
+            if (!HasLiveSel(p)) return "no selection";
             string t = SelectionText(p); CopySelection(p); return $"copied {t.Length} chars";
         });
 
@@ -474,7 +476,7 @@ internal partial class Program
         {
             var p = PaneForTarget(target); if (p is null) return "no session";
             FinalizeSelection(p);
-            return _config.CopyOnSelect ? (p.HasSel ? "finalized (copied)" : "finalized (empty)") : "finalized (copy-on-select off)";
+            return _config.CopyOnSelect ? (HasLiveSel(p) ? "finalized (copied)" : "finalized (empty)") : "finalized (copy-on-select off)";
         });
 
         public string SessionPaste(string? target, string? text) => InvokeOnUi(() =>

--- a/src/Agwinterm.Win32/Program.Input.cs
+++ b/src/Agwinterm.Win32/Program.Input.cs
@@ -156,7 +156,7 @@ internal partial class Program
             case "previous_prompt": JumpPrompt(-1); break;
             case "next_prompt": JumpPrompt(1); break;
             case "select_all": if (ActiveSurface() is { } sa) SelectAll(sa); break;
-            case "copy_selection": if (ActiveSurface() is { } sc && sc.HasSel) CopySelection(sc); break;
+            case "copy_selection": if (ActiveSurface() is { } sc && HasLiveSel(sc)) CopySelection(sc); break;
             case "paste": if (ActiveSurface() is { } sp2) PasteInto(sp2); break;
         }
     }
@@ -592,9 +592,74 @@ internal partial class Program
         (l1, c1) = ancFirst ? (p.SelFocLine, p.SelFocCol) : (p.SelAncLine, p.SelAncCol);
     }
 
+    /// <summary>Record the buffer a selection was just made against. Absolute line indices only mean
+    /// something relative to this snapshot, and ReconcileSel reconciles the two later.</summary>
+    private static void StampSel(Pane p)
+    {
+        var em = p.S.Emulator;
+        lock (p.S.SyncRoot)
+        {
+            p.SelGen = em.ScrollGeneration;
+            p.SelHist = em.HistoryCount;
+            p.SelAlt = em.IsAltScreen;
+            // Trackable = every line leaving the screen is either kept in history or countable as
+            // evicted, so a shift can be MEASURED. Without scrollback there is no history to count
+            // against; inside a partial DECSTBM region (a reserved status line) rows move with no
+            // history push at all; the alt screen has no history by definition. ScrollGeneration
+            // stays flat in all three — see TerminalEmulator.ScrollRegionUp's guard — so a selection
+            // taken there can only ever be dropped, never followed.
+            p.SelTrackable = !em.IsAltScreen && em.ScrollbackMax > 0
+                             && em.ScrollTop == 0 && em.ScrollBottom == em.Screen.Rows - 1;
+        }
+        p.SelOutSeq = System.Threading.Interlocked.Read(ref p.OutputSeq);
+    }
+
+    /// <summary>Reconcile a selection with everything that has happened to the buffer since it was
+    /// made, and report whether anything is still selected. UI THREAD ONLY — the pty reader never
+    /// touches selection state, it only bumps <see cref="Pane.OutputSeq"/>.</summary>
+    private static bool HasLiveSel(Pane p) => p.HasSel && ReconcileSel(p);
+
+    /// <summary>The reconcile itself, WITHOUT the <see cref="Pane.HasSel"/> guard.
+    ///
+    /// A drag needs this: <see cref="BeginSelect"/> deliberately leaves HasSel false (a plain click
+    /// must not select), so the first mouse-move would otherwise pair an anchor in the numbering of
+    /// mouse-down with a focus in today's — and the next reconcile would shift the fresh end too.
+    /// Returns false when the stamped coordinates no longer refer to anything, in which case the
+    /// caller must re-anchor and re-stamp rather than carry them forward.</summary>
+    private static bool ReconcileSel(Pane p)
+    {
+        var em = p.S.Emulator;
+        long gen; int hist, rows; bool alt; int top, bottom, sbMax;
+        lock (p.S.SyncRoot)
+        {
+            gen = em.ScrollGeneration; hist = em.HistoryCount; rows = em.Screen.Rows;
+            alt = em.IsAltScreen; top = em.ScrollTop; bottom = em.ScrollBottom; sbMax = em.ScrollbackMax;
+        }
+        // The alt screen is a different buffer: an index into one names unrelated text in the other.
+        if (alt != p.SelAlt) { p.ClearSel(); return false; }
+        bool trackable = !alt && sbMax > 0 && top == 0 && bottom == rows - 1;
+        if (!trackable || !p.SelTrackable)
+        {
+            // Content can move here with nothing to measure it by. Drop the selection the moment
+            // anything is printed rather than let it cover text the user never highlighted.
+            if (System.Threading.Interlocked.Read(ref p.OutputSeq) != p.SelOutSeq) { p.ClearSel(); return false; }
+            return true;
+        }
+        // One generation per line pushed into history: what scrolled but did not grow history was
+        // evicted off the front, and eviction is the only thing that renumbers absolute indices.
+        long evicted = (gen - p.SelGen) - (hist - p.SelHist);
+        if (evicted > 0)
+        {
+            p.SelGen = gen; p.SelHist = hist;
+            if (Math.Min(p.SelAncLine, p.SelFocLine) < evicted) { p.ClearSel(); return false; }
+            p.SelAncLine -= (int)evicted; p.SelFocLine -= (int)evicted;
+        }
+        return true;
+    }
+
     private static string SelectionText(Pane pane)
     {
-        if (!pane.HasSel) return "";
+        if (!HasLiveSel(pane)) return "";
         var em = pane.S.Emulator;
         var sb = new StringBuilder();
         lock (pane.S.SyncRoot)
@@ -634,6 +699,7 @@ internal partial class Program
         lock (p.S.SyncRoot) { hist = em.HistoryCount; row = em.CursorRow; col = em.CursorCol; }
         int abs = hist - Math.Clamp(p.ScrollOffset, 0, hist) + row;   // buffer-absolute caret line
         p.SelAncLine = p.SelFocLine = abs; p.SelAncCol = p.SelFocCol = col; p.HasSel = true; p.BlockSel = false;
+        StampSel(p);
         _markMode = true;
         ShowToast("mark mode: arrows select · Shift+arrows by word/line · Enter copies · Esc exits");
         RequestRedraw();
@@ -643,6 +709,10 @@ internal partial class Program
     private bool MarkModeKey(int vk, bool ctrl)
     {
         if (ActiveSurface() is not { } p) { _markMode = false; return false; }
+        // Reconcile first, for the reason UpdateSelect does: the clamps below are computed from the
+        // CURRENT history count and applied to the stored focus, so an unreconciled anchor would be
+        // left in the old numbering and the two ends would name different eras of the buffer.
+        if (p.HasSel && !ReconcileSel(p)) { _markMode = false; p.ClearSel(); RequestRedraw(); return true; }
         var em = p.S.Emulator;
         int cols, rows, hist;
         lock (p.S.SyncRoot) { cols = em.Screen.Cols; rows = em.Screen.Rows; hist = em.HistoryCount; }
@@ -671,12 +741,24 @@ internal partial class Program
 
     private void BeginSelect(Pane p, int line, int col, bool extend)
     {
-        if (extend && p.HasSel) { p.SelFocLine = line; p.SelFocCol = col; _selMoved = true; }
-        else { p.SelAncLine = p.SelFocLine = line; p.SelAncCol = p.SelFocCol = col; p.HasSel = false; _selMoved = false; }
+        if (extend && HasLiveSel(p)) { p.SelFocLine = line; p.SelFocCol = col; _selMoved = true; }
+        else { p.SelAncLine = p.SelFocLine = line; p.SelAncCol = p.SelFocCol = col; p.HasSel = false; _selMoved = false; StampSel(p); }
     }
 
     private void UpdateSelect(Pane p, int line, int col)
     {
+        // Reconcile BEFORE writing: `line` is in today's numbering, while the anchor may still be in
+        // the numbering of whenever the drag started. Storing them together would leave the next
+        // reconcile shifting the fresh end as well, dragging the selection off its text.
+        //
+        // And HONOUR the answer. Setting HasSel = true after a reconcile that dropped the selection
+        // would revive an anchor that was never shifted next to a baseline that was — the selection
+        // then looks self-consistent and quietly covers text the user never highlighted.
+        if (!ReconcileSel(p))
+        {
+            p.SelAncLine = line; p.SelAncCol = col;   // its anchor is gone: start again from here
+            StampSel(p);
+        }
         p.SelFocLine = line; p.SelFocCol = col; p.HasSel = true; _selMoved = true;
     }
 
@@ -696,14 +778,14 @@ internal partial class Program
             int a = col, b = col;
             while (a > 0 && Word(a - 1)) a--;
             while (b < cols - 1 && Word(b + 1)) b++;
-            p.SelAncLine = p.SelFocLine = line; p.SelAncCol = a; p.SelFocCol = b; p.HasSel = true;
+            p.SelAncLine = p.SelFocLine = line; p.SelAncCol = a; p.SelFocCol = b; p.HasSel = true; StampSel(p);
         }
     }
 
     private void SelectLine(Pane p, int line)
     {
         int cols; lock (p.S.SyncRoot) cols = p.S.Emulator.Screen.Cols;
-        p.SelAncLine = p.SelFocLine = line; p.SelAncCol = 0; p.SelFocCol = cols - 1; p.HasSel = true;
+        p.SelAncLine = p.SelFocLine = line; p.SelAncCol = 0; p.SelFocCol = cols - 1; p.HasSel = true; StampSel(p);
     }
 
     private void CopySelection(Pane pane, bool clear = true)
@@ -723,6 +805,7 @@ internal partial class Program
         p.SelAncLine = 0; p.SelAncCol = 0;
         p.SelFocLine = hist + rows - 1; p.SelFocCol = cols - 1;
         p.HasSel = (hist + rows) > 0 && cols > 0;
+        StampSel(p);   // the one creation site that did not, so the first reconcile dropped it
         RequestRedraw();
     }
 
@@ -730,7 +813,7 @@ internal partial class Program
     /// by copying to the clipboard without clearing the highlight.</summary>
     private void FinalizeSelection(Pane p)
     {
-        if (_config.CopyOnSelect && p.HasSel) CopySelection(p, clear: false);
+        if (_config.CopyOnSelect && HasLiveSel(p)) CopySelection(p, clear: false);
     }
 
     private void StopSelAutoscroll()
@@ -1009,8 +1092,8 @@ internal partial class Program
                 // Ctrl+Shift+C is the explicit copy shortcut (always consumed). Plain Ctrl+C copies the
                 // selection only when copy-on-ctrl-c is on — otherwise it falls through and interrupts,
                 // so with nothing selected (or the option off) the shell still gets ^C.
-                if (shift) { if (ap.HasSel) { CopySelection(ap); ShowToast("Text copied", 500); } return true; }
-                if (_config.CopyOnCtrlC && ap.HasSel) { CopySelection(ap); ShowToast("Text copied", 500); return true; }
+                if (shift) { if (HasLiveSel(ap)) { CopySelection(ap); ShowToast("Text copied", 500); } return true; }
+                if (_config.CopyOnCtrlC && HasLiveSel(ap)) { CopySelection(ap); ShowToast("Text copied", 500); return true; }
                 // plain Ctrl+C with no selection (or option off) falls through to the interrupt below
             }
             else if (vk == 0x56) { PasteInto(ap); return true; } // Ctrl+V / Ctrl+Shift+V

--- a/src/Agwinterm.Win32/Program.Render.cs
+++ b/src/Agwinterm.Win32/Program.Render.cs
@@ -386,7 +386,9 @@ internal partial class Program
         {
             var snap = _cellSnap;
             Cell CellAt(int r, int c) => snap[r * cols + c];
-            bool hasSel = selPane is { HasSel: true };
+            // Reconcile before drawing: the highlight must sit on the text the user selected,
+            // and a selection whose lines have been evicted must stop being drawn at all.
+            bool hasSel = selPane is not null && HasLiveSel(selPane);
             int sl0 = 0, sc0 = 0, sl1 = 0, sc1 = 0;
             if (hasSel) NormSel(selPane!, out sl0, out sc0, out sl1, out sc1);
             bool searchHere = _searchActive && selPane is not null && ReferenceEquals(selPane, ActiveSurface());

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -75,20 +75,29 @@ internal partial class Program
                 session = InProcessSessionBackend.Instance.Create(paneId, cols, rows);
                 ShowToast("pty-host unavailable (" + ex.Message + ") — session created in-process", 5000);
             }
-        session.Emulator.ScrollbackMax = _config.Scrollback;
+        // Under the session lock: with the Rust core this setter now crosses into native code and
+        // re-syncs the mirrors, and an ADOPTED session's reader thread is already feeding by now.
+        lock (session.SyncRoot) session.Emulator.ScrollbackMax = _config.Scrollback;
         var pane = new Pane { Id = paneId, S = session, StartCwd = cwd, FontSize = fontSize };
-        // New output only snaps this pane back to the live bottom and drops the selection when the buffer
-        // ACTUALLY scrolled (a line pushed into history) — not on every repaint. TUIs like Claude Code
-        // redraw in place without scrolling, so a mouse selection now survives those frames and Ctrl+C can
-        // copy it (previously any repaint wiped the selection microseconds after you made it). #copy-selection
+        // New output snaps this pane back to the live bottom when the buffer ACTUALLY scrolled (a line
+        // pushed into history) — not on every repaint. TUIs like Claude Code redraw in place without
+        // scrolling, so a mouse selection survives those frames. #copy-selection
+        //
+        // Scrolling used to DROP the selection outright here, which made Ctrl+C-copies-the-selection
+        // close to unusable next to a running agent: the agent prints, the selection you just made is
+        // gone, and Ctrl+C falls through to the interrupt — cancelling its turn. The selection is
+        // reconciled in ReconcileSel instead, on the UI thread, against the snapshot taken when it was made.
+        // This handler therefore writes NOTHING about the selection; it only bumps a counter that lets
+        // the reconcile tell "output has arrived since" from "nothing has happened".
         // Repaints are requested ONLY when this pane is on screen: a background tab's output flood
         // used to repaint the (unchanged!) foreground at the full frame cap, starving typing on slow
         // machines. The emulator still consumes everything; switching to the pane shows current
         // content, and the sidebar title catches up on the next paint (cursor blink at the latest).
         session.OutputReceived += () =>
         {
+            System.Threading.Interlocked.Increment(ref pane.OutputSeq);
             long gen = session.Emulator.ScrollGeneration;
-            if (gen != pane.LastScrollGen) { pane.LastScrollGen = gen; pane.ScrollOffset = 0; pane.ClearSel(); }
+            if (gen != pane.LastScrollGen) { pane.LastScrollGen = gen; pane.ScrollOffset = 0; }
             // Synchronized output (DECSET ?2026): while the app is mid-frame, defer painting so a
             // partial redraw never reaches the screen — the closing 2026l chunk clears the mode and
             // paints the frame atomically. The cursor-blink InvalidateRect still repaints within ~one

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -287,11 +287,22 @@ internal partial class Program : ISessionHost, IWindowHost
         public float Ratio = 1f;   // fraction of the session's content width (ratios in a session sum to 1)
         public int ScrollOffset;   // lines scrolled up from the live bottom (0 = live; clamped to HistoryCount)
         public long LastScrollGen; // emulator ScrollGeneration last seen on output (detects real scroll vs in-place repaint)
+        public long OutputSeq;     // bumped (Interlocked) on every output; the only thing the reader thread writes here
         public int Unread;         // unread desktop-notification count (OSC 9/777 / notify) since last visit
         public bool ReadOnly;      // block keyboard input to this pane (protect a running agent from stray keys)
         // Text selection (absolute line index: [0..HistoryCount) history, then the live grid rows).
         public bool HasSel;
         public int SelAncLine, SelAncCol, SelFocLine, SelFocCol;
+        // The buffer as it was when the selection was made. Absolute indices only mean anything
+        // relative to this: scrolling leaves them alone, but EVICTION renumbers, and the alt screen
+        // is a different buffer entirely. Everything is recorded at selection time and compared on
+        // the UI thread when the selection is used, so nothing about a selection is ever written
+        // from the thread reading the pty. SelTrackable = false means the shift cannot be measured
+        // at all (no scrollback, a partial DECSTBM region, the alt screen) — such a selection is
+        // dropped as soon as any output arrives rather than left pointing at whatever moved in.
+        public long SelGen, SelOutSeq;
+        public int SelHist;
+        public bool SelAlt, SelTrackable;
         public bool BlockSel;   // rectangular (Alt+drag) selection: clip each row to [minCol,maxCol]
         public void ClearSel() => HasSel = false;
         public int UiaAnnouncedAbs = -1;   // absolute buffer line (history + cursor row) last spoken to a screen reader

--- a/tests/Agwinterm.Core.Tests/RustEmulatorCoreTests.cs
+++ b/tests/Agwinterm.Core.Tests/RustEmulatorCoreTests.cs
@@ -342,4 +342,41 @@ public class RustEmulatorCoreTests
         rust.ClearPlacements();
         Assert.Empty(rust.Placements);
     }
+
+    [Fact]
+    public void Adapter_ScrollbackMax_ReachesTheCore()
+    {
+        if (!Available) return;
+        // `scrollback-lines` was read from the config, assigned to this property, and then dropped:
+        // there was no way to tell the core, so it kept its own 5000 whatever the user asked for.
+        using var rust = new RustTerminalCore(10, 3);
+        rust.ScrollbackMax = 50;
+        for (int i = 1; i <= 900; i++) rust.Feed(System.Text.Encoding.ASCII.GetBytes($"L{i}\r\n"));
+        Assert.Equal(50, rust.ScrollbackMax);
+        // Trimming is batched, so the cap is a floor with slack above it - not 5000.
+        Assert.InRange(rust.HistoryCount, 50, 50 + 512);
+    }
+
+    [Fact]
+    public void Adapter_ScrollbackZero_KeepsNoHistory()
+    {
+        if (!Available) return;
+        using var rust = new RustTerminalCore(10, 3);
+        rust.ScrollbackMax = 0;
+        for (int i = 1; i <= 200; i++) rust.Feed(System.Text.Encoding.ASCII.GetBytes($"L{i}\r\n"));
+        Assert.Equal(0, rust.HistoryCount);
+    }
+
+    [Fact]
+    public void Adapter_LoweringScrollback_TrimsWhatIsAlreadyStored()
+    {
+        if (!Available) return;
+        // Applying a lower cap must take effect at once. If it only applied to future scrolls, a
+        // user who turned scrollback down would keep the old megabytes until something scrolled.
+        using var rust = new RustTerminalCore(10, 3);
+        for (int i = 1; i <= 900; i++) rust.Feed(System.Text.Encoding.ASCII.GetBytes($"L{i}\r\n"));
+        Assert.True(rust.HistoryCount > 100, "expected a full-ish history before lowering the cap");
+        rust.ScrollbackMax = 20;
+        Assert.Equal(20, rust.HistoryCount);
+    }
 }

--- a/tests/Agwinterm.Core.Tests/ScrollbackTests.cs
+++ b/tests/Agwinterm.Core.Tests/ScrollbackTests.cs
@@ -57,9 +57,39 @@ public class ScrollbackTests
     public void ScrollbackCap_DropsOldest()
     {
         var t = new TerminalEmulator(10, 3) { ScrollbackMax = 100 };
-        for (int i = 1; i <= 700; i++) Feed(t, $"X\r\n");
+        for (int i = 1; i <= 700; i++) Feed(t, $"L{i}\r\n");
         // ~698 scrolls but bounded near the cap (batched trim allows a little slack), far below 698.
         Assert.InRange(t.HistoryCount, 100, 100 + 512);
+        // WHICH rows went, not only how many. Distinct content per line, because "X" everywhere let
+        // a trim from the wrong end - or of the wrong size - pass unnoticed.
+        Assert.StartsWith("L", HistoryRow(t, 0, 10));
+        int oldest = int.Parse(HistoryRow(t, 0, 10).Substring(1));
+        int newest = int.Parse(HistoryRow(t, t.HistoryCount - 1, 10).Substring(1));
+        Assert.Equal(t.HistoryCount - 1, newest - oldest);   // a contiguous run: the FRONT was trimmed
+    }
+
+    [Fact]
+    public void EvictionCount_IsScrollGenerationMinusHistoryGrowth()
+    {
+        // The identity the panes' selection tracking is built on: every line that scrolled either
+        // stayed in history or fell off the front, so
+        //     evicted = (delta ScrollGeneration) - (delta HistoryCount)
+        // and the rows that went are the OLDEST. If the trim end or its size ever changed, a
+        // selection would silently follow the wrong text and paste something never selected.
+        var t = new TerminalEmulator(10, 3) { ScrollbackMax = 100 };
+        for (int i = 1; i <= 800; i++) Feed(t, $"L{i}\r\n");   // trimming is BATCHED (cap + slack),
+        //                                                        so hundreds of lines pass before any drop
+        long gen0 = t.ScrollGeneration;
+        int hist0 = t.HistoryCount;
+        int oldest0 = int.Parse(HistoryRow(t, 0, 10).Substring(1));
+
+        for (int i = 801; i <= 1600; i++) Feed(t, $"L{i}\r\n");
+        long evicted = (t.ScrollGeneration - gen0) - (t.HistoryCount - hist0);
+        Assert.True(evicted > 0, $"gen {gen0}->{t.ScrollGeneration}, hist {hist0}->{t.HistoryCount}: nothing was evicted");
+
+        // The line that sat at history index `evicted` is now at index 0 - exactly the oldest
+        // `evicted` rows were dropped, from the front.
+        Assert.Equal($"L{oldest0 + evicted}", HistoryRow(t, 0, 10));
     }
 
     [Fact]


### PR DESCRIPTION
Boris, using it more: *"the same problem with ctrl+c in agwinterm as I started using it more"*.

`copy-on-ctrl-c = true` was set and the copy branch has been in since v0.12.1 — the setting was never the problem. **Any output cleared the selection.** You select, the agent prints one more line, and by the time you press Ctrl+C there is nothing to copy, so it falls through to the interrupt and cancels the agent's turn. That is why it reads as a Ctrl+C bug.

## Reconcile, don't clear

A selection now records the buffer it was made against — generation, history count, alt-screen flag, output sequence — and the UI thread reconciles that against the current buffer when the selection is *used*.

Scrolling does not renumber absolute line indices: a line pushed into history keeps the index it had on screen. Only **eviction** renumbers, and the core already does this arithmetic for its own FTCS marks, so `evicted = (Δ generation) − (Δ history)`.

Where a shift cannot be measured at all — no scrollback, a partial DECSTBM region, the alt screen — the selection is dropped on the next output instead of being left on top of whatever moved in. Losing a selection is a nuisance; **pasting something you never selected is a defect you cannot notice**, and that asymmetry decided every judgement call here.

The pty reader thread now writes exactly one thing: `Interlocked.Increment(ref pane.OutputSeq)`.

## `scrollback-lines` never worked

Found while testing the above. The config was read, assigned to `RustTerminalCore.ScrollbackMax`, and dropped on the floor — the core hardcoded 5000 and had **no way to be told otherwise**. New export `agwcore_emu_set_scrollback` (ABI **15 → 16**, both declarations bumped, agliteterm's pin moves in its own PR), and a *lower* cap trims immediately, so turning scrollback down frees the memory now rather than at the next scroll.

## Two revmux rounds

The second found a **critical the first had blessed**:

- `SelectAll` was the one creation site of five that never stamped, so every select-all died on its first reconcile — Ctrl+Shift+A, the menu item, the keybinding and the `selection all` verb all answering "empty" for a full buffer. Nothing caught it: the control-API test runs against a stub that returns `"selected"` unconditionally.
- Extending a drag **revived a selection the reconcile had just dropped**, pairing an unshifted anchor with a refreshed baseline — self-consistent, and pointing at text nobody highlighted.
- The **first mouse-move of every drag could not reconcile at all** (`HasLiveSel` bails on `HasSel == false`, which `BeginSelect` deliberately sets). Split into `ReconcileSel`, which works on the stamp regardless.
- Mark-mode arrows mixed two numberings.
- `ScrollbackMax` was set **off the session lock** — harmless as a field store, a data race now that it crosses into native code and rebuilds the mirrors while an adopted session's reader thread is feeding.

Their minors are in too: the `# Safety` section on the new export, comments naming a function that does not exist, and a test that asserted nothing about which rows a trim drops.

## Verified

Live probes against a sandbox instance (drag by `PostMessage`, Ctrl+C through the app's own input queue — no global injection):

```
PASS  survives an in-place repaint
PASS  survives output that scrolls        (exact text, distinct content per line)
PASS  Ctrl+C copies it after output arrived
PASS  dropped once its lines are evicted
PASS  dropped on entering the alt screen
PASS  dropped when scrollback is disabled
```

Three of those fail on the previous build. **189 core tests**, including two new ones pinning the eviction identity and *which* rows a trim drops — the old `ScrollbackCap_DropsOldest` fed the identical line `"X"` 700 times and asserted only a count, so it would have passed if the trim took from the wrong end — and three proving the cap now reaches the core.

## Worth knowing for the next probe

.NET resolves `LocalApplicationData` through the known-folder API, so overriding `%LOCALAPPDATA%` does **not** isolate this app — the probes had been reading the real config the whole time. `--app-id` is the seam that works, and it is what they use now.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
