### PR TITLE
docs: P3-lite shipped (agliteterm #28) - session.context and restore.capture mirrored, with the three deliberate divergences

### DIFF
--- a/docs/lite-parity.md
+++ b/docs/lite-parity.md
@@ -133,7 +133,7 @@ checks that need the newer client (`--stdin`, a strict `--size-percent`, `sideba
 probe it and SKIP — red under `-Strict`, which is the release gate, the P1-lite rule.
 
 ### Mirrored: what P3 (agwinterm #233) owed lite — P3-lite shipped
-Batch **P3-lite** — agliteterm **#TBD** (2026-09-05; plan `docs/plans/2026-09-05-p3-lite-mirror.md`
+Batch **P3-lite** — agliteterm **#28** (2026-09-05; plan `docs/plans/2026-09-05-p3-lite-mirror.md`
 there) — delivered both verbs batch **P3** (agwinterm **#233**, plan
 `docs/plans/completed/2026-09-05-p3-persistence.md`) added; lite's verb count is **45** with them,
 and the two items below read as what was owed. Three deliberate divergences, each recorded in

--- a/docs/lite-parity.md
+++ b/docs/lite-parity.md
@@ -161,7 +161,13 @@ The persistence lands as two additive line types in lite's `sessions.tsv` — `C
 `S` block) and `K` (the captured slots, after the `P` lines whose split its second field names) —
 positional like `P`, refused wholesale on a count mismatch with the `P` guard's wording, and every
 loaded context validated through the verb's own rules (`docs/state-file.md` there). The refusal
-wording is `SessionContexts` / `RestoreCaptureReply` verbatim. What P3 owed, for the record:
+wording is `SessionContexts` / `RestoreCaptureReply` verbatim. Two revmux rounds, both without a
+Major: round 1's nine Minors were fixed in one commit (a stale save overtaking a newer one, a
+`restore capture` answering ok on a failed save, an exited pane's recycled pid, an unlocked paint
+read), and that commit's own suite run found lite's JSON was not ASCII-safe — `café 🚀` came back
+through the CLI's stdout as `caf? ??` on a non-UTF-8 console — so lite's `jsonEscape` now escapes
+non-ASCII as `\uXXXX` the way agwinterm's server does. Round 2's six Minors are agliteterm #29.
+Both products' P3 checks run for real since agwinterm **0.17.12** (2026-09-05). What P3 owed, for the record:
 
 - **`session.context`** — one line of "what is this pane for", set over the API, shown dimmed after
   the name in the title bar and the sidebar row, carried in `tree --json` as `context` on the session
@@ -194,7 +200,8 @@ step pinning the reply keys, and the two errors-block refusals) landed in the si
 that file again and `check-contract` is in step. P3-lite's own checks (the honesty P3 block, the
 matrix's context/capture cells, the four conformance steps) probe the client (`agwintermctl
 restore` answers a usage line on a post-#233 build) and SKIP against the released `agwintermctl`
-until the release that carries #233 + #235 is tagged — red under `-Strict`, the release gate.
+until the release that carries #233 + #235 is tagged — red under `-Strict`, the release gate
+(**0.17.12**, tagged 2026-09-05, closed it).
 
 ---
 

--- a/docs/lite-parity.md
+++ b/docs/lite-parity.md
@@ -132,9 +132,36 @@ again and `check-contract` is in step. Until the agwinterm release that carries 
 checks that need the newer client (`--stdin`, a strict `--size-percent`, `sidebar width N`, `caller`)
 probe it and SKIP — red under `-Strict`, which is the release gate, the P1-lite rule.
 
-### Owed: what P3 (agwinterm, persistence) adds — P3-lite
-Batch **P3** (agwinterm, plan `docs/plans/completed/2026-09-05-p3-persistence.md`; PR pending) adds two verbs
-agwinterm answers and lite does not, so the count above grows by two until **P3-lite** lands them:
+### Mirrored: what P3 (agwinterm #233) owed lite — P3-lite shipped
+Batch **P3-lite** — agliteterm **#TBD** (2026-09-05; plan `docs/plans/2026-09-05-p3-lite-mirror.md`
+there) — delivered both verbs batch **P3** (agwinterm **#233**, plan
+`docs/plans/completed/2026-09-05-p3-persistence.md`) added; lite's verb count is **45** with them,
+and the two items below read as what was owed. Three deliberate divergences, each recorded in
+lite's README and its shipped skill text rather than left for a reader to trip over:
+
+- **No title-bar surface.** lite's caption is the OS caption, set once to the instance name; no
+  session name has ever been in it, so a context there would be a new behaviour, not a mirror, and
+  could not be "dimmed". The sidebar row — lite's one per-session text surface — draws the context
+  dimmed after the name in its post-paint pass, beside the pennant and the unread pill it already
+  draws, and the badges do not move (`qa/persistence.md` there has the capture).
+- **`replayOnRestore` is a constant `false`.** lite restores a session's LAUNCH spec at the next
+  start and never types a slot back (`session.restore` is P9), so the truthful answer is `false`;
+  a toggle with nothing behind it, or `true`, would be the lie P2 existed to end. The shape is the
+  contract's, so one script reads both products; the field starts reporting a toggle when P9 lands
+  the replay. The capture itself is in-process (one Toolhelp32 snapshot plus the PEB read lite
+  already does for a shell's cwd — milliseconds, no child process, so none of the CIM query's
+  timeout-and-kill semantics), with agwinterm's default denylist frozen as a constant: lite has no
+  `restore-denylist.conf`.
+- **A hidden pane refuses `session context`.** lite's `resolveTarget` reaches a split shell by id;
+  a context set on it would be drawn nowhere (no row) and saved nowhere (no `S` line, so no `C`
+  slot) — "succeeded, then vanished". Refused naming the id, the same rule as the cover-pane
+  refusal on `restore.capture`.
+
+The persistence lands as two additive line types in lite's `sessions.tsv` — `C` (context, after the
+`S` block) and `K` (the captured slots, after the `P` lines whose split its second field names) —
+positional like `P`, refused wholesale on a count mismatch with the `P` guard's wording, and every
+loaded context validated through the verb's own rules (`docs/state-file.md` there). The refusal
+wording is `SessionContexts` / `RestoreCaptureReply` verbatim. What P3 owed, for the record:
 
 - **`session.context`** — one line of "what is this pane for", set over the API, shown dimmed after
   the name in the title bar and the sidebar row, carried in `tree --json` as `context` on the session
@@ -161,11 +188,13 @@ agwinterm answers and lite does not, so the count above grows by two until **P3-
   keyed by pane id like `restoreCommands`. Lite has no `session.restore` yet (that is **P9**), so
   this lands the slot and the verb first and the pin later.
 
-The conformance steps for both (a `session context` step after the `session.rename` one, a `tree`
-read-back asserting `context`, the errors-block refusal, and a `restore capture` step pinning the
-reply keys) land in the sibling contract PR right after P3 merges, agwinterm-first as the rule says;
-agliteterm's `check-contract` is red for the gap until P3-lite, which is the gate. P3-lite's own
-checks SKIP against the released `agwintermctl` until the release that carries P3 is tagged.
+The conformance steps for both (the `session context` set and `--clear` steps, the `restore capture`
+step pinning the reply keys, and the two errors-block refusals) landed in the sibling contract PR
+**#235** right after #233, agwinterm-first as the rule says; agliteterm's `test/control-api.json` is
+that file again and `check-contract` is in step. P3-lite's own checks (the honesty P3 block, the
+matrix's context/capture cells, the four conformance steps) probe the client (`agwintermctl
+restore` answers a usage line on a post-#233 build) and SKIP against the released `agwintermctl`
+until the release that carries #233 + #235 is tagged — red under `-Strict`, the release gate.
 
 ---
 

--- a/docs/plans/2026-09-03-parity-batches.md
+++ b/docs/plans/2026-09-03-parity-batches.md
@@ -84,12 +84,15 @@ Alone because it is the first restore-format change of this backlog, and lite ha
 format later — as an additive line type, the way `P` was.
 
 **Shipped:** #233 (2026-09-05) — plan at
-[completed/2026-09-05-p3-persistence.md](completed/2026-09-05-p3-persistence.md); contract steps in a sibling PR after
-this merges and before the release, as #229 followed #226. Set the restore-format rule the later
-batches inherit: additive keys only, no version field, every loaded value validated. Round-4
-leftovers from P2 (#227 / #228) remain, in `SessionOverlay`. Mirror: agliteterm P3-lite —
-`session.context` as a `C` line type after the `S` lines, plus `restore.capture`; its checks SKIP
-against the released `agwintermctl` until the release that carries this batch is tagged.
+[completed/2026-09-05-p3-persistence.md](completed/2026-09-05-p3-persistence.md); contract steps in
+the sibling PR #235, as #229 followed #226. Set the restore-format rule the later batches inherit:
+additive keys only, no version field, every loaded value validated. Round-4 leftovers from P2
+(#227 / #228) remain, in `SessionOverlay`. Mirror: agliteterm P3-lite — **shipped** as agliteterm
+#28 (2026-09-05; plan `docs/plans/2026-09-05-p3-lite-mirror.md` there): `session.context` as a `C`
+line type after the `S` lines, `restore.capture` as a `K` line with an in-process Toolhelp32 + PEB
+query instead of the CIM one, `replayOnRestore` a constant `false` until P9 lands the replay, and a
+hidden pane refusing `session context` (the three divergences are in `docs/lite-parity.md`); its
+checks SKIP against the released `agwintermctl` until the release that carries #233 + #235 is tagged.
 
 ### P4 · agwinterm · splits get their full shape
 axis on `session.split` (`h|v`, surviving restore) · `session.split.close` · `session.split` **returns
@@ -132,8 +135,9 @@ Same model as P6, different surface — split because it is UI work with a diffe
 `surface.cursor` · `statusChangedAt` · `version` → **P1-lite — shipped** (agliteterm #20,
 2026-09-04, six revmux rounds; plan `docs/plans/completed/2026-09-03-p1-lite-mirror.md` there) ·
 `--stdin` · size-percent validation · `sidebar width` · the caller-workspace default for a bare
-`session new` → **P2-lite — shipped** (agliteterm #26, 2026-09-04) · `session.context` → P3-lite. Each runs right after its agwinterm batch
-merges.
+`session new` → **P2-lite — shipped** (agliteterm #26, 2026-09-04) · `session.context` ·
+`restore.capture` → **P3-lite — shipped** (agliteterm #28, 2026-09-05). Each runs right after its
+agwinterm batch merges.
 
 ### P9 · lite · driving a pane
 `session.readonly` **first** — it is how you stop stray keys reaching a running agent — then


### PR DESCRIPTION
The agwinterm-side follow-up for agliteterm #28 (P3-lite, the mirror of #233 + #235), the routine #231 followed for P2-lite.

- `docs/lite-parity.md`: the P3 section reads as **mirrored — P3-lite shipped**, carries the PR number, and records the three deliberate divergences so a reader does not trip over them: no title-bar surface (lite's caption is the OS caption with the instance name; the sidebar row draws the context dimmed after the name), `replayOnRestore` a constant `false` (lite restores launch specs and never types a slot back until P9), and a hidden pane refusing `session context` (no row, no `S` line, no `C` slot). Also names the in-process capture (Toolhelp32 + the PEB read lite already does, agwinterm's denylist frozen as a constant), the `C`/`K` line types with the `P` guard, and the contract PR #235.
- `docs/plans/2026-09-03-parity-batches.md`: the P3 entry's mirror sentence says shipped as agliteterm #28 with the divergences; the P8 list moves `session.context` and `restore.capture` to **P3-lite — shipped**.

No code. lite's P3 checks SKIP against the released `agwintermctl` until the release that carries #233 + #235 is tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
