### PR TITLE
contract: P2 steps (session new unknown workspace, --size-percent, sidebar width, sidebar refusals)

### DIFF
--- a/docs/lite-parity.md
+++ b/docs/lite-parity.md
@@ -94,7 +94,8 @@ agliteterm's `check-contract` is red by design; that is the gate, not a bug. `st
 nested tree field the shape runner cannot express, so each product pins it in its own tests.
 
 ### Being mirrored next: what P2 (agwinterm #226) owes lite
-Batch **P2-lite** owes three things, none of them a new verb:
+Batch **P2-lite** (agliteterm `docs/plans/2026-09-04-p2-lite-mirror.md`) owes four things, one of
+them a new verb:
 
 - **`--stdin` on `session type` / `session write`**, refusing invalid UTF-8 client-side with the
   byte offset named, sending nothing, stripping exactly one trailing newline, and refusing `--stdin`
@@ -109,11 +110,17 @@ Batch **P2-lite** owes three things, none of them a new verb:
   `caller` argument to the dispatcher (the CLI already sends `AGWINTERM_SESSION_ID`) and resolves
   that pane's workspace before creating, with *active* as the last fallback rather than the first.
 
+- **`sidebar width`** — the new verb, and the one the contract now pins: lite has a real `g_sidebarW`
+  and a `sidebar` verb that today **toggles on any op it does not know** (`sidebar width` flips the
+  sidebar and answers ok), so the mirror is cheap and the honesty fix is overdue. Lite's own range
+  (90..900, what its splitter and registry already allow) replaces agwinterm's 120..600; the contract
+  pins the reply shape and the refusal, not the numbers.
+
 `session.new`'s **refusal** of an unknown workspace needs no mirror — lite had it first, which is why
-decision 1 went that way. `session.restore`'s pane reply and `sidebar.width` are agwinterm-only until
-P9 / P10 bring those verbs to lite at all. The conformance steps for `session new --workspace
-no-such-workspace`, `--size-percent` and `sidebar width` land in a small sibling contract PR after
-#226 merges, so `check-contract` is red by design for the gap between that merge and P2-lite.
+decision 1 went that way. `session.restore`'s pane reply stays agwinterm-only until P9 brings the
+verb to lite at all. The conformance steps for `session new --workspace no-such-workspace`,
+`--size-percent`, `sidebar width` and the two sidebar refusals landed in the sibling contract PR
+right after #226, so `check-contract` is red by design for the gap between that merge and P2-lite.
 
 ---
 

--- a/docs/plans/2026-09-03-parity-batches.md
+++ b/docs/plans/2026-09-03-parity-batches.md
@@ -65,10 +65,11 @@ validates `--size-percent` as 1–100 instead of clamping silently · `session.r
 pane received the content · `sidebar.width` distinguishing a clamped request from an honoured one ·
 `session.new` refuses an unknown workspace *(decision 1)*
 
-**Shipped:** #226 — plan at [2026-09-04-p2-honesty.md](2026-09-04-p2-honesty.md) (moves to
-`completed/` with the merge); contract step and release to follow, as #223 / #224 followed P1.
-Grew one item on the way: a bare `session new` lands in the **caller's** workspace (task 5a).
-Mirror: agliteterm P2-lite.
+**Shipped:** #226 (2026-09-04, four revmux rounds) — plan at
+[completed/2026-09-04-p2-honesty.md](completed/2026-09-04-p2-honesty.md); contract steps in this
+PR; release to follow, as #224 followed P1. Grew one item on the way: a bare `session new` lands in
+the **caller's** workspace (task 5a). Round-4 leftovers: #228. Mirror: agliteterm P2-lite (plan
+`docs/plans/2026-09-04-p2-lite-mirror.md` there, with lite #23 and #24 riding along).
 
 Every item is the same defect class as the control-byte refusal already shipped in #213: a call that
 appears to succeed while doing something other than what was asked. Same test shape throughout.
@@ -118,10 +119,11 @@ the posted `WM_MOUSEWHEEL` that never reaches lite's handler (harness finding, 0
 Same model as P6, different surface — split because it is UI work with a different test shape.
 
 ### P8 · lite · mirror Wave 1 — dissolved into per-batch mirrors
-`surface.cursor` · `statusChangedAt` · `version` → **P1-lite** (agliteterm
-`docs/plans/2026-09-03-p1-lite-mirror.md`, 2026-09-03) · `--stdin` · size-percent validation ·
-the caller-workspace default for a bare `session new` → P2-lite · `session.context` → P3-lite. Each
-runs right after its agwinterm batch merges.
+`surface.cursor` · `statusChangedAt` · `version` → **P1-lite — shipped** (agliteterm #20,
+2026-09-04, six revmux rounds; plan `docs/plans/completed/2026-09-03-p1-lite-mirror.md` there) ·
+`--stdin` · size-percent validation · `sidebar width` · the caller-workspace default for a bare
+`session new` → P2-lite · `session.context` → P3-lite. Each runs right after its agwinterm batch
+merges.
 
 ### P9 · lite · driving a pane
 `session.readonly` **first** — it is how you stop stray keys reaching a running agent — then

--- a/tests/conformance/control-api.json
+++ b/tests/conformance/control-api.json
@@ -258,6 +258,19 @@
       "args": [
         "session",
         "overlay",
+        "open",
+        "cmd /c exit 0",
+        "--size-percent",
+        "40"
+      ],
+      "result": "string",
+      "note": "P2: --size-percent is VALIDATED (1..100), not clamped. 40 is honoured; 0, 150 and a non-number are refusals (see errors). What the string is differs by product (the full app returns the overlay id, lite a status word) - only its kind is the contract. The program exits at once, so the close that follows may find nothing open, and that is ok too: close on a session with no overlay stays ok."
+    },
+    {
+      "verb": "session.overlay",
+      "args": [
+        "session",
+        "overlay",
         "close"
       ],
       "result": "string"
@@ -355,6 +368,33 @@
         "on"
       ],
       "result": "string"
+    },
+    {
+      "verb": "sidebar.width",
+      "args": [
+        "sidebar",
+        "width"
+      ],
+      "result": "object",
+      "fields": [
+        "width",
+        "visible"
+      ],
+      "note": "P2: the width in effect (device-independent pixels) and whether the sidebar is visible. Extra fields are allowed (the full app adds `applied` on a set)."
+    },
+    {
+      "verb": "sidebar.width",
+      "args": [
+        "sidebar",
+        "width",
+        "260"
+      ],
+      "result": "object",
+      "fields": [
+        "width",
+        "visible"
+      ],
+      "note": "P2: a set replies with the width IN EFFECT, which is how a caller tells an honoured request from anything else; out of range is a refusal (see errors), never a clamp. The number here is inside every product's range."
     },
     {
       "verb": "window.list",
@@ -513,6 +553,41 @@
         "select",
         "--target",
         "no-such-workspace"
+      ]
+    },
+    {
+      "note": "P2: session.new with an unknown workspace is a REFUSAL, not a session in the active workspace. Silently falling back is how a caller believes it placed a session somewhere it did not. No session may exist behind this reply.",
+      "args": [
+        "session",
+        "new",
+        "--workspace",
+        "no-such-workspace"
+      ]
+    },
+    {
+      "note": "P2: --size-percent outside 1..100 is refused, naming the value and the range, and NO overlay opens. It used to clamp (or, in lite, be ignored) and answer ok.",
+      "args": [
+        "session",
+        "overlay",
+        "open",
+        "cmd /c exit 0",
+        "--size-percent",
+        "150"
+      ]
+    },
+    {
+      "note": "P2: a sidebar op the product cannot do is refused and changes nothing. It used to answer ok and do nothing (the full app) or toggle the sidebar (lite).",
+      "args": [
+        "sidebar",
+        "sideways"
+      ]
+    },
+    {
+      "note": "P2: sidebar width outside the product's range is refused with the range named, and the divider stays where it was.",
+      "args": [
+        "sidebar",
+        "width",
+        "5"
       ]
     }
   ],


### PR DESCRIPTION
The sibling contract PR that follows #226, as #223 followed #221. `tests/conformance/control-api.json` gains:

**steps**
- `session overlay open "cmd /c exit 0" --size-percent 40` → string (the value is product-specific; the kind is the contract)
- `sidebar width` (read) and `sidebar width 260` (set) → object with `width`, `visible`

**errors** (must be `ok:false`)
- `session new --workspace no-such-workspace` — no session behind the reply
- `session overlay open … --size-percent 150` — validated, not clamped
- `sidebar sideways` — an op the product cannot do is refused (lite toggles today)
- `sidebar width 5` — out of range, the divider stays

Verified: `tests/conformance/conformance.ps1 -Strict` against a sandbox on `main` + this file — all passed, the nine new/affected lines included.

**agliteterm goes red on `check-contract` when this merges**, until P2-lite (plan already on `feat/p2-lite-mirror` there) copies the file — expected, the same gap P1-lite had.

Trackers: P2 marked shipped in the batches index (plan under `completed/`, round-4 leftovers #228); the P8 line records **P1-lite shipped as agliteterm #20**; `lite-parity.md` records that P2-lite owes `sidebar width` as a real verb, with lite's own range.

Next: the release (P2 added `sidebar.width`, so the per-batch release rule applies — Boris calls the tag; `*.*.18` skipped unless a checkpoint is wanted), then P2-lite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k
