### PR TITLE
release: 0.17.11

### DIFF
--- a/installer/agwinterm.iss
+++ b/installer/agwinterm.iss
@@ -2,7 +2,7 @@
 ; Build via installer\build.ps1 (publishes to stage\ then runs ISCC on this file).
 
 #define AppName    "agwinterm"
-#define AppVersion "0.17.10"
+#define AppVersion "0.17.11"
 #define AppExe     "Agwinterm.Win32.exe"
 #define AppPublisher "Boris Kudriashov"
 ; The main app defaults new sessions to the Rust pty-host as a first-run seed only (it never


### PR DESCRIPTION
Version bump to **0.17.11**. This release exists so agliteterm's CI can drive P2's verbs through a published `agwintermctl`: lite's suites currently skip nine checks with *"this agwintermctl predates agwinterm #226"*, and a skip fails `run-all -Strict`, so **agliteterm #26 cannot go green until this ships**.

**Since v0.17.10**
- **#226 — P2, "stop lying to the caller"** (four revmux rounds): `--stdin` on `session type`/`write` with invalid UTF-8 refused client-side and nothing sent; `--size-percent` validated as 1–100 instead of clamped; `session.restore` naming the pane it pinned, and `restoreCommands` finally on the wire; **`sidebar.width`** (new verb) and an unknown `sidebar` op refused instead of answered `ok`, with `on`/`off` aliased so the conformance step passes because the alias works; `session.new` refusing an unknown workspace *(decision 1)*; and a bare `session.new` landing in the **caller's** workspace. Leftovers: #227, #228.
- **#229** — the contract steps for those.
- **#230** — `session.split` honours its target instead of splitting whatever is active.
- **#225**, **#231** — docs.

**Package managers:** the gate computes `patch % 9`, so 11 does **not** submit to winget or Chocolatey. Releases + Scoop only.

**After merge:** tag `v0.17.11` → the workflow publishes `agwintermctl.exe`, `agwinterm_core-abi18.dll`, `agwinterm-ptyhost-abi18.exe`. Then agliteterm #26's CI is re-run and its nine skips become real assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k
