### PR TITLE
fix(control): session.split honours its target instead of splitting whatever is active

### DIFF
--- a/src/Agwinterm.Pty/AgentSkill.cs
+++ b/src/Agwinterm.Pty/AgentSkill.cs
@@ -224,7 +224,7 @@ public static class AgentSkill
           then the follow-up key. Drive/observe it with `agwintermctl command leader state|begin|cancel|key:<chord>`.
 
         ## Splits, font, sidebar, theme
-        - `agwintermctl session split on|off|toggle` · `session focus left|right|other` · `session resize --split-ratio 0.7` (or `--grow-left/--grow-right N`)
+        - `agwintermctl session split on|off|toggle [--target <id>]` (the target session, not the active one) · `session focus left|right|other` · `session resize --split-ratio 0.7` (or `--grow-left/--grow-right N`)
         - `agwintermctl font inc|dec|reset [--target <id>]`      — font zoom; target a session (active pane) or a specific split/scratch/quick pane by its id (see `tree` paneIds)
         - `agwintermctl dashboard [<id> ...] [--close] [--font-size N]` — grid overlay of live sessions (no ids = most-recent; `--close` dismisses; Ctrl+Shift+D toggles it in the UI)
         - `agwintermctl sidebar show|hide|toggle|expand|collapse` (`on`/`off` are aliases of show/hide). An op the sidebar

--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -250,7 +250,7 @@ public sealed class ControlServer : IDisposable
                 case "workspace.move": return host.WorkspaceReorder(target, GetString(args, "dir") ?? "down") ? Ok("moved") : Err("workspace not found");
                 case "workspace.collapse": return host.WorkspaceCollapse(target, expand: false) ? Ok("collapsed") : Err("workspace not found");
                 case "workspace.expand": return host.WorkspaceCollapse(target, expand: true) ? Ok("expanded") : Err("workspace not found");
-                case "session.split": host.Split(GetString(args, "op") ?? "toggle"); return Ok("split");
+                case "session.split": return host.Split(target, GetString(args, "op") ?? "toggle") ? Ok("split") : Err("session not found");
                 case "session.focus": host.FocusPaneDir(GetString(args, "dir") ?? "right"); return Ok("focus");
                 case "session.resize":
                     {

--- a/src/Agwinterm.Pty/ISessionHost.cs
+++ b/src/Agwinterm.Pty/ISessionHost.cs
@@ -172,8 +172,10 @@ public interface ISessionHost
     /// <summary>Reorder a workspace among its siblings: dir = up|down|top|bottom.</summary>
     bool WorkspaceReorder(string? target, string dir);
 
-    /// <summary>Split the active session: op = on|off|toggle.</summary>
-    void Split(string op);
+    /// <summary>Split the targeted session (null/"active" = the active one): op = on|off|toggle.
+    /// False when the target names no session. Splitting a session that is not the active one
+    /// does not move focus to it: the split appears when the user next selects that session.</summary>
+    bool Split(string? target, string op);
     /// <summary>Move pane focus in the active session: dir = left|right|other.</summary>
     void FocusPaneDir(string dir);
     /// <summary>Set the active session's split: an absolute left ratio (0..1) or grow left/right by N columns.</summary>
@@ -349,7 +351,7 @@ public sealed class SingleSessionHost : ISessionHost
     public bool WorkspaceCollapse(string? target, bool expand) => false;
     public bool WorkspaceSelect(string? target) => false;
     public bool WorkspaceReorder(string? target, string dir) => false;
-    public void Split(string op) { }
+    public bool Split(string? target, string op) => false;
     public void FocusPaneDir(string dir) { }
     public void ResizeSplit(double? ratio, int growLeft, int growRight) { }
     public IReadOnlyList<string> ThemeList() => Array.Empty<string>();

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -460,7 +460,16 @@ internal partial class Program
         return true;
     }
 
-    public void Split(string op) => Post(() => SplitOp(op));
+    public bool Split(string? target, string op)
+    {
+        // Resolved here, on the caller's thread, so a bad target answers false instead of being
+        // dropped on the UI queue. Same order as SessionScratch: null/"active" is the active
+        // session; otherwise a session id, a pane id, or a prefix of either.
+        var ses = FindSesForTarget(target);
+        if (ses is null) return false;
+        Post(() => SplitOp(op, ses));
+        return true;
+    }
 
     public void FocusPaneDir(string dir)
     {

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -1194,10 +1194,8 @@ internal partial class Program
 
     // ---- Splits ----
 
-    private void SplitActivePane()
+    private void SplitPane(Ses ses)
     {
-        var ses = _active;
-        if (ses is null) return;
         if (ses.Panes.Count >= 2) return;   // agterm model: strictly primary + one split (no 3+ panes)
         var cur = ses.ActivePane;
         string? cwd = string.IsNullOrEmpty(cur.StartCwd) ? null : cur.StartCwd;
@@ -1206,8 +1204,11 @@ internal partial class Program
         cur.Ratio = half; np.Ratio = half;
         int idx = ses.Panes.IndexOf(cur);
         lock (_workspaces) ses.Panes.Insert(idx + 1, np);   // exclude the control-pipe reader mid-enumeration (issue #85)
-        ses.Active = idx + 1;            // focus the new pane
-        _session = ses.S;
+        ses.Active = idx + 1;            // focus the new pane, within its session
+        // Only the active session's focused pane is the window's focused surface. Pointing
+        // `_session` at a pane of some other session would leave the window focused on a
+        // surface that is not on screen.
+        if (ReferenceEquals(ses, _active)) _session = ses.S;
         RegridSession(ses);
         RequestRedraw();
         SaveState();
@@ -1523,28 +1524,34 @@ internal partial class Program
         }
     }
 
-    private void SplitOp(string op)
+    /// <summary>The keyboard, the title-bar button and the palette all split the active session.</summary>
+    private void SplitOp(string op) => SplitOp(op, _active);
+
+    /// <summary>Split or collapse <paramref name="ses"/>. The control API reaches this with a
+    /// resolved target, which need not be the active session: `session split on --target X` from
+    /// an agent's pane used to split whatever the user happened to be looking at.</summary>
+    private void SplitOp(string op, Ses? ses)
     {
-        int panes = _active?.Panes.Count ?? 1;
+        if (ses is null) return;
+        int panes = ses.Panes.Count;
         switch (op)
         {
-            case "on": if (panes <= 1) SplitActivePane(); break;
-            case "off": if (panes > 1) CollapseToSinglePane(); break;
-            default: if (panes > 1) CollapseToSinglePane(); else SplitActivePane(); break; // toggle
+            case "on": if (panes <= 1) SplitPane(ses); break;
+            case "off": if (panes > 1) CollapseToSinglePane(ses); break;
+            default: if (panes > 1) CollapseToSinglePane(ses); else SplitPane(ses); break; // toggle
         }
     }
 
     /// <summary>Collapse the active session to just its focused pane (dispose the rest).</summary>
-    private void CollapseToSinglePane()
+    private void CollapseToSinglePane(Ses ses)
     {
-        var ses = _active;
-        if (ses is null || ses.Panes.Count <= 1) return;
+        if (ses.Panes.Count <= 1) return;
         var keep = ses.Panes[0];   // agterm: collapsing the split keeps the primary (left) pane, not whichever is focused
         foreach (var p in ses.Panes) if (!ReferenceEquals(p, keep)) { try { p.S.Dispose(); } catch { } }
         // Clear+Add as one atomic step so the control-pipe reader never sees an empty pane list (issue #85).
         lock (_workspaces) { ses.Panes.Clear(); ses.Panes.Add(keep); }
         keep.Ratio = 1f; ses.Active = 0;
-        _session = ses.S;
+        if (ReferenceEquals(ses, _active)) _session = ses.S;
         RegridSession(ses); RequestRedraw(); SaveState();
     }
 

--- a/tests/Agwinterm.Pty.Tests/ControlApiTests.cs
+++ b/tests/Agwinterm.Pty.Tests/ControlApiTests.cs
@@ -58,7 +58,7 @@ public class ControlApiTests
     public void Tree_ExposesSplitReadBack_AfterSplit()
     {
         var (server, host) = New();
-        host.Split("on");   // 2 panes, 0.5/0.5
+        host.Split(null, "on");   // 2 panes, 0.5/0.5
         host.FocusPaneDir("right");
         var s = Sessions0(server);
         Assert.Equal(2, s.GetProperty("paneCount").GetInt32());
@@ -309,5 +309,46 @@ public class ControlApiTests
     {
         var (server, _) = New();
         Assert.False(Ok(Dispatch(server, "session.close", target: "nope-does-not-exist")));
+    }
+    // session.split used to ignore its target and always split the ACTIVE session. An agent
+    // running in one pane that asked for a split while the user was looking at another session
+    // split the user's session instead - and its "undo" then collapsed a pane of that session
+    // (2026-09-03, a Claude session against a finished ralphex session). These pin the target.
+
+    [Fact]
+    public void SessionSplit_HonoursTarget_NotTheActiveSession()
+    {
+        var (server, host) = New();
+        var original = host.ActiveSess!;
+        string other = Dispatch(server, "session.new", new { name = "other" }).GetProperty("result").GetString()!;
+        Assert.Equal("other", host.ActiveSess!.Name);      // session.new made the new one active
+
+        var r = Dispatch(server, "session.split", new { op = "on" }, target: original.Id);
+        Assert.True(Ok(r));
+        Assert.Equal(2, original.PaneCount);                // the targeted session split
+        Assert.Equal(1, host.ActiveSess!.PaneCount);        // the active one was left alone
+        Assert.Equal("other", host.ActiveSess!.Name);       // and focus did not move
+    }
+
+    [Fact]
+    public void SessionSplit_WithoutTarget_SplitsTheActiveSession()
+    {
+        var (server, host) = New();
+        var r = Dispatch(server, "session.split", new { op = "on" });
+        Assert.True(Ok(r));
+        Assert.Equal(2, host.ActiveSess!.PaneCount);
+        r = Dispatch(server, "session.split", new { op = "off" });
+        Assert.True(Ok(r));
+        Assert.Equal(1, host.ActiveSess!.PaneCount);
+    }
+
+    [Fact]
+    public void SessionSplit_UnknownTarget_IsRefused()
+    {
+        var (server, host) = New();
+        var r = Dispatch(server, "session.split", new { op = "on" }, target: "no-such-session");
+        Assert.False(Ok(r));
+        Assert.Contains("session not found", r.GetProperty("error").GetString());
+        Assert.Equal(1, host.ActiveSess!.PaneCount);        // and nothing was split as a fallback
     }
 }

--- a/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
+++ b/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
@@ -280,7 +280,17 @@ internal sealed class FakeSessionHost : ISessionHost
     public bool WorkspaceDelete(string? target) { var w = FindWs(target); if (w is null || Workspaces.Count <= 1) return false; Workspaces.Remove(w); if (ReferenceEquals(ActiveWs, w)) { ActiveWs = Workspaces[0]; ActiveSess = ActiveWs.Sessions.FirstOrDefault(); } return true; }
     public bool WorkspaceSelect(string? target) { var w = FindWs(target); if (w is null) return false; ActiveWs = w; ActiveSess = w.Sessions.FirstOrDefault(); return true; }
     public bool WorkspaceReorder(string? target, string dir) => FindWs(target) is not null;
-    public void Split(string op) { if (ActiveSess is null) return; ActiveSess.PaneCount = op == "off" ? 1 : 2; ActiveSess.Ratios = op == "off" ? new() { 1.0 } : new() { 0.5, 0.5 }; }
+    public bool Split(string? target, string op)
+    {
+        // Mirrors the app: the target resolves like every other session verb (null/"active",
+        // a session or pane id, or a prefix), and the split lands on THAT session - not on
+        // whichever one is active. Toggle is modelled too, since the app's default op is toggle.
+        var s = Find(target);
+        if (s is null) return false;
+        s.PaneCount = op switch { "on" => 2, "off" => 1, _ => s.PaneCount > 1 ? 1 : 2 };
+        s.Ratios = s.PaneCount == 1 ? new() { 1.0 } : new() { 0.5, 0.5 };
+        return true;
+    }
     public void FocusPaneDir(string dir) { if (ActiveSess is { PaneCount: > 1 }) ActiveSess.FocusedPane ^= 1; }
     public void ResizeSplit(double? ratio, int growLeft, int growRight) { if (ActiveSess is { PaneCount: > 1 } && ratio is { } r) ActiveSess.Ratios = new() { r, 1 - r }; }
     public IReadOnlyList<string> ThemeList() => new[] { "dark", "light" };


### PR DESCRIPTION
`session.split` was the one session verb that ignored `target`: `ControlServer` called `host.Split(op)` and the host split `_active`. From an agent's pane that is harmless only while the user happens to be looking at that pane.

It isn't hypothetical. On 2026-09-03 an agent asked for `session split on --target <its own session>` while the user's active session was a finished ralphex run. The split landed on the ralphex session, and the agent's "undo" — `session split off` — then collapsed a pane of *that* session.

## Change

- `ISessionHost.Split(string? target, string op)` returns false for an unknown target; the server answers `ok:false "session not found"` instead of silently splitting the active session. Resolution is `session.scratch`'s: null/`active`, a session id, a pane id, or a prefix of either.
- `SplitOp`/`SplitPane`/`CollapseToSinglePane` take the session they act on. The keyboard, title-bar button and palette pass the active one, as before.
- Splitting a session that is not the active one **does not move focus**: `_session` is repointed only when the split session is the active one, so the window never ends up focused on a surface that is not on screen. The split appears when the user next selects that session.
- Skill text documents `[--target <id>]`.

## Tests

`FakeSessionHost.Split` mirrors the resolution (and models toggle, the server's default op). Three new cases in `ControlApiTests`: target honoured with the active session left alone and focus unmoved; no target still means active; unknown target refused with nothing split as a fallback. Pty tests green.

The contract entry for `session.split` is unchanged — `target` is the envelope's generic field, and the conformance argv (`session split off`) still exercises the active-session path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6QmtYN1U1zctCf4WL2tMy