### PR TITLE
fix(control): session.type's refusal named an escape hatch that cannot work

### DIFF
--- a/src/Agwinterm.Ctl/Program.cs
+++ b/src/Agwinterm.Ctl/Program.cs
@@ -14,7 +14,7 @@ using System.Text.Json;
 //   agwintermctl sidebar state                      (read-back: "visible tree" | "hidden flagged" | ...)
 //   agwintermctl session status <idle|active|blocked|completed> [--sound [name]] [--blink] [--auto-reset] [--target ID]
 //   agwintermctl session text [--lines N] [--target ID]   (N reaches into scrollback; default = screen)
-//   agwintermctl session type <text...> [--target ID]     (refuses control bytes; use write for raw)
+//   agwintermctl session type <text...> [--allow-control] [--target ID]   (control bytes refused unless allowed)
 //   agwintermctl session write <text...> [--target ID]
 //   agwintermctl session copy [--target ID]           (returns the selection text)
 //   agwintermctl session paste <text...> [--target ID] (pastes text; clipboard if omitted)
@@ -143,6 +143,11 @@ switch (area)
                 if (options.TryGetValue("sound", out var sndOpt)) cargs["sound"] = sndOpt; // "true" (default alert) or a name/.wav path
                 break;
             case "type":
+                // Deliberate control bytes (an escape sequence for a TUI, a lone ^C). Without it a
+                // control byte is refused, because the usual reason one is there is that a caller
+                // built the string wrong.
+                if (options.ContainsKey("allow-control")) cargs["allow-control"] = true;
+                goto case "write";
             case "write":
                 // --select <text> (agterm parity): text may come via --select instead of positionals.
                 cargs["text"] = rest.Count > 0 ? string.Join(' ', rest) : (Opt("select") ?? "");

--- a/src/Agwinterm.Pty/AgentSkill.cs
+++ b/src/Agwinterm.Pty/AgentSkill.cs
@@ -94,8 +94,9 @@ public static class AgentSkill
 
         ## Type into a session
         - `agwintermctl session type "npm test" --target <id>`   — send keystrokes (newline = Enter). Control bytes are
-          REFUSED, not stripped: a NUL would truncate your command while its Return still fired. Use `session write`
-          when you really mean raw bytes (an escape sequence, a lone ^C)
+          REFUSED, not stripped: a NUL would truncate your command while its Return still fired. Add `--allow-control`
+          when you really mean one (an escape sequence for a TUI, a lone ^C). `session write` is NOT the way — it
+          injects into the display and never reaches the shell
 
         ## Scratch & quick terminals
         - `agwintermctl session scratch on|off|toggle [--target <id>]` — a per-session extra shell drawn over that session's content (opens in the session's cwd; stays alive when hidden; not restored)

--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -360,14 +360,19 @@ public sealed class ControlServer : IDisposable
     /// Return and ran. Stripping produces that same shortened line; refusing tells the caller its
     /// text was not what it thought.
     ///
-    /// TAB stays (completion is typing). A caller that genuinely wants raw bytes - an escape
-    /// sequence, a lone ^C - has session.write, which promises nothing about its content.</summary>
+    /// TAB stays (completion is typing). A caller that genuinely means the control byte - an escape
+    /// sequence for a TUI, a lone ^C - passes allow-control and gets exactly what it asked for.
+    ///
+    /// It does NOT get sent to session.write, whatever an earlier version of this message said:
+    /// session.write injects into the emulator and never reaches the shell (ISession.Inject), so as
+    /// a way to deliver bytes to a program it does not work at all. Pointing a caller at a verb that
+    /// silently cannot do the job is worse than the refusal it was meant to soften.</summary>
     private static string HandleType(ISession s, JsonElement args)
     {
         string text = (GetString(args, "text") ?? "").Replace("\r\n", "\r").Replace('\n', '\r');
-        if (FirstControlByte(text) is { } bad)
+        if (!GetBool(args, "allow-control") && FirstControlByte(text) is { } bad)
             return Err($"session.type refuses control byte 0x{(int)bad:X2} at index {text.IndexOf(bad)} " +
-                       "(CR, LF and TAB are fine) - use session.write for raw bytes");
+                       "(CR, LF and TAB are fine) - pass --allow-control if you mean it");
         s.Write(Encoding.UTF8.GetBytes(text));
         return Ok("typed");
     }

--- a/tests/Agwinterm.Pty.Tests/ControlServerTypeTextTests.cs
+++ b/tests/Agwinterm.Pty.Tests/ControlServerTypeTextTests.cs
@@ -42,7 +42,7 @@ public class ControlServerTypeTextTests
         string resp = Type(server, "rm -rf /tmp/safe\0 --force");
         Assert.Contains("\"ok\":false", resp);
         Assert.Contains("0x00", resp);            // says WHICH byte (JSON-escaped "+" is why this is hex)
-        Assert.Contains("session.write", resp);   // the escape hatch is named
+        Assert.Contains("allow-control", resp);   // and names the escape hatch that actually works
     }
 
     [Fact]
@@ -63,6 +63,27 @@ public class ControlServerTypeTextTests
         string before = session.Emulator.DumpRow(0);
         Assert.Contains("\"ok\":false", Type(server, "echo hi\0\r"));
         Assert.Equal(before, session.Emulator.DumpRow(0));
+    }
+
+    /// <summary>The escape hatch has to exist, and has to be the one the refusal names. The first
+    /// version of that message sent callers to session.write, which injects into the emulator and
+    /// never reaches the shell — so a caller with a legitimate control byte had nowhere to go.</summary>
+    [Fact]
+    public void Type_AllowControl_SendsItAnyway()
+    {
+        var (server, _) = New();
+        string resp = server.Dispatch(
+            "{\"cmd\":\"session.type\",\"args\":{\"allow-control\":true,\"text\":\"ls\u001b[A\"}}");
+        Assert.DoesNotContain("refuses", resp);
+    }
+
+    [Fact]
+    public void Type_Refusal_NamesTheEscapeHatch_NotSessionWrite()
+    {
+        var (server, _) = New();
+        string resp = Type(server, "oops" + (char)0x1b);
+        Assert.Contains("allow-control", resp);
+        Assert.DoesNotContain("session.write", resp);
     }
 
     [Fact]


### PR DESCRIPTION
**#213 shipped a wrong instruction.** Its refusal told callers to "use `session.write` for raw bytes" — but `session.write` calls `ISession.Inject`, which the interface documents as *"feed bytes into the EMULATOR only (display injection; never reaches the shell)"*.

So the one verb the message named cannot deliver a byte to a program at all. The refusal **removed** a capability rather than redirecting it: a caller with a legitimate escape sequence for a TUI, or a deliberate ^C, had nowhere left to go.

## The fix

`session.type` takes `--allow-control`. The refusal still fires by default — the usual reason a control byte is in typed text is that the caller built the string wrong — but a caller that *means* it says so and gets exactly what it asked for. Newline normalisation is unchanged either way; this is still typing.

```
{"text":"ls\u001b[A"}                        -> ok:false  "...pass --allow-control if you mean it"
{"allow-control":true,"text":"ls\u001b[A"}   -> ok:true
```

Verified against a live pipe: with the flag, an `ESC [ A` reaches the shell and **recalls the previous command** — the line editor interpreting it is the proof the raw byte arrived.

`AgentSkill.cs` says the same, including that `session.write` is *not* the way, since that is the belief this corrects. Three new tests, 321 passing.

## How it was caught

Adding `session.write` to agliteterm for exactly the reason the message claimed. Reading the full app's implementation to copy its semantics showed the semantics were not what I had written down.

Nothing shipped with the bad advice — 0.17.7 predates #213.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k