### PR TITLE
ci: pull scorecard from ghcr, where v2.4.4 lives

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2.4.0
+        uses: ossf/scorecard-action@v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Every scorecard run on this repository has failed since at least 2026-09-02 — in 17–29
seconds, before analysis starts:

```
failure  Merge pull request #218 ...            scorecard  25s
failure  docs: cut the parity backlog (#217)    scorecard  23s
failure  release: 0.17.8 (#216)                 scorecard  23s
failure  docs: parity tracker (#215)            scorecard  17s
failure  fix(control): session.type… (#214)     scorecard  18s
```

`scorecard-action@v2.4.0` runs from `gcr.io/openssf/scorecard-action`, and that registry now
refuses the manifest request:

```
denied: This API method requires billing to be enabled. Please enable billing on
project #367732848534 ...
```

That is OpenSSF's own GCR project, not anything about this repository. Three retries per run,
same answer.

It went unnoticed because nothing depends on the job and the badge renders as *unrated*
rather than *broken*.

## The fix

v2.4.4 declares `docker://ghcr.io/ossf/scorecard-action:v2.4.4` — a different registry. That's
the entire change: one line.

Verified on [agwinterm-browser](https://github.com/yeroo/agwinterm-browser), which copied this
workflow and hit the identical failure on its first push. The bump alone took the job from
failing in 29s to passing in 30s.

## Deliberately not included

`actions/checkout@v4` and `actions/upload-artifact@v4` here still run on the Node 20
generation, and the runner annotates every run to say so. Bumping them is a separate change:
the last time that was bundled with a fix (on agwinterm-browser), it broke a job that had just
passed.

Note: the scorecard workflow triggers on push to `main`, not on pull requests, so this PR's
checks only cover `ci.yml`. The fix itself is exercised by the first push to `main` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6QmtYN1U1zctCf4WL2tMy
