### PR TITLE
docs: parity tracker against agterm v0.26.0

### DIFF
--- a/docs/agterm-gap-analysis-2026-07.md
+++ b/docs/agterm-gap-analysis-2026-07.md
@@ -1,5 +1,8 @@
 # agterm → agwinterm gap analysis — July 2026 refresh
 
+> **Superseded (2026-09-02):** current parity against agterm **v0.26.0** is tracked in **[agterm-parity.md](agterm-parity.md)**. This file compares against the July 2026 waves and is history.
+
+
 Snapshot date: **2026-07-07**. Three inputs, all evidence-based:
 
 1. **agterm's merged PRs #1–#161** (the ~60 feature/fix PRs of 2026-07-01…07-07 post-date our

--- a/docs/agterm-parity.md
+++ b/docs/agterm-parity.md
@@ -169,14 +169,11 @@ which ConPTY makes necessary), shell `profiles`, `omp` theme control, `claude.ad
 
 ## agliteterm, against agwinterm
 
-lite implements the same protocol with a smaller command set. Missing relative to agwinterm:
-`selection.*` (all four), every `image.*`, and `session.background`, `session.bind`, `session.focus`,
-`session.metrics`, `session.readonly`, `session.resize`, `session.restore`, `session.search`,
-`session.switch`, plus `workspace.move`.
-
-For the hub's own tooling that is survivable — `peer-chat.py` and `agmsg peek` need only `tree`,
-`session.text` and `session.type` — but `selection.*` missing means the copy tooling and anything
-reading a user's selection cannot work there.
+Tracked separately, in **[lite-parity.md](lite-parity.md)** — the goal there is that the two products
+expose the same features, so it is a list with an end, not a survey. Short version as of 2026-09-02:
+agliteterm answers **41 of agwinterm's 85** control verbs, the sharpest gap being `selection.*`
+(it can read a selection but not make one). It is also *ahead* in three places, which should move the
+other way.
 
 ---
 

--- a/docs/agterm-parity.md
+++ b/docs/agterm-parity.md
@@ -1,0 +1,185 @@
+# agterm parity tracker
+
+What [umputun/agterm](https://github.com/umputun/agterm) has that **agwinterm** and **agliteterm** do
+not, and what we have closed.
+
+- Compared against **agterm v0.26.0** (2026-09-02), releases 0.22.0 → 0.26.0.
+- Ours: agwinterm **0.17.7** released (main is ahead), agliteterm **0.17.13** released.
+- Update this file in the PR that closes an item. A line that says "missing" long after it shipped
+  is worse than no tracker.
+- **This supersedes the earlier gap docs in this directory** (`agterm-gap-analysis*.md`,
+  `agterm-roadmap.md`), which compare against agterm v0.10.2 and the July waves. Those describe a
+  version of both products that no longer exists; read them as history.
+
+agterm is macOS + libghostty; we are Win32 + ConPTY. Some items do not port at all, and those are
+named as such rather than left to look like a backlog nobody is working on.
+
+---
+
+## Closed
+
+| Item | agterm | Closed by |
+| --- | --- | --- |
+| `session.text --lines N` reaching scrollback | 0.25.0 | agwinterm #213 |
+| `session.type` refuses control bytes (NUL truncation) | 0.25.0 | agwinterm #213, lite #15 *(open)* |
+| An escape hatch that works: `--allow-control` | — | agwinterm #214 *(open)*, lite #15 *(open)* |
+| `session.overlay` stops widening a pane id to its session | — | agwinterm #213 |
+| `session.write` (display injection) in lite | — | lite #15 *(open)* |
+| Per-session split panes (lite matched agwinterm) | — | lite #13 |
+| `session.new --workspace` in lite | — | lite #13 |
+
+The overlay entry is the *honesty* half only: a pane id is now refused rather than silently widened.
+Pane-scoped overlays themselves are still open, below.
+
+---
+
+## Open — agent-facing control API
+
+Everything here is portable. Ordered by what costs us work today.
+
+### 1. `surface.cursor` — the caret column
+**agterm 0.24.0.** Reports a surface's cursor column as a bare integer.
+
+The only gap that makes tooling *weaker* rather than more laborious. It is the last check before
+typing into another agent's composer: the caret rests at a known column in an empty box, so anything
+else means a draft is sitting there and the send should refuse. Without it, `AI/bin/peer-chat.py`
+proves emptiness from rendered text against a whitelist of each agent's placeholder string — which
+fails both ways (an unrecognised placeholder refuses a safe send; a draft that looks like a
+placeholder reads as empty) and rots as agents change their prompt chrome.
+
+**Shape:** `agwintermctl surface cursor --target <pane-id>` printing a bare integer.
+**Size:** small. The emulator already tracks `CursorRow`/`CursorCol`.
+
+### 2. `statusChangedAt` on the tree's session node
+**agterm 0.25.0.** Epoch seconds recording when a status was last written.
+
+`tree --json` reports `"status":"active"` with no age, so nothing can tell a working agent from one
+whose hook died forty minutes ago. `AI/state/agents.json` keeps a `last_seen` per agent purely
+because of this — shadow state that exists to answer a question the tree should answer.
+
+**Size:** small. One field on `SessionSnapshot`, set where status is written.
+
+### 3. `session.context` — per-session descriptive text
+**agterm 0.26.0.** Text set over the API, shown in the title bar and tree, persisted across restarts.
+
+"What is this pane for" is currently guessable only from a name that also has to be short.
+
+**Size:** small, plus one field in the restore format (lite: an additive line type, the way `P` was).
+
+### 4. Pane-scoped overlays, and reading an overlay
+**agterm 0.24.0 (`session.overlay.copy`, `session.overlay.text`), pane scoping 2026-08-01.**
+
+An overlay covers the whole session, so a review TUI aimed at the right pane blanks the left pane the
+user is reading. agterm delivers it as `--pane left|right` on the existing verbs, with the flag
+omitted keeping session-wide behaviour. Separately, `session text` addresses the pane *underneath* an
+overlay, so an overlay's own output cannot be read at all.
+
+**Size:** medium (the scoping is real work in the renderer); the two read verbs are small.
+
+### 5. `session.swap`
+**agterm 0.26.0.** Exchange the split panes, preserving axis, ratio, focus, overlays and status
+ownership. We cannot swap at all. Our peer tooling addresses panes by id rather than by side, so this
+is convenience here rather than a blocker.
+**Size:** small–medium.
+
+### 6. Splits are thinner than theirs
+- **Horizontal splits** (0.23.0): an axis on `session.split`, surviving restore. Ours is
+  `on|off|toggle` only.
+- **`session.split.close`** (0.23.0): destroys the pane. agwinterm's `off` and lite's unsplit already
+  destroy the shell, so this is naming, not behaviour.
+- **agwinterm's `session.split` returns nothing.** lite returns the split's id, which is the only
+  handle on a hidden split shell. agwinterm should do the same — a small, real gap *within* our own
+  family.
+
+### 7. `sidebar.width`, `restore.capture`
+**agterm 0.26.0.** Set/report the sidebar divider (distinguishing a clamped request from an honoured
+one); fill captured-command slots on demand rather than only at exit. Both small.
+
+### 8. `agwintermctl version`
+**agterm 0.25.0.** Reports which app is serving the socket **and the resolved path of the CLI that
+ran**. This machine has `agwintermctl.exe` in the install directory and in two source build trees,
+and none of them on `PATH` — exactly the confusion this catches.
+**Size:** small.
+
+### 9. `--stdin` on `session type` / `quick type`, rejecting invalid UTF-8
+**agterm 0.26.0.** We have no `--stdin` at all, so text with quotes or newlines has to survive a
+command line. Worth pairing with the control-byte refusal already shipped.
+
+---
+
+## Open — UI
+
+### 10. `control.pick` — the native picker, driven over the API
+**agterm 2026-07-28.** Half the agterm cookbook is built on it: project launcher, workspace picker,
+conversation picker, backlog picker, SQLite browser. Nothing here can do that without shipping a
+picker binary of its own.
+**The biggest single capability gap.** Size: large.
+
+### 11. `session.hud` and `--position`
+**agterm 0.22.0 / 0.24.0.** A transient overlay for status an agent wants seen without printing into
+the terminal, anchored to one of nine positions. Size: medium.
+
+### 12. Quick terminal: screen percentage, and a global hotkey
+**agterm 0.24.0 / 0.25.0.** Sizes as 40–90% of the screen, and a system-wide hotkey summons it over
+any app. Ours is a fixed size with no global hotkey. Size: medium (the hotkey is a `RegisterHotKey`
+and a policy decision about stealing a chord system-wide).
+
+### 13. Workspace navigation and keymap alternatives
+**agterm 0.23.0 / 0.24.0.** `workspace.go next|prev`, `toggle_workspace_collapse`, and keymap entries
+that accept several chords for one action separated by `|` (a native chord *and* a tmux-style
+leader). We have `session go`; workspaces are keyboard-unreachable without a chord. Size: small.
+
+### 14. Smaller things from 0.26
+Cursor shape and blink settings; sidebar tooltips revealing truncated names; the tree naming the
+shell holding each pane's foreground process; `session.restore` reporting which pane received the
+content; `session.overlay.open` validating `--size-percent` as 1–100 (we clamp silently instead).
+
+---
+
+## Not chasing, with reasons
+
+### Live and remote sessions (zmx)
+**agterm 0.26.0.** Processes survive a restart through a bundled zmx multiplexer; sessions on another
+Mac attach over SSH. Requires zsh as the login shell and macOS.
+
+**We are partly there by a different route, and it is worth knowing where the line is.** Our pty-host
+outlives the UI by design, and lite *adopts* live shells on restart rather than relaunching them — so
+"quit the app, come back to running processes" already works here. What we do not have is surviving a
+**reboot**, or attaching to another machine's sessions. agwinterm's `restore-commands` re-runs a
+captured command line, which is a much weaker thing: the agent's conversation is gone, only the
+invocation comes back.
+
+### GPU buffer release for hidden panes
+**agterm 0.26.0.** Hidden panes release their Metal swap chain buffers; their measurement was 1.1 GB
+→ 199 MB with 11 hidden panes. Our renderer is Direct2D with a different allocation shape — measure
+before assuming it applies, then decide.
+
+### macOS-only
+Voice dictation and the accessibility tree (0.22.0), hardened-runtime and TCC entitlements, Apple
+notarisation. agwinterm has its own UIA path.
+
+---
+
+## Where we are ahead
+
+Not a one-way list. Ours have, and agterm's control surface does not appear to: `session.readonly`,
+`session.metrics` (live cell and pixel geometry), `image.frameshm` (shared-memory frame delivery,
+which ConPTY makes necessary), shell `profiles`, `omp` theme control, `claude.adopt` / `claude.yolo`
+/ `claude.update`, and `app.update`.
+
+## agliteterm, against agwinterm
+
+lite implements the same protocol with a smaller command set. Missing relative to agwinterm:
+`selection.*` (all four), every `image.*`, and `session.background`, `session.bind`, `session.focus`,
+`session.metrics`, `session.readonly`, `session.resize`, `session.restore`, `session.search`,
+`session.switch`, plus `workspace.move`.
+
+For the hub's own tooling that is survivable — `peer-chat.py` and `agmsg peek` need only `tree`,
+`session.text` and `session.type` — but `selection.*` missing means the copy tooling and anything
+reading a user's selection cannot work there.
+
+---
+
+*The 0.22–0.25 survey this builds on was done by another session on 2026-09-01 and lives at
+`C:\Users\boris\AI\docs\agterm-parity.md`; this file is the maintained copy, extended to 0.26.0 and
+corrected where we have since closed items.*

--- a/docs/agterm-roadmap.md
+++ b/docs/agterm-roadmap.md
@@ -1,5 +1,8 @@
 # agwinterm roadmap — closing the agterm gap
 
+> **Superseded (2026-09-02):** current parity against agterm **v0.26.0** is tracked in **[agterm-parity.md](agterm-parity.md)**. This file compares against agterm v0.10.2 and is history.
+
+
 Execution plan to close every gap in [agterm-gap-analysis.md](agterm-gap-analysis.md).
 Ordered by value ÷ effort and by dependency. Effort: S (hours) / M (a day-ish) / L (multi-day).
 

--- a/docs/lite-parity.md
+++ b/docs/lite-parity.md
@@ -1,0 +1,120 @@
+# agliteterm ↔ agwinterm parity tracker
+
+**Goal: the two products expose the same features.** agliteterm is a separate product with its own
+repository, not a cut-down build — so a gap here is a gap, not a design decision, unless this file
+says otherwise and gives the reason.
+
+- agwinterm **0.17.7** released (main ahead), agliteterm **0.17.13** released.
+- Verb lists below were **extracted from both dispatchers** on 2026-09-02, not written from memory:
+  85 verbs in agwinterm, 41 in agliteterm.
+- Update this file in the PR that closes an item.
+
+The control API is the half that has to match exactly: `tests/conformance/control-api.json` in this
+repo is the canonical contract, agliteterm's CI checks its copy against it, and an agent written
+against one product should work against the other. The UI half can differ where the platform or the
+product's purpose justifies it.
+
+---
+
+## Control API: 44 verbs agliteterm does not answer
+
+Grouped by what they cost an agent, not alphabetically.
+
+### Selection — the sharpest gap
+`selection.all` · `selection.clear` · `selection.copy` · `selection.finalize`
+
+lite has `session.copy` (the selection's text) but no way to **make**, clear or finalise one. So
+copy tooling, anything reading a user's selection, and the QA cases that drive selection through the
+API all stop at the door. A step that calls `selection clear` there does nothing and returns an
+error most callers ignore — a setup that silently did not happen, which is the failure mode the QA
+cases exist to prevent (`qa/product.md` in that repo says so).
+
+**Size:** small. lite already has the selection model behind `session.copy`.
+
+### Reading and driving a pane
+`session.search` · `session.focus` · `session.switch` · `session.resize` · `session.background` ·
+`session.readonly` · `session.bind` · `session.restore` · `session.write`
+
+`session.write` is in flight (agliteterm #15). `session.readonly` matters most of the rest: it is how
+you stop stray keys reaching a running agent.
+
+### Images
+`image.show` · `image.sixel` · `image.clear` · `image.frame`
+
+lite renders no images at all. `image.frameshm` (shared-memory frame delivery) is the one ConPTY
+makes necessary, and it is agwinterm-only. **Size:** large.
+
+### Configuration and appearance
+`config.get` · `config.list` · `config.set` · `theme.list` · `theme.set` · `omp.list` · `omp.set` ·
+`font` · `settings.open` · `keymap.reload` · `profiles.list` · `profiles.reload`
+
+lite keeps settings in the registry (`HKCU\Software\agliteterm`) with a Properties dialog, so this is
+not a straight port — but `config.get`/`set` over the API is what lets an agent set up a workspace
+without a human clicking. **Size:** medium as a group, small each.
+
+### Commands and installers
+`command.list` · `command.run` · `command.leader` · `install.cli` · `install.hooks` ·
+`install.shell` · `app.update`
+
+lite has `install.skill` only.
+
+### Agent integration
+`claude.adopt` · `claude.yolo` · `claude.update`
+
+Adoption is the interesting one: pointing the terminal at an already-running Claude session.
+
+### Everything else
+`broadcast` · `notify` · `dashboard` · `restore.clear` · `workspace.move`
+
+---
+
+## Where agliteterm is AHEAD
+
+Not a one-way list, and these should move the other way.
+
+- **`session.split` returns the split's id.** agwinterm's returns nothing, and a hidden split shell
+  has no other handle. **agwinterm should copy this** — tracked in `agterm-parity.md` too.
+- **Splits scroll into main-screen history on the alt screen.** lite's renderer and hit-test derive
+  their row from the same offset on either screen; agwinterm pins the alt screen to 0. Both are
+  self-consistent (highlight and clipboard agree either way), so this is a difference to decide about
+  rather than a defect — see `qa/product.md` in the lite repo.
+- **An unknown workspace is refused, not silently swapped** for the active one on `session.new`.
+  agwinterm falls back. Silently falling back is how a caller ends up believing it placed a session
+  somewhere it did not; **agwinterm should probably refuse too**, which is a contract change worth
+  making deliberately.
+
+---
+
+## UI and terminal features agliteterm lacks
+
+Not exhaustive the way the verb list is — these are the gaps found while working on both products,
+and the list should grow as more turn up.
+
+| Feature | Notes |
+| --- | --- |
+| Mark mode (keyboard selection) | agwinterm: Ctrl+Shift+M, arrows, Enter copies |
+| Select All | no equivalent |
+| Drag-autoscroll | dragging past the pane edge does not extend the selection |
+| Configurable scrollback | lite does not call `agwcore_emu_set_scrollback`; the cap is the core default |
+| Images / graphics | see the `image.*` verbs above |
+| Dashboard, quick-terminal parity, multi-window | agwinterm has a window library; lite has one window plus popups |
+| Wheel over the pane | a posted `WM_MOUSEWHEEL` does not reach lite's handler (harness finding, 0.17.11) |
+
+---
+
+## What is deliberately different
+
+- **Settings storage.** agwinterm reads `agwinterm.conf` and honours `--app-id`; lite uses the
+  registry and a `%LOCALAPPDATA%` override. That is why the two QA adapters isolate differently, and
+  it is not worth unifying.
+- **Splits as sessions.** lite models a split as a hidden session; agwinterm models panes inside a
+  session. Behaviour matches now (a split belongs to its session, closes with it, restores with it),
+  and the internal shape can stay different.
+- **The native core is shared.** Both load `agwinterm_core.dll` across the same C ABI, so emulator
+  behaviour — widths, scrollback, alt screen — is common by construction. A difference there is a
+  bug in one of the clients, not a parity gap.
+
+---
+
+*Companion to [agterm-parity.md](agterm-parity.md), which tracks both products against umputun's
+agterm. This file tracks them against each other.*


### PR DESCRIPTION
agterm shipped **0.26.0** on 2026-09-02. The newest survey we had covered 0.25.0 and predates three items we have since closed, so this is the maintained copy: what they have that we do not, what we closed and in which PR, and what is deliberately not being chased.

Ordered by **what costs work**, not by size.

**The three at the top are all small and all agent-facing:**
- `surface.cursor` — the only gap that makes tooling *weaker* rather than more laborious. It is how you prove a composer is empty before typing into another agent's pane; `peer-chat.py` currently guesses from placeholder strings, which fails both ways and rots.
- `statusChangedAt` — without it, a status that has read `active` for forty minutes is indistinguishable from a live one. The hub keeps shadow state purely because of this.
- `session.context` — per-session descriptive text in the title bar and tree.

**New in 0.26 and now tracked:** `session.context`, `session.swap`, `sidebar.width`, `restore.capture`, shell identification in the tree, cursor shape/blink, and the live/remote session work built on zmx.

**Written down as _not_ being chased,** with the line drawn explicitly: our pty-host already outlives the UI and lite *adopts* live shells on restart, so "quit and come back to running processes" works here. Surviving a **reboot** and attaching to **another machine's** sessions do not — that is the actual gap, and it is smaller than "we don't have zmx" makes it sound.

Also flagged: agwinterm's `session.split` returns nothing while lite returns the split's id — a real gap *within* our own family.

The three older gap docs here compare against v0.10.2 and the July waves. They now say so at the top and point at this one, because a stale analysis read as current is worse than none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k