### PR TITLE
release: 0.17.13

### DIFF
--- a/installer/agwinterm.iss
+++ b/installer/agwinterm.iss
@@ -2,7 +2,7 @@
 ; Build via installer\build.ps1 (publishes to stage\ then runs ISCC on this file).
 
 #define AppName    "agwinterm"
-#define AppVersion "0.17.12"
+#define AppVersion "0.17.13"
 #define AppExe     "Agwinterm.Win32.exe"
 #define AppPublisher "Boris Kudriashov"
 ; The main app defaults new sessions to the Rust pty-host as a first-run seed only (it never


### PR DESCRIPTION
Version bump to **0.17.13**. This release exists so agliteterm's CI can drive P4's verbs through a published `agwintermctl`: lite's suites skip the `--axis` / `split close` / `swap` / `focus` checks with *"this agwintermctl predates agwinterm #238"*, and a skip fails `run-all -Strict`, so **agliteterm's `main` (P4-lite, #30) cannot go green until this ships**. Not a package checkpoint (`patch % 9 != 0`): GitHub Releases + Scoop only; winget/choco wait for 0.17.18.

**Since v0.17.12**
- **#238 — P4, splits get their full shape** (four revmux rounds): every `session split` reply is a pane id (the split pane's on `on`, the survivor's on `off`); `--axis vertical|horizontal` (agterm's words), re-orients live, `axis` in `tree --json` and the second additive restore key (`SessionState.Axis`); `session split close` closes either pane, the survivor's id as the reply, a one-pane session refused; `session swap` exchanges the two panes — **moves panes, never ids** (the one divergence from agterm's swap, recorded in `docs/agterm-parity.md` with what a downgrade to 0.17.12 costs a swapped session); pane ids durable across split, close, swap and restore. Leftovers: #239.
- **#240, #241** — the contract steps for those; the swap step pinned once P4-lite (agliteterm #30) took it.
- **#236, #242** — `lite-parity.md` and the batch index for P3-lite and P4-lite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k
