### PR TITLE
release: 0.17.12

### DIFF
--- a/installer/agwinterm.iss
+++ b/installer/agwinterm.iss
@@ -2,7 +2,7 @@
 ; Build via installer\build.ps1 (publishes to stage\ then runs ISCC on this file).
 
 #define AppName    "agwinterm"
-#define AppVersion "0.17.11"
+#define AppVersion "0.17.12"
 #define AppExe     "Agwinterm.Win32.exe"
 #define AppPublisher "Boris Kudriashov"
 ; The main app defaults new sessions to the Rust pty-host as a first-run seed only (it never


### PR DESCRIPTION
Version bump to **0.17.12**. This release exists so agliteterm's CI can drive P3's verbs through a published `agwintermctl`: lite's suites skip the `session context` / `restore capture` checks with *"this agwintermctl predates agwinterm #233"*, and a skip fails `run-all -Strict`, so **agliteterm #28 cannot go green until this ships**. Not a package checkpoint (`patch % 9 != 0`): GitHub Releases + Scoop only; winget/choco wait for 0.17.18.

**Since v0.17.11**
- **#233 — P3, persistence** (two revmux rounds): `session.context` — one line of text per session, set over the API, shown dimmed beside the name in the title bar, the sidebar row and the palette, in `tree --json` as `context`, restored after a restart and after `session reopen`; control characters, blank and over-length refused, `--clear` removes it. `restore.capture` — fill every real pane's captured-command slot **now** with a per-pane reply, not only at quit; the slot is durable across ordinary saves (it used to be wiped by every one); `capturedCommands` on the tree; `replayOnRestore` reports the toggle. First additive key in the per-window restore file (`SessionState.Context`; older builds drop it on write-back, verified against 0.17.11). Leftovers: #234.
- **#235** — the contract steps for those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k
