### PR TITLE
docs: lite-parity "Splits as sessions" after P4-lite; P4-lite shipped in the batch index

### DIFF
--- a/docs/agterm-parity.md
+++ b/docs/agterm-parity.md
@@ -42,7 +42,7 @@ named as such rather than left to look like a backlog nobody is working on.
 | `session.split` replies with the **pane id** (the split pane's on `on`, also when already split; the survivor's on `off`) | — | agwinterm *(P4, #238)*; lite had it (#13) |
 | Horizontal splits — `--axis vertical\|horizontal` on `session.split` (agterm's words: vertical = left/right, horizontal = top/bottom), per session, re-orients live, survives restore, `axis` in `tree`; `session.focus` takes `primary\|split\|left\|right\|top\|bottom\|other`, `session.resize` gains `--grow-top` / `--grow-bottom` | 0.23.0 | agwinterm *(P4, #238)*, lite: P4-lite |
 | `session.split.close` — closes **either** pane, the survivor's id as the reply; a one-pane session refused | 0.23.0 | agwinterm *(P4, #238)*, lite: P4-lite |
-| `session.swap` — the panes exchanged; axis, ratio sequence, focus's pane, overlays, status and **every id** kept | 0.26.0 | agwinterm *(P4, #238)*, lite: P4-lite *(expensive there — see [lite-parity.md](lite-parity.md))* |
+| `session.swap` — the panes exchanged; axis, ratio sequence, focus's pane, overlays, status and **every id** kept | 0.26.0 | agwinterm *(P4, #238)*, lite: P4-lite *(agliteterm #30 — one flag read in its hidden-session model; see [lite-parity.md](lite-parity.md))* |
 
 The overlay entry is the *honesty* half only: a pane id is now refused rather than silently widened.
 Pane-scoped overlays themselves are still open, below.

--- a/docs/lite-parity.md
+++ b/docs/lite-parity.md
@@ -255,14 +255,35 @@ and the list should grow as more turn up.
   registry and a `%LOCALAPPDATA%` override. That is why the two QA adapters isolate differently, and
   it is not worth unifying.
 - **Splits as sessions.** lite models a split as a hidden session; agwinterm models panes inside a
-  session. Behaviour matches now (a split belongs to its session, closes with it, restores with it),
-  and the internal shape can stay different. **P4's `session swap` is the first item this model makes
-  expensive**: agwinterm reverses two panes inside one session and no id moves, while lite would have
-  to exchange the visible session's tree identity with its hidden split's (name, context, flag,
-  workspace position, the `D`/`C`/`K` lines) or invert `splitId` and both `hidden` flags — the P4-lite
-  plan should decide whether to defer the swap the way `session.restore` went to P9 rather than let
-  the batch discover it. The axis (a fifth field on the `P` line) and `split close` (promote the hidden
-  session when pane 0 closes) are cheap there.
+  session. Behaviour matches — a split belongs to its session, closes with it, restores with it, axis
+  and order included (an `L` line beside the `P`) — and the internal shape stays different. P4-lite
+  (agliteterm #30) implemented `session swap` after all: the hidden session is drawn in the owner's
+  other slot, so a swap is one flag read where the two panes are laid out and hit-tested; no tree
+  identity moves, no id moves, the `K` line stays by role. `session split close` on the session's own
+  shell promotes the hidden session's object into the session's place (same id, name, workspace,
+  flag, context, sidebar row; its own pane id kept — `Session::paneId`, set once and never written),
+  with a `tree` event and no `session closed` — agwinterm's `[B]` picture. What differs, all recorded
+  in the P4-lite plan (`docs/plans/completed/2026-09-06-p4-lite-mirror.md` there):
+  - **One node shape agwinterm never emits.** That promoted session's node carries `paneIds` alone
+    (`[<its shell's id>]`, no `paneCount`), so in lite the presence of `paneIds` does not imply a
+    split — `paneCount` is the split discriminator in both products. agwinterm reaches the same
+    state (its env vars are per pane too; closing the pane that carries the session id keeps the
+    session) and emits nothing for it (`ControlServer` writes `paneIds` only under `paneCount > 1`);
+    lite's key exists so the survivor's own agent, whose `AGWINTERM_SESSION_ID` is no node's `id`,
+    can find its session's node — a gap agwinterm's own skill has no recipe for.
+  - **The session-id rule differs by one sentence.** agwinterm's session id names the FOCUSED pane
+    while no pane carries it; lite's always names the session's own shell, and the split's shell is
+    reached only by its own id (no per-session pane resolution). One exception: after a kill-restart
+    a promoted session is adopted by its shell's id and comes back under it.
+  - **`session close <split shell's id>`** is a pre-P4 divergence in lite's favour: it closes that
+    shell (an unsplit) where agwinterm answers `session not found` for a pane id.
+  - **Restore.** Split shells are recreated, never adopted, so their ids are fresh after a graceful
+    restart; the `L` line puts the axis and order back onto the recreated pair.
+  - **`tree`.** A lite node is `active` when the displayed session is it, whichever pane has focus;
+    the split's shell has no node. A split side whose shell exits collapses to the survivor in both
+    products; a one-pane session's exit stays on screen as `(exited)` in lite.
+  Not a divergence, checked both ways: `session select` never moves the active workspace in either
+  product.
 - **The native core is shared.** Both load `agwinterm_core.dll` across the same C ABI, so emulator
   behaviour — widths, scrollback, alt screen — is common by construction. A difference there is a
   bug in one of the clients, not a parity gap.

--- a/docs/plans/2026-09-03-parity-batches.md
+++ b/docs/plans/2026-09-03-parity-batches.md
@@ -112,9 +112,11 @@ moves panes, never ids — the one divergence P4 adds to agterm's swap, recorded
 `docs/agterm-parity.md` together with what it costs a downgrade to 0.17.12 (a swapped session's
 two panes both carry the session id there; checked once, no `.bad`). Pane ids are durable across
 split, close, swap and restore (`CreateSession` takes pane 0's id separately). Mirror: P4-lite —
-the axis and `split close` are cheap in lite's model, `swap` is not (`docs/lite-parity.md`); the
-P4-lite plan decides whether the swap defers the way `session.restore` went to P9. Review rounds
-and the release (0.17.13, the next number — Boris tags) follow the PR.
+**shipped** as agliteterm #30 (2026-09-06; plan `docs/plans/completed/2026-09-06-p4-lite-mirror.md`
+there), swap included (Boris's call; the hidden session is drawn in the owner's other slot, so a
+swap is one flag read — no tree identity moves). The contract pins the swap in #241. Four revmux
+rounds, no Major after r1; the divergences P4-lite records are in `docs/lite-parity.md` ("Splits as
+sessions"). The release (0.17.13, the next number — Boris tags) follows.
 
 ### P5 · agwinterm · overlays stop being session-wide
 `--pane left|right` on the overlay verbs, flag omitted keeping today's session-wide behaviour ·


### PR DESCRIPTION
Docs only. P4-lite shipped as agliteterm #30 (squash `42cf7d4`, 2026-09-06) with the swap included, so the `lite-parity.md` paragraph that called the swap expensive under lite's model and asked the P4-lite plan to decide on deferring it is replaced by what shipped and what differs.

## What changed

- **`docs/lite-parity.md` "Splits as sessions"** — the model (hidden session drawn in the owner's other slot; a swap is one flag read, no tree identity or id moves; `split close` on the session's own shell promotes the hidden session's object into its place, `Session::paneId` kept) and the divergences P4-lite records, one bullet each:
  - the promoted single node carries `paneIds` alone (`[<its shell's id>]`, no `paneCount`) — agwinterm reaches the same state and emits nothing for it (`ControlServer` writes `paneIds` only under `paneCount > 1`); `paneCount` is the split discriminator in both products; lite's key exists so the survivor's own agent (its `AGWINTERM_SESSION_ID` is no node's `id`) can find its node;
  - the session-id rule's one differing sentence (agwinterm: the FOCUSED pane while no pane carries it; lite: always the session's own shell) and its kill-restart exception;
  - `session close <split shell's id>` (lite closes that shell; agwinterm answers `session not found`);
  - restore (split shells recreated, ids fresh after a graceful restart, the `L` line) and `tree`'s `active`.
  - Checked both ways and NOT a divergence: `session select` never moves the active workspace in either product.
- **`docs/plans/2026-09-03-parity-batches.md`** — the P4 entry's mirror line: P4-lite shipped, swap included, pinned by contract #241.
- **`docs/agterm-parity.md`** — the `session.swap` row's "expensive there" parenthetical replaced.

Source for every claim: the P4-lite plan (`docs/plans/completed/2026-09-06-p4-lite-mirror.md` in agliteterm) and its four revmux rounds; the agwinterm side of the promoted-node claim was re-read at `ControlServer.cs:456-470` and `AgentSkill.cs:30` on `main`. This PR also resolves the present-tense "recorded in agwinterm's lite-parity.md" pointers in lite's `src/main.cpp` (agliteterm #31).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k
