### PR TITLE
fix: P4 round-4 leftovers (#239)

### DIFF
--- a/src/Agwinterm.Pty/AgentSkill.cs
+++ b/src/Agwinterm.Pty/AgentSkill.cs
@@ -239,7 +239,8 @@ public static class AgentSkill
         ## Splits, font, sidebar, theme
         A session has at most TWO panes. Each pane has its own id (`tree --json` lists them as `paneIds`). THE SESSION-ID
         RULE, by condition and not by verb: a session id names the pane that carries it while one does — pane 0 of a fresh or
-        reopened session; after a `swap`, either side — and names the session's FOCUSED pane while none does. None does once
+        reopened session; after a `swap`, either side (a restore keeps the order it saved) — and names the session's FOCUSED
+        pane while none does. None does once
         the carrier was closed, however it was closed: `split close` on it, Ctrl+Shift+W on it, `split off` after a `swap`
         (that collapses onto the other pane), or its shell exiting. A later `split` mints a fresh id, so the state persists
         until the session is closed and reopened (a reopened session's pane 0 carries the id again). In a split session,

--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -381,7 +381,8 @@ public sealed class ControlServer : IDisposable
                 // session NAME reports its focused pane — a cursor is a per-pane thing, and focus is
                 // the only non-arbitrary answer for a session-wide target. The session-id rule, by
                 // condition (P4): while a pane carries the session's id — pane 0 of a fresh session,
-                // either side after a session.swap — the id reports THAT pane wherever it sits,
+                // either side after a session.swap, a restore keeping the order it saved — the id
+                // reports THAT pane wherever it sits,
                 // regardless of focus (Resolve's exact-pane-first order); while none does — the
                 // carrier was closed, by split.close, Ctrl+Shift+W, split off after a swap, or its
                 // shell exiting — the id falls through to the exact-session arm and reports the
@@ -529,7 +530,11 @@ public sealed class ControlServer : IDisposable
     /// "keep the session's orientation", a string must be one of <see cref="SplitAxes"/>' two words,
     /// and a non-string (a number, an object) is refused with the same wording rather than defaulted —
     /// a caller that sent <c>"axis": 1</c> meant something, and a vertical split with ok:true would
-    /// be the silent-success class. Every refusal splits nothing.
+    /// be the silent-success class. <c>op</c> is read the same way, here and not only in the CLI:
+    /// absent is toggle, a string must be one of <see cref="SplitAxes.IsOp"/>' three words, and
+    /// anything else — <c>"Close"</c>, <c>"clos"</c>, <c>""</c>, a number — is refused with
+    /// <see cref="SplitAxes.OpRefusal"/> before the host is reached, because the host treats an
+    /// unknown op as toggle and a toggle on a split session closes a pane. Every refusal splits nothing.
     /// </summary>
     private static string HandleSessionSplit(ISessionHost host, string? target, JsonElement args)
     {
@@ -544,7 +549,7 @@ public sealed class ControlServer : IDisposable
         // with ok:true (revmux r2/r3 of P4). Absent = toggle; anything else must be one of the three.
         if (args.ValueKind == JsonValueKind.Object && args.TryGetProperty("op", out var ov))
         {
-            if (ov.ValueKind != JsonValueKind.String) return Err(SplitAxes.OpRefusal(ov.GetRawText()));
+            if (ov.ValueKind != JsonValueKind.String) return Err(SplitAxes.OpRefusal(ov.GetRawText(), quoted: false));
             if (!SplitAxes.IsOp(ov.GetString()!)) return Err(SplitAxes.OpRefusal(ov.GetString()!));
         }
         return HostReply(host.Split(target, GetString(args, "op") ?? "toggle", axis));

--- a/src/Agwinterm.Pty/ISessionHost.cs
+++ b/src/Agwinterm.Pty/ISessionHost.cs
@@ -230,8 +230,8 @@ public interface ISessionHost
     /// was already split (the caller that does not know whether it split gets something addressable
     /// either way, and nothing changes); <c>off</c> → the survivor's id (pane 0), also when already
     /// single; <c>toggle</c> → whichever it produced. Or <see cref="RefusePrefix"/> + a refusal —
-    /// <c>session not found</c>, the axis refusal — and nothing split (the op refusal is the server's,
-    /// above, and never reaches here).</para>
+    /// <c>session not found</c>, the only one the host owes — and nothing split (the axis and the op
+    /// refusals are both the server's, above, and neither reaches here).</para>
     /// <para><b>Invariants (#230)</b>: the target is resolved on the caller's thread so an unknown
     /// target answers a refusal with nothing queued; the split lands on THAT session, not on whichever
     /// is active; splitting a session that is not the active one does not move focus to it (the

--- a/src/Agwinterm.Pty/ISessionHost.cs
+++ b/src/Agwinterm.Pty/ISessionHost.cs
@@ -213,7 +213,11 @@ public interface ISessionHost
 
     /// <summary>
     /// <c>session.split</c>: split or collapse the targeted session (null/"active" = the active one):
-    /// op = on|off|toggle. The axis names the ARRANGEMENT, agterm's words: vertical = left/right panes
+    /// op = on|off|toggle — exactly those three, lowercase, already checked by the server against
+    /// <see cref="SplitAxes.IsOp"/> (absent = toggle; anything else, <c>"Close"</c> or <c>""</c> or a
+    /// number, is refused with <see cref="SplitAxes.OpRefusal"/> before this is called, because the
+    /// host's switch treats an unknown op as toggle and a toggle on a split session closes a pane).
+    /// The axis names the ARRANGEMENT, agterm's words: vertical = left/right panes
     /// (the default of a session never split), horizontal = top/bottom panes. <paramref name="axis"/> is
     /// <see cref="SplitAxes.Vertical"/> or <see cref="SplitAxes.Horizontal"/>, already parsed by the
     /// server through <see cref="SplitAxes.TryParse"/>; null keeps the session's current orientation. The axis is PER SESSION and survives <c>off</c> (agterm:
@@ -226,7 +230,8 @@ public interface ISessionHost
     /// was already split (the caller that does not know whether it split gets something addressable
     /// either way, and nothing changes); <c>off</c> → the survivor's id (pane 0), also when already
     /// single; <c>toggle</c> → whichever it produced. Or <see cref="RefusePrefix"/> + a refusal —
-    /// <c>session not found</c>, the axis refusal — and nothing split.</para>
+    /// <c>session not found</c>, the axis refusal — and nothing split (the op refusal is the server's,
+    /// above, and never reaches here).</para>
     /// <para><b>Invariants (#230)</b>: the target is resolved on the caller's thread so an unknown
     /// target answers a refusal with nothing queued; the split lands on THAT session, not on whichever
     /// is active; splitting a session that is not the active one does not move focus to it (the
@@ -245,8 +250,9 @@ public interface ISessionHost
     /// <para><b>Target</b>: null / "" / "active" = the active session's focused pane (what Ctrl+Shift+W
     /// closes); else the content verbs' resolver (exact pane, exact session → its focused pane, pane
     /// prefix, session prefix / name → its focused pane). THE SESSION-ID RULE, by condition: while a
-    /// pane carries the session id (pane 0 of a fresh or reopened session; either side after a swap) it
-    /// names THAT pane through the exact-pane arm; while none does — the carrier was closed by this
+    /// pane carries the session id (pane 0 of a fresh or reopened session; either side after a swap;
+    /// slot 1 of a session restored from a file saved after a swap — the pane list comes back
+    /// verbatim, no swap having happened in this process) it names THAT pane through the exact-pane arm; while none does — the carrier was closed by this
     /// verb, by Ctrl+Shift+W, by <c>split off</c> after a swap, or by its shell exiting — the id falls
     /// through to the exact-session arm and names the FOCUSED pane, like a name does. A later split
     /// mints a fresh id; a reopen puts the id back on pane 0. <see cref="SplitCloseReply"/> has the

--- a/src/Agwinterm.Pty/SplitAxes.cs
+++ b/src/Agwinterm.Pty/SplitAxes.cs
@@ -22,8 +22,12 @@ public static class SplitAxes
     /// client sends what it means. Anything else is refused rather than treated as toggle.</summary>
     public static bool IsOp(string op) => op is "on" or "off" or "toggle";
 
-    public static string OpRefusal(string raw) =>
-        $"session split: unknown op {raw} — on, off or toggle (close is `session split close`); an unknown op is not a toggle, because a toggle on a split session closes a pane. Nothing was split or closed.";
+    /// <summary>The wire refusal for an op <see cref="IsOp"/> rejects. A string op is QUOTED, as
+    /// <see cref="Refusal"/> and the CLI quote theirs — an empty op reads "unknown op ''" rather than
+    /// two spaces (#239); a non-string op arrives as its raw JSON (<c>quoted: false</c>), which is its
+    /// own delimiter.</summary>
+    public static string OpRefusal(string raw, bool quoted = true) =>
+        $"session split: unknown op {(quoted ? $"'{raw}'" : raw)} — on, off or toggle (close is `session split close`); an unknown op is not a toggle, because a toggle on a split session closes a pane. Nothing was split or closed.";
 
     /// <summary>Left/right panes. The default.</summary>
     public const string Vertical = "vertical";

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -908,13 +908,15 @@ internal partial class Program
     // uses (exact pane, exact session, pane prefix, session prefix/name) rather than the FindPaneById
     // it used before P2. While the pane carrying the session id still exists the two agree for every
     // target the old resolver accepted: exactly one pane carries its session's id (pane 0 until a
-    // session.swap moves it — P4), so the exact-session step only repeats the exact-pane hit, and the
+    // session.swap moves it — P4; a restore keeps the order it saved), so the exact-session step only
+    // repeats the exact-pane hit, and the
     // prefix step is the same predicate in the same order. Two things changed. A
-    // session NAME now reaches that session's focused pane instead of being refused. And once pane 0
-    // has been CLOSED in a split (split panes get fresh ids, and closing the focused pane can remove
-    // index 0), a session id or id-prefix that the old resolver either refused or steered onto a
-    // scratch/overlay cover pane ("<id>:scratch:…" matched the prefix step) now resolves to the
-    // session's active pane — the better answer in both cases. The empty / "active" refusal and the
+    // session NAME now reaches that session's focused pane instead of being refused. And once NO pane
+    // carries the session id — the carrier was closed, however it was closed (ISessionHost.SplitClose
+    // states the rule by condition; split panes get fresh ids, so nothing re-mints it), a session id
+    // or id-prefix that the old resolver either refused or steered onto a scratch/overlay cover pane
+    // ("<id>:scratch:…" matched the prefix step) now resolves to the session's active pane — the
+    // better answer in both cases. The empty / "active" refusal and the
     // ""/"none" folding live in ControlServer, where the fake host can exercise them.
     //
     // Resolve, validate, write and save happen in ONE UI-thread hop, and that hop travels the

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -913,7 +913,8 @@ internal partial class Program
     // prefix step is the same predicate in the same order. Two things changed. A
     // session NAME now reaches that session's focused pane instead of being refused. And once NO pane
     // carries the session id — the carrier was closed, however it was closed (ISessionHost.SplitClose
-    // states the rule by condition; split panes get fresh ids, so nothing re-mints it), a session id
+    // states the rule by condition; split panes get fresh ids, so nothing re-mints it until the session
+    // is closed and reopened, which puts the id back on pane 0), a session id
     // or id-prefix that the old resolver either refused or steered onto a scratch/overlay cover pane
     // ("<id>:scratch:…" matched the prefix step) now resolves to the session's active pane — the
     // better answer in both cases. The empty / "active" refusal and the

--- a/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
+++ b/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
@@ -163,7 +163,8 @@ internal sealed class FakeSessionHost : ISessionHost
 
     // A pane, not a session, and in the app's order: active surface, then ANY pane by id or id
     // prefix, then a session by name -> its FOCUSED pane. While a pane carries the session id (pane
-    // 0 until a swap moves it), an id target lands on THAT pane and never on the focused pane; that
+    // 0 until a swap moves it; a restore keeps the order it saved), an id target lands on THAT pane
+    // and never on the focused pane; that
     // is deliberate, and it is the guarantee session.text / session.type rely on (the pane you CHECK
     // is the pane you then type into). While no pane carries the id — the carrier was closed, by any
     // path — it resolves like a name, to the focused pane (P4, the session-id rule by condition).
@@ -182,7 +183,8 @@ internal sealed class FakeSessionHost : ISessionHost
     {
         // The app's FindControlPane, arm for arm: exact pane, exact SESSION → its focused pane, pane
         // prefix, session prefix / unique name → its focused pane. While a pane carries the session id
-        // (always, until P4's `split close` removes that pane), the exact-pane arm takes the session id
+        // (until the carrier was closed, by any path — `split close` on it, or `split off` on a swapped
+        // session, whose collapse removes slot 1), the exact-pane arm takes the session id
         // first and the exact-session arm is never reached for it; once that pane is gone the session
         // id still resolves — to the survivor, the focused pane — exactly as win32-control.ps1's
         // "exact session id resolves content verbs to the surviving regular pane" pins for the app.

--- a/tests/Agwinterm.Pty.Tests/SessionSplitTests.cs
+++ b/tests/Agwinterm.Pty.Tests/SessionSplitTests.cs
@@ -114,13 +114,13 @@ public class SessionSplitTests
         {
             var r = Op(server, bad);
             Assert.False(Ok(r), bad);
-            Assert.Contains("unknown op", Error(r));
+            Assert.Contains($"unknown op '{bad}'", Error(r));                  // quoted, so "" reads as '' (#239)
             Assert.Equal(2, PaneCount(server));                               // the split stood
             Assert.Equal(split, PaneIds(server)[1]);                          // with the same pane
         }
         var nonString = Split(server, null, "{\"op\":1}");
         Assert.False(Ok(nonString));
-        Assert.Contains("unknown op", Error(nonString));
+        Assert.Contains("unknown op 1 ", Error(nonString));                   // raw JSON, unquoted
         Assert.Equal(2, PaneCount(server));
     }
 

--- a/tests/integration/win32-control.ps1
+++ b/tests/integration/win32-control.ps1
@@ -156,6 +156,18 @@ function Get-SessionSnapshot([string]$id) {
     return $null
 }
 
+# The ACTIVE session's node — the one a verb sent without --target acts on.
+function Get-ActiveSessionSnapshot {
+    $tree = Invoke-Ctl @('tree')
+    if (-not $tree.ok) { return $null }
+    foreach ($workspace in @($tree.result.workspaces)) {
+        foreach ($session in @($workspace.sessions)) {
+            if ($session.active) { return $session }
+        }
+    }
+    return $null
+}
+
 function Send-TestClick([IntPtr]$hwnd, [int]$x, [int]$y) {
     $packed = (($y -band 0xffff) -shl 16) -bor ($x -band 0xffff)
     [void][Agwinterm.Win32ControlTest.NativeMethods]::SendMessageW(
@@ -384,15 +396,25 @@ try {
     Check 'the survivor keeps its id and its shell: session text by the old pane 1 id, and by the session id, still shows what was typed there' `
         ($scTyped -and $scText.ok -and ([string]$scText.result).Contains($scMarker) -and $scViaSession.ok -and ([string]$scViaSession.result).Contains($scMarker)) `
         "typed=$scTyped byPane=$($scText.ok) bySession=$($scViaSession.ok)"
-    # The CLI-side refusals of the split family (revmux r1-r3 of P4), each proved twice: exit 2 with the
-    # message, and the ORACLE — the split-close fixture still has two panes. Every one of these acted on
-    # the caller's own pane with exit 0 before it was refused. Run BEFORE the close below, on the split.
+    # The CLI-side refusals of the split family (revmux r1-r3 of P4). The proof is the exit code and the
+    # message: exit 2 with "Nothing sent" means the CLI refused before opening the pipe. Before they were
+    # refused, these shapes acted with exit 0 — the ones with no --target (a positional where an option
+    # was meant) on the ACTIVE session, the rest on the p4-split-guards fixture below — so both nodes
+    # are read before the loop and asserted unchanged after it, belt and braces over the exit code.
+    # Run BEFORE the close below, on the split.
     $scGuardMade = Invoke-Ctl @('session', 'new', '--name', 'p4-split-guards', '--no-select')
     $scGuardId = [string]$scGuardMade.result
     for ($i = 0; $i -lt 30 -and -not (Get-SessionSnapshot $scGuardId); $i++) { Start-Sleep -Milliseconds 200 }
     $scGuardSplit = Invoke-Ctl @('session', 'split', 'on', '--target', $scGuardId)
     $scGuardPane1 = [string]$scGuardSplit.result
     for ($i = 0; $i -lt 30; $i++) { $n = Get-SessionSnapshot $scGuardId; if ($n -and @($n.paneIds).Count -eq 2) { break }; Start-Sleep -Milliseconds 200 }
+    $scActiveBefore = Get-ActiveSessionSnapshot
+    # The two `--target ''` shapes must SEND an empty target (the "is empty" arm), not a valueless
+    # `--target` (refused by the splitter's valued arm with the same words, so the message alone could
+    # not tell them apart). Legacy argument passing drops an empty native argument; Standard passes it
+    # as "" — pinned here rather than left to the shell's default mode (#239).
+    $scArgMode = $PSNativeCommandArgumentPassing
+    $PSNativeCommandArgumentPassing = 'Standard'
     foreach ($shape in @(
             @(@('session', 'split', 'off', $scGuardPane1), 'unexpected argument'),
             @(@('session', 'split', 'close', $scGuardPane1), 'unexpected argument'),
@@ -407,9 +429,15 @@ try {
         $code = $LASTEXITCODE
         Check "the CLI refuses '$($argv -join ' ')' before sending anything ($want)" ($code -eq 2 -and ("$out" -match $want) -and ("$out" -match 'Nothing sent')) "exit $code, output: $out"
     }
+    $PSNativeCommandArgumentPassing = $scArgMode
     $scGuardStill = Get-SessionSnapshot $scGuardId
-    Check 'and none of the refused shapes touched the fixture: still two panes, the same two' `
+    Check 'and none of the refused shapes touched the p4-split-guards fixture: still two panes, the same two' `
         ($scGuardStill -and @($scGuardStill.paneIds).Count -eq 2 -and @($scGuardStill.paneIds)[1] -eq $scGuardPane1) "node=$($scGuardStill | ConvertTo-Json -Compress)"
+    $scActiveAfter = Get-ActiveSessionSnapshot
+    Check 'nor the active session, where the shapes without --target would have landed: same id, same panes' `
+        ($scActiveBefore -and $scActiveAfter -and $scActiveAfter.id -eq $scActiveBefore.id -and
+         ((@($scActiveAfter.paneIds) -join ',') -eq (@($scActiveBefore.paneIds) -join ','))) `
+        "before=$($scActiveBefore | ConvertTo-Json -Compress) after=$($scActiveAfter | ConvertTo-Json -Compress)"
     # And the case fix: `Close` is `close` (it used to fall through to toggle and collapse the split —
     # pane 1 gone, ok:true). Closing pane 1 by its id leaves pane 0 (the session id) as the survivor.
     $scCase = Invoke-Ctl @('session', 'split', 'Close', '--target', $scGuardPane1)

--- a/tests/integration/win32-control.ps1
+++ b/tests/integration/win32-control.ps1
@@ -398,9 +398,12 @@ try {
         "typed=$scTyped byPane=$($scText.ok) bySession=$($scViaSession.ok)"
     # The CLI-side refusals of the split family (revmux r1-r3 of P4). The proof is the exit code and the
     # message: exit 2 with "Nothing sent" means the CLI refused before opening the pipe. Before they were
-    # refused, these shapes acted with exit 0 — the ones with no --target (a positional where an option
-    # was meant) on the ACTIVE session, the rest on the p4-split-guards fixture below — so both nodes
-    # are read before the loop and asserted unchanged after it, belt and braces over the exit code.
+    # refused, these shapes acted with exit 0 — seven of the eight on the ACTIVE session, by one of
+    # three routes: no --target at all (a positional where an option was meant), a misspelt `--targt`
+    # that swallows the id so no target reaches the request, or an empty `--target` that the request
+    # builder drops; only `session split clos --target <id>` carries a target that resolves, and it
+    # alone would have landed on the p4-split-guards fixture below. So both nodes are read before the
+    # loop and asserted unchanged after it, belt and braces over the exit code.
     # Run BEFORE the close below, on the split.
     $scGuardMade = Invoke-Ctl @('session', 'new', '--name', 'p4-split-guards', '--no-select')
     $scGuardId = [string]$scGuardMade.result


### PR DESCRIPTION
Closes #239 — the five Minors and two pre-existing items revmux round 4 of #238 left behind, in one small PR with its own round, as #228 (P2) and #234 (P3). No happy-path reply changes.

## Items

1. **`SplitAxes.OpRefusal` quotes a string op** the way `Refusal` and the CLI do — an empty op now refuses with `unknown op ''` instead of two spaces; the non-string arm keeps its raw JSON (`quoted: false`). `UnknownOp_IsRefusedOnTheWire_…` asserts the quoted value per case and the unquoted `1`.
2. **`ISessionHost.Split`'s contract names the server-side op refusal** (absent = toggle; anything outside `SplitAxes.IsOp` refused before the host — the host's switch treats an unknown op as toggle, and a toggle on a split session closes a pane), and its refusal list says the only refusal the host owes is `session not found`. `HandleSessionSplit`'s summary carries the same paragraph beside the axis one.
3. **The guard block in `win32-control.ps1`** says what its proof is (exit 2 + "Nothing sent"), names the `p4-split-guards` fixture, and reads the ACTIVE session's node before the loop and asserts it unchanged after (`Get-ActiveSessionSnapshot`), beside the fixture's — seven of the eight unguarded shapes would have landed on the active session (no `--target`, a misspelt `--targt`, or an empty `--target` the builder drops); only `split clos --target <id>` would have hit the fixture.
4. **The two `--target ''` shapes now SEND an empty argument**: they run under `$PSNativeCommandArgumentPassing = 'Standard'` (restored after), so the "is empty" arm refuses, not the splitter's valueless arm with the same words. Verified: pwsh 7.6 `Windows` mode already passes it; `Legacy` and PS 5.1 drop it.
5. **The pin comment in `Program.ControlHost.cs`** states the carrier-less state by condition (the carrier was closed, however it was closed; `ISessionHost.SplitClose` has the rule) — and its "nothing re-mints it" clause now adds the one path that does: close and reopen the session, which puts the id back on pane 0.

**Pre-existing** — "one more production comment stating the rule by verb": grepped `pane 0 … closed` / `closing pane 0` / `split close` across `src/`; the only hit is `CollapseToSinglePane`'s summary, which names the verbs' survivors, not the id rule. Left as is.

**Immaterial (taken anyway)** — the canonical rule's list of where the carrier sits gains restore (a session restored from a file saved after a swap comes back with the carrier in slot 1, no swap having happened in this process — `Program.Services.cs`'s "verbatim" pane list), at `ISessionHost.SplitClose` and its three copies (the skill, the `surface.cursor` comment in `ControlServer`, the pin comment), found by grepping the old wording. The first commit's message calls that comment `session.cursor`; it is `surface.cursor`.

## Verification

- `dotnet test tests/Agwinterm.Pty.Tests` — 613 passed (on both commits).
- `tests/integration/win32-control.ps1 -Strict` — all passed, including the two new checks (active-session node unchanged across the guard loop; the empty-target shapes refused by the "is empty" arm under pwsh 7.6).
- Build: 0 errors, 0 warnings.

## Review

- `.revmux/tasks/p4-leftovers/01-initial` on `fe9338e`: **no Major, no Critical.** Minors: the `Split` contract put the axis refusal on the host's side; the pin comment's "nothing re-mints it" omitted reopen; the guard comment attributed the shapes to the wrong fixture split; two `FakeSessionHost` comments (pre-existing) said "always, until `split close`" / omitted restore. All four are prose and were fixed in `1db1fdf` without a further round — one leftovers round, as agreed; nothing in the fix touches code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k
