### PR TITLE
docs: cut the parity backlog into runnable batches

### DIFF
--- a/docs/agterm-parity.md
+++ b/docs/agterm-parity.md
@@ -4,6 +4,8 @@ What [umputun/agterm](https://github.com/umputun/agterm) has that **agwinterm** 
 not, and what we have closed.
 
 - Compared against **agterm v0.26.0** (2026-09-02), releases 0.22.0 → 0.26.0.
+- **The running order lives in [plans/2026-09-03-parity-batches.md](plans/2026-09-03-parity-batches.md)** —
+  this file is what is missing, that file is which batch builds it and when.
 - Ours: agwinterm **0.17.7** released (main is ahead), agliteterm **0.17.13** released.
 - Update this file in the PR that closes an item. A line that says "missing" long after it shipped
   is worse than no tracker.

--- a/docs/lite-parity.md
+++ b/docs/lite-parity.md
@@ -8,6 +8,8 @@ says otherwise and gives the reason.
 - Verb lists below were **extracted from both dispatchers** on 2026-09-02, not written from memory:
   85 verbs in agwinterm, 41 in agliteterm.
 - Update this file in the PR that closes an item.
+- The verbs below are cut into runnable batches (P6–P12) in
+  [plans/2026-09-03-parity-batches.md](plans/2026-09-03-parity-batches.md).
 
 The control API is the half that has to match exactly: `tests/conformance/control-api.json` in this
 repo is the canonical contract, agliteterm's CI checks its copy against it, and an agent written

--- a/docs/plans/2026-09-03-parity-batches.md
+++ b/docs/plans/2026-09-03-parity-batches.md
@@ -1,0 +1,177 @@
+# Parity backlog, cut into runnable batches
+
+The gap lists in [agterm-parity.md](../agterm-parity.md) and [lite-parity.md](../lite-parity.md) say
+*what* is missing. This file says **in what order it gets built**, split so each part is one ralphex
+plan, one branch, one PR — run with review steps disabled, then reviewed by revmux.
+
+Nothing here is implemented. Each `P<n>` becomes its own plan file in this directory when it is its
+turn; expanding all of them up front would just produce stale plans.
+
+## The rules the split obeys
+
+- **One plan = one repository.** ralphex runs in one worktree, so an agwinterm batch and its
+  agliteterm mirror are always separate plans, never one.
+- **Contract before mirror.** `tests/conformance/control-api.json` is canonical here and agliteterm's
+  CI checks its copy against it. So a verb is defined in agwinterm first; the lite batch that mirrors
+  it runs after, never beside it.
+- **A batch is a theme, not a size quota.** Items travel together when they share a test area or a
+  format change, so one revmux round covers them coherently.
+- **Every batch exits the same way:** its own tests, the QA cases in `qa/` (both products have them),
+  the full suite green, then revmux — **two rounds minimum**; the second round is where criticals have
+  historically surfaced.
+- **Releases happen at wave boundaries**, not per batch. Only `*.*.9` / `*.*.18` / `*.*.27` reach
+  Chocolatey and winget.
+
+## Blocked on a decision from you
+
+Three contract questions gate their batches. They are cheap to answer and expensive to guess.
+
+| # | Question | Gates |
+| --- | --- | --- |
+| 1 | `session.new` with an unknown workspace: **refuse** (lite does) or **fall back to active** (agwinterm does)? Falling back silently is how a caller believes it placed a session somewhere it did not. | P2 |
+| 2 | On the alt screen, do splits scroll into main-screen history (lite) or pin to row 0 (agwinterm)? Both are self-consistent; they cannot both stay. | P6, P7 |
+| 3 | Is `control.pick` (P16) worth its size, or does the picker stay out of scope? It is the biggest single capability gap and also the biggest plan. | P16 |
+
+---
+
+## Wave 1 — agwinterm control API: the cheap half
+
+### P1 · agwinterm · the read-only trio
+`surface.cursor` · `statusChangedAt` on the tree's session node · `agwintermctl version`
+
+Three small, read-only additions with no persistence and no renderer risk. First because this is the
+only batch that makes **our own tooling less fragile** rather than merely less laborious:
+`AI/bin/peer-chat.py` can drop its per-agent placeholder whitelist, and `AI/state/agents.json` can
+drop the `last_seen` shadow state. It is also a gentle first run of the new pipeline.
+
+**Exit:** `surface cursor --target <pane>` prints a bare integer; `tree --json` carries epoch seconds
+alongside `status`; `version` names the serving app **and the resolved path of the CLI that ran**.
+
+### P2 · agwinterm · stop lying to the caller
+`--stdin` on `session type` / `quick type` (rejecting invalid UTF-8) · `session.overlay.open`
+validates `--size-percent` as 1–100 instead of clamping silently · `session.restore` reports which
+pane received the content · `sidebar.width` distinguishing a clamped request from an honoured one ·
+`session.new` refuses an unknown workspace *(decision 1)*
+
+Every item is the same defect class as the control-byte refusal already shipped in #213: a call that
+appears to succeed while doing something other than what was asked. Same test shape throughout.
+
+### P3 · agwinterm · persistence
+`session.context` (text set over the API, shown in title bar and tree, surviving restart) ·
+`restore.capture` (fill captured-command slots on demand, not only at exit)
+
+Alone because it is the first restore-format change of this backlog, and lite has to mirror the
+format later — as an additive line type, the way `P` was.
+
+### P4 · agwinterm · splits get their full shape
+axis on `session.split` (`h|v`, surviving restore) · `session.split.close` · `session.split` **returns
+the pane id** · `session.swap`
+
+One subsystem, one restore-format change, one test area. The returned id is a gap inside our own
+family: lite already returns it, and a hidden split shell has no other handle.
+
+### P5 · agwinterm · overlays stop being session-wide
+`--pane left|right` on the overlay verbs, flag omitted keeping today's session-wide behaviour ·
+`session.overlay.copy` · `session.overlay.text`
+
+Kept separate from P2–P4 because it is the only control-API batch with real renderer work. #213
+closed the honesty half — a pane id is refused rather than silently widened — so this closes the
+capability half: a review TUI in the right pane stops blanking the left pane the user is reading, and
+an overlay's own output becomes readable at all.
+
+---
+
+## Wave 2 — agliteterm catches up
+
+44 verbs behind. Taken in one go that is not a plan, it is a rewrite. Ordered by what an agent
+actually hits first.
+
+### P6 · lite · `selection.*`
+`selection.all` · `selection.clear` · `selection.copy` · `selection.finalize`
+
+The sharpest gap in the product: lite can *read* a selection (`session.copy`) but not make, clear or
+finalise one, so the lite QA cases that drive selection through the API silently do nothing — the
+exact failure mode `qa/product.md` exists to prevent. The model already exists behind `session.copy`.
+*Needs decision 2.*
+
+### P7 · lite · selection by keyboard and mouse
+mark mode (Ctrl+Shift+M, arrows, Enter copies) · Select All · drag-autoscroll past the pane edge ·
+the posted `WM_MOUSEWHEEL` that never reaches lite's handler (harness finding, 0.17.11)
+
+Same model as P6, different surface — split because it is UI work with a different test shape.
+
+### P8 · lite · mirror Wave 1
+`surface.cursor` · `statusChangedAt` · `version` · `--stdin` · size-percent validation ·
+`session.context`
+
+Runs only after P1–P3 land, so the contract is fixed before it is copied.
+
+### P9 · lite · driving a pane
+`session.readonly` **first** — it is how you stop stray keys reaching a running agent — then
+`session.focus` · `session.switch` · `session.resize` · `session.background` · `session.search` ·
+`session.bind` · `session.restore`
+
+### P10 · lite · the configuration surface
+`config.get/list/set` · `theme.list/set` · `omp.list/set` · `font` · `settings.open` ·
+`keymap.reload` · `profiles.list/reload` · configurable scrollback (`agwcore_emu_set_scrollback`,
+which lite never calls, so its cap is the core default)
+
+Not a straight port: lite keeps settings in `HKCU\Software\agliteterm` behind a Properties dialog.
+The real work of this plan is naming the keys once. `config.get/set` over the API is what lets an
+agent set up a workspace without a human clicking.
+
+### P11 · lite · commands, installers, agent integration
+`command.list/run/leader` · `install.cli/hooks/shell` · `app.update` · `claude.adopt/yolo/update`
+
+lite ships `install.skill` only. `claude.adopt` — pointing the terminal at an already-running Claude
+session — is the interesting one.
+
+### P12 · lite · the remainder
+`broadcast` · `notify` · `dashboard` · `restore.clear` · `workspace.move`
+
+Closes the verb list except images. **After this, lite answers every agwinterm verb but `image.*`.**
+
+---
+
+## Wave 3 — the UI gaps against agterm
+
+### P13 · agwinterm · `session.hud` and `--position`
+A transient overlay for status an agent wants seen without printing into the terminal, anchored to
+one of nine positions.
+
+### P14 · agwinterm · quick terminal
+Size as 40–90% of the screen · a system-wide hotkey that summons it over any app
+
+The hotkey is a `RegisterHotKey` plus a policy decision about stealing a chord machine-wide, which
+the plan should state rather than assume.
+
+### P15 · agwinterm · navigation and the small sweep
+`workspace.go next|prev` · `toggle_workspace_collapse` · keymap entries accepting several chords for
+one action separated by `|` · sidebar tooltips revealing truncated names · the tree naming the shell
+holding each pane's foreground process · cursor shape and blink settings
+
+Workspaces are currently keyboard-unreachable without a chord.
+
+### P16 · agwinterm · `control.pick`
+The native picker driven over the API. Half the agterm cookbook is built on it — project launcher,
+workspace picker, conversation picker, backlog picker, SQLite browser — and nothing here can do that
+without shipping a picker binary of its own. **The biggest single capability gap and the biggest
+plan; expect more than two revmux rounds.** *Needs decision 3.*
+
+### P17 · lite · mirror Wave 3
+Whatever of P13–P16 survives contact, mirrored. Sized once P13–P16 are real rather than guessed at.
+
+---
+
+## Deferred, deliberately
+
+- **`image.*` in lite** (`image.show`, `image.sixel`, `image.clear`, `image.frame`). lite renders no
+  images at all; this is a wave of its own, not a batch. `image.frameshm` stays agwinterm-only —
+  shared-memory frame delivery is what ConPTY makes necessary, and lite has no consumer for it.
+- Everything under *Not chasing* in [agterm-parity.md](../agterm-parity.md): zmx live/remote
+  sessions, the GPU buffer release measurement, and the macOS-only items.
+
+---
+
+*Companion to the two trackers. When a batch lands, tick it in the tracker it came from — a line that
+still says "missing" long after it shipped is worse than no tracker.*


### PR DESCRIPTION
The two parity trackers say *what* is missing; nothing said in what order it gets built. This adds `docs/plans/2026-09-03-parity-batches.md` — **P1–P17**, each one ralphex plan / one branch / one PR, to be run with review steps disabled and then reviewed by revmux.

No code. Docs only.

## The split

| Wave | Batches |
| --- | --- |
| 1 — agwinterm control API, the cheap half | P1 read-only trio · P2 stop lying to the caller · P3 persistence · P4 splits · P5 pane-scoped overlays |
| 2 — agliteterm catches up (44 verbs) | P6 `selection.*` · P7 selection UI · P8 mirror wave 1 · P9 driving a pane · P10 config surface · P11 commands/installers · P12 remainder |
| 3 — UI gaps against agterm | P13 `session.hud` · P14 quick terminal · P15 navigation + sweep · P16 `control.pick` · P17 lite mirror |

Two hard constraints shaped it: **one plan never spans both repositories** (ralphex runs in one worktree), and **a verb is defined in agwinterm before the lite batch mirrors it**, since `tests/conformance/control-api.json` is canonical here and lite's CI checks its copy against it.

## Three decisions are gates, not guesses

1. `session.new` with an unknown workspace — refuse (lite) or fall back (agwinterm)? → gates P2
2. Alt-screen splits — scroll into main history (lite) or pin to row 0 (agwinterm)? → gates P6/P7
3. Is `control.pick` worth its size? → gates P16

`image.*` in lite and everything under *Not chasing* are deferred explicitly, with reasons, so they stop reading as a backlog nobody is working on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k