### PR TITLE
contract: P4 `session swap` step and its one-pane refusal

### DIFF
--- a/tests/conformance/control-api.json
+++ b/tests/conformance/control-api.json
@@ -298,6 +298,24 @@
       "note": "P4: the reply is the PANE ID the op produced or found (a bare string) — the only handle on the shell it just created. `--axis` in agterm's words: vertical = left/right panes (the default of a session never split), horizontal = top/bottom. `on` when already split answers the existing split pane's id; anything but the two axis words is refused (see errors). The tree carries `axis` beside `paneIds` on a split session."
     },
     {
+      "verb": "session.swap",
+      "args": [
+        "session",
+        "swap",
+        "--target",
+        "{beta}"
+      ],
+      "result": "object",
+      "fields": [
+        "session",
+        "paneIds",
+        "focusedPane",
+        "axis"
+      ],
+      "settle": 1,
+      "note": "P4: exchanges the two panes of a split session — the order reversed, the focus following the pane it was on, the axis kept — and answers the session's split block AFTER the swap (the tree's `paneIds` / `focusedPane` / `axis`), so a caller reads the new order without a second round trip. A swap moves panes, never ids: every id keeps naming the shell it named, now in the other slot, which is why the `split close` below still reaches the pane it captured. A one-pane session is refused (see errors)."
+    },
+    {
       "verb": "session.split.close",
       "args": [
         "session",
@@ -691,6 +709,15 @@
         "session",
         "split",
         "close",
+        "--target",
+        "{alpha}"
+      ]
+    },
+    {
+      "note": "P4: `session swap` on a one-pane session is refused naming `session split on`, and nothing moves — there is no other pane to exchange with, and a swap that quietly did nothing would be the silent-success class one verb over.",
+      "args": [
+        "session",
+        "swap",
         "--target",
         "{alpha}"
       ]


### PR DESCRIPTION
The sibling of agliteterm #30 (P4-lite with `session swap`). #240 carried the split steps; the swap shipped in #238 without a contract row.

- **Step** after `split on --axis horizontal --target {beta}`: `session swap --target {beta}` → object `{session, paneIds, focusedPane, axis}` (the split block after the flip). The `split close --target {pane}` that follows still reaches the pane it captured — the contract's own demonstration that a swap moves panes, never ids.
- **Refusal**: `session swap --target {alpha}` (one pane) names `session split on`, moves nothing.

**Evidence**

- agwinterm: `tests/conformance/conformance.ps1 -Strict` on this branch's build — `conformance: all passed`, rows `PASS session.swap` and `PASS refuses: session swap --target {alpha}`.
- agliteterm (`feat/p4-lite-mirror` @ `5089ae9`): `test/conformance.ps1 -Strict -Spec <this file>` — `conformance: all passed`, the same rows.

Merge order: this after agliteterm #30 is ready to take `tools/check-contract.ps1 -Update` (lite's CI diffs its copy against `main`'s), so the two land together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k
