### PR TITLE
feat(control): refuse control bytes in session.type, reach scrollback in session.text, stop widening an overlay target

### DIFF
--- a/src/Agwinterm.Ctl/Program.cs
+++ b/src/Agwinterm.Ctl/Program.cs
@@ -13,7 +13,8 @@ using System.Text.Json;
 //   agwintermctl session seen [--target ID]        (clear the unseen-notification badge)
 //   agwintermctl sidebar state                      (read-back: "visible tree" | "hidden flagged" | ...)
 //   agwintermctl session status <idle|active|blocked|completed> [--sound [name]] [--blink] [--auto-reset] [--target ID]
-//   agwintermctl session type <text...> [--target ID]
+//   agwintermctl session text [--lines N] [--target ID]   (N reaches into scrollback; default = screen)
+//   agwintermctl session type <text...> [--target ID]     (refuses control bytes; use write for raw)
 //   agwintermctl session write <text...> [--target ID]
 //   agwintermctl session copy [--target ID]           (returns the selection text)
 //   agwintermctl session paste <text...> [--target ID] (pastes text; clipboard if omitted)
@@ -146,7 +147,9 @@ switch (area)
                 // --select <text> (agterm parity): text may come via --select instead of positionals.
                 cargs["text"] = rest.Count > 0 ? string.Join(' ', rest) : (Opt("select") ?? "");
                 break;
-            case "text": break; // dump the buffer; target only
+            case "text": // dump the buffer; --lines N reaches back into scrollback (default: the visible screen)
+                if (int.TryParse(Opt("lines"), out var textLines)) cargs["lines"] = textLines;
+                break;
             case "copy": break;  // return the target's selection text; target only
             case "seen": break;  // clear the unseen-notification badge; target only
             case "output": break; // last completed command's output (FTCS marks); target only

--- a/src/Agwinterm.Pty/AgentSkill.cs
+++ b/src/Agwinterm.Pty/AgentSkill.cs
@@ -77,7 +77,9 @@ public static class AgentSkill
         - `agwintermctl workspace collapse [WS] [--target WS]` / `workspace expand [WS]` — collapse/expand a single workspace's session list (default: active)
 
         ## Read a session's output
-        - `agwintermctl session text [--target <id>]`            — dump the session's visible buffer as plain text (great for reading command output)
+        - `agwintermctl session text [--lines N] [--target <id>]` — dump the pane as plain text. Without `--lines` that is the
+          visible screen; `--lines N` returns the last N lines ending at the bottom of the screen, reaching back into
+          scrollback — which is where a launch banner or an error printed before a full-screen app started still lives
         - `agwintermctl session copy [--target <id>]`            — return the session's current mouse text selection ("" if none)
         - `agwintermctl session search "<term>"`                 — open the find bar over the active session; returns "N of M" (or "no matches")
         - `agwintermctl session search --next|--prev|--close`    — step matches / close the find bar
@@ -91,7 +93,9 @@ public static class AgentSkill
         - config `copy-on-select = true` auto-copies each finished selection (no Ctrl+C needed)
 
         ## Type into a session
-        - `agwintermctl session type "npm test" --target <id>`   — send keystrokes (newline = Enter)
+        - `agwintermctl session type "npm test" --target <id>`   — send keystrokes (newline = Enter). Control bytes are
+          REFUSED, not stripped: a NUL would truncate your command while its Return still fired. Use `session write`
+          when you really mean raw bytes (an escape sequence, a lone ^C)
 
         ## Scratch & quick terminals
         - `agwintermctl session scratch on|off|toggle [--target <id>]` — a per-session extra shell drawn over that session's content (opens in the session's cwd; stays alive when hidden; not restored)

--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -193,9 +193,17 @@ public sealed class ControlServer : IDisposable
                 case "session.scratch": return host.SessionScratch(target, GetString(args, "op") ?? "toggle") ? Ok("scratch") : Err("session not found");
                 case "quick": host.Quick(GetString(args, "op") ?? "toggle"); return Ok("quick");
                 case "session.overlay":
-                    return Ok(host.SessionOverlay(target, GetString(args, "action") ?? "open",
+                {
+                    // A refusal has to answer ok:false, or a caller that checks `ok` reads "I would
+                    // not do that" as "done" — the exact dishonesty the refusal exists to end. The
+                    // host marks one by prefixing REFUSE_PREFIX; everything else is a result string.
+                    string ovl = host.SessionOverlay(target, GetString(args, "action") ?? "open",
                         GetString(args, "command"), GetInt(args, "size-percent", 0),
-                        GetBool(args, "wait"), GetBool(args, "block")));
+                        GetBool(args, "wait"), GetBool(args, "block"));
+                    return ovl.StartsWith(ISessionHost.RefusePrefix, StringComparison.Ordinal)
+                        ? Err(ovl[ISessionHost.RefusePrefix.Length..])
+                        : Ok(ovl);
+                }
                 case "notify":
                     return host.Notify(target, GetString(args, "title"), GetString(args, "body") ?? "")
                         ? Ok("notified") : Err("session not found");
@@ -241,7 +249,7 @@ public sealed class ControlServer : IDisposable
             {
                 "session.write" => HandleWrite(s, args),
                 "session.type" => HandleType(s, args),
-                "session.text" => HandleText(s),
+                "session.text" => HandleText(s, args),
                 "session.status" => HandleStatus(s, args),
                 "image.show" => HandleImageShow(s, args),
                 "image.sixel" => HandleImageSixel(s, args),
@@ -343,21 +351,55 @@ public sealed class ControlServer : IDisposable
         return Ok("written");
     }
 
+    /// <summary>Type text as if the user had. Newlines become CR (the Enter convention); every other
+    /// control byte is REFUSED.
+    ///
+    /// Why refuse rather than strip: a control byte in typed text reaches the shell's line editor
+    /// before anything parses it, and the damage is silent. agterm hardened this in v0.25.0 after a
+    /// NUL truncated an injection and the call still answered ok - the shortened line kept its
+    /// Return and ran. Stripping produces that same shortened line; refusing tells the caller its
+    /// text was not what it thought.
+    ///
+    /// TAB stays (completion is typing). A caller that genuinely wants raw bytes - an escape
+    /// sequence, a lone ^C - has session.write, which promises nothing about its content.</summary>
     private static string HandleType(ISession s, JsonElement args)
     {
         string text = (GetString(args, "text") ?? "").Replace("\r\n", "\r").Replace('\n', '\r');
+        if (FirstControlByte(text) is { } bad)
+            return Err($"session.type refuses control byte 0x{(int)bad:X2} at index {text.IndexOf(bad)} " +
+                       "(CR, LF and TAB are fine) - use session.write for raw bytes");
         s.Write(Encoding.UTF8.GetBytes(text));
         return Ok("typed");
     }
 
-    /// <summary>Dump the target session's active-pane buffer as plain text (trailing blank lines trimmed).</summary>
-    private static string HandleText(ISession s)
+    /// <summary>The first C0/DEL control character that is not CR, LF or TAB, or null.</summary>
+    private static char? FirstControlByte(string text)
     {
+        foreach (char c in text)
+            if ((c < ' ' || c == '\u007f') && c != '\r' && c != '\n' && c != '\t') return c;
+        return null;
+    }
+
+    /// <summary>Dump the target session's active-pane buffer as plain text (trailing blank lines
+    /// trimmed). `lines` reaches back into scrollback: the last N lines ending at the bottom of the
+    /// visible screen, so an N larger than the screen height picks up history. Omitted (or 0) keeps
+    /// the old meaning exactly - the visible screen.
+    ///
+    /// Scrollback matters because the interesting part is usually already gone: a launch banner, a
+    /// version, an error printed before a full-screen app took the alt screen. An agent reading a
+    /// pane it did not watch could reach none of it.</summary>
+    private static string HandleText(ISession s, JsonElement args)
+    {
+        int want = GetInt(args, "lines", 0);
         var sb = new StringBuilder();
         lock (s.SyncRoot)
         {
             var em = s.Emulator;
-            for (int r = 0; r < em.Screen.Rows; r++) sb.Append(em.DumpRow(r)).Append('\n');
+            int rows = em.Screen.Rows, hist = em.HistoryCount;
+            int take = want <= 0 ? rows : Math.Min(want, rows + hist);
+            // Absolute numbering: [0, hist) is scrollback, then the live rows.
+            for (int abs = hist + rows - take; abs < hist + rows; abs++)
+                sb.Append(abs < hist ? em.DumpHistoryRow(abs) : em.DumpRow(abs - hist)).Append('\n');
         }
         return Ok(sb.ToString().TrimEnd('\n'));
     }

--- a/src/Agwinterm.Pty/ISessionHost.cs
+++ b/src/Agwinterm.Pty/ISessionHost.cs
@@ -27,6 +27,11 @@ public sealed record WindowStateSnapshot(bool SidebarVisible, bool Fullscreen, b
 /// </summary>
 public interface ISessionHost
 {
+    /// <summary>Marker a host puts in front of a verb's result to mean "refused, and here is why" —
+    /// the control server turns it into an ok:false error. Needed where the host returns a string
+    /// rather than a bool, so a refusal cannot be mistaken for a result.</summary>
+    public const string RefusePrefix = "refuse:";
+
     ISession? Resolve(string? target);
 
     /// <summary>The full workspace→session tree.</summary>

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -519,8 +519,27 @@ internal partial class Program
 
         public void Quick(string op) => Post(() => QuickOp(op));
 
+        /// <summary>An overlay covers a whole SESSION. When the caller named one pane of a split, that
+        /// is not what they asked for - say so rather than widen it in silence and blank the pane the
+        /// user was reading. (Found for real: a review TUI aimed at the right pane took the left one
+        /// too, and nothing in the reply said it would.) A pane in a single-pane session is refused
+        /// nothing: there, covering the session covers exactly that pane.</summary>
+        private string? OverlayTargetRefusal(string? target)
+        {
+            if (string.IsNullOrEmpty(target) || target == "active") return null;
+            var ses = FindSesForTarget(target);
+            if (ses is null || ses.Panes.Count <= 1) return null;   // one pane: covering the session covers it
+            // A string that names the SESSION keeps session behaviour; only a pane id is refused.
+            if (ses.Id == target || ses.Id.StartsWith(target, StringComparison.Ordinal)) return null;
+            if (!ses.Panes.Any(p => p.Id == target || p.Id.StartsWith(target, StringComparison.Ordinal))) return null;
+            return ISessionHost.RefusePrefix +
+                   $"'{target}' names one pane of a {ses.Panes.Count}-pane session; session.overlay covers " +
+                   $"the whole session. Pass the session id ({ses.Id}) to cover it, or omit --target.";
+        }
+
         public string SessionOverlay(string? target, string action, string? command, int sizePercent, bool wait, bool block)
         {
+            if (action != "result" && OverlayTargetRefusal(target) is { } refusal) return refusal;
             switch (action)
             {
                 case "result":

--- a/tests/Agwinterm.Pty.Tests/ControlServerTypeTextTests.cs
+++ b/tests/Agwinterm.Pty.Tests/ControlServerTypeTextTests.cs
@@ -1,0 +1,99 @@
+using Agwinterm.Core;
+using Agwinterm.Pty;
+
+namespace Agwinterm.Pty.Tests;
+
+/// <summary>
+/// Two control-API promises an agent has to be able to rely on.
+///
+/// session.type REFUSES control bytes. agterm hardened this in v0.25.0 after a NUL truncated an
+/// injection and the call still answered ok — the shortened line kept its Return and ran. Stripping
+/// would produce that same shortened line silently, so the answer is a refusal.
+///
+/// session.text reaches into scrollback with `lines`. Without it the caller sees the visible screen
+/// only, which is never where a launch banner or a pre-TUI error still lives.
+/// </summary>
+public class ControlServerTypeTextTests
+{
+    private static (ControlServer server, TerminalSession session) New(int rows = 6)
+    {
+        var session = new TerminalSession(40, rows);
+        return (new ControlServer(session), session);
+    }
+
+    private static string Type(ControlServer server, string text)
+        => server.Dispatch("{\"cmd\":\"session.type\",\"args\":{\"text\":" + System.Text.Json.JsonSerializer.Serialize(text) + "}}");
+
+    /// <summary>The guard must not reject legitimate typing. These assert the REFUSAL does not fire —
+    /// not that the write succeeded, since an unstarted session has no pty to write to.</summary>
+    [Fact]
+    public void Type_AcceptsOrdinaryTextAndNewlines()
+    {
+        var (server, _) = New();
+        Assert.DoesNotContain("refuses", Type(server, "npm test\n"));
+        Assert.DoesNotContain("refuses", Type(server, "git status\r\n"));
+        Assert.DoesNotContain("refuses", Type(server, "cd src\tsrc\t"));   // TAB is completion, i.e. typing
+    }
+
+    [Fact]
+    public void Type_RefusesNul_AndSaysWhere()
+    {
+        var (server, _) = New();
+        string resp = Type(server, "rm -rf /tmp/safe\0 --force");
+        Assert.Contains("\"ok\":false", resp);
+        Assert.Contains("0x00", resp);            // says WHICH byte (JSON-escaped "+" is why this is hex)
+        Assert.Contains("session.write", resp);   // the escape hatch is named
+    }
+
+    [Fact]
+    public void Type_RefusesEscapeAndInterrupt()
+    {
+        var (server, _) = New();
+        Assert.Contains("\"ok\":false", Type(server, "ls" + (char)0x1b + "[A"));   // an escape sequence smuggled into typing
+        Assert.Contains("\"ok\":false", Type(server, "wait" + (char)0x03));       // a lone interrupt byte
+        Assert.Contains("\"ok\":false", Type(server, "back" + (char)0x7f));       // DEL
+    }
+
+    [Fact]
+    public void Type_RefusalWritesNothing()
+    {
+        // The whole point: a refused call must not deliver the truncated prefix, which is what made
+        // the original defect dangerous — the shortened command still got its Return.
+        var (server, session) = New();
+        string before = session.Emulator.DumpRow(0);
+        Assert.Contains("\"ok\":false", Type(server, "echo hi\0\r"));
+        Assert.Equal(before, session.Emulator.DumpRow(0));
+    }
+
+    [Fact]
+    public void Text_WithoutLines_IsTheVisibleScreenOnly()
+    {
+        var (server, session) = New(rows: 4);
+        for (int i = 1; i <= 10; i++) session.Emulator.Feed(System.Text.Encoding.UTF8.GetBytes($"L{i}\r\n"));
+        string resp = server.Dispatch("{\"cmd\":\"session.text\"}");
+        Assert.Contains("\"ok\":true", resp);
+        Assert.DoesNotContain("L1\\n", resp);      // scrolled off; unreachable without `lines`
+        Assert.Contains("L10", resp);
+    }
+
+    [Fact]
+    public void Text_WithLines_ReachesScrollback()
+    {
+        var (server, session) = New(rows: 4);
+        for (int i = 1; i <= 10; i++) session.Emulator.Feed(System.Text.Encoding.UTF8.GetBytes($"L{i}\r\n"));
+        string resp = server.Dispatch("{\"cmd\":\"session.text\",\"args\":{\"lines\":12}}");
+        Assert.Contains("\"ok\":true", resp);
+        Assert.Contains("L1", resp);               // the line the screen alone cannot show
+        Assert.Contains("L10", resp);
+    }
+
+    [Fact]
+    public void Text_LinesLargerThanTheBuffer_IsNotAnError()
+    {
+        var (server, session) = New(rows: 4);
+        session.Emulator.Feed(System.Text.Encoding.UTF8.GetBytes("only\r\n"));
+        string resp = server.Dispatch("{\"cmd\":\"session.text\",\"args\":{\"lines\":9999}}");
+        Assert.Contains("\"ok\":true", resp);
+        Assert.Contains("only", resp);
+    }
+}


### PR DESCRIPTION
Three gaps from a parity sweep against agterm v0.25.0. All three are the terminal refusing to do something surprising, or answering a question it could already answer.

## 1. `session.type` refuses control bytes

agterm hardened this in v0.25.0 after a NUL **truncated an injection while the call still answered ok** — and because the text and its Return are separate keystrokes, the shortened line got its Return and ran. Ours wrote whatever arrived.

Stripping would produce that same shortened line, so it is a refusal naming the byte and its index. CR/LF stay (the Enter convention), TAB stays (completion is typing), `session.write` remains for raw bytes.

```
{"cmd":"session.type","args":{"text":"echo SAFE\u0000 --force\r"}}
-> {"ok":false,"error":"session.type refuses control byte 0x00 at index 9 (CR, LF and TAB are fine) - use session.write for raw bytes"}
screen shows SAFE? False          <- the prefix was never delivered
```

Not reachable through argv — a Win32 command line is NUL-terminated. The vector is any client writing JSON, which is every agent we have.

## 2. `session.text --lines N` reaches scrollback

The last N lines ending at the bottom of the screen. Omitted, it is the visible screen exactly as before. The interesting text is usually already gone — a launch banner, a version, an error printed before a full-screen app took the alt screen.

```
visible screen reaches MARKER-1 : False   rows=32
--lines 200 reaches MARKER-1    : True    rows=44
```

## 3. `session.overlay` refuses a pane id instead of widening it

An overlay covers a whole session. Passing one pane of a split got the caller two panes with nothing said — which is how a review TUI aimed at the right pane blanked the left one the user was reading. A pane in a single-pane session is refused nothing, since there the two are the same thing.

And the refusal answers **ok:false**, not ok:true with an explanation in `result` — a caller checking `ok` would otherwise read "I would not do that" as "done", which is the same dishonesty.

```
pane id    -> {"ok":false,"error":"'7dd9cfc2…' names one pane of a 2-pane session; session.overlay covers the whole session. Pass the session id (eebb71ae…) to cover it, or omit --target."}
session id -> {"ok":true,"result":"eebb71ae…:overlay:744de1"}
```

## Verification

7 new unit tests (`ControlServerTypeTextTests`) including that a refusal **writes nothing** — the trap that made the original defect dangerous. Full suite **319 passed**, conformance suite all passed, plus the live sandbox runs quoted above.

Docs updated where agents actually read them: `AgentSkill.cs` and the `agwintermctl` usage banner.

Not included: pane-scoped overlays (a feature, not a correction), and `surface.cursor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k