### PR TITLE
release: 0.17.8

### DIFF
--- a/installer/agwinterm.iss
+++ b/installer/agwinterm.iss
@@ -2,7 +2,7 @@
 ; Build via installer\build.ps1 (publishes to stage\ then runs ISCC on this file).
 
 #define AppName    "agwinterm"
-#define AppVersion "0.17.7"
+#define AppVersion "0.17.8"
 #define AppExe     "Agwinterm.Win32.exe"
 #define AppPublisher "Boris Kudriashov"
 ; The main app defaults new sessions to the Rust pty-host as a first-run seed only (it never


### PR DESCRIPTION
Selecting text in a full-screen TUI works, and Ctrl+C over that selection copies instead of reaching the app as an interrupt — the codex / Claude Code case (#210, three revmux rounds).

**Control API:** `session.text --lines N` reaches scrollback; `session.type` refuses control bytes with `--allow-control` for a caller that means one (#213, #214); `session.overlay` refuses a pane id instead of silently covering the whole session.

**Also:** markdown QA cases executed by the `ui-qa` skill (#212), `SelectionBoundsTests`, and parity trackers against agterm v0.26.0 and against agliteterm (#215).

Not a checkpoint version, so GitHub release only (next checkpoint is 0.17.9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k