### PR TITLE
fix: settle frame cache liveness in phase 2 only (#220 round-8 follow-up)

### DIFF
--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -617,14 +617,15 @@ public sealed class ControlServer : IDisposable
         // Phase 2 (BRIEF lock): swap placements and register any new pixels — dictionary/list
         // updates only, microseconds, so a big image appearing never stalls the paint thread.
         long t0 = System.Diagnostics.Stopwatch.GetTimestamp();
-        List<int>? staleIds = null;
+        HashSet<int>? staleIds = null;
         s.MutateLocked(em =>
         {
             // Phase 1 trusted the cache dictionary alone; this is the only check that the emulator
             // still holds the cached image. A child can replace an id at any time, so abort before
             // clearing placements; the one automatic retry below will transmit the pixels again.
-            // Every stale id is collected, not just the first, so the retry re-reads exactly those
-            // and a live sibling keeps its cache hit.
+            // Every stale id is collected, not just the first: a live sibling keeps its cache hit,
+            // so the retry (a full re-run of phase 1) re-reads only the stale ids plus whatever
+            // already missed the cache on this attempt.
             foreach (var op in ops.Where(op => op.data is null && op.cached is not null))
                 if (!em.Images.TryGetValue(op.id, out var image) || !ReferenceEquals(image, op.cached!.Image))
                     (staleIds ??= new()).Add(op.id);
@@ -757,7 +758,7 @@ public sealed class ControlServer : IDisposable
         // Phase 2 (BRIEF lock): dictionary/list swaps only, exactly as image.frame does - the
         // megabytes were already copied above, so the paint thread stalls for microseconds.
         long t0 = System.Diagnostics.Stopwatch.GetTimestamp();
-        List<int>? staleIds = null;
+        HashSet<int>? staleIds = null;
         string? commitError = null;
         s.MutateLocked(em =>
         {
@@ -804,7 +805,8 @@ public sealed class ControlServer : IDisposable
 
             // The only liveness check for a cache hit (phase 1 read the dictionary alone): the
             // emulator must still hold the very image the entry was recorded against. All stale
-            // ids are collected so the retry copies only those out of shared memory.
+            // ids are collected so a live sibling keeps its cache hit: the retry re-runs phase 1
+            // and copies only the stale ids plus whatever already missed the cache this attempt.
             foreach (var op in ops.Where(op => op.frame is null && op.cached is not null))
                 if (!em.Images.TryGetValue(op.id, out var image) || !ReferenceEquals(image, op.cached!.Image))
                     (staleIds ??= new()).Add(op.id);

--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -617,15 +617,18 @@ public sealed class ControlServer : IDisposable
         // Phase 2 (BRIEF lock): swap placements and register any new pixels — dictionary/list
         // updates only, microseconds, so a big image appearing never stalls the paint thread.
         long t0 = System.Diagnostics.Stopwatch.GetTimestamp();
-        bool invalidCache = false;
+        List<int>? staleIds = null;
         s.MutateLocked(em =>
         {
             // Phase 1 trusted the cache dictionary alone; this is the only check that the emulator
             // still holds the cached image. A child can replace an id at any time, so abort before
             // clearing placements; the one automatic retry below will transmit the pixels again.
+            // Every stale id is collected, not just the first, so the retry re-reads exactly those
+            // and a live sibling keeps its cache hit.
             foreach (var op in ops.Where(op => op.data is null && op.cached is not null))
                 if (!em.Images.TryGetValue(op.id, out var image) || !ReferenceEquals(image, op.cached!.Image))
-                { invalidCache = true; return; }
+                    (staleIds ??= new()).Add(op.id);
+            if (staleIds is not null) return;
 
             em.ClearPlacements();
             var updates = new List<(int id, FrameCacheEntry entry)>();
@@ -644,9 +647,9 @@ public sealed class ControlServer : IDisposable
             lock (state)
                 foreach (var update in updates) state[update.id] = update.entry;
         });
-        if (invalidCache)
+        if (staleIds is not null)
         {
-            RemoveInvalidCacheEntries(state, ops.Select(op => (op.id, op.cached)));
+            RemoveInvalidCacheEntries(state, ops.Where(op => staleIds.Contains(op.id)).Select(op => (op.id, op.cached)));
             return retryInvalidCache
                 ? HandleImageFrame(s, args, retryInvalidCache: false)
                 : Err("image.frame cache changed while the frame was prepared; retry");
@@ -754,7 +757,7 @@ public sealed class ControlServer : IDisposable
         // Phase 2 (BRIEF lock): dictionary/list swaps only, exactly as image.frame does - the
         // megabytes were already copied above, so the paint thread stalls for microseconds.
         long t0 = System.Diagnostics.Stopwatch.GetTimestamp();
-        bool invalidCache = false;
+        List<int>? staleIds = null;
         string? commitError = null;
         s.MutateLocked(em =>
         {
@@ -800,10 +803,12 @@ public sealed class ControlServer : IDisposable
             }
 
             // The only liveness check for a cache hit (phase 1 read the dictionary alone): the
-            // emulator must still hold the very image the entry was recorded against.
+            // emulator must still hold the very image the entry was recorded against. All stale
+            // ids are collected so the retry copies only those out of shared memory.
             foreach (var op in ops.Where(op => op.frame is null && op.cached is not null))
                 if (!em.Images.TryGetValue(op.id, out var image) || !ReferenceEquals(image, op.cached!.Image))
-                { invalidCache = true; return; }
+                    (staleIds ??= new()).Add(op.id);
+            if (staleIds is not null) return;
 
             if (!FitsRetainedSharedFrameBudget(
                 em,
@@ -846,9 +851,9 @@ public sealed class ControlServer : IDisposable
                         op.identity, latestPositiveSequence, generation, Sequenced: op.token > 0);
                 }
         });
-        if (invalidCache)
+        if (staleIds is not null)
         {
-            RemoveInvalidCacheEntries(state, ops.Select(op => (op.id, op.cached)));
+            RemoveInvalidCacheEntries(state, ops.Where(op => staleIds.Contains(op.id)).Select(op => (op.id, op.cached)));
             return retryInvalidCache
                 ? HandleImageFrameShm(s, args, retryInvalidCache: false, requestGeneration)
                 : Err("image.frameshm cache changed while the frame was prepared; retry");

--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -601,8 +601,8 @@ public sealed class ControlServer : IDisposable
 
             long sig = ContentSignature(path);
             FrameCacheEntry? cacheEntry = null;
-            bool cached = sig != 0 && IsCurrentFrameCacheHit(
-                s, state, id, FrameSource.File, path, sig, out cacheEntry);
+            bool cached = sig != 0 && IsFrameCacheHit(
+                state, id, FrameSource.File, path, sig, out cacheEntry);
 
             byte[]? data = null;
             if (!cached)
@@ -620,7 +620,8 @@ public sealed class ControlServer : IDisposable
         bool invalidCache = false;
         s.MutateLocked(em =>
         {
-            // A child can replace an id between phase 1's cache check and this lock. Abort before
+            // Phase 1 trusted the cache dictionary alone; this is the only check that the emulator
+            // still holds the cached image. A child can replace an id at any time, so abort before
             // clearing placements; the one automatic retry below will transmit the pixels again.
             foreach (var op in ops.Where(op => op.data is null && op.cached is not null))
                 if (!em.Images.TryGetValue(op.id, out var image) || !ReferenceEquals(image, op.cached!.Image))
@@ -723,10 +724,11 @@ public sealed class ControlServer : IDisposable
             // The (id, name, seq) cache, the shm analogue of image.frame's content signature: a
             // repeated sequence from the same producer means "nothing changed, just re-place it".
             // Cache hits still validate the live mapping and header below; only the pixel copy is
-            // skipped. Seq 0 means "read whatever is in the slot" and is never cacheable.
+            // skipped, and phase 2 confirms the emulator still holds the image. Seq 0 means "read
+            // whatever is in the slot" and is never cacheable.
             FrameCacheEntry? cacheEntry = null;
-            bool cached = seq > 0 && IsCurrentFrameCacheHit(
-                s, state, id, FrameSource.SharedMemory, name, seq, out cacheEntry);
+            bool cached = seq > 0 && IsFrameCacheHit(
+                state, id, FrameSource.SharedMemory, name, seq, out cacheEntry);
 
             ShmFrame? frame = null;
             var request = new ShmFrameRequest(name, slot, seq, width, height, stride, format);
@@ -797,6 +799,8 @@ public sealed class ControlServer : IDisposable
                 }
             }
 
+            // The only liveness check for a cache hit (phase 1 read the dictionary alone): the
+            // emulator must still hold the very image the entry was recorded against.
             foreach (var op in ops.Where(op => op.frame is null && op.cached is not null))
                 if (!em.Images.TryGetValue(op.id, out var image) || !ReferenceEquals(image, op.cached!.Image))
                 { invalidCache = true; return; }
@@ -897,8 +901,15 @@ public sealed class ControlServer : IDisposable
         return true;
     }
 
-    private static bool IsCurrentFrameCacheHit(
-        ISession session,
+    /// <summary>
+    /// Phase-1 cache lookup: does the pane already hold this exact content under this id? Answers
+    /// from the cache dictionary alone and never takes the render lock — whether the emulator still
+    /// holds the cached image is settled in phase 2, under the one lock that also applies the frame
+    /// (a stale entry there aborts, is dropped, and the request is retried once with the pixels
+    /// re-read). Probing here as well would cost one lock round-trip per image per frame for a
+    /// check phase 2 has to repeat anyway.
+    /// </summary>
+    private static bool IsFrameCacheHit(
         Dictionary<int, FrameCacheEntry> state,
         int id,
         FrameSource source,
@@ -906,25 +917,14 @@ public sealed class ControlServer : IDisposable
         long token,
         out FrameCacheEntry? entry)
     {
-        FrameCacheEntry candidate;
         lock (state)
         {
             if (!state.TryGetValue(id, out var cached) || cached.Source != source ||
                 cached.Identity != identity || cached.Token != token)
             { entry = null; return false; }
-            candidate = cached;
+            entry = cached;
+            return true;
         }
-        entry = candidate;
-
-        bool current = false;
-        session.MutateLocked(em =>
-            current = em.Images.TryGetValue(id, out var image) && ReferenceEquals(image, candidate.Image));
-        if (current) return true;
-
-        lock (state)
-            if (state.TryGetValue(id, out var found) && ReferenceEquals(found, candidate)) state.Remove(id);
-        entry = null;
-        return false;
     }
 
     private static void RemoveInvalidCacheEntries(

--- a/tests/Agwinterm.Pty.Tests/ControlServerFrameShmTests.cs
+++ b/tests/Agwinterm.Pty.Tests/ControlServerFrameShmTests.cs
@@ -547,6 +547,34 @@ public class ControlServerFrameShmTests : IDisposable
         Assert.Equal(2, session.Emulator.Placements.Count);
     }
 
+    // Both cached ids replaced at once. The liveness loop must collect EVERY stale id: a loop that
+    // stopped at the first would drop one entry, retry, go stale on the other with no retry left,
+    // and answer an error while the pane kept the previous frame.
+    [Fact]
+    public void TwoStaleIdsAreBothRecopiedInTheSingleRetry()
+    {
+        var (server, session) = New();
+        var a = NewProducer();
+        var b = NewProducer();
+        long seqA = a.Publish(0xA2);
+        long seqB = b.Publish(0xB2);
+        string request = Request("{\"images\":[" + Image(a, seqA, a.Slot, id: 1) + "," +
+            Image(b, seqB, b.Slot, id: 2, row: 6) + "]}");
+        Assert.Contains("frame:2/2", server.Dispatch(request));
+        Assert.Contains("frame:2/0", server.Dispatch(request));
+
+        session.MutateLocked(em =>
+        {
+            em.SetImageData(1, KittyFormat.Rgba, 1, 1, new byte[] { 1, 2, 3, 4 });
+            em.SetImageData(2, KittyFormat.Rgba, 1, 1, new byte[] { 5, 6, 7, 8 });
+        });
+
+        Assert.Contains("frame:2/2", server.Dispatch(request));
+        Assert.Equal(Packed(0xA2), session.Emulator.Images[1].Data);
+        Assert.Equal(Packed(0xB2), session.Emulator.Images[2].Data);
+        Assert.Equal(2, session.Emulator.Placements.Count);
+    }
+
     [Fact]
     public void ACacheReplacementBetweenValidationAndCommitRetransmitsOnce()
     {
@@ -778,8 +806,10 @@ public class ControlServerFrameShmTests : IDisposable
             "{\"images\":[" + Image(p, newerSeq, newerSlot, id: 1) + "]}");
         Assert.Contains("frame:1/1", server.Dispatch(newerRequest));
 
-        // Replacing the image invalidates and removes the retransmit-cache entry during the next
-        // phase 1. Accepted sequence order is separate state and must remain authoritative.
+        // Replacing the image leaves the retransmit-cache entry in place: phase 1 still answers
+        // a hit from the dictionary, phase 2 finds the emulator's image is not the cached one,
+        // drops the entry and retries. Accepted sequence order is separate state and must remain
+        // authoritative through all of that.
         session.MutateLocked(em =>
             em.SetImageData(1, KittyFormat.Rgba, 1, 1, new byte[] { 1, 2, 3, 4 }));
         using var newerPrepared = new ManualResetEventSlim();
@@ -798,7 +828,7 @@ public class ControlServerFrameShmTests : IDisposable
         try
         {
             Assert.True(newerPrepared.Wait(TimeSpan.FromSeconds(10)),
-                "newer request did not finish cache invalidation and phase 1");
+                "newer request did not finish phase 1");
             olderResponse = server.Dispatch(Request(
                 "{\"images\":[" + Image(p, olderSeq, olderSlot, id: 1) + "]}"));
         }

--- a/tests/Agwinterm.Pty.Tests/ControlServerFrameShmTests.cs
+++ b/tests/Agwinterm.Pty.Tests/ControlServerFrameShmTests.cs
@@ -2,7 +2,6 @@ using System.IO.MemoryMappedFiles;
 using System.Text.Json;
 using Agwinterm.Core;
 using Agwinterm.Pty;
-using Microsoft.Win32.SafeHandles;
 
 namespace Agwinterm.Pty.Tests;
 
@@ -36,83 +35,6 @@ public class ControlServerFrameShmTests : IDisposable
             ? new ControlServer(session, limit)
             : new ControlServer(session);
         return (server, session);
-    }
-
-    /// <summary>
-    /// Delegates a real session while exposing the narrow scheduling seam needed to put an image
-    /// replacement between the cache's phase-1 validation and phase-2 commit. The callback runs
-    /// after the inner render lock is released, so another request can make progress while one is
-    /// deliberately paused there.
-    /// </summary>
-    private sealed class InterceptSession : ISession
-    {
-        private readonly TerminalSession _inner = new(80, 24);
-        private int _mutateCalls;
-
-        public Action<int>? AfterMutate { get; set; }
-        public ITerminalCore Emulator => _inner.Emulator;
-        public int Cols => _inner.Cols;
-        public int Rows => _inner.Rows;
-        public int? ChildProcessId => _inner.ChildProcessId;
-        public object SyncRoot => _inner.SyncRoot;
-        public AgentStatus Status => _inner.Status;
-        public bool Blink => _inner.Blink;
-        public bool AutoReset => _inner.AutoReset;
-        public int? ExitCode => _inner.ExitCode;
-        public bool HasExited => _inner.HasExited;
-
-        public event Action? OutputReceived
-        {
-            add => _inner.OutputReceived += value;
-            remove => _inner.OutputReceived -= value;
-        }
-
-        public event Action? StatusChanged
-        {
-            add => _inner.StatusChanged += value;
-            remove => _inner.StatusChanged -= value;
-        }
-
-        public event Action<string?>? SoundRequested
-        {
-            add => _inner.SoundRequested += value;
-            remove => _inner.SoundRequested -= value;
-        }
-
-        public event Action<int>? Exited
-        {
-            add => _inner.Exited += value;
-            remove => _inner.Exited -= value;
-        }
-
-        public void SetStatus(AgentStatus status, bool blink = false, bool autoReset = false,
-            bool sound = false, string? soundName = null)
-            => _inner.SetStatus(status, blink, autoReset, sound, soundName);
-
-        public void NotifyActivity() => _inner.NotifyActivity();
-        public Task<int> RunAsync(string app, string[] commandLine, bool verbatimCommandLine = false,
-            CancellationToken ct = default) => _inner.RunAsync(app, commandLine, verbatimCommandLine, ct);
-        public Task StartAsync(string app, string[] commandLine, bool verbatimCommandLine = false,
-            IReadOnlyDictionary<string, string>? extraEnv = null, string? cwd = null,
-            bool deElevate = false, bool freshEnv = true, CancellationToken ct = default)
-            => _inner.StartAsync(app, commandLine, verbatimCommandLine, extraEnv, cwd, deElevate, freshEnv, ct);
-        public void Attach(SafeFileHandle conOut, SafeFileHandle conIn, SafeFileHandle signal,
-            IntPtr clientProcess, int pid) => _inner.Attach(conOut, conIn, signal, clientProcess, pid);
-        public void Inject(ReadOnlySpan<byte> bytes) => _inner.Inject(bytes);
-
-        public void MutateLocked(Action<ITerminalCore> mutate)
-        {
-            int call = Interlocked.Increment(ref _mutateCalls);
-            _inner.MutateLocked(mutate);
-            AfterMutate?.Invoke(call);
-        }
-
-        public void MutateInner(Action<ITerminalCore> mutate) => _inner.MutateLocked(mutate);
-        public void Write(ReadOnlySpan<byte> bytes) => _inner.Write(bytes);
-        public void Resize(int cols, int rows) => _inner.Resize(cols, rows);
-        public string SnapshotRow(int row) => _inner.SnapshotRow(row);
-        public void Detach() => _inner.Detach();
-        public void Dispose() => _inner.Dispose();
     }
 
     /// <summary>Padded BGRA whose every pixel carries the frame's tag, so a copy is identifiable.</summary>
@@ -605,21 +527,26 @@ public class ControlServerFrameShmTests : IDisposable
     [Fact]
     public void ACacheReplacementBetweenValidationAndCommitRetransmitsOnce()
     {
-        using var session = new InterceptSession();
+        // Phase 1 answers a cache hit from the dictionary alone, so the emulator can lose the
+        // cached image any time before phase 2 takes the lock. Phase 2 must notice, drop the
+        // entry and retry once with the pixels re-read - the caller sees one clean success.
+        using var session = new TerminalSession(80, 24);
         var server = new ControlServer(session);
         var p = NewProducer();
         long seq = p.Publish(0xE1);
         string request = Request("{\"images\":[" + Image(p, seq, p.Slot, id: 1) + "]}");
         Assert.Contains("frame:1/1", server.Dispatch(request));
 
-        session.AfterMutate = call =>
+        int preparedCalls = 0;
+        server.SharedFramePrepared = () =>
         {
-            if (call == 2)
-                session.MutateInner(em =>
+            if (Interlocked.Increment(ref preparedCalls) == 1)
+                session.MutateLocked(em =>
                     em.SetImageData(1, KittyFormat.Rgba, 1, 1, new byte[] { 1, 2, 3, 4 }));
         };
 
         string resp = server.Dispatch(request);
+        Assert.Equal(2, preparedCalls);
 
         Assert.Contains("frame:1/1", resp);
         Assert.Equal(Packed(0xE1), session.Emulator.Images[1].Data);
@@ -629,7 +556,7 @@ public class ControlServerFrameShmTests : IDisposable
     [Fact]
     public async Task ASecondCacheReplacementDuringTheRetryReturnsAnErrorWithoutChangingPlacements()
     {
-        using var session = new InterceptSession();
+        using var session = new TerminalSession(80, 24);
         var server = new ControlServer(session);
         var p = NewProducer();
         long seq = p.Publish(0xE2);
@@ -639,18 +566,23 @@ public class ControlServerFrameShmTests : IDisposable
         using var firstValidationDone = new ManualResetEventSlim();
         using var resumeFirstRequest = new ManualResetEventSlim();
         byte[] finalExternalPixels = { 9, 8, 7, 6 };
-        session.AfterMutate = call =>
+        // Prepared-seam order: 1 = the paused first request, 2 and 3 = the test thread's request
+        // and its retry, 4 = the first request's retry, which finds the re-cached entry and then
+        // loses it once more before it can commit.
+        int preparedCalls = 0;
+        server.SharedFramePrepared = () =>
         {
-            if (call == 2)
+            switch (Interlocked.Increment(ref preparedCalls))
             {
-                firstValidationDone.Set();
-                if (!resumeFirstRequest.Wait(TimeSpan.FromSeconds(10)))
-                    throw new TimeoutException("test did not release the first cache validation");
-            }
-            else if (call == 6)
-            {
-                session.MutateInner(em =>
-                    em.SetImageData(1, KittyFormat.Rgba, 1, 1, finalExternalPixels));
+                case 1:
+                    firstValidationDone.Set();
+                    if (!resumeFirstRequest.Wait(TimeSpan.FromSeconds(10)))
+                        throw new TimeoutException("test did not release the first cache validation");
+                    break;
+                case 4:
+                    session.MutateLocked(em =>
+                        em.SetImageData(1, KittyFormat.Rgba, 1, 1, finalExternalPixels));
+                    break;
             }
         };
 
@@ -659,12 +591,13 @@ public class ControlServerFrameShmTests : IDisposable
         {
             Assert.True(firstValidationDone.Wait(TimeSpan.FromSeconds(10)),
                 "first request did not reach cache validation");
-            session.MutateInner(em =>
+            session.MutateLocked(em =>
                 em.SetImageData(1, KittyFormat.Rgba, 1, 1, new byte[] { 5, 6, 7, 8 }));
 
             // Re-cache the same sequence with a new image while the first request is paused. Its
-            // retry will accept this entry in phase 1, then the call-6 hook replaces it once more.
+            // retry will accept this entry in phase 1, then the seam hook replaces it once more.
             Assert.Contains("frame:1/1", server.Dispatch(request));
+            Assert.Equal(3, preparedCalls);
         }
         finally
         {
@@ -991,6 +924,39 @@ public class ControlServerFrameShmTests : IDisposable
         Assert.Contains("retained pixel budget", ErrorOf(rejected));
         Assert.Single(session.Emulator.Images);
         Assert.Equal(1, Assert.Single(session.Emulator.Placements).ImageId);
+    }
+
+    [Fact]
+    public void ReplacingAnExistingIdIsAcceptedWhileAnotherPathHoldsTheSessionOverBudget()
+    {
+        // The budget is a ceiling on what shared frames may ADD, not a gate on the session's total:
+        // a Kitty or sixel image that arrived through the pty can put the pane over the limit on
+        // its own, and a producer replacing its own id then makes nothing worse, so it must not be
+        // locked out. Only a request that would grow the excess is refused.
+        using var session = new TerminalSession(80, 24);
+        long oneFrameBytes = Packed(0).LongLength;
+        var server = new ControlServer(
+            session,
+            ControlServer.MaxSharedFrameRequestBytes,
+            retainedSharedFrameByteLimit: oneFrameBytes,
+            ControlServer.MaxRetainedSharedFrameImages);
+        var p = NewProducer();
+
+        Assert.Contains("frame:1/1", server.Dispatch(Request(
+            "{\"images\":[" + Image(p, p.Publish(0xB1), p.Slot, id: 1) + "]}")));
+        // Something else (the pty stream, say) parks four frames' worth of pixels under another id.
+        session.MutateLocked(em => em.SetImageData(2, KittyFormat.Png, 0, 0, new byte[oneFrameBytes * 4]));
+
+        string replaced = server.Dispatch(Request(
+            "{\"images\":[" + Image(p, p.Publish(0xB2), p.Slot, id: 1) + "]}"));
+        Assert.Contains("frame:1/1", replaced);
+        Assert.Equal(Packed(0xB2), session.Emulator.Images[1].Data);
+        Assert.Equal(1, Assert.Single(session.Emulator.Placements).ImageId);
+
+        string grown = server.Dispatch(Request(
+            "{\"images\":[" + Image(p, p.Publish(0xB3), p.Slot, id: 3) + "]}"));
+        Assert.Contains("retained pixel budget", ErrorOf(grown));
+        Assert.Equal(2, session.Emulator.Images.Count);
     }
 
     [Fact]

--- a/tests/Agwinterm.Pty.Tests/ControlServerFrameShmTests.cs
+++ b/tests/Agwinterm.Pty.Tests/ControlServerFrameShmTests.cs
@@ -524,6 +524,29 @@ public class ControlServerFrameShmTests : IDisposable
         Assert.Equal(Packed(0xE0), session.Emulator.Images[1].Data);
     }
 
+    // Two cached ids, one replaced behind the verb's back: the retry copies that one out of shared
+    // memory and the live sibling keeps its cache hit - the burst this cache exists to avoid.
+    [Fact]
+    public void OnlyTheStaleIdIsRecopiedWhenASiblingIsStillLive()
+    {
+        var (server, session) = New();
+        var a = NewProducer();
+        var b = NewProducer();
+        long seqA = a.Publish(0xA1);
+        long seqB = b.Publish(0xB1);
+        string request = Request("{\"images\":[" + Image(a, seqA, a.Slot, id: 1) + "," +
+            Image(b, seqB, b.Slot, id: 2, row: 6) + "]}");
+        Assert.Contains("frame:2/2", server.Dispatch(request));
+        Assert.Contains("frame:2/0", server.Dispatch(request));
+
+        session.MutateLocked(em => em.SetImageData(2, KittyFormat.Rgba, 1, 1, new byte[] { 1, 2, 3, 4 }));
+
+        Assert.Contains("frame:2/1", server.Dispatch(request));
+        Assert.Equal(Packed(0xA1), session.Emulator.Images[1].Data);
+        Assert.Equal(Packed(0xB1), session.Emulator.Images[2].Data);
+        Assert.Equal(2, session.Emulator.Placements.Count);
+    }
+
     [Fact]
     public void ACacheReplacementBetweenValidationAndCommitRetransmitsOnce()
     {

--- a/tests/Agwinterm.Pty.Tests/ControlServerTests.cs
+++ b/tests/Agwinterm.Pty.Tests/ControlServerTests.cs
@@ -90,14 +90,7 @@ public class ControlServerTests
         var (server, session) = New();
 
         // Minimal 1x1 PNG.
-        byte[] png =
-        {
-            0x89,0x50,0x4E,0x47,0x0D,0x0A,0x1A,0x0A,0x00,0x00,0x00,0x0D,0x49,0x48,0x44,0x52,
-            0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x01,0x08,0x02,0x00,0x00,0x00,0x90,0x77,0x53,
-            0xDE,0x00,0x00,0x00,0x0C,0x49,0x44,0x41,0x54,0x08,0xD7,0x63,0xF8,0xCF,0xC0,0x00,
-            0x00,0x00,0x03,0x01,0x01,0x00,0x18,0xDD,0x8D,0xB0,0x00,0x00,0x00,0x00,0x49,0x45,
-            0x4E,0x44,0xAE,0x42,0x60,0x82,
-        };
+        byte[] png = OnePixelPng;
         string file = Path.Combine(Path.GetTempPath(), "agw_ctrl_test.png");
         File.WriteAllBytes(file, png);
 
@@ -117,14 +110,7 @@ public class ControlServerTests
     public void ImageClear_RemovesPlacements()
     {
         var (server, session) = New();
-        byte[] png =
-        {
-            0x89,0x50,0x4E,0x47,0x0D,0x0A,0x1A,0x0A,0x00,0x00,0x00,0x0D,0x49,0x48,0x44,0x52,
-            0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x01,0x08,0x02,0x00,0x00,0x00,0x90,0x77,0x53,
-            0xDE,0x00,0x00,0x00,0x0C,0x49,0x44,0x41,0x54,0x08,0xD7,0x63,0xF8,0xCF,0xC0,0x00,
-            0x00,0x00,0x03,0x01,0x01,0x00,0x18,0xDD,0x8D,0xB0,0x00,0x00,0x00,0x00,0x49,0x45,
-            0x4E,0x44,0xAE,0x42,0x60,0x82,
-        };
+        byte[] png = OnePixelPng;
         string file = Path.Combine(Path.GetTempPath(), "agw_ctrl_clear.png");
         File.WriteAllBytes(file, png);
         server.Dispatch("{\"cmd\":\"image.show\",\"args\":{\"path\":" + System.Text.Json.JsonSerializer.Serialize(file) + ",\"id\":1}}");
@@ -139,14 +125,7 @@ public class ControlServerTests
     public void ImageFrame_AtomicallyReplacesWithCellDims()
     {
         var (server, session) = New();
-        byte[] png =
-        {
-            0x89,0x50,0x4E,0x47,0x0D,0x0A,0x1A,0x0A,0x00,0x00,0x00,0x0D,0x49,0x48,0x44,0x52,
-            0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x01,0x08,0x02,0x00,0x00,0x00,0x90,0x77,0x53,
-            0xDE,0x00,0x00,0x00,0x0C,0x49,0x44,0x41,0x54,0x08,0xD7,0x63,0xF8,0xCF,0xC0,0x00,
-            0x00,0x00,0x03,0x01,0x01,0x00,0x18,0xDD,0x8D,0xB0,0x00,0x00,0x00,0x00,0x49,0x45,
-            0x4E,0x44,0xAE,0x42,0x60,0x82,
-        };
+        byte[] png = OnePixelPng;
         string file = Path.Combine(Path.GetTempPath(), "agw_frame.png");
         File.WriteAllBytes(file, png);
         string pj = System.Text.Json.JsonSerializer.Serialize(file);
@@ -193,6 +172,40 @@ public class ControlServerTests
         finally { File.Delete(file); }
     }
 
+    // Both cached ids replaced at once. The liveness loop must collect EVERY stale id: a loop that
+    // stopped at the first would drop one entry, retry, go stale on the other with no retry left,
+    // and answer an error while the pane kept the previous frame.
+    [Fact]
+    public void ImageFrame_TwoStaleIdsAreBothReReadInTheSingleRetry()
+    {
+        var (server, session) = New();
+        string file = Path.Combine(Path.GetTempPath(), "agw_frame_twostale_" + Guid.NewGuid().ToString("N") + ".png");
+        File.WriteAllBytes(file, OnePixelPng);
+        try
+        {
+            string pj = System.Text.Json.JsonSerializer.Serialize(file);
+            string req = "{\"cmd\":\"image.frame\",\"args\":{\"images\":[" +
+                "{\"path\":" + pj + ",\"row\":1,\"col\":0,\"cols\":4,\"rows\":2,\"id\":1}," +
+                "{\"path\":" + pj + ",\"row\":5,\"col\":0,\"cols\":4,\"rows\":2,\"id\":2}]}}";
+            Assert.Contains("frame:2/2", server.Dispatch(req));
+            Assert.Contains("frame:2/0", server.Dispatch(req));
+
+            session.MutateLocked(em =>
+            {
+                em.SetImageData(1, KittyFormat.Rgba, 1, 1, new byte[] { 1, 2, 3, 4 });
+                em.SetImageData(2, KittyFormat.Rgba, 1, 1, new byte[] { 5, 6, 7, 8 });
+            });
+
+            string resp = server.Dispatch(req);
+            Assert.Contains("\"ok\":true", resp);
+            Assert.Contains("frame:2/2", resp);
+            Assert.Equal(OnePixelPng, session.Emulator.Images[1].Data);
+            Assert.Equal(OnePixelPng, session.Emulator.Images[2].Data);
+            Assert.Equal(2, session.Emulator.Placements.Count);
+        }
+        finally { File.Delete(file); }
+    }
+
     // A frame of two cached ids where only one went stale: the retry re-reads that one file, and
     // the live sibling keeps its cache hit instead of being re-read along with it.
     [Fact]
@@ -219,6 +232,7 @@ public class ControlServerTests
         finally { File.Delete(file); }
     }
 
+    // A 1x1 PNG, the fixture every image.frame test here writes to disk.
     private static readonly byte[] OnePixelPng =
     {
         0x89,0x50,0x4E,0x47,0x0D,0x0A,0x1A,0x0A,0x00,0x00,0x00,0x0D,0x49,0x48,0x44,0x52,

--- a/tests/Agwinterm.Pty.Tests/ControlServerTests.cs
+++ b/tests/Agwinterm.Pty.Tests/ControlServerTests.cs
@@ -167,4 +167,64 @@ public class ControlServerTests
         Assert.Equal(10, p1.Cols);
         Assert.Equal(5, p1.Rows);
     }
+
+    // Phase 1 answers a cache hit from the dictionary alone; the only check that the emulator still
+    // holds the cached image is in phase 2, which drops the entry and retries once. A child that
+    // replaced the id (Kitty output, image.show) must therefore cost one re-read, not an error.
+    [Fact]
+    public void ImageFrame_ACacheHitRetransmitsAfterTheImageIdWasReplacedOutsideTheFrameVerb()
+    {
+        var (server, session) = New();
+        string file = Path.Combine(Path.GetTempPath(), "agw_frame_replaced_" + Guid.NewGuid().ToString("N") + ".png");
+        File.WriteAllBytes(file, OnePixelPng);
+        try
+        {
+            string pj = System.Text.Json.JsonSerializer.Serialize(file);
+            string req = "{\"cmd\":\"image.frame\",\"args\":{\"images\":[" +
+                "{\"path\":" + pj + ",\"row\":1,\"col\":2,\"cols\":10,\"rows\":5,\"id\":1}]}}";
+            Assert.Contains("frame:1/1", server.Dispatch(req));
+
+            session.MutateLocked(em => em.SetImageData(1, KittyFormat.Rgba, 1, 1, new byte[] { 1, 2, 3, 4 }));
+
+            Assert.Contains("frame:1/1", server.Dispatch(req));
+            Assert.Equal(OnePixelPng, session.Emulator.Images[1].Data);
+            Assert.Single(session.Emulator.Placements);
+        }
+        finally { File.Delete(file); }
+    }
+
+    // A frame of two cached ids where only one went stale: the retry re-reads that one file, and
+    // the live sibling keeps its cache hit instead of being re-read along with it.
+    [Fact]
+    public void ImageFrame_OnlyTheStaleIdIsReReadWhenASiblingIsStillLive()
+    {
+        var (server, session) = New();
+        string file = Path.Combine(Path.GetTempPath(), "agw_frame_sibling_" + Guid.NewGuid().ToString("N") + ".png");
+        File.WriteAllBytes(file, OnePixelPng);
+        try
+        {
+            string pj = System.Text.Json.JsonSerializer.Serialize(file);
+            string req = "{\"cmd\":\"image.frame\",\"args\":{\"images\":[" +
+                "{\"path\":" + pj + ",\"row\":1,\"col\":0,\"cols\":4,\"rows\":2,\"id\":1}," +
+                "{\"path\":" + pj + ",\"row\":5,\"col\":0,\"cols\":4,\"rows\":2,\"id\":2}]}}";
+            Assert.Contains("frame:2/2", server.Dispatch(req));
+            Assert.Contains("frame:2/0", server.Dispatch(req));
+
+            session.MutateLocked(em => em.SetImageData(2, KittyFormat.Rgba, 1, 1, new byte[] { 1, 2, 3, 4 }));
+
+            Assert.Contains("frame:2/1", server.Dispatch(req));
+            Assert.Equal(OnePixelPng, session.Emulator.Images[2].Data);
+            Assert.Equal(2, session.Emulator.Placements.Count);
+        }
+        finally { File.Delete(file); }
+    }
+
+    private static readonly byte[] OnePixelPng =
+    {
+        0x89,0x50,0x4E,0x47,0x0D,0x0A,0x1A,0x0A,0x00,0x00,0x00,0x0D,0x49,0x48,0x44,0x52,
+        0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x01,0x08,0x02,0x00,0x00,0x00,0x90,0x77,0x53,
+        0xDE,0x00,0x00,0x00,0x0C,0x49,0x44,0x41,0x54,0x08,0xD7,0x63,0xF8,0xCF,0xC0,0x00,
+        0x00,0x00,0x03,0x01,0x01,0x00,0x18,0xDD,0x8D,0xB0,0x00,0x00,0x00,0x00,0x49,0x45,
+        0x4E,0x44,0xAE,0x42,0x60,0x82,
+    };
 }

--- a/tests/Agwinterm.Pty.Tests/FrameShmPipeIntegrationTests.cs
+++ b/tests/Agwinterm.Pty.Tests/FrameShmPipeIntegrationTests.cs
@@ -300,9 +300,10 @@ public class FrameShmPipeIntegrationTests : IDisposable
         var p = NewProducer();
         string request = CtlRequest(p, seq: 1, slot: 1, ("id", "7"), ("cols", "10"));
 
-        // The regression this guards is silent and total: ControlServer's GetInt throws on a
-        // string, so a quoted number would reject every frame with "requires an element of type
-        // 'Number'". Asserting on the serialized text is the only place that shape is visible.
+        // The regression this guards is total: ControlServer's TryNum rejects a quoted number
+        // ("'slot' must be a JSON number, not string"), so a CLI that serialized its numeric
+        // options as strings would have every frame refused. The wire text is where that shape
+        // is decided, so that is what gets asserted.
         Assert.Contains("\"slot\":1", request);
         Assert.Contains("\"seq\":1", request);
         Assert.Contains("\"id\":7", request);

--- a/tests/integration/win32-control.ps1
+++ b/tests/integration/win32-control.ps1
@@ -517,21 +517,23 @@ finally {
     if ($sessionId) {
         try { Invoke-Ctl @('session', 'close', $sessionId) | Out-Null } catch { }
     }
-    if (Test-Path -LiteralPath $captureFile) { Remove-Item -LiteralPath $captureFile -Force }
-    if (Test-Path -LiteralPath $releaseFile) { Remove-Item -LiteralPath $releaseFile -Force }
-    foreach ($mouseFile in @($mouseCellReadyFile, $mousePixelReadyFile, $mouseCellFile, $mousePixelFile)) {
-        if (Test-Path -LiteralPath $mouseFile) { Remove-Item -LiteralPath $mouseFile -Force }
+    # Every step here is guarded: $ErrorActionPreference is Stop, and a terminating error inside a
+    # finally abandons the rest of the block - the environment restore at the end included.
+    foreach ($file in @($captureFile, $releaseFile, $mouseCellReadyFile, $mousePixelReadyFile, $mouseCellFile, $mousePixelFile)) {
+        try { if (Test-Path -LiteralPath $file) { Remove-Item -LiteralPath $file -Force } } catch { }
     }
     if ($process) {
         try { $process.CloseMainWindow() | Out-Null } catch { }
-        if (-not $process.WaitForExit(2000)) {
-            Stop-Process -Id $process.Id -Force
-            $process.WaitForExit()
-        }
+        try {
+            if (-not $process.WaitForExit(2000)) {
+                Stop-Process -Id $process.Id -Force
+                $process.WaitForExit()
+            }
+        } catch { }
     }
     # Both directories were proved to be direct children of LocalApplicationData before launch.
     foreach ($dir in @($testAppDir, $envAppDir)) {
-        if ($dir -and (Test-Path -LiteralPath $dir)) { Remove-Item -LiteralPath $dir -Recurse -Force }
+        try { if ($dir -and (Test-Path -LiteralPath $dir)) { Remove-Item -LiteralPath $dir -Recurse -Force } } catch { }
     }
     foreach ($name in $savedEnv.Keys) {
         [Environment]::SetEnvironmentVariable($name, $savedEnv[$name])

--- a/tests/integration/win32-control.ps1
+++ b/tests/integration/win32-control.ps1
@@ -64,7 +64,13 @@ if (-not $Exe) { "  SKIP  agwinterm build not found (build src\Agwinterm.Win32 o
 "  using: $(Split-Path $Exe -Leaf) from $(Split-Path $Exe -Parent)"
 
 # Do not inherit routing from the developer's current terminal. This process gets its own pipe and
-# every mutation below is sent only to the process this script starts.
+# every mutation below is sent only to the process this script starts. Dot-sourced or run from a
+# pane inside agwinterm, these are the caller's own routing variables, so they are put back at the
+# end rather than left pointing at a pipe that no longer exists.
+$savedEnv = @{}
+foreach ($name in 'AGWINTERM_SESSION_ID', 'AGWINTERM_PANE_ID', 'AGWINTERM_PIPE', 'AGWINTERM_APP_ID') {
+    $savedEnv[$name] = [Environment]::GetEnvironmentVariable($name)
+}
 $env:AGWINTERM_SESSION_ID = $null
 $env:AGWINTERM_PANE_ID = $null
 $env:AGWINTERM_PIPE = $null
@@ -526,6 +532,9 @@ finally {
     # Both directories were proved to be direct children of LocalApplicationData before launch.
     foreach ($dir in @($testAppDir, $envAppDir)) {
         if ($dir -and (Test-Path -LiteralPath $dir)) { Remove-Item -LiteralPath $dir -Recurse -Force }
+    }
+    foreach ($name in $savedEnv.Keys) {
+        [Environment]::SetEnvironmentVariable($name, $savedEnv[$name])
     }
 }
 


### PR DESCRIPTION
Follow-up to #220: the four Minors from its final revmux round (08, all lenses, no Major/Critical), which landed after the PR was merged.

## What changed

- **`ControlServer.cs`** — phase 1 of `image.frame` / `image.frameshm` answered a cache hit from the dictionary and then took the render lock **once per image** to confirm the emulator still held that image. Phase 2 repeats that exact check under the lock that applies the frame, drops a stale entry, and retries once — so the phase-1 probe is gone. Phase 1 is now the "off the render lock" pass its comments claimed; the comments say so.
- **`ControlServerFrameShmTests.cs`** — the two seam tests that counted `MutateLocked` calls to land a replacement between the phases now use the `SharedFramePrepared` seam the other six use (`InterceptSession` removed). New test: a producer replacing its **own** id is accepted while another image path holds the session over the pixel budget, and a request that would grow the excess is still refused.
- **`FrameShmPipeIntegrationTests.cs`** — the comment names `TryNum`'s real rejection (`'slot' must be a JSON number, not string`), not a `GetInt` throw.
- **`tests/integration/win32-control.ps1`** — captures `AGWINTERM_APP_ID` / `_SESSION_ID` / `_PANE_ID` / `_PIPE` before overriding them and restores them in `finally`, so a run from inside an agwinterm pane no longer leaves the shell routed at a dead pipe.

## Evidence

- `dotnet test tests/Agwinterm.Pty.Tests -c Release`: **332/332** (on `feat/image-frameshm-control` tip and again after the cherry-pick onto `main`).
- `pwsh -NoProfile -File tests/integration/win32-control.ps1 -Strict`: **21/21**, `Win32 control-host integration: all passed`.
- **revmux round 1** (all four lenses): **no Major/Critical**, three Minors, fixed in `b2b179f`: the phase-2 abort dropped *every* cached entry in the request before retrying (a 32-image frame with one id replaced by terminal output re-copied all 32) — the liveness loop now collects the stale ids and only those entries are removed, so a live sibling keeps its cache hit; `image.frame`'s invalidate-and-retry path got the test it lacked (plus a sibling-keeps-its-hit test on each transport); the integration script's `finally` guards every cleanup step so a failed `Remove-Item` cannot skip the env restore.
- **revmux round 2**: **no Major/Critical**, three Minors, fixed in `d763c9c`/`5829ecc`: a two-stale-ids test on each transport (both fail against an early-return mutant of the loop — checked), the phase-2 comments now say the retry re-runs phase 1 and skips only live cached siblings, a stale test comment describing the deleted phase-1 invalidation rewritten; plus the HashSet and PNG-constant nits.
- Final: `dotnet test tests/Agwinterm.Pty.Tests -c Release` **337/337**; `tests/integration/win32-control.ps1 -Strict` all 21 passed on a sandbox instance (on `b2b179f`; the later commits touch tests and comments only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k

