### PR TITLE
test(qa): markdown QA cases an agent executes against a live build

### DIFF
--- a/qa/fixtures/althold.ps1
+++ b/qa/fixtures/althold.ps1
@@ -1,0 +1,6 @@
+# Enters the alt screen and HOLDS it. Typed as two separate commands, the shell prompt redraw
+# lands in between and the buffer is back before the check runs.
+$e = [char]27
+[Console]::Write("$e[?1049h")
+Start-Sleep 6
+[Console]::Write("$e[?1049l")

--- a/qa/fixtures/flood.ps1
+++ b/qa/fixtures/flood.ps1
@@ -1,0 +1,2 @@
+# Past the 5000-line cap plus the batched-trim slack (512), so eviction really happens.
+1..6000 | ForEach-Object { Write-Host "flood-$_" }

--- a/qa/fixtures/marker.ps1
+++ b/qa/fixtures/marker.ps1
@@ -1,0 +1,3 @@
+# 40 rows, each DISTINCT: identical rows would let a selection that slid onto other text compare
+# equal to the original and pass.
+1..40 | ForEach-Object { Write-Host "MARKER-$_-xxxxxxxxxxxxxxxx" }

--- a/qa/fixtures/noise.ps1
+++ b/qa/fixtures/noise.ps1
@@ -1,0 +1,2 @@
+# Enough output to scroll the screen, without evicting anything.
+1..40 | ForEach-Object { Write-Host "noise-$_" }

--- a/qa/fixtures/tui.ps1
+++ b/qa/fixtures/tui.ps1
@@ -1,0 +1,13 @@
+# A codex-shaped TUI: alt screen, a static body, a status line repainting in place about once a
+# second - the pattern that made every mouse-move drop the selection. After ~14s it BLANKS the
+# body and idles, which is the state where a live selection holds no text.
+#
+# The counter is the interrupt detector: an interrupted script never reaches its own ?1049l, so
+# the alt screen stays up either way - what tells a kill from a survivor is the number freezing.
+$e = [char]27
+[Console]::Write("$e[?1049h$e[H$e[2J")
+1..25 | ForEach-Object { [Console]::Write("BODY-$_-tttttttttttttttt$e[K`r`n") }
+foreach ($i in 1..14) { [Console]::Write("$e[26;1H$e[Kworking $i"); Start-Sleep 1 }
+[Console]::Write("$e[H$e[2J")
+foreach ($i in 1..120) { [Console]::Write("$e[26;1H$e[Kblanked $i"); Start-Sleep 1 }
+[Console]::Write("$e[?1049l")

--- a/qa/product.md
+++ b/qa/product.md
@@ -1,0 +1,111 @@
+# agwinterm — QA adapter
+
+How the `ui-qa` skill brings this product up, drives it and observes it. The cases in `qa/*.md`
+assume everything here.
+
+## Build
+
+```powershell
+dotnet build Agwinterm.slnx -c Release
+```
+
+**Two Release output roots exist and only one is fresh.** The solution sets Platform=x64, so the
+build writes `src\Agwinterm.Win32\bin\x64\Release\net10.0-windows\win-x64\`. The sibling
+`src\Agwinterm.Win32\bin\Release\net10.0-windows\win-x64\` is a leftover from an older
+configuration and is never refreshed — launching it runs months-old code and reports green for a
+fix that is not there. That happened, on the bug half these cases exist for.
+
+`Resolve-Binary` in `tests/ui/lib.ps1` handles it: it takes the **newest** matching exe under
+`bin`, and prints which one it chose. Read that line before trusting a run.
+
+The native core is separate and can be stale in the same way — a mismatched ABI fails five unit
+tests before QA starts:
+
+```powershell
+cd native\agwinterm-core; cargo build --release
+```
+
+## Launching an isolated instance
+
+`Start-Sandbox` in `tests/ui/lib.ps1`:
+
+```powershell
+. tests\ui\lib.ps1
+$exe = Resolve-Binary $null 'Agwinterm.Win32.exe' 'Agwinterm.Win32'
+$ctl = Resolve-Binary $env:AGWINTERMCTL 'agwintermctl.exe' 'Agwinterm.Ctl'
+$s = Start-Sandbox -Exe $exe -Ctl $ctl -Pipe 'qa1' -Conf @('copy-on-ctrl-c = true')
+```
+
+It passes `--pipe <name> --app-id <name> --no-restore`, waits for the control pipe to answer,
+un-maximises the window and places it at a **fixed size (1100x700 at 150,100)** — every coordinate
+in every case is client-relative to that window.
+
+`--app-id` is what isolates config and state. A `%LOCALAPPDATA%` override does **not** work here:
+.NET resolves LocalApplicationData through the known-folder API and reads the user's real profile
+regardless, so a case that relied on it would be writing to the user's own session list.
+
+`Stop-Sandbox $s` kills the instance and removes its directory. Always in a `finally`.
+
+## Driving input
+
+`tests/ui/lib.ps1` defines `[AgwUi]`, all `PostMessage` to the sandbox window:
+
+| call | what it does |
+| --- | --- |
+| `Drag($h, x1,y1, x2,y2)` | press, 8 moves, release — client coordinates |
+| `DragHold($h, x1,y1, x2,y2, holdMs)` | as above but **holds** outside the pane, so drag-autoscroll ticks |
+| `Click($h, button, x, y)` | 1 = left, 2 = right |
+| `Wheel($h, cx, cy, notches)` | wheel up; takes client coords and converts (WM_MOUSEWHEEL carries screen coords) |
+| `Key($h, vk, times)` | a key with no modifiers |
+| `Chord($h, vk, $shift)` | Ctrl(+Shift)+key |
+
+`Chord` is the only one that touches key state: a posted `WM_KEYDOWN` cannot make `GetKeyState`
+see Ctrl, so it attaches to **this instance's** input queue for the duration and restores what it
+found. Nothing is injected globally — the user keeps typing in their own window throughout.
+
+## Observing
+
+Through the real control client, `agwintermctl`, against the sandbox pipe:
+
+| helper | verb | what it answers |
+| --- | --- | --- |
+| `Get-PaneText $s` | `session text` | what the pane is showing right now |
+| `Get-PaneSelection $s` | `session copy` | what a copy would return — the same path Ctrl+C takes |
+| `Send-Ctl $s @('session','type', "text`r")` | `session type` | type into the sandbox |
+| `Send-Ctl $s @('selection','all' / 'clear')` | `selection.*` | drive selection without the mouse |
+
+**The invariant most cases rest on:** `session copy` and `session text` must agree. A selection may
+only name lines the pane can SHOW, so anything the copy returns has to be findable in the visible
+text. That is why the checks compare the two rather than comparing against a literal.
+
+**Clear `AGWINTERM_SESSION_ID` / `AGWINTERM_PANE_ID` / `AGWINTERM_PIPE` before every ctl call.**
+`Send-Ctl` does it, and it matters more than it looks: a QA run is started from inside an agwinterm
+pane, so those variables are set, and a verb with no `--target` resolves *the caller's* session.
+Against a sandbox that session does not exist — `session text` comes back empty and `session type`
+is accepted and thrown away, with no error anywhere. A pass built on that is a pass over nothing;
+it happened on the first run of this suite.
+
+The clipboard is read with `Get-Clipboard`. Some machines have none — the cases that need it skip
+rather than fail, and say so. Always restore what was on it.
+
+## Fixtures
+
+`qa/fixtures/*.ps1`, written into the sandbox's temp dir and run with `session type`. Paths use
+forward slashes so no case has to quote a backslash.
+
+## What a run looks like
+
+```powershell
+. tests\ui\lib.ps1     # driver
+# then follow qa/selection.md, qa/clipboard.md
+```
+
+There is no runner script by design: the cases are the specification, and the agent executing them
+is the runner. `tests/ui/lib.ps1` is plumbing — it holds no assertions and no cases.
+
+## Also worth running before a PR
+
+```powershell
+dotnet test Agwinterm.slnx -c Release           # 312 incl. SelectionBoundsTests
+pwsh tests\conformance\conformance.ps1          # control-API shape, shared with agliteterm
+```

--- a/qa/selection.md
+++ b/qa/selection.md
@@ -1,0 +1,222 @@
+# Selection
+
+What happens to a selection while the buffer moves under it. Every case here is a bug that shipped.
+
+**The rule they all serve:** a selection may only name lines its screen can SHOW, and the highlight
+and the clipboard read the same cells — so what lands on the clipboard is always what is visibly
+highlighted.
+
+Where a shift can be *measured* (main screen, scrollback on, full scroll region) a selection follows
+its text and dies with its lines. Where it cannot — a full-screen TUI repainting in place, a
+reserved DECSTBM line, scrollback off — it cannot follow, so it stays on the cells it covers,
+bounded to the visible range. On the alt screen that range starts at `HistoryCount`: below it is the
+*other* screen's scrollback, which the renderer never draws there.
+
+Setup for every case: sandbox instance per `qa/product.md`, `copy-on-select = false`,
+`copy-on-ctrl-c = true`, unless the case says otherwise. Fixtures print **distinct** text per line
+throughout — with identical lines, a selection that slid onto different rows compares equal to the
+original and passes, which is the exact defect being tested for.
+
+---
+
+## A drag makes a selection, and it follows its text when output scrolls
+
+**Guards:** the original behaviour. Scrolling used to drop the selection outright, which made
+Ctrl+C-copies close to unusable next to a running agent: the agent prints, the selection is gone,
+Ctrl+C interrupts and cancels its turn.
+
+**Setup:** run `qa/fixtures/marker.ps1` (40 rows of `MARKER-<n>-xxxxxxxxxxxxxxxx`).
+
+**Steps:**
+1. Drag (300,150) → (900,400).
+2. Record what `session copy` returns.
+3. Run `qa/fixtures/noise.ps1` (40 more rows), wait for it to finish.
+
+**Expect:** `session copy` returns a non-empty selection at step 2, and the *same* string at step 3.
+Non-empty **and** equal — two empty strings compare equal, so a drag that selected nothing would
+otherwise pass this while proving the opposite.
+
+**Fails when:** `ReconcileSel`'s eviction shift stops being applied on the trackable path, or the
+output handler goes back to clearing the selection.
+
+---
+
+## A selection dies with its lines when they are evicted
+
+**Guards:** the other half of the rule. Buffer-absolute rows renumber when scrollback eviction drops
+the oldest lines; a selection that ignores that keeps naming the same numbers while the text under
+them moves, so the highlight and `session copy` quietly return something the user never selected.
+
+**Setup:** `marker.ps1`, then a drag as above.
+
+**Steps:** run `qa/fixtures/flood.ps1` (6000 rows — past the 5000-line cap plus the batched-trim
+slack, so eviction really happens). Wait ~25s.
+
+**Expect:** `session copy` returns empty. Dropped, not shifted onto a stranger's text.
+
+**Fails when:** the `evicted = Δgeneration − Δhistory` arithmetic in `ReconcileSel` is wrong, or the
+`min(anchor, focus) < evicted` drop is removed.
+
+---
+
+## Crossing into the alt screen drops the selection
+
+**Guards:** the alt screen is a different buffer — an index into one names unrelated text in the
+other. A full-screen app starting up is the common case, and the highlight would otherwise sit on
+top of its UI and copy that.
+
+**Setup:** `marker.ps1`, then a drag as above.
+
+**Steps:** run `qa/fixtures/althold.ps1`, which enters the alt screen and **holds** it for 6s.
+(Typed as two separate commands, the shell's prompt redraw lands in between and the buffer is back
+before the check runs — the case would then pass for the wrong reason.)
+
+**Expect:** `session copy` returns empty while the alt screen is up.
+
+**Fails when:** the `alt != p.SelAlt` drop at the top of `ReconcileSel` is removed or moved below
+the clamp.
+
+---
+
+## A drag inside a repainting TUI builds a selection and keeps it
+
+**Guards:** the codex/Claude Code report — *"in codex I'm not able to copy text; when I press Ctrl+C
+with selected text, codex interrupts something"*. The rule was to drop a non-measurable selection on
+the first byte of output. codex repaints its status line about once a second, so that fired
+mid-drag: every mouse-move found new output, dropped the anchor and re-anchored under the cursor.
+The drag never built a selection at all. Fixed in v0.17.7.
+
+**Setup:** run `marker.ps1` first (so the pane has real main-screen history), then
+`qa/fixtures/tui.ps1` — alt screen, 25 distinct `BODY-<n>` rows, a status line repainting every
+second, which after 14s blanks the body and idles.
+
+**Steps:**
+1. Wheel up 10 notches over the pane. On the alt screen this must change nothing.
+2. Drag (300,150) → (900,300).
+3. Read `session copy` immediately, then again after ~5s of repaints.
+
+**Expect:** a non-empty selection at both reads, the same both times; it contains no `MARKER-` text;
+and its first non-blank line appears in `session text`.
+
+The `MARKER-` clause is the point of step 1: the wheel used to accumulate a scroll offset the alt
+screen never renders, so the drag mapped onto main-screen history — a selection nothing highlighted,
+which Ctrl+C then copied.
+
+**Fails when:** `ReconcileSel`'s non-trackable branch drops on output again, or `CellAtPx` stops
+pinning the alt screen's offset to 0.
+
+---
+
+## Ctrl+C over that selection copies instead of interrupting
+
+**Guards:** the user-visible half of the same bug.
+
+**Setup:** the selection from the previous case.
+
+**Steps:** put `SENTINEL` on the clipboard, send Ctrl+C, wait 2s.
+
+(When you need to KILL a fixture between cases, clear the selection first. Otherwise Ctrl+C copies
+instead of interrupting — which is the feature under test, and it will leave the old fixture running
+under the next case. That happened during this file's first run.)
+
+**Expect:** the clipboard holds exactly what `session copy` returned. Not `SENTINEL`.
+
+**Skips when:** the machine has no usable clipboard. Say so — a skip is not a pass.
+
+**Fails when:** the `_config.CopyOnCtrlC && HasLiveSel(ap)` branch stops consuming the key, or
+`HasLiveSel` returns false for a live TUI selection.
+
+---
+
+## Drag-autoscroll cannot walk into the other screen's history
+
+**Guards:** found by review round two. Dragging past the pane's top edge starts a 50ms autoscroll
+timer that raised `ScrollOffset` and mapped through it — one tick at a time down into main-screen
+scrollback, with the highlight stopping at the top of the screen and the copy carrying on.
+
+**Setup:** the TUI from above, selection cleared, and **while it is still showing its body** — after
+it blanks (t+14s) a drag selects nothing, and "nothing" contains no `MARKER-` either, so the case
+would pass having proved nothing. Restart the fixture if the body is gone.
+
+**Steps:** drag from (400,400) to (400,5) and **hold the button there for ~3s** before releasing, so
+the timer actually ticks. Releasing early is the same trap: the timer never runs and the case passes.
+
+**Expect:** `session copy` is non-empty **and** contains `BODY-` rows **and** contains no `MARKER-`.
+All three: the first two are what stop the third from being vacuous.
+
+**Fails when:** `SelAutoscrollTick` stops pinning `no = 0` on the alt screen, or `ClampSel` loses its
+`minLine`.
+
+---
+
+## Select All on the alt screen takes only the alt screen
+
+**Guards:** review round two. `SelectAll` anchors at line 0, which on the alt screen is hundreds of
+rows below anything it shows, and the copy pulled all of it through `GetHistoryCell`.
+
+**Steps:** with the TUI up, run `selection all`, then read `session copy`.
+
+**Expect:** non-empty, and no `MARKER-` text.
+
+**Fails when:** `ClampSel`'s `minLine = alt ? hist : 0` becomes `0`. Verified: reverting it fails
+this case and two of `SelectionBoundsTests`.
+
+---
+
+## Mark-mode Up stops at the top of the alt screen
+
+**Guards:** review round two. `case VK_UP` floored at 0 rather than at the first visible line, so the
+caret walked off the top into rows nothing highlights and Enter/Ctrl+C copied them.
+
+**Steps:** with the TUI up and the selection cleared, put `SENTINEL` on the clipboard, then
+Ctrl+Shift+M (mark mode), Up ×40 (further than the screen is tall), Ctrl+C.
+
+**Expect:** the clipboard contains no `MARKER-` text.
+
+**Skips when:** no clipboard.
+
+**Fails when:** `minLine` stops bounding `VK_UP` in `MarkModeKey`.
+
+---
+
+## Ctrl+C over a blank selection reaches the app, and leaves the clipboard alone
+
+**Guards:** review round one, and this is the sharpest one — the *fix* for the original bug
+reintroduced it. `CopySelection` decided "did we copy anything?" by string length, but the copy joins
+its rows with CRLF whether or not a row held text. A blanked six-row selection was ten characters of
+pure separator, so it read as a successful copy: the clipboard was overwritten with newlines, a
+"Text copied" toast fired, and Ctrl+C was swallowed. Every selection taller than one row.
+
+**Setup:** the TUI, ~14s in, after it has blanked its body. Drag (300,150) → (900,300) over the now-
+blank rows.
+
+**Steps:** confirm `session copy` returns nothing but whitespace; put `SENTINEL` on the clipboard;
+send Ctrl+C; wait 3s.
+
+**Expect:**
+- the clipboard still holds `SENTINEL`;
+- the interrupt reached the app. Observe it by the TUI's counter **freezing**, not by the alt screen
+  going away: an interrupted script never reaches its own `?1049l`, so the alt screen stays up
+  either way. Read `blanked (\d+)` from `session text`, wait 4s, read again — equal means killed.
+
+**Fails when:** emptiness goes back to being measured by string length, or the Ctrl+C branch stops
+gating on `CopySelection`'s return value.
+
+---
+
+## With scrollback off, the selection stays put — and copies what is on screen
+
+**Guards:** with `scrollback-lines = 0` nothing is ever pushed into history, so no shift can be
+measured. The selection cannot follow its text; keeping it is only safe because the highlight and
+the copy read the same cells.
+
+**Setup:** a second sandbox instance with `scrollback-lines = 0`. Run `marker.ps1`, drag
+(300,150) → (900,400), then run `noise.ps1`.
+
+**Expect:** `session copy` is still non-empty, and its first non-blank line is present in
+`session text`. A selected row may legitimately be blank after the scroll — compare the first row
+that carries text, and require **at least 8 characters** of it: a one-character row like `6` is
+present in almost any screen, so matching on it proves nothing.
+
+**Fails when:** `scrollback-lines` stops reaching the core (it is an ABI call, and it silently did
+nothing once), or the non-trackable branch starts dropping on output again.

--- a/tests/ui/lib.ps1
+++ b/tests/ui/lib.ps1
@@ -1,0 +1,230 @@
+# Shared plumbing for the UI checks — the ones that need a real window, real mouse buttons and a
+# real modifier key, which no unit test can reach.
+#
+# Suite rules, and they are not negotiable:
+#   - ALWAYS a sandbox instance: --pipe <name> AND --app-id <name>. A %LOCALAPPDATA% override does
+#     NOT isolate agwinterm — .NET resolves LocalApplicationData through the known-folder API, so an
+#     override is ignored and the app reads the real profile. --app-id is the seam that works.
+#     Getting this wrong means a check writes to the user's session list.
+#   - NEVER inject global input. No keybd_event, no SendInput. Everything is PostMessage to this
+#     instance's own window handles, so whatever the user is typing in stays untouched. Ctrl+C is the
+#     one thing PostMessage cannot express alone (the modifier must be visible to GetKeyState), and
+#     it is done by attaching to THIS instance's input queue and setting the shared key state.
+#   - Capture with PrintWindow, never CopyFromScreen, which grabs whatever is on top.
+#
+# Dot-source this, then Start-Sandbox / Send-Ctl / Stop-Sandbox.
+
+# Build layouts differ by where the build ran: locally bin\Release\..., in CI bin\x64\Release\...
+# because the solution config sets a platform. BOTH exist on a dev machine and only one is fresh —
+# launching the stale root is how a fix once "proved" it did nothing. So binaries are FOUND, newest
+# first, and a miss reports what it looked at.
+function Resolve-Binary([string]$explicit, [string]$name, [string]$projectDir) {
+    $roots = @()
+    if ($explicit) { $roots += $explicit }
+    $built = Join-Path (Join-Path $PSScriptRoot '..\..') "src\$projectDir\bin"
+    if (Test-Path $built) {
+        $roots += (Get-ChildItem $built -Recurse -Filter $name -ErrorAction SilentlyContinue |
+                   Sort-Object LastWriteTime -Descending | Select-Object -ExpandProperty FullName)
+    }
+    $roots += "$env:LOCALAPPDATA\Programs\agwinterm\$name"
+    foreach ($r in $roots) { if ($r -and (Test-Path $r)) { return $r } }
+    return $null
+}
+
+Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+public static class AgwUi {
+    [StructLayout(LayoutKind.Sequential)] public struct POINT { public int X, Y; }
+    [DllImport("user32.dll")] public static extern bool PostMessageW(IntPtr h, uint m, IntPtr w, IntPtr l);
+    [DllImport("user32.dll")] public static extern bool SetWindowPos(IntPtr h, IntPtr a, int x, int y, int cx, int cy, uint f);
+    [DllImport("user32.dll")] public static extern bool ShowWindow(IntPtr h, int c);
+    [DllImport("user32.dll")] public static extern bool IsZoomed(IntPtr h);
+    [DllImport("user32.dll")] static extern bool ClientToScreen(IntPtr h, ref POINT p);
+    [DllImport("user32.dll")] static extern bool AttachThreadInput(uint a, uint b, bool attach);
+    [DllImport("user32.dll")] static extern uint GetWindowThreadProcessId(IntPtr h, IntPtr pid);
+    [DllImport("kernel32.dll")] static extern uint GetCurrentThreadId();
+    [DllImport("user32.dll")] static extern bool SetKeyboardState(byte[] s);
+    [DllImport("user32.dll")] static extern bool GetKeyboardState(byte[] s);
+
+    static IntPtr Pt(int x, int y) { return (IntPtr)((y << 16) | (x & 0xFFFF)); }
+
+    /// <summary>Press, drag, release. Client coordinates, like the button messages carry.</summary>
+    public static void Drag(IntPtr h, int x1, int y1, int x2, int y2) {
+        PostMessageW(h, 0x0201, (IntPtr)1, Pt(x1, y1));
+        for (int i = 1; i <= 8; i++) {
+            PostMessageW(h, 0x0200, (IntPtr)1, Pt(x1 + (x2 - x1) * i / 8, y1 + (y2 - y1) * i / 8));
+            System.Threading.Thread.Sleep(40);
+        }
+        PostMessageW(h, 0x0202, IntPtr.Zero, Pt(x2, y2));
+        System.Threading.Thread.Sleep(250);
+    }
+
+    /// <summary>As Drag, but HOLDS the button outside the pane for holdMs first. Drag-autoscroll only
+    /// ticks while the button is down and the cursor is off the pane: release too early and its 50ms
+    /// timer never runs, so a check that means to exercise it silently exercises nothing.</summary>
+    public static void DragHold(IntPtr h, int x1, int y1, int x2, int y2, int holdMs) {
+        PostMessageW(h, 0x0201, (IntPtr)1, Pt(x1, y1));
+        for (int i = 1; i <= 8; i++) {
+            PostMessageW(h, 0x0200, (IntPtr)1, Pt(x1 + (x2 - x1) * i / 8, y1 + (y2 - y1) * i / 8));
+            System.Threading.Thread.Sleep(40);
+        }
+        for (int i = 0; i < holdMs / 100; i++) {
+            PostMessageW(h, 0x0200, (IntPtr)1, Pt(x2, y2));
+            System.Threading.Thread.Sleep(100);
+        }
+        PostMessageW(h, 0x0202, IntPtr.Zero, Pt(x2, y2));
+        System.Threading.Thread.Sleep(250);
+    }
+
+    public static void Click(IntPtr h, int button, int x, int y) {
+        uint down = button == 2 ? 0x0204u : 0x0201u, up = button == 2 ? 0x0205u : 0x0202u;
+        PostMessageW(h, down, (IntPtr)(button == 2 ? 2 : 1), Pt(x, y));
+        System.Threading.Thread.Sleep(120);
+        PostMessageW(h, up, IntPtr.Zero, Pt(x, y));
+        System.Threading.Thread.Sleep(300);
+    }
+
+    /// <summary>WM_MOUSEWHEEL carries SCREEN coordinates, unlike the button messages.</summary>
+    public static void Wheel(IntPtr h, int cx, int cy, int notches) {
+        var p = new POINT(); p.X = cx; p.Y = cy; ClientToScreen(h, ref p);
+        for (int i = 0; i < notches; i++) {
+            PostMessageW(h, 0x020A, (IntPtr)(120 << 16), Pt(p.X, p.Y));
+            System.Threading.Thread.Sleep(60);
+        }
+        System.Threading.Thread.Sleep(300);
+    }
+
+    /// <summary>A key with no modifiers, n times.</summary>
+    public static void Key(IntPtr h, int vk, int times) {
+        for (int i = 0; i < times; i++) {
+            PostMessageW(h, 0x0100, (IntPtr)vk, (IntPtr)1);
+            PostMessageW(h, 0x0101, (IntPtr)vk, (IntPtr)1);
+            System.Threading.Thread.Sleep(30);
+        }
+        System.Threading.Thread.Sleep(250);
+    }
+
+    /// <summary>Ctrl (+Shift) + key. A posted WM_KEYDOWN cannot make GetKeyState see the modifier,
+    /// so this attaches to the target's input queue and sets the shared state for the duration —
+    /// scoped to this instance, nothing injected globally.</summary>
+    public static void Chord(IntPtr h, int vk, bool shift) {
+        uint me = GetCurrentThreadId(), it = GetWindowThreadProcessId(h, IntPtr.Zero);
+        AttachThreadInput(me, it, true);
+        var st = new byte[256]; GetKeyboardState(st);
+        st[0x11] = 0x80; st[0xA2] = 0x80;                      // VK_CONTROL, VK_LCONTROL
+        if (shift) { st[0x10] = 0x80; st[0xA0] = 0x80; }       // VK_SHIFT, VK_LSHIFT
+        SetKeyboardState(st);
+        PostMessageW(h, 0x0100, (IntPtr)vk, (IntPtr)1);
+        System.Threading.Thread.Sleep(400);
+        st[0x11] = 0; st[0xA2] = 0; st[0x10] = 0; st[0xA0] = 0;
+        SetKeyboardState(st);
+        PostMessageW(h, 0x0101, (IntPtr)vk, (IntPtr)1);
+        AttachThreadInput(me, it, false);
+        System.Threading.Thread.Sleep(300);
+    }
+}
+'@
+
+<#
+.SYNOPSIS Launch an isolated agwinterm and wait until its control pipe answers.
+.PARAMETER Conf Lines for the instance's agwinterm.conf, e.g. "scrollback-lines = 0".
+#>
+function Start-Sandbox {
+    param([Parameter(Mandatory)][string]$Exe, [Parameter(Mandatory)][string]$Ctl,
+          [Parameter(Mandatory)][string]$Pipe, [string[]]$Conf = @(), [int]$Width = 1100, [int]$Height = 700)
+
+    # An id nothing else can be using, so a forgotten instance from an earlier run cannot answer.
+    $appId  = "$Pipe-" + [Guid]::NewGuid().ToString('N').Substring(0, 8)
+    $appDir = Join-Path $env:LOCALAPPDATA $appId
+    New-Item -ItemType Directory -Force $appDir | Out-Null
+    if ($Conf.Count) { ($Conf -join "`n") | Set-Content (Join-Path $appDir 'agwinterm.conf') -Encoding UTF8 }
+
+    # A check must never inherit the pane it is being RUN from, or `session type` lands in the
+    # caller's own terminal instead of the sandbox.
+    foreach ($v in 'AGWINTERM_SESSION_ID', 'AGWINTERM_PANE_ID', 'AGWINTERM_PIPE') {
+        Remove-Item "env:$v" -ErrorAction SilentlyContinue
+    }
+
+    $p = Start-Process $Exe -ArgumentList @('--pipe', $Pipe, '--app-id', $appId, '--no-restore') -PassThru
+    $s = [pscustomobject]@{ Proc = $p; Ctl = $Ctl; Pipe = $Pipe; AppDir = $appDir; Hwnd = [IntPtr]::Zero }
+    for ($i = 0; $i -lt 80; $i++) {
+        Start-Sleep -Milliseconds 500
+        if ((Send-Ctl $s @('ping')) -match '"ok":true') { break }
+    }
+    Start-Sleep 5
+    $s.Hwnd = $p.MainWindowHandle
+    if ($s.Hwnd -ne [IntPtr]::Zero) {
+        # A maximised window makes every coordinate in every check depend on the monitor.
+        if ([AgwUi]::IsZoomed($s.Hwnd)) { [void][AgwUi]::ShowWindow($s.Hwnd, 9); Start-Sleep 1 }
+        [void][AgwUi]::SetWindowPos($s.Hwnd, [IntPtr]::Zero, 150, 100, $Width, $Height, 0x0004)
+        Start-Sleep 2
+    }
+    return $s
+}
+
+<#
+.SYNOPSIS Re-attach to a sandbox this session already launched.
+An agent runs a case file across several shell invocations and shell state does not survive them,
+while the instance does. This rebuilds the handle object from the running process, found by the
+--pipe it was launched with, so the next step can carry on driving the same window.
+#>
+function Connect-Sandbox {
+    param([Parameter(Mandatory)][string]$Ctl, [Parameter(Mandatory)][string]$Pipe)
+    $proc = Get-CimInstance Win32_Process -Filter "Name = 'Agwinterm.Win32.exe'" |
+            Where-Object { $_.CommandLine -match "--pipe\s+$([regex]::Escape($Pipe))(\s|$)" } |
+            Select-Object -First 1
+    if (-not $proc) { throw "no sandbox instance is running on pipe '$Pipe'" }
+    $p = Get-Process -Id $proc.ProcessId
+    $appId = ([regex]::Match($proc.CommandLine, '--app-id\s+(\S+)')).Groups[1].Value
+    [pscustomobject]@{
+        Proc = $p; Ctl = $Ctl; Pipe = $Pipe; Hwnd = $p.MainWindowHandle
+        AppDir = if ($appId) { Join-Path $env:LOCALAPPDATA $appId } else { $null }
+    }
+}
+
+function Stop-Sandbox {
+    param([Parameter(Mandatory)]$S)
+    if ($S.Proc -and -not $S.Proc.HasExited) { $S.Proc.CloseMainWindow() | Out-Null; Start-Sleep 3 }
+    if ($S.Proc -and -not $S.Proc.HasExited) { Stop-Process -Id $S.Proc.Id -Force }
+    if ($S.AppDir) { Remove-Item $S.AppDir -Recurse -Force -ErrorAction SilentlyContinue }
+}
+
+function Send-Ctl {
+    param([Parameter(Mandatory)]$S, [Parameter(Mandatory)][string[]]$Argv)
+    # EVERY call, not just at launch. A verb with no --target resolves the CALLER's session from
+    # these variables, and a QA run is itself started from inside an agwinterm pane: leave them set
+    # and `session text` answers about a session the sandbox has never heard of (empty), while
+    # `session type` is accepted and discarded. Nothing errors, and a whole suite goes green having
+    # driven nothing at all.
+    foreach ($v in 'AGWINTERM_SESSION_ID', 'AGWINTERM_PANE_ID', 'AGWINTERM_PIPE') {
+        Remove-Item "env:$v" -ErrorAction SilentlyContinue
+    }
+    (& $S.Ctl @Argv --pipe $S.Pipe --json 2>&1) -join ''
+}
+
+function Get-CtlResult {
+    param([Parameter(Mandatory)]$S, [Parameter(Mandatory)][string[]]$Argv)
+    $raw = Send-Ctl $S $Argv
+    try { (ConvertFrom-Json $raw).result } catch { '' }
+}
+
+function Get-PaneText { param([Parameter(Mandatory)]$S, [string]$Target)
+    if ($Target) { Get-CtlResult $S @('session', 'text', '--target', $Target) }
+    else { Get-CtlResult $S @('session', 'text') }
+}
+
+function Get-PaneSelection { param([Parameter(Mandatory)]$S) Get-CtlResult $S @('session', 'copy') }
+
+<#
+.SYNOPSIS Write a .ps1 into $Dir and return a path safe to type into a shell.
+Forward slashes throughout: a Windows path typed through `session type` is fine with them, and it
+keeps backslash escapes out of every quoted string in the checks.
+#>
+function New-ScriptFile {
+    param([Parameter(Mandatory)][string]$Dir, [Parameter(Mandatory)][string]$Name,
+          [Parameter(Mandatory)][string[]]$Lines)
+    $path = Join-Path $Dir $Name
+    $Lines | Set-Content $path -Encoding UTF8
+    return $path.Replace([char]92, '/')
+}


### PR DESCRIPTION
Three fixes for one selection bug shipped without a check failing in between — nothing in either repo could hold a check like that.

The cases are **markdown** (`qa/*.md`), executed by an agent through the `ui-qa` skill against a live build. Each case carries a **Fails when** line naming the change that must break it; that is the contract, the steps are just how you get there. `qa/product.md` is the adapter (build, isolate, drive, observe). `tests/ui/lib.ps1` is plumbing only — no assertions, no cases.

**All ten selection cases pass on v0.17.7.** Running them found three ways a case can pass while checking nothing — a stale session id that made every control call a no-op, an autoscroll case that ran after its fixture had blanked, and a match on a one-character line. All three are fixed, and the details are in the commit message.

Next: the same `qa/` for agliteterm, and `clipboard.md` (paste paths) here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k