### PR TITLE
release: 0.17.10

### DIFF
--- a/installer/agwinterm.iss
+++ b/installer/agwinterm.iss
@@ -2,7 +2,7 @@
 ; Build via installer\build.ps1 (publishes to stage\ then runs ISCC on this file).
 
 #define AppName    "agwinterm"
-#define AppVersion "0.17.8"
+#define AppVersion "0.17.10"
 #define AppExe     "Agwinterm.Win32.exe"
 #define AppPublisher "Boris Kudriashov"
 ; The main app defaults new sessions to the Rust pty-host as a first-run seed only (it never


### PR DESCRIPTION
Version bump to **0.17.10** — `0.17.9` is skipped deliberately (checkpoint version → package managers); this release exists so agliteterm's CI can drive P1's verbs through a published `agwintermctl`.

Since v0.17.8: #220 (`image.frameshm`, `session.metrics`, SGR-Pixels mouse, **ABI 16 → 18**), #222, #221 (P1: `surface.cursor`, `statusChangedAt`, `agwintermctl version`), #223 (contract step), #217/#218/#219 (parity batch index, ralphex-revmux bridge, scorecard CI). Full notes in the commit message.

After merge: tag `v0.17.10` → release workflow publishes `agwintermctl.exe`, `agwinterm_core-abi18.dll`, `agwinterm-ptyhost-abi18.exe`. The checkpoint check computes `patch % 9`, so 10 does not submit packages.

agliteterm follow-up (in the P1-lite PR): `kRequiredAbi` 16 → 18, proto schema unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k
