### PR TITLE
contract: surface.cursor step + per-batch lite mirroring

### DIFF
--- a/docs/lite-parity.md
+++ b/docs/lite-parity.md
@@ -74,23 +74,24 @@ Adoption is the interesting one: pointing the terminal at an already-running Cla
 ### Everything else
 `broadcast` · `notify` · `dashboard` · `restore.clear` · `workspace.move`
 
-### Owed by P8: the read-only trio agwinterm shipped in P1
+### Being mirrored now: the read-only trio agwinterm shipped in P1
 `surface.cursor` — the only *verb* of the three, and so the only one counted above. The other two
 are a tree node FIELD (`statusChangedAt`) and a CLI verb (`agwintermctl version`), owed just as much
 and invisible to a verb count.
 
-Landed in agwinterm as **#221** (batch P1), so this is now a gap in the strict sense: three
-read-only answers an agent gets from one product and not the other. `surface.cursor` is the one that
-changes behaviour rather than convenience — it is the check before typing into another agent's
-composer, and without it a caller has to guess emptiness from rendered text.
+Landed in agwinterm as **#221** (batch P1). The lite mirror is agliteterm's
+`docs/plans/2026-09-03-p1-lite-mirror.md` (batch **P1-lite**), in flight the same day: the two
+products now advance batch by batch rather than lite catching up in one P8 after wave 1.
+`surface.cursor` is the one that changes behaviour rather than convenience — it is the check before
+typing into another agent's composer, and without it a caller has to guess emptiness from rendered
+text. lite has no `version` verb to add: `agwintermctl version` reports the app from `ping`, and
+lite's `ping` answered a hard-coded `"agliteterm 0.1"`, so the mirror of that item is a truthful
+`ping`.
 
-The conformance steps for all three are **P8's** work as well, deliberately: adding them to
-`tests/conformance/control-api.json` before lite answers them would turn agliteterm's CI red for
-weeks, so agwinterm shipped the verbs and the shared contract file was left untouched. Whoever runs
-P8 adds the verbs and the steps in the same PR.
-
-**Size:** small in lite. The cursor read is a local emulator query, `statusChangedAt` is one field
-stamped where status is written, and `version` is a presentation change over the existing ping.
+The conformance step for `surface.cursor` (a new `integer` result kind in the runner) is in the
+canonical file as of this PR — agwinterm-first, as the contract rule says. Until P1-lite merges,
+agliteterm's `check-contract` is red by design; that is the gate, not a bug. `statusChangedAt` is a
+nested tree field the shape runner cannot express, so each product pins it in its own tests.
 
 ---
 

--- a/docs/plans/2026-09-03-parity-batches.md
+++ b/docs/plans/2026-09-03-parity-batches.md
@@ -15,6 +15,11 @@ without a **Shipped** line below has not started.
 - **Contract before mirror.** `tests/conformance/control-api.json` is canonical here and agliteterm's
   CI checks its copy against it. So a verb is defined in agwinterm first; the lite batch that mirrors
   it runs after, never beside it.
+- **Mirror per batch, not per wave** (Boris, 2026-09-03: "I want both terminals to be on par"). Each
+  agwinterm batch is followed immediately by its lite mirror (`P1-lite`, `P2-lite`, ...), a separate
+  plan in the agliteterm repo. The contract step for a new verb lands in agwinterm in a small
+  sibling PR that merges first; lite's CI is red on `check-contract` for exactly the gap between the
+  two merges. P8 below is therefore dissolved into those per-batch mirrors.
 - **A batch is a theme, not a size quota.** Items travel together when they share a test area or a
   format change, so one revmux round covers them coherently.
 - **Every batch exits the same way:** its own tests, the QA cases in `qa/` (both products have them),
@@ -103,11 +108,10 @@ the posted `WM_MOUSEWHEEL` that never reaches lite's handler (harness finding, 0
 
 Same model as P6, different surface — split because it is UI work with a different test shape.
 
-### P8 · lite · mirror Wave 1
-`surface.cursor` · `statusChangedAt` · `version` · `--stdin` · size-percent validation ·
-`session.context`
-
-Runs only after P1–P3 land, so the contract is fixed before it is copied.
+### P8 · lite · mirror Wave 1 — dissolved into per-batch mirrors
+`surface.cursor` · `statusChangedAt` · `version` → **P1-lite** (agliteterm
+`docs/plans/2026-09-03-p1-lite-mirror.md`, 2026-09-03) · `--stdin` · size-percent validation →
+P2-lite · `session.context` → P3-lite. Each runs right after its agwinterm batch merges.
 
 ### P9 · lite · driving a pane
 `session.readonly` **first** — it is how you stop stray keys reaching a running agent — then

--- a/tests/conformance/conformance.ps1
+++ b/tests/conformance/conformance.ps1
@@ -99,6 +99,10 @@ function Test-Shape($resp, [string]$kind, $fields) {
     $r = $resp.result
     switch ($kind) {
         'string' { if ($r -isnot [string]) { return "result is $($r.GetType().Name), expected string" } }
+        # A bare JSON number with no fraction. ConvertFrom-Json gives [long] for a whole number and
+        # [double] once there is a decimal point, and a quoted "12" stays a [string] — so the type
+        # check alone separates `12` from `"12"` and `12.0`, which is the whole contract here.
+        'integer' { if ($r -isnot [int] -and $r -isnot [long]) { return "result is $($r.GetType().Name), expected a bare integer" } }
         'object' {
             if ($r -isnot [psobject]) { return "result is not an object" }
             foreach ($f in $fields) { if ($r.PSObject.Properties.Name -notcontains $f) { return "result is missing '$f'" } }

--- a/tests/conformance/control-api.json
+++ b/tests/conformance/control-api.json
@@ -12,7 +12,7 @@
     "Steps run in order and share state — a session must exist before anything can select it — and",
     "{placeholders} carry captured values forward.",
     "",
-    "The full app implements a superset (38 verbs here; it also has search, output, readonly, bind,",
+    "The full app implements a superset (41 verbs here; it also has search, output, readonly, bind,",
     "background, theme.*, config.*, install.*, ...). Those are deliberately NOT in this file: this is",
     "the shared floor both products stand on, not an inventory of either one."
   ],
@@ -146,6 +146,17 @@
       ],
       "result": "string",
       "note": "the visible buffer. A string even when the pane is empty."
+    },
+    {
+      "verb": "surface.cursor",
+      "args": [
+        "surface",
+        "cursor",
+        "--target",
+        "{alpha}"
+      ],
+      "result": "integer",
+      "note": "the caret COLUMN of the pane, bare, as agterm reports it. Row is deliberately absent; a caller checking 'is that composer empty' compares one number. Value is not compared: it is a shell prompt's width."
     },
     {
       "verb": "session.output",


### PR DESCRIPTION
## What

- `tests/conformance/control-api.json`: a `surface.cursor` step after `session.text`, result kind **`integer`** — the bare-column shape P1 (#221) shipped and agterm reports. P1 left this out on purpose so lite's CI stayed green through wave 1; the programme has changed (below), so it lands now.
- `tests/conformance/conformance.ps1`: the `integer` kind — `[int]`/`[long]` only. ConvertFrom-Json types `12` as Int64, `"12"` as String and `12.0` as Double, so the type check alone is the contract.
- The `$comment` verb count said 38 with 40 verbs in the file; it now says 41.
- `docs/lite-parity.md` + `docs/plans/2026-09-03-parity-batches.md`: **both products advance batch by batch**. Each agwinterm batch is followed immediately by its lite mirror; P8 is dissolved into P1-lite / P2-lite / P3-lite. The agliteterm plan for P1-lite is `docs/plans/2026-09-03-p1-lite-mirror.md` there, running now.

## Merge order

This merges **first**. agliteterm's `check-contract` fetches this file from `main`, so lite is red on that one check between this merge and the P1-lite merge — by design, the contract gate.

## Evidence

- `tests/conformance/conformance.ps1 -Strict` locally against the current Release build: `PASS surface.cursor`, `conformance: all passed`.
- `12` / `"12"` / `12.0` / `0` through ConvertFrom-Json → Int64 / String / Double / Int64; the kind accepts the first and last only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k
