### PR TITLE
fix(select): keep a selection alive in a repainting TUI, so Ctrl+C copies

### DIFF
--- a/src/Agwinterm.Pty/ISessionHost.cs
+++ b/src/Agwinterm.Pty/ISessionHost.cs
@@ -127,7 +127,9 @@ public interface ISessionHost
 
     /// <summary>Select the target pane's whole buffer (scrollback + live grid).</summary>
     string SelectionAll(string? target);
-    /// <summary>Copy the target pane's current selection to the Windows clipboard.</summary>
+    /// <summary>Copy the target pane's current selection to the Windows clipboard. A live selection
+    /// whose cells hold no text — a full-screen app repainted over them — copies nothing and leaves
+    /// the clipboard untouched, answering "nothing to copy".</summary>
     string SelectionCopy(string? target);
     /// <summary>Clear the target pane's selection.</summary>
     string SelectionClear(string? target);

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -462,7 +462,12 @@ internal partial class Program
         {
             var p = PaneForTarget(target); if (p is null) return "no session";
             if (!HasLiveSel(p)) return "no selection";
-            string t = SelectionText(p); CopySelection(p); return $"copied {t.Length} chars";
+            // Report what actually happened: a live selection over cells a TUI has blanked copies
+            // nothing and leaves the clipboard alone, and an agent acting on this reply must not be
+            // told otherwise. Length is not the measure — SelectionText joins rows with CRLF whether
+            // or not a row held text.
+            string t = SelectionText(p);
+            return CopySelection(p) ? $"copied {t.Length} chars" : "nothing to copy";
         });
 
         public string SelectionClear(string? target) => InvokeOnUi(() =>

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -466,8 +466,7 @@ internal partial class Program
             // nothing and leaves the clipboard alone, and an agent acting on this reply must not be
             // told otherwise. Length is not the measure — SelectionText joins rows with CRLF whether
             // or not a row held text.
-            string t = SelectionText(p);
-            return CopySelection(p) ? $"copied {t.Length} chars" : "nothing to copy";
+            return CopySelection(p, out string copied) ? $"copied {copied.Length} chars" : "nothing to copy";
         });
 
         public string SelectionClear(string? target) => InvokeOnUi(() =>
@@ -480,8 +479,11 @@ internal partial class Program
         public string SelectionFinalize(string? target) => InvokeOnUi(() =>
         {
             var p = PaneForTarget(target); if (p is null) return "no session";
-            FinalizeSelection(p);
-            return _config.CopyOnSelect ? (HasLiveSel(p) ? "finalized (copied)" : "finalized (empty)") : "finalized (copy-on-select off)";
+            // Ask the copy what happened rather than inferring it from a surviving selection: since
+            // FinalizeSelection passes clear:false, the selection survives either way, so the
+            // "(empty)" arm was unreachable and a declined copy was reported as a copy.
+            bool copied = FinalizeSelection(p);
+            return _config.CopyOnSelect ? (copied ? "finalized (copied)" : "finalized (empty)") : "finalized (copy-on-select off)";
         });
 
         public string SessionPaste(string? target, string? text) => InvokeOnUi(() =>

--- a/src/Agwinterm.Win32/Program.Input.cs
+++ b/src/Agwinterm.Win32/Program.Input.cs
@@ -607,16 +607,15 @@ internal partial class Program
             // against; inside a partial DECSTBM region (a reserved status line) rows move with no
             // history push at all; the alt screen has no history by definition. ScrollGeneration
             // stays flat in all three — see TerminalEmulator.ScrollRegionUp's guard — so a selection
-            // taken there can only ever be dropped, never followed.
+            // taken there cannot follow its text; it stays on the cells it was drawn over.
             p.SelTrackable = !em.IsAltScreen && em.ScrollbackMax > 0
                              && em.ScrollTop == 0 && em.ScrollBottom == em.Screen.Rows - 1;
         }
-        p.SelOutSeq = System.Threading.Interlocked.Read(ref p.OutputSeq);
     }
 
     /// <summary>Reconcile a selection with everything that has happened to the buffer since it was
     /// made, and report whether anything is still selected. UI THREAD ONLY — the pty reader never
-    /// touches selection state, it only bumps <see cref="Pane.OutputSeq"/>.</summary>
+    /// touches selection state.</summary>
     private static bool HasLiveSel(Pane p) => p.HasSel && ReconcileSel(p);
 
     /// <summary>The reconcile itself, WITHOUT the <see cref="Pane.HasSel"/> guard.
@@ -629,10 +628,10 @@ internal partial class Program
     private static bool ReconcileSel(Pane p)
     {
         var em = p.S.Emulator;
-        long gen; int hist, rows; bool alt; int top, bottom, sbMax;
+        long gen; int hist, rows, cols; bool alt; int top, bottom, sbMax;
         lock (p.S.SyncRoot)
         {
-            gen = em.ScrollGeneration; hist = em.HistoryCount; rows = em.Screen.Rows;
+            gen = em.ScrollGeneration; hist = em.HistoryCount; rows = em.Screen.Rows; cols = em.Screen.Cols;
             alt = em.IsAltScreen; top = em.ScrollTop; bottom = em.ScrollBottom; sbMax = em.ScrollbackMax;
         }
         // The alt screen is a different buffer: an index into one names unrelated text in the other.
@@ -640,10 +639,18 @@ internal partial class Program
         bool trackable = !alt && sbMax > 0 && top == 0 && bottom == rows - 1;
         if (!trackable || !p.SelTrackable)
         {
-            // Content can move here with nothing to measure it by. Drop the selection the moment
-            // anything is printed rather than let it cover text the user never highlighted.
-            if (System.Threading.Interlocked.Read(ref p.OutputSeq) != p.SelOutSeq) { p.ClearSel(); return false; }
-            return true;
+            // Content can move here with nothing to measure it by — a full-screen TUI repainting in
+            // place, a reserved status line, scrollback off. The selection cannot FOLLOW its text,
+            // but it can stay on the cells it covers: the highlight is redrawn from these very
+            // coordinates every frame and SelectionText reads the same cells the renderer draws, so
+            // what lands on the clipboard is always what is visibly highlighted.
+            //
+            // Dropping it on the first byte of output instead (as this did) made selection
+            // impossible in exactly the apps people select from most. codex repaints its status line
+            // about once a second: every mouse-move mid-drag found new output, dropped the anchor and
+            // re-anchored under the cursor, so the drag never built a selection at all — and Ctrl+C,
+            // finding nothing live, fell through to the app as an interrupt.
+            return ClampSel(p, hist, rows, cols);
         }
         // One generation per line pushed into history: what scrolled but did not grow history was
         // evicted off the front, and eviction is the only thing that renumbers absolute indices.
@@ -654,6 +661,20 @@ internal partial class Program
             if (Math.Min(p.SelAncLine, p.SelFocLine) < evicted) { p.ClearSel(); return false; }
             p.SelAncLine -= (int)evicted; p.SelFocLine -= (int)evicted;
         }
+        return true;
+    }
+
+    /// <summary>Hold a selection inside the buffer it is drawn against. Only a resize moves those
+    /// bounds under it; a selection left entirely past the end is dropped rather than pinned to the
+    /// last row, where it would highlight text the user never touched.</summary>
+    private static bool ClampSel(Pane p, int hist, int rows, int cols)
+    {
+        int maxLine = hist + rows - 1, maxCol = Math.Max(0, cols - 1);
+        if (maxLine < 0 || Math.Min(p.SelAncLine, p.SelFocLine) > maxLine) { p.ClearSel(); return false; }
+        p.SelAncLine = Math.Clamp(p.SelAncLine, 0, maxLine);
+        p.SelFocLine = Math.Clamp(p.SelFocLine, 0, maxLine);
+        p.SelAncCol = Math.Clamp(p.SelAncCol, 0, maxCol);
+        p.SelFocCol = Math.Clamp(p.SelFocCol, 0, maxCol);
         return true;
     }
 
@@ -788,12 +809,16 @@ internal partial class Program
         p.SelAncLine = p.SelFocLine = line; p.SelAncCol = 0; p.SelFocCol = cols - 1; p.HasSel = true; StampSel(p);
     }
 
-    private void CopySelection(Pane pane, bool clear = true)
+    /// <summary>Copy the selection; false if there was nothing to copy. A live selection can still
+    /// hold no text — a TUI that repaints blanks the cells under it — and the caller needs to tell
+    /// the two apart: plain Ctrl+C must interrupt rather than be swallowed by a copy of nothing.</summary>
+    private bool CopySelection(Pane pane, bool clear = true)
     {
         string t = SelectionText(pane);
         if (t.Length > 0) ClipboardSet(t);
-        if (clear) pane.ClearSel();
+        if (clear || t.Length == 0) pane.ClearSel();
         RequestRedraw();
+        return t.Length > 0;
     }
 
     /// <summary>Select the pane's entire buffer — all scrollback history through the last live row.</summary>
@@ -1092,9 +1117,10 @@ internal partial class Program
                 // Ctrl+Shift+C is the explicit copy shortcut (always consumed). Plain Ctrl+C copies the
                 // selection only when copy-on-ctrl-c is on — otherwise it falls through and interrupts,
                 // so with nothing selected (or the option off) the shell still gets ^C.
-                if (shift) { if (HasLiveSel(ap)) { CopySelection(ap); ShowToast("Text copied", 500); } return true; }
-                if (_config.CopyOnCtrlC && HasLiveSel(ap)) { CopySelection(ap); ShowToast("Text copied", 500); return true; }
-                // plain Ctrl+C with no selection (or option off) falls through to the interrupt below
+                if (shift) { if (HasLiveSel(ap) && CopySelection(ap)) ShowToast("Text copied", 500); return true; }
+                if (_config.CopyOnCtrlC && HasLiveSel(ap) && CopySelection(ap)) { ShowToast("Text copied", 500); return true; }
+                // plain Ctrl+C with no selection, nothing under it, or the option off falls through
+                // to the interrupt below
             }
             else if (vk == 0x56) { PasteInto(ap); return true; } // Ctrl+V / Ctrl+Shift+V
         }

--- a/src/Agwinterm.Win32/Program.Input.cs
+++ b/src/Agwinterm.Win32/Program.Input.cs
@@ -568,9 +568,12 @@ internal partial class Program
     private (int line, int col) CellAtPx(Pane pane, float ox, float oy, float cw, float ch, int px, int py)
     {
         var em = pane.S.Emulator;
-        int cols, rows, hist;
-        lock (pane.S.SyncRoot) { cols = em.Screen.Cols; rows = em.Screen.Rows; hist = em.HistoryCount; }
-        int off = Math.Clamp(pane.ScrollOffset, 0, hist);
+        int cols, rows, hist; bool alt;
+        lock (pane.S.SyncRoot) { cols = em.Screen.Cols; rows = em.Screen.Rows; hist = em.HistoryCount; alt = em.IsAltScreen; }
+        // The alt screen shows no history, so the renderer pins its offset to 0 (Program.Render.cs)
+        // and so must this: mapping a click through a stale offset would name history rows that are
+        // not on screen — a selection nothing highlights, which Ctrl+C would then copy.
+        int off = alt ? 0 : Math.Clamp(pane.ScrollOffset, 0, hist);
         int vr = Math.Clamp((int)((py - oy) / ch), 0, rows - 1);
         int col = Math.Clamp((int)((px - ox) / cw), 0, cols - 1);
         int line = Math.Clamp(hist - off + vr, 0, hist + rows - 1);
@@ -661,7 +664,11 @@ internal partial class Program
             if (Math.Min(p.SelAncLine, p.SelFocLine) < evicted) { p.ClearSel(); return false; }
             p.SelAncLine -= (int)evicted; p.SelFocLine -= (int)evicted;
         }
-        return true;
+        // Same bounds check as the branch above: Resize shrinks the screen without reflowing or
+        // pushing the lost rows into history, so a selection on the bottom rows of an ordinary shell
+        // can end up past the end of the buffer, where SelectionText reads Cell.Empty and copies
+        // blank lines the renderer never highlighted.
+        return ClampSel(p, hist, rows, cols);
     }
 
     /// <summary>Hold a selection inside the buffer it is drawn against. Only a resize moves those
@@ -671,6 +678,11 @@ internal partial class Program
     {
         int maxLine = hist + rows - 1, maxCol = Math.Max(0, cols - 1);
         if (maxLine < 0 || Math.Min(p.SelAncLine, p.SelFocLine) > maxLine) { p.ClearSel(); return false; }
+        // Columns only name text for a rectangle or a one-row selection; when such a selection sits
+        // entirely right of a narrower screen, drop it rather than pin it to the last column, where
+        // it would highlight an unrelated stripe. (A taller linear selection still covers whole rows.)
+        if ((p.BlockSel || p.SelAncLine == p.SelFocLine) && Math.Min(p.SelAncCol, p.SelFocCol) > maxCol)
+        { p.ClearSel(); return false; }
         p.SelAncLine = Math.Clamp(p.SelAncLine, 0, maxLine);
         p.SelFocLine = Math.Clamp(p.SelFocLine, 0, maxLine);
         p.SelAncCol = Math.Clamp(p.SelAncCol, 0, maxCol);
@@ -716,9 +728,9 @@ internal partial class Program
         if (_markMode) { _markMode = false; ShowToast("mark mode off"); RequestRedraw(); return; }
         if (ActiveSurface() is not { } p) return;
         var em = p.S.Emulator;
-        int hist, row, col;
-        lock (p.S.SyncRoot) { hist = em.HistoryCount; row = em.CursorRow; col = em.CursorCol; }
-        int abs = hist - Math.Clamp(p.ScrollOffset, 0, hist) + row;   // buffer-absolute caret line
+        int hist, row, col; bool alt;
+        lock (p.S.SyncRoot) { hist = em.HistoryCount; row = em.CursorRow; col = em.CursorCol; alt = em.IsAltScreen; }
+        int abs = hist - (alt ? 0 : Math.Clamp(p.ScrollOffset, 0, hist)) + row;   // buffer-absolute caret line
         p.SelAncLine = p.SelFocLine = abs; p.SelAncCol = p.SelFocCol = col; p.HasSel = true; p.BlockSel = false;
         StampSel(p);
         _markMode = true;
@@ -735,8 +747,8 @@ internal partial class Program
         // left in the old numbering and the two ends would name different eras of the buffer.
         if (p.HasSel && !ReconcileSel(p)) { _markMode = false; p.ClearSel(); RequestRedraw(); return true; }
         var em = p.S.Emulator;
-        int cols, rows, hist;
-        lock (p.S.SyncRoot) { cols = em.Screen.Cols; rows = em.Screen.Rows; hist = em.HistoryCount; }
+        int cols, rows, hist; bool alt;
+        lock (p.S.SyncRoot) { cols = em.Screen.Cols; rows = em.Screen.Rows; hist = em.HistoryCount; alt = em.IsAltScreen; }
         int maxLine = hist + rows - 1;
         switch (vk)
         {
@@ -747,17 +759,29 @@ internal partial class Program
             case VK_DOWN: p.SelFocLine = Math.Min(maxLine, p.SelFocLine + 1); break;
             case VK_HOME: p.SelFocCol = 0; break;
             case VK_END: p.SelFocCol = cols - 1; break;
-            case VK_RETURN: CopySelection(p, clear: false); _markMode = false; ShowToast("copied"); RequestRedraw(); return true;
-            case 0x43 when ctrl: CopySelection(p, clear: false); _markMode = false; ShowToast("copied"); RequestRedraw(); return true; // Ctrl+C
+            case VK_RETURN: MarkModeCopy(p); return true;
+            case 0x43 when ctrl: MarkModeCopy(p); return true;   // Ctrl+C
             default: return true;   // swallow everything else while in mark mode
         }
         p.HasSel = true;
-        // keep the focus line visible (scroll the pane if the caret walked off the top)
-        int topAbs = hist - Math.Clamp(p.ScrollOffset, 0, hist);
+        // keep the focus line visible (scroll the pane if the caret walked off the top). The alt
+        // screen shows no history, so there is nothing to scroll and its offset stays pinned at 0.
+        int topAbs = hist - (alt ? 0 : Math.Clamp(p.ScrollOffset, 0, hist));
+        if (alt) { RequestRedraw(); return true; }
         if (p.SelFocLine < topAbs) p.ScrollOffset = Math.Clamp(hist - p.SelFocLine, 0, hist);
         else if (p.SelFocLine >= topAbs + rows) p.ScrollOffset = Math.Clamp(hist - (p.SelFocLine - rows + 1), 0, hist);
         RequestRedraw();
         return true;
+    }
+
+    /// <summary>Mark mode's two copy keys (Enter, Ctrl+C). Keeps the highlight up so the user can see
+    /// what was taken, and says plainly when the cells held nothing.</summary>
+    private void MarkModeCopy(Pane p)
+    {
+        bool copied = CopySelection(p, clear: false);
+        _markMode = false;
+        ShowToast(copied ? "copied" : "nothing to copy");
+        RequestRedraw();
     }
 
     private void BeginSelect(Pane p, int line, int col, bool extend)
@@ -811,14 +835,21 @@ internal partial class Program
 
     /// <summary>Copy the selection; false if there was nothing to copy. A live selection can still
     /// hold no text — a TUI that repaints blanks the cells under it — and the caller needs to tell
-    /// the two apart: plain Ctrl+C must interrupt rather than be swallowed by a copy of nothing.</summary>
+    /// the two apart: plain Ctrl+C must interrupt rather than be swallowed by a copy of nothing.
+    ///
+    /// "Nothing" is decided on CONTENT, not on length: SelectionText joins its rows with CRLF
+    /// whether or not a row contributed a character, so a blanked six-row selection is ten
+    /// characters of pure separator — non-empty by length, and it would swallow the interrupt in
+    /// exactly the case this is here to catch. Clearing stays the caller's decision, so
+    /// copy-on-select and mark mode keep the highlight they explicitly asked to keep.</summary>
     private bool CopySelection(Pane pane, bool clear = true)
     {
         string t = SelectionText(pane);
-        if (t.Length > 0) ClipboardSet(t);
-        if (clear || t.Length == 0) pane.ClearSel();
+        bool any = t.AsSpan().IndexOfAnyExcept('\r', '\n', ' ') >= 0;
+        if (any) ClipboardSet(t);
+        if (clear) pane.ClearSel();
         RequestRedraw();
-        return t.Length > 0;
+        return any;
     }
 
     /// <summary>Select the pane's entire buffer — all scrollback history through the last live row.</summary>

--- a/src/Agwinterm.Win32/Program.Input.cs
+++ b/src/Agwinterm.Win32/Program.Input.cs
@@ -96,7 +96,14 @@ internal partial class Program
     {
         var p = ActiveSurface();
         if (p is null) return false;
-        if (p.S.Emulator.IsAltScreen) return true;   // no history to scroll to; an offset here is never rendered
+        // The alt screen has no history to scroll to, and an offset taken here is never rendered.
+        // Zeroing one is still allowed — and is in fact the only way back if some other path left an
+        // offset behind, which is what Shift+End is for.
+        if (p.S.Emulator.IsAltScreen)
+        {
+            if (p.ScrollOffset != 0) { p.ScrollOffset = 0; RequestRedraw(); }
+            return true;
+        }
         int hist = p.S.Emulator.HistoryCount;
         int no = deltaLines == int.MaxValue ? hist : deltaLines == int.MinValue ? 0
                : Math.Clamp(p.ScrollOffset + deltaLines, 0, hist);
@@ -858,11 +865,18 @@ internal partial class Program
     /// characters of pure separator — non-empty by length, and it would swallow the interrupt in
     /// exactly the case this is here to catch. Clearing stays the caller's decision, so
     /// copy-on-select and mark mode keep the highlight they explicitly asked to keep.</summary>
-    private bool CopySelection(Pane pane, bool clear = true)
+    private bool CopySelection(Pane pane, bool clear = true) => CopySelection(pane, out _, clear);
+
+    /// <summary>As above, handing back exactly what reached the clipboard (empty when nothing did).
+    /// Callers that report on the copy must use this rather than scanning again: the pty reader
+    /// feeds the emulator on its own thread and SelectionText holds the session lock only for one
+    /// scan, so a second scan can measure a different buffer than the one that was copied.</summary>
+    private bool CopySelection(Pane pane, out string copied, bool clear = true)
     {
         string t = SelectionText(pane);
+        copied = t;
         bool any = t.AsSpan().IndexOfAnyExcept('\r', '\n', ' ') >= 0;
-        if (any) ClipboardSet(t);
+        if (any) ClipboardSet(t); else copied = "";
         if (clear) pane.ClearSel();
         RequestRedraw();
         return any;
@@ -883,10 +897,8 @@ internal partial class Program
 
     /// <summary>Called when a selection is finished (drag mouse-up / word / line select). Honors copy-on-select
     /// by copying to the clipboard without clearing the highlight.</summary>
-    private void FinalizeSelection(Pane p)
-    {
-        if (_config.CopyOnSelect && HasLiveSel(p)) CopySelection(p, clear: false);
-    }
+    private bool FinalizeSelection(Pane p)
+        => _config.CopyOnSelect && HasLiveSel(p) && CopySelection(p, clear: false);
 
     private void StopSelAutoscroll()
     {
@@ -962,7 +974,10 @@ internal partial class Program
         {
             int cols = em.Screen.Cols, rows = em.Screen.Rows, hist = em.HistoryCount;
             var sb = new StringBuilder(cols);
-            for (int line = 0; line < hist + rows; line++)
+            // On the alt screen the pane shows only the live grid: matches below `hist` belong to the
+            // other screen, cannot be highlighted or scrolled to, and would inflate "n of m".
+            int from = em.IsAltScreen ? hist : 0;
+            for (int line = from; line < hist + rows; line++)
             {
                 sb.Clear();
                 for (int c = 0; c < cols; c++)
@@ -997,7 +1012,9 @@ internal partial class Program
         if (ap is null || _searchCur < 0 || _searchCur >= _searchMatches.Count) return;
         int ml = _searchMatches[_searchCur].Line;
         var em = ap.S.Emulator;
-        int rows, hist; lock (ap.S.SyncRoot) { rows = em.Screen.Rows; hist = em.HistoryCount; }
+        int rows, hist; bool alt;
+        lock (ap.S.SyncRoot) { rows = em.Screen.Rows; hist = em.HistoryCount; alt = em.IsAltScreen; }
+        if (alt) return;   // nothing to scroll to, and the offset would never be rendered
         ap.ScrollOffset = Math.Clamp(hist - ml + rows / 2, 0, hist); // centre the match; live grid => snaps to 0
     }
 

--- a/src/Agwinterm.Win32/Program.Input.cs
+++ b/src/Agwinterm.Win32/Program.Input.cs
@@ -53,8 +53,9 @@ internal partial class Program
         if (p is null) return;
         var em = p.S.Emulator;
         List<int> lines;
-        int hist;
-        lock (p.S.SyncRoot) { lines = em.Marks.Select(m => m.PromptLine).ToList(); hist = em.HistoryCount; }
+        int hist; bool alt;
+        lock (p.S.SyncRoot) { lines = em.Marks.Select(m => m.PromptLine).ToList(); hist = em.HistoryCount; alt = em.IsAltScreen; }
+        if (alt) { ShowToast("no shell marks on a full-screen app's buffer"); return; }
         if (lines.Count == 0) { ShowToast("no shell marks yet (FTCS comes from the pwsh prompt wrap)"); return; }
         int curTop = hist - p.ScrollOffset;
         int target = dir < 0 ? lines.Where(l => l < curTop).DefaultIfEmpty(-1).Max()
@@ -95,6 +96,7 @@ internal partial class Program
     {
         var p = ActiveSurface();
         if (p is null) return false;
+        if (p.S.Emulator.IsAltScreen) return true;   // no history to scroll to; an offset here is never rendered
         int hist = p.S.Emulator.HistoryCount;
         int no = deltaLines == int.MaxValue ? hist : deltaLines == int.MinValue ? 0
                : Math.Clamp(p.ScrollOffset + deltaLines, 0, hist);
@@ -653,7 +655,7 @@ internal partial class Program
             // about once a second: every mouse-move mid-drag found new output, dropped the anchor and
             // re-anchored under the cursor, so the drag never built a selection at all — and Ctrl+C,
             // finding nothing live, fell through to the app as an interrupt.
-            return ClampSel(p, hist, rows, cols);
+            return ClampSel(p, hist, rows, cols, alt);
         }
         // One generation per line pushed into history: what scrolled but did not grow history was
         // evicted off the front, and eviction is the only thing that renumbers absolute indices.
@@ -668,23 +670,34 @@ internal partial class Program
         // pushing the lost rows into history, so a selection on the bottom rows of an ordinary shell
         // can end up past the end of the buffer, where SelectionText reads Cell.Empty and copies
         // blank lines the renderer never highlighted.
-        return ClampSel(p, hist, rows, cols);
+        return ClampSel(p, hist, rows, cols, alt);
     }
 
-    /// <summary>Hold a selection inside the buffer it is drawn against. Only a resize moves those
-    /// bounds under it; a selection left entirely past the end is dropped rather than pinned to the
-    /// last row, where it would highlight text the user never touched.</summary>
-    private static bool ClampSel(Pane p, int hist, int rows, int cols)
+    /// <summary>Hold a selection inside the range of lines the pane can actually SHOW, which is the
+    /// range the renderer highlights — that equality is the whole invariant: a selection outside it
+    /// is painted nowhere yet still copies, handing over text the user never saw highlighted.
+    ///
+    /// On the main screen that range starts at 0 (history is scrolled to and highlighted). On the
+    /// ALT screen it starts at <paramref name="hist"/>: the main-screen history is still in the
+    /// buffer, but it belongs to the other screen — the renderer pins the alt offset to 0 and never
+    /// draws below `hist`. Every path that can push a line below it (Select All, mark-mode Up, drag
+    /// autoscroll) is bounded here rather than one at a time. A selection left entirely outside the
+    /// range is dropped rather than pinned to its nearest row, where it would highlight text the
+    /// user never touched.</summary>
+    private static bool ClampSel(Pane p, int hist, int rows, int cols, bool alt)
     {
-        int maxLine = hist + rows - 1, maxCol = Math.Max(0, cols - 1);
-        if (maxLine < 0 || Math.Min(p.SelAncLine, p.SelFocLine) > maxLine) { p.ClearSel(); return false; }
+        int minLine = alt ? hist : 0, maxLine = hist + rows - 1, maxCol = Math.Max(0, cols - 1);
+        if (maxLine < minLine) { p.ClearSel(); return false; }
+        if (Math.Min(p.SelAncLine, p.SelFocLine) > maxLine || Math.Max(p.SelAncLine, p.SelFocLine) < minLine)
+        { p.ClearSel(); return false; }
+        p.SelAncLine = Math.Clamp(p.SelAncLine, minLine, maxLine);
+        p.SelFocLine = Math.Clamp(p.SelFocLine, minLine, maxLine);
         // Columns only name text for a rectangle or a one-row selection; when such a selection sits
         // entirely right of a narrower screen, drop it rather than pin it to the last column, where
         // it would highlight an unrelated stripe. (A taller linear selection still covers whole rows.)
+        // Tested AFTER the line clamp, since that clamp is what can collapse two rows into one.
         if ((p.BlockSel || p.SelAncLine == p.SelFocLine) && Math.Min(p.SelAncCol, p.SelFocCol) > maxCol)
         { p.ClearSel(); return false; }
-        p.SelAncLine = Math.Clamp(p.SelAncLine, 0, maxLine);
-        p.SelFocLine = Math.Clamp(p.SelFocLine, 0, maxLine);
         p.SelAncCol = Math.Clamp(p.SelAncCol, 0, maxCol);
         p.SelFocCol = Math.Clamp(p.SelFocCol, 0, maxCol);
         return true;
@@ -749,13 +762,15 @@ internal partial class Program
         var em = p.S.Emulator;
         int cols, rows, hist; bool alt;
         lock (p.S.SyncRoot) { cols = em.Screen.Cols; rows = em.Screen.Rows; hist = em.HistoryCount; alt = em.IsAltScreen; }
-        int maxLine = hist + rows - 1;
+        // Same floor ClampSel enforces: on the alt screen the pane cannot show a line below `hist`,
+        // so the caret must not walk into main-screen history where nothing highlights it.
+        int minLine = alt ? hist : 0, maxLine = hist + rows - 1;
         switch (vk)
         {
             case VK_ESCAPE: _markMode = false; p.ClearSel(); RequestRedraw(); return true;
             case VK_LEFT: p.SelFocCol = Math.Max(0, p.SelFocCol - 1); break;
             case VK_RIGHT: p.SelFocCol = Math.Min(cols - 1, p.SelFocCol + 1); break;
-            case VK_UP: p.SelFocLine = Math.Max(0, p.SelFocLine - 1); break;
+            case VK_UP: p.SelFocLine = Math.Max(minLine, p.SelFocLine - 1); break;
             case VK_DOWN: p.SelFocLine = Math.Min(maxLine, p.SelFocLine + 1); break;
             case VK_HOME: p.SelFocCol = 0; break;
             case VK_END: p.SelFocCol = cols - 1; break;
@@ -764,10 +779,11 @@ internal partial class Program
             default: return true;   // swallow everything else while in mark mode
         }
         p.HasSel = true;
-        // keep the focus line visible (scroll the pane if the caret walked off the top). The alt
-        // screen shows no history, so there is nothing to scroll and its offset stays pinned at 0.
-        int topAbs = hist - (alt ? 0 : Math.Clamp(p.ScrollOffset, 0, hist));
+        // Keep the focus line visible (scroll the pane if the caret walked off the top). The alt
+        // screen shows no history: there is nothing to scroll to, and the focus is already bounded
+        // to the live grid above.
         if (alt) { RequestRedraw(); return true; }
+        int topAbs = hist - Math.Clamp(p.ScrollOffset, 0, hist);
         if (p.SelFocLine < topAbs) p.ScrollOffset = Math.Clamp(hist - p.SelFocLine, 0, hist);
         else if (p.SelFocLine >= topAbs + rows) p.ScrollOffset = Math.Clamp(hist - (p.SelFocLine - rows + 1), 0, hist);
         RequestRedraw();
@@ -882,11 +898,15 @@ internal partial class Program
     private void SelAutoscrollTick()
     {
         if (!_selecting || _selAutoDir == 0 || _selPane is not { } sp || PaneBox(sp) is not { } bx) { StopSelAutoscroll(); return; }
-        int cols, rows, hist;
-        lock (sp.S.SyncRoot) { cols = sp.S.Emulator.Screen.Cols; rows = sp.S.Emulator.Screen.Rows; hist = sp.S.Emulator.HistoryCount; }
+        int cols, rows, hist; bool alt;
+        lock (sp.S.SyncRoot)
+        { cols = sp.S.Emulator.Screen.Cols; rows = sp.S.Emulator.Screen.Rows; hist = sp.S.Emulator.HistoryCount; alt = sp.S.Emulator.IsAltScreen; }
         // dir -1 (mouse above) reveals older lines -> larger ScrollOffset; dir +1 (below) -> smaller.
-        int no = Math.Clamp(sp.ScrollOffset - _selAutoDir, 0, hist);
-        sp.ScrollOffset = no;
+        // The alt screen has nothing to reveal: dragging past its top edge extends the selection to
+        // the top visible row and stops, instead of accumulating an offset that is never rendered
+        // and walking the selection down into main-screen history.
+        int no = alt ? 0 : Math.Clamp(sp.ScrollOffset - _selAutoDir, 0, hist);
+        if (!alt) sp.ScrollOffset = no;
         int vr = _selAutoDir < 0 ? 0 : rows - 1;                      // extend to the top/bottom visible row
         int line = Math.Clamp(hist - no + vr, 0, hist + rows - 1);
         int col = Math.Clamp((int)((_selMouseX - bx.ox) / bx.cw), 0, cols - 1);

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -87,15 +87,13 @@ internal partial class Program
         // close to unusable next to a running agent: the agent prints, the selection you just made is
         // gone, and Ctrl+C falls through to the interrupt — cancelling its turn. The selection is
         // reconciled in ReconcileSel instead, on the UI thread, against the snapshot taken when it was made.
-        // This handler therefore writes NOTHING about the selection; it only bumps a counter that lets
-        // the reconcile tell "output has arrived since" from "nothing has happened".
+        // This handler therefore writes NOTHING about the selection at all.
         // Repaints are requested ONLY when this pane is on screen: a background tab's output flood
         // used to repaint the (unchanged!) foreground at the full frame cap, starving typing on slow
         // machines. The emulator still consumes everything; switching to the pane shows current
         // content, and the sidebar title catches up on the next paint (cursor blink at the latest).
         session.OutputReceived += () =>
         {
-            System.Threading.Interlocked.Increment(ref pane.OutputSeq);
             long gen = session.Emulator.ScrollGeneration;
             if (gen != pane.LastScrollGen) { pane.LastScrollGen = gen; pane.ScrollOffset = 0; }
             // Synchronized output (DECSET ?2026): while the app is mid-frame, defer painting so a

--- a/src/Agwinterm.Win32/Program.WndProc.cs
+++ b/src/Agwinterm.Win32/Program.WndProc.cs
@@ -544,6 +544,7 @@ internal partial class Program
                     // Otherwise scroll the pane under the cursor through its scrollback history.
                     if (_cover is not null && pt.x >= (int)_sidebarW && pt.y >= (int)TitleBarH)
                     {
+                        if (_cover.S.Emulator.IsAltScreen) return IntPtr.Zero;
                         int hn = _cover.S.Emulator.HistoryCount;
                         int step = Math.Clamp(_config.ScrollSpeed, 1, 10);
                         int no = Math.Clamp(_cover.ScrollOffset + (HiWord(wParam) > 0 ? step : -step), 0, hn);
@@ -554,6 +555,9 @@ internal partial class Program
                         foreach (var (p, x, _, w, _) in PaneLayout(_active))
                             if (pt.x >= x && pt.x < x + w)
                             {
+                                // The alt screen shows no history: an offset accumulated here would
+                                // never be rendered, and silently move where clicks land.
+                                if (p.S.Emulator.IsAltScreen) break;
                                 int histN = p.S.Emulator.HistoryCount;
                                 int dir = HiWord(wParam) > 0 ? 1 : -1; // wheel up scrolls back into history
                                 int no = Math.Clamp(p.ScrollOffset + dir * Math.Clamp(_config.ScrollSpeed, 1, 10), 0, histN);

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -287,7 +287,6 @@ internal partial class Program : ISessionHost, IWindowHost
         public float Ratio = 1f;   // fraction of the session's content width (ratios in a session sum to 1)
         public int ScrollOffset;   // lines scrolled up from the live bottom (0 = live; clamped to HistoryCount)
         public long LastScrollGen; // emulator ScrollGeneration last seen on output (detects real scroll vs in-place repaint)
-        public long OutputSeq;     // bumped (Interlocked) on every output; the only thing the reader thread writes here
         public int Unread;         // unread desktop-notification count (OSC 9/777 / notify) since last visit
         public bool ReadOnly;      // block keyboard input to this pane (protect a running agent from stray keys)
         // Text selection (absolute line index: [0..HistoryCount) history, then the live grid rows).
@@ -298,9 +297,9 @@ internal partial class Program : ISessionHost, IWindowHost
         // is a different buffer entirely. Everything is recorded at selection time and compared on
         // the UI thread when the selection is used, so nothing about a selection is ever written
         // from the thread reading the pty. SelTrackable = false means the shift cannot be measured
-        // at all (no scrollback, a partial DECSTBM region, the alt screen) — such a selection is
-        // dropped as soon as any output arrives rather than left pointing at whatever moved in.
-        public long SelGen, SelOutSeq;
+        // at all (no scrollback, a partial DECSTBM region, the alt screen) — such a selection cannot
+        // follow its text, so it stays on the cells it covers and copies exactly what they hold.
+        public long SelGen;
         public int SelHist;
         public bool SelAlt, SelTrackable;
         public bool BlockSel;   // rectangular (Alt+drag) selection: clip each row to [minCol,maxCol]

--- a/tests/Agwinterm.Core.Tests/ScrollbackTests.cs
+++ b/tests/Agwinterm.Core.Tests/ScrollbackTests.cs
@@ -101,6 +101,28 @@ public class ScrollbackTests
         Assert.Equal(0, t.HistoryCount);
     }
 
+    /// <summary>The premise the Win32 selection bound rests on (see SelectionBoundsTests): entering
+    /// the alt screen leaves the main screen's history in place, so `HistoryCount` is exactly the
+    /// first line the alt screen can show. A change that CLEARED history on the transition would
+    /// pass the test above — it enters with an empty history — while quietly turning that bound back
+    /// into 0, which is how invisible scrollback ended up on the clipboard.</summary>
+    [Fact]
+    public void AltScreen_LeavesMainScreenHistoryIntact()
+    {
+        var t = new TerminalEmulator(10, 3);
+        for (int i = 0; i < 10; i++) Feed(t, $"M{i}\r\n");
+        int before = t.HistoryCount;
+        Assert.True(before > 0, "the main screen should have scrolled some lines into history");
+
+        Feed(t, "\x1b[?1049h");
+        Assert.Equal(before, t.HistoryCount);
+        for (int i = 0; i < 10; i++) Feed(t, "A\r\n");
+        Assert.Equal(before, t.HistoryCount);   // the alt screen never pushes, and never drops
+
+        Feed(t, "\x1b[?1049l");
+        Assert.Equal(before, t.HistoryCount);
+    }
+
     [Fact]
     public void Clear_DoesNotRecordHistory()
     {

--- a/tests/Agwinterm.Core.Tests/SelectionBoundsTests.cs
+++ b/tests/Agwinterm.Core.Tests/SelectionBoundsTests.cs
@@ -1,0 +1,119 @@
+using System.Reflection;
+
+namespace Agwinterm.Core.Tests;
+
+/// <summary>
+/// Guards the one bound the whole selection invariant now rests on.
+///
+/// A selection may only name lines the pane can SHOW, because the highlight and the clipboard read
+/// the same absolute rows: a selection outside that range is painted nowhere yet still copies,
+/// handing over text the user never saw highlighted. On the main screen the range starts at line 0.
+/// On the ALT screen it starts at HistoryCount — the main screen's scrollback is still in the
+/// buffer, but it belongs to the other screen and the renderer never draws it there.
+///
+/// That rule lives in one place, Program.ClampSel, which every reconcile ends in. It was reached
+/// three times by three different doors (Select All anchoring at 0, mark-mode Up flooring at 0,
+/// drag-autoscroll walking the focus down through a scroll offset), and each fix reopened it
+/// somewhere else. Nothing in the repo failed when it regressed, hence this.
+///
+/// Reflection over the built UI assembly, following PInvokeCharSetTests: Program is internal and
+/// ClampSel is private static, but it is pure over ints and a Pane field bag.
+/// </summary>
+public class SelectionBoundsTests
+{
+    private static string FindUiAssembly()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir != null && !Directory.Exists(Path.Combine(dir, "src", "Agwinterm.Win32")))
+            dir = Path.GetDirectoryName(dir);
+        Assert.NotNull(dir);
+        var bin = Path.Combine(dir!, "src", "Agwinterm.Win32", "bin");
+        Assert.True(Directory.Exists(bin), $"build Agwinterm.Win32 first (no {bin})");
+        var hits = Directory.GetFiles(bin, "Agwinterm.Win32.dll", SearchOption.AllDirectories)
+                            .OrderByDescending(File.GetLastWriteTimeUtc).ToArray();
+        Assert.True(hits.Length > 0, $"build Agwinterm.Win32 first (no dll under {bin})");
+        return hits[0];
+    }
+
+    private static readonly Assembly Ui = Assembly.LoadFrom(FindUiAssembly());
+
+    private static Type PaneType => Ui.GetTypes().First(t => t.Name == "Pane");
+
+    private static MethodInfo Clamp => Ui.GetTypes().First(t => t.Name == "Program")
+        .GetMethod("ClampSel", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("Program.ClampSel is gone — the selection bound moved, so this test must follow it");
+
+    /// <summary>A Pane without running its constructor: ClampSel touches only the Sel* fields.</summary>
+    private static object NewPane(int ancLine, int ancCol, int focLine, int focCol, bool block = false)
+    {
+        object p = System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(PaneType);
+        void Set(string f, object v) => PaneType.GetField(f)!.SetValue(p, v);
+        Set("SelAncLine", ancLine); Set("SelAncCol", ancCol);
+        Set("SelFocLine", focLine); Set("SelFocCol", focCol);
+        Set("HasSel", true); Set("BlockSel", block);
+        return p;
+    }
+
+    private static int Get(object pane, string field) => (int)PaneType.GetField(field)!.GetValue(pane)!;
+
+    private static bool Run(object pane, int hist, int rows, int cols, bool alt)
+        => (bool)Clamp.Invoke(null, new object[] { pane, hist, rows, cols, alt })!;
+
+    [Fact]
+    public void AltScreen_SelectionCannotReachTheOtherScreensHistory()
+    {
+        // What Select All builds: line 0 through the last live row. On the alt screen every line
+        // below `hist` is main-screen scrollback the renderer will not highlight.
+        var p = NewPane(0, 0, 529, 79);
+        Assert.True(Run(p, hist: 500, rows: 30, cols: 80, alt: true));
+        Assert.Equal(500, Get(p, "SelAncLine"));   // pulled up to the first line the alt screen shows
+        Assert.Equal(529, Get(p, "SelFocLine"));
+    }
+
+    [Fact]
+    public void AltScreen_SelectionEntirelyInHistoryIsDropped()
+    {
+        // Mark-mode Up and drag-autoscroll used to walk the focus down here; nothing highlights it,
+        // so it must die rather than be pinned to the top row.
+        var p = NewPane(480, 0, 495, 79);
+        Assert.False(Run(p, hist: 500, rows: 30, cols: 80, alt: true));
+        Assert.False((bool)PaneType.GetField("HasSel")!.GetValue(p)!);
+    }
+
+    [Fact]
+    public void MainScreen_DeepScrollbackSelectionIsUntouched()
+    {
+        // The same call with alt: false must be a no-op — history IS shown on the main screen.
+        var p = NewPane(12, 3, 34, 40);
+        Assert.True(Run(p, hist: 500, rows: 30, cols: 80, alt: false));
+        Assert.Equal(12, Get(p, "SelAncLine"));
+        Assert.Equal(34, Get(p, "SelFocLine"));
+        Assert.Equal(3, Get(p, "SelAncCol"));
+        Assert.Equal(40, Get(p, "SelFocCol"));
+    }
+
+    [Fact]
+    public void SelectionPastTheEndIsDropped_NotPinnedToTheLastRow()
+    {
+        // Resize shrinks the screen without reflowing, so a selection on the bottom rows can end up
+        // past the end of the buffer, where SelectionText reads blank cells.
+        var p = NewPane(540, 0, 545, 79);
+        Assert.False(Run(p, hist: 500, rows: 30, cols: 80, alt: false));
+    }
+
+    [Fact]
+    public void BlockSelectionRightOfANarrowerScreenIsDropped()
+    {
+        // Clamping both columns would move the rectangle onto an unrelated stripe.
+        var p = NewPane(10, 100, 14, 110, block: true);
+        Assert.False(Run(p, hist: 0, rows: 30, cols: 80, alt: false));
+    }
+
+    [Fact]
+    public void ColumnsAreClampedWithinTheScreen()
+    {
+        var p = NewPane(2, 0, 6, 200);
+        Assert.True(Run(p, hist: 0, rows: 30, cols: 80, alt: false));
+        Assert.Equal(79, Get(p, "SelFocCol"));
+    }
+}


### PR DESCRIPTION
## The report

> I updated agwinterm and running codex. In codex I'm not able to copy text - when I press Ctrl+C with selected text (or Enter) - codex interrupts something

## What was wrong

`codex.exe` contains `?1049h` / `?2004h` and **no** `?1000` / `?1002` / `?1006` — it never grabs the mouse, so the selection is agwinterm's own and the terminal is what threw it away.

`ReconcileSel` split selections into two kinds. Where a shift can be *measured* (main screen, scrollback on, full scroll region) it follows its text through eviction. Where it cannot — a TUI repainting in place, a reserved DECSTBM line, scrollback off — the rule was to **drop it on the first byte of output**, so it could never cover text the user had not highlighted.

In a TUI that repaints roughly once a second that rule fires *mid-drag*: every mouse-move found new output, dropped the anchor and re-anchored under the cursor, so the drag never built a selection at all. Ctrl+C then found nothing live and fell through to the app — codex read it as an interrupt. Enter went through for the same reason: as far as the terminal was concerned, nothing was selected.

## The change

Such a selection cannot *follow* its text, but it can stay on the cells it covers. The highlight is redrawn from those coordinates every frame and `SelectionText` reads the same cells the renderer draws, so what reaches the clipboard is always what is visibly highlighted.

That invariant then has to hold everywhere, which is what the review rounds below are about. It is now enforced in one place — `ClampSel`, which every reconcile ends in: a selection is bounded to the lines its screen can **show**, and one left wholly outside that range is dropped rather than pinned to the nearest row. On the main screen that range starts at line 0; on the alt screen it starts at `HistoryCount`, because everything below belongs to the other screen's scrollback, which the renderer never draws there.

Unchanged: crossing into or out of the alt screen still drops the selection (different buffer), and a trackable main-screen selection still follows its text and still dies with its lines on eviction.

Also here:
- plain Ctrl+C falls through to the interrupt when the live selection holds **no text** (a repaint blanked the cells under it) instead of being swallowed by a copy of nothing. Ctrl+Shift+C stays an explicit copy and is always consumed.
- the output counter the old rule needed is gone — nothing on the reader thread writes selection state any more.

## Review

Three revmux rounds (`.revmux/tasks/altscreen-selection/`), each on the previous one's rework.

**Round one** — one major, two minors, two pre-existing:
- `CopySelection` decided "copied something" with `t.Length`, but `SelectionText` emits a CRLF joiner per row boundary regardless of content. A blanked six-row selection was ten characters of pure separator, so it read as a successful copy: clipboard overwritten with newlines, Ctrl+C swallowed — **the original bug, back for every selection taller than one row**. Emptiness is decided on content now.
- that guard also cleared the highlight when the caller passed `clear: false` (copy-on-select, mark mode); mark mode toasted "copied" when nothing was.
- `CellAtPx` was missing the alt-screen `off = 0` guard the renderer and UIA snapshot both apply, so a wheel-up made a drag select invisible main-screen history.

**Round two** — three majors: the same invariant break through three doors round one left open (mark-mode Up flooring at 0, drag-autoscroll mapping through an alt-screen offset, `ClampSel` using 0 as the alt lower bound, which let Select All take hundreds of invisible rows), plus `selection.copy` over the control API still reporting `copied N chars` by string length when the copy had been declined.

**Round three** ran on the final rework.

## Verification

Sandbox instance throughout (`--pipe` + `--app-id`), `PostMessage` only, `PrintWindow` for captures. Ctrl+C is driven by attaching to the instance's own input queue, so `GetKeyState` sees the modifier without anything being injected globally.

**A/B on the same build root, synthetic alt-screen TUI repainting every 700 ms** (`altsel.ps1`):

```
before (origin/main)                       after
  selection made : <empty>                   selection made : ssssss
  after ~5s      : <empty>                   after ~5s      : ssssss
  lines selected : 0                         lines selected : 6
  => a repaint dropped it — Ctrl+C           => PASS: Ctrl+C copied the selection
     would fall through as an interrupt         instead of interrupting
```

**Real codex, no prompt sent** (`codexsel.ps1`) — drag over the banner, wait through its repaints, then Ctrl+C:

```
  selection dragged over codex : :     gpt-5.6-sol xhigh   /model to change │
  after ~5s                    : :     gpt-5.6-sol xhigh   /model to change │
  lines selected               : 6
  => PASS: Ctrl+C copied the selection instead of interrupting
  => codex saw no interrupt
```

**Every review finding, as a check** (`selfix.ps1`), A/B on the same build root — all three round-two majors reproduce before the fix and pass after:

```
--- the alt screen ignores a stale scroll offset ---
  PASS  a drag on the alt screen still selects
  PASS  it does not reach main-screen history
  PASS  what it copies is on the visible screen
--- the other three doors into the other screen's history ---
  PASS  drag-autoscroll stays on the alt screen          (was: pulled in history)
  PASS  select-all takes only the alt screen             (was: reached history)
  PASS  mark-mode Up stops at the top of the alt screen  (was: copied history)
--- a blanked multi-row selection must not swallow Ctrl+C ---
  PASS  the selection is live but holds no text
  PASS  the clipboard was left alone
  PASS  the interrupt reached the app                    (proved by the TUI's counter freezing)
```

**Rules that had to keep holding** (`agw-sel-untrackable.ps1`), at `scrollback-lines` 0 and 5000: kept-and-on-screen, follows-its-text, and dropped on alt-screen entry — all pass.

`dotnet test`: **305 passed, 0 failed** (Core 189, Pty 116).

**agliteterm needs no change** — its `syncSelection` only shifts by eviction and drops on the alt-screen crossing; it never had the drop-on-output rule. Verified with the same codex probe against `agliteterm.exe`: 10 lines selected, survived the repaints, Ctrl+C copied them, codex saw no interrupt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k
