### PR TITLE
fix: P3 round-2 leftovers (#234)

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,8 @@ Thirteen of those answer a question a script would otherwise have to guess at:
   `restore-commands` setting, off by default: the capture always happens, the typing-back at restart
   only happens when that is on, and a script that wants the replay checks the flag rather than
   assuming. It takes one process query for all panes, so allow seconds, not milliseconds. An unknown
-  target, a scratch/overlay/quick pane, or a query that fails is refused and nothing is written;
+  target, an empty one (`--target ''` — only an OMITTED target means every pane), a
+  scratch/overlay/quick pane, or a query that fails is refused and nothing is written;
   `tree --json` reads the slots back as `capturedCommands`, keyed by pane id like `restoreCommands`.
 - `session context "<text>"` sets one line of **what a session is for**, shown dimmed after the name
   in the title bar and the sidebar row and on the session palette's second line, where a name has to

--- a/docs/lite-parity.md
+++ b/docs/lite-parity.md
@@ -188,9 +188,10 @@ Both products' P3 checks run for real since agwinterm **0.17.12** (2026-09-05). 
   a port of agwinterm's CIM query. The reply is `{captured, replayOnRestore, panes:[{pane, session,
   captured|null}]}`: `null` = the shell had no non-denylisted child, and null is written too (a
   fresh capture replaces an older checkpoint); `replayOnRestore` reports the restore-commands
-  toggle, which gates the replay at restart and never the capture. An unknown target or a pane
-  that is never restored is refused with nothing written; a process query that fails is a refusal,
-  not an empty answer for every pane. `tree --json` reads the slots back as `capturedCommands`,
+  toggle, which gates the replay at restart and never the capture. An unknown target, a present
+  but empty one (only an OMITTED `--target` means every real pane) or a pane that is never restored
+  is refused with nothing written; a process query that fails is a refusal, not an empty answer for
+  every pane. `tree --json` reads the slots back as `capturedCommands`,
   keyed by pane id like `restoreCommands`. Lite has no `session.restore` yet (that is **P9**), so
   this lands the slot and the verb first and the pin later.
 

--- a/docs/plans/completed/2026-09-05-p3-persistence.md
+++ b/docs/plans/completed/2026-09-05-p3-persistence.md
@@ -330,7 +330,9 @@ Server and tests:
       through `InvokeOnUi`. `--target` resolves with the resolver `session.restore` uses (a pane; a
       session id is its first pane); an unknown target is a verb-specific refusal, not `"no session"`
   - `"active"` (only reachable as an explicit `--target active`) = the active session's active pane in
-    both hosts; null / `""` = every real pane. A pane closed between the snapshot and the hop is
+    both hosts; null (omitted) = every real pane, and a present but empty target is refused in the
+    server with `EmptyTarget` before either host is asked (the r1 fix; the hosts' `""` arms are
+    unreachable through the wire). A pane closed between the snapshot and the hop is
     dropped from the reply, not written to; the save runs only when something landed
 - [x] the verb ignores the `restore-commands` toggle for the **capture** — the pin ignores it too,
       and a no-op verb on a default install is the silent-success class — but the reply carries

--- a/docs/plans/completed/2026-09-05-p3-persistence.md
+++ b/docs/plans/completed/2026-09-05-p3-persistence.md
@@ -232,8 +232,9 @@ Server and tests:
 
 ### Task 2: the context on every surface
 - [x] `Ses.Context` (`Program.cs:320-346`), beside `CustomName` (added in Task 1 — the host needs the field)
-- [x] title bar: a dimmed run in `_uiSmall` / `ChromeDim` after the title, **before** the pill strip
-      (`Program.Services.cs:306-317`), ellipsized within the same `titleAvail` budget so the bell and
+- [x] title bar: a dimmed run in `_uiSmall` / `ChromeDim` after the title and **after** the pill strip
+      (as shipped by the round-1 fix — the strip is anchored on the title, see the round record below;
+      `Program.Services.cs:301-355`), ellipsized within the same `titleAvail` budget so the bell and
       the right button group never move; drawn only when set. Say in a comment why it is a suffix
       and not a second line (`TitleBarH` 40/30/0)
 - [x] sidebar row (`DrawSessionRow`, `Chrome.cs:143-206`): the same dimmed suffix after the name in

--- a/docs/plans/completed/2026-09-06-p4-splits.md
+++ b/docs/plans/completed/2026-09-06-p4-splits.md
@@ -1,8 +1,8 @@
 # P4 — splits get their full shape
 
 Batch **P4** of the parity programme in
-[2026-09-03-parity-batches.md](2026-09-03-parity-batches.md). Closes items 2 (`session.swap`) and
-3 (the three split gaps) of [agterm-parity.md](../agterm-parity.md), as numbered today. The second
+[2026-09-03-parity-batches.md](../2026-09-03-parity-batches.md). Closes items 2 (`session.swap`) and
+3 (the three split gaps) of [agterm-parity.md](../../agterm-parity.md), as numbered today. The second
 restore-format change of the backlog; it inherits P3's rule and P3's test
 (`src/Agwinterm.Pty/RestoreState.cs:6-30`, `tests/Agwinterm.Pty.Tests/RestoreStateTests.cs`).
 

--- a/qa/persistence.md
+++ b/qa/persistence.md
@@ -80,9 +80,11 @@ as `$sid = Sid $s` and confirm `Node $s $sid` has no `context`.
 
 **Fails when:** `DrawTitleBar` draws the context outside the `titleAvail` budget, drops the trimming
 sign, reserves room for a context it then does not draw (a title cut short for nothing), or moves the
-pill strip for a title that FITS — the strip (`pillX`) is anchored on the title's right edge, the
-context is drawn after the pills, and the only way a context reaches a pill is by shortening a title
-longer than its share, which is the one case where the strip legitimately moves left (#234).
+pill strip for a title it did not shorten — the strip (`pillX`) is anchored on the title's right edge
+and the context is drawn after the pills, so the strip moves if and only if the title shows the
+trimming sign: a title longer than what is left of the shared budget after the pills and the
+context's reserve (at least 60% of the share, since the reserve is capped at 40%) is cut and its
+pills follow; a shorter one is drawn in full and its pills stay, whatever the context (#234).
 
 *Seen (2026-09-05, task 2 smoke): `~  build the persistence batch` dimmed before the bell at 150%
 DPI; the row read `session 1  build the persistence…`.*

--- a/qa/persistence.md
+++ b/qa/persistence.md
@@ -79,8 +79,10 @@ as `$sid = Sid $s` and confirm `Node $s $sid` has no `context`.
 - step 5: `Compare-Capture $t0 $t3` is **true** — clearing puts the title bar back exactly.
 
 **Fails when:** `DrawTitleBar` draws the context outside the `titleAvail` budget, drops the trimming
-sign, or the pill strip origin (`pillX`) starts depending on the context's width — it is anchored on
-the title alone, and the context is drawn AFTER the pills for exactly that reason.
+sign, reserves room for a context it then does not draw (a title cut short for nothing), or moves the
+pill strip for a title that FITS — the strip (`pillX`) is anchored on the title's right edge, the
+context is drawn after the pills, and the only way a context reaches a pill is by shortening a title
+longer than its share, which is the one case where the strip legitimately moves left (#234).
 
 *Seen (2026-09-05, task 2 smoke): `~  build the persistence batch` dimmed before the bell at 150%
 DPI; the row read `session 1  build the persistence…`.*

--- a/src/Agwinterm.Ctl/Program.cs
+++ b/src/Agwinterm.Ctl/Program.cs
@@ -431,7 +431,7 @@ switch (area)
         if (rest.Count > 0) { Console.Error.WriteLine($"restore capture: unexpected argument '{rest[0]}' — the target is `--target <pane or session>`; with no --target EVERY real pane is captured, so a stray word is refused rather than widened. Nothing sent."); return 2; }
         var unknown = options.Keys.FirstOrDefault(k => !Agwinterm.Ctl.FrameShmCli.GlobalValuedOptions.Contains(k, StringComparer.OrdinalIgnoreCase));
         if (unknown is not null) { Console.Error.WriteLine($"restore capture: unknown option --{unknown} (it takes only --target). Nothing sent."); return 2; }
-        if (options.TryGetValue("target", out var capTarget) && (capTarget.Length == 0 || capTarget == "true"))
+        if (options.TryGetValue("target", out var capTarget) && (capTarget.Length == 0 || !valued.Contains("target")))   // a valueless flag, not the WORD true — a session may be named that
         { Console.Error.WriteLine("restore capture: --target is empty — omit it to capture every real pane, or name one pane or session. Nothing sent."); return 2; }
         target = Opt("target");
         break;

--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -510,10 +510,12 @@ public sealed class ControlServer : IDisposable
     /// restore.capture: capture every real pane's foreground command (or one pane's, with a target)
     /// into its durable restore slot now, and report per pane what was captured (P3). The reply is
     /// <see cref="RestoreCaptureReply"/>'s object, OkRaw; the read-back is <c>tree</c>'s
-    /// <c>capturedCommands</c>. Every refusal — an unknown target, a cover pane, a failed process
-    /// query, a UI hop that could not run — is the host's, behind <see cref="RestoreCaptureResult.Refusal"/>
-    /// or a throw, and each captures nothing for anyone. There is no server-side rule to apply: the
-    /// verb takes no value, only a target.
+    /// <c>capturedCommands</c>. One refusal is the server's own, taken before the host is asked: a
+    /// present but EMPTY target (<see cref="RestoreCaptureReply.EmptyTarget"/> — only an OMITTED
+    /// target means every real pane; the hosts' "" arms are unreachable through the wire). Every
+    /// other refusal — an unknown target, a cover pane, a failed process query, a UI hop that could
+    /// not run — is the host's, behind <see cref="RestoreCaptureResult.Refusal"/> or a throw, and each
+    /// captures nothing for anyone. The verb takes no value, only the target.
     /// </summary>
     private static string HandleRestoreCapture(ISessionHost host, string? target)
     {

--- a/src/Agwinterm.Pty/ISessionHost.cs
+++ b/src/Agwinterm.Pty/ISessionHost.cs
@@ -385,7 +385,10 @@ public interface ISessionHost
     /// ordinary save wrote "" into the slot because the captured command had no in-memory field. The
     /// slot is durable now (the app's <c>Pane.CapturedCommand</c>, written by this verb and by the
     /// quit-time capture, read by every save), so a checkpoint survives until the next capture.
-    /// <para><b>Target</b>: null / "" = every real pane of every session, in tree order; "active" =
+    /// <para><b>Target</b>: null (omitted) = every real pane of every session, in tree order; a
+    /// present but EMPTY target is refused by the server with <see cref="RestoreCaptureReply.EmptyTarget"/>
+    /// before the host is asked (a caller that built the request wrong must not clear every idle
+    /// pane's checkpoint on a typo; the hosts' "" arms are unreachable through the wire); "active" =
     /// the active session's active pane; else the resolver <c>session.restore</c> uses (exact pane,
     /// exact session → its active pane, pane prefix, session prefix / unique name). An unknown target
     /// is refused with <see cref="RestoreCaptureReply.UnknownTarget"/>; a scratch / overlay / quick
@@ -401,9 +404,12 @@ public interface ISessionHost
     /// carries it so the caller knows.</para>
     /// <para><b>Threading</b> (the app): the pane + pid snapshot and the CIM query run on the calling
     /// pipe thread with the 15 s timeout the non-quit callers use — never on the UI thread — and
-    /// every slot write plus one save land in a single FIFO queued hop; a hop that cannot run throws,
-    /// which the server turns into ok:false with nothing written. A pane closed between the snapshot
-    /// and the hop is dropped from the reply rather than written to.</para>
+    /// every slot write plus one save land in a single FIFO queued hop. A hop that cannot be queued,
+    /// or that the window closes under, throws — ok:false, nothing written, nothing saved. A hop that
+    /// TIMES OUT (a message loop that is alive but not pumping) is ok:false too, but the action stays
+    /// queued and may still land when the loop resumes, and the reply says so rather than claiming
+    /// nothing was written. A pane closed between the snapshot and the hop is dropped from the reply
+    /// rather than written to.</para>
     /// </summary>
     RestoreCaptureResult RestoreCapture(string? target);
     /// <summary>Poll the event log for events after <paramref name="since"/> (0 = all buffered), up to

--- a/src/Agwinterm.Win32/Program.Services.cs
+++ b/src/Agwinterm.Win32/Program.Services.cs
@@ -301,41 +301,50 @@ internal partial class Program
         // session.context (P3): a dimmed, smaller run AFTER the title and after the pill strip. It is
         // a suffix and not a second caption line because TitleBarH is 40/30/0 by toolbar mode — there
         // is no room for a second row at 30 and no row at all at 0. Title and context share the ONE
-        // titleAvail budget: a long title yields at most 40% of it to the context, both are ellipsized
-        // inside their share, and the run never grows past titleAvail — so the bell (which follows the
-        // run) is clamped exactly where it was without a context, and the right button group never
-        // moves. The pills sit between them, anchored on the TITLE alone, so their origin does not
-        // depend on the context either (qa/persistence.md names that as the failure; revmux r1).
+        // titleAvail budget, in this order of claim: the pills (measured FIRST, below) are taken off
+        // the top, the context reserves at most 40% of what is left and only when that reserve can
+        // actually be drawn (a context under 20 px reserves nothing, so a title is never cut for a
+        // run that then does not appear), and the title takes the rest, ellipsized. The pill strip is
+        // anchored on the TITLE: it starts where the title ends, so a context moves it only through
+        // the title, and only when the title is longer than its share — a title that fits is never
+        // shortened by a context and its pills never move (qa/persistence.md states it that way; the
+        // earlier "never depends on the context" was more than the layout does — #234). The bell
+        // follows the run (title, pills, then the context) and clamps on its own at `rgLeft - bellW -
+        // 14`, the same edge the budget was cut from, so a run that fills the budget puts it exactly
+        // there and the right button group never moves (revmux r1).
+        var pills = new List<(string label, Color4 bg, float w)>();
+        void Pill(string label, Color4 bg) => pills.Add((label, bg, MeasureText(label, _uiSmall) + 14f));   // small status pill after the title
+        if (_broadcast) Pill("BROADCAST", new Color4(0.85f, 0.25f, 0.25f, 0.95f));  // typing fans out to the workspace
+        if (ActiveSurface() is { ReadOnly: true }) Pill("READ-ONLY", new Color4(0.45f, 0.45f, 0.5f, 0.95f));
+        float pillsW = pills.Count == 0 ? 0f : 10f + pills.Sum(p => p.w + 6f) - 6f;   // leading gap, the pills, the gaps between them
+        float titleShare = titleAvail - pillsW;   // what the title and the context divide
         string? ctx = _active?.Context;
         float ctxGap = 8f, ctxMeasured = 0f, ctxReserve = 0f;
         if (ctx is not null)
         {
             ctxMeasured = MeasureText(ctx, _uiSmall);
-            ctxReserve = MathF.Min(ctxMeasured + ctxGap, titleAvail * 0.4f);
+            ctxReserve = MathF.Min(ctxMeasured + ctxGap, titleShare * 0.4f);
+            if (ctxReserve - ctxGap < 20f) ctxReserve = 0f;   // would not be drawn (the 20 px floor below): reserve nothing, shorten no title
         }
-        float titleW = MathF.Max(30f, MathF.Min(titleMeasured, titleAvail - ctxReserve));
+        float titleW = MathF.Max(30f, MathF.Min(titleMeasured, titleShare - ctxReserve));
         brush.Color = ChromeText;
         rt.DrawText(title, _uiTitle, new Rect(titleX, 0f, titleW, TitleBarH), brush);  // one vertically-centered, ellipsized row
         float runEnd = titleX + titleW;   // right edge of the title run (title, pills, then the context suffix when set)
         float pillX = runEnd + 10f;       // anchored on the title alone — never on the context
-        bool anyPill = false;
-        void Pill(string label, Color4 bg)   // small status pill after the title
+        foreach (var (label, bg, w) in pills)
         {
-            float w = MeasureText(label, _uiSmall) + 14f;
             brush.Color = bg;
             rt.FillRoundedRectangle(new RoundedRectangle { Rect = new Rect(pillX, (TitleBarH - 20f) / 2f, w, 20f), RadiusX = 5f, RadiusY = 5f }, brush);
             brush.Color = new Color4(1f, 1f, 1f, 1f);
             rt.DrawText(label, _uiSmall, new Rect(pillX + 7f, (TitleBarH - 20f) / 2f + 2f, w, 16f), brush);
             pillX += w + 6f;
-            anyPill = true;
         }
-        if (_broadcast) Pill("BROADCAST", new Color4(0.85f, 0.25f, 0.25f, 0.95f));  // typing fans out to the workspace
-        if (ActiveSurface() is { ReadOnly: true }) Pill("READ-ONLY", new Color4(0.45f, 0.45f, 0.5f, 0.95f));
-        if (anyPill) runEnd = pillX - 6f;   // the strip's right edge (its last inter-pill gap removed)
+        if (pills.Count > 0) runEnd = pillX - 6f;   // the strip's right edge (its last inter-pill gap removed)
         if (ctx is not null)
         {
-            // The context takes what is left of the title budget after the title and the pills, so a
-            // pill can shorten it but it can never move a pill.
+            // The context takes what is left of the title budget after the title and the pills: at
+            // least its reserve when the title was cut for it (the pills were off the top before the
+            // reserve was taken), more when the title is short. A pill can shorten it, never move.
             float ctxW = MathF.Min(ctxMeasured, titleX + titleAvail - runEnd - ctxGap);
             if (ctxW >= 20f)   // nothing drawn when the title (and pills) fill the budget — the palette line carries the long form
             {
@@ -1318,8 +1327,10 @@ internal partial class Program
             // only consulted after the child has already closed stdout — a powershell wedged inside
             // the CIM query keeps the handle open, so neither the 4 s nor the 15 s bound ever fired
             // and the caller (a control-pipe thread, for restore.capture) hung with it (revmux r1).
-            // On expiry the whole tree goes (powershell + the WMI provider host it may have spawned),
-            // which also completes the pending read, and the partial output is never parsed.
+            // On expiry powershell is killed (the tree flag for any child it did spawn — the WMI
+            // provider host is the WMI service's child, not ours, and never held our pipe), which
+            // closes the last write handle on its stdout so the pending read completes with EOF, and
+            // the partial output is never parsed.
             var read = proc.StandardOutput.ReadToEndAsync();
             if (!proc.WaitForExit(timeoutMs))
             {

--- a/src/Agwinterm.Win32/Program.Services.cs
+++ b/src/Agwinterm.Win32/Program.Services.cs
@@ -306,9 +306,10 @@ internal partial class Program
         // actually be drawn (a context under 20 px reserves nothing, so a title is never cut for a
         // run that then does not appear), and the title takes the rest, ellipsized. The pill strip is
         // anchored on the TITLE: it starts where the title ends, so a context moves it only through
-        // the title, and only when the title is longer than its share — a title that fits is never
-        // shortened by a context and its pills never move (qa/persistence.md states it that way; the
-        // earlier "never depends on the context" was more than the layout does — #234). The bell
+        // the title — only when the title is longer than what is left of the shared budget after the
+        // pills and the context's reserve (at least 60% of `titleShare`); a shorter title is drawn in
+        // full and its pills stay put, whatever the context (qa/persistence.md states the same bound;
+        // the earlier "never depends on the context" was more than the layout does — #234). The bell
         // follows the run (title, pills, then the context) and clamps on its own at `rgLeft - bellW -
         // 14`, the same edge the budget was cut from, so a run that fills the budget puts it exactly
         // there and the right button group never moves (revmux r1).

--- a/tests/integration/restore-roundtrip.ps1
+++ b/tests/integration/restore-roundtrip.ps1
@@ -277,6 +277,9 @@ Cell -Name 'quit-capture' -Conf @('restore-commands = true') -Setup {
     Check 'quit-capture: session context replies with the value in effect' ($set.ok -and $set.result.context -eq $ctxText) ($set | ConvertTo-Json -Compress)
     $idle = [string](Reply $s @('session', 'new', '--name', 'idle', '--no-select')).result
     for ($i = 0; $i -lt 30 -and -not (Node $s $idle); $i++) { Start-Sleep -Milliseconds 200 }
+    # The idle shell must have a pid before the warm-up names it: a pane whose child has not started
+    # yet is filtered out of the query, and a capture with no pids never runs powershell at all.
+    if (-not (Wait-Prompt $s $idle)) { throw 'the idle shell never drew a prompt' }
     if (-not (Start-Child $s $sid)) { throw 'the ping child never echoed in the first pane' }
     $warm = Reply $s @('restore', 'capture', '--target', $idle)
     $warmMine = @($warm.result.panes) | Where-Object { $_.pane -eq $sid }

--- a/tests/integration/restore-roundtrip.ps1
+++ b/tests/integration/restore-roundtrip.ps1
@@ -16,6 +16,9 @@
 #   replay     restore-commands = true in the sandbox's own agwinterm.conf, killed: after the
 #              relaunch the captured command is typed back into the pane (`session text` shows it
 #              with the `& ` prefix the replay adds, which the original typed line never had)
+#   quit-capture  restore-commands = true, a child running, NO `restore capture` for its pane, WM_CLOSE:
+#              after the relaunch `capturedCommands` names the child — the slot WM_DESTROY's own
+#              capture filled (the one path SaveState(captureCommands: true) is reached from; #234)
 #
 # P4 (docs/plans/completed/2026-09-06-p4-splits.md, task 3) adds the split axis to the file, and two cells:
 #
@@ -48,7 +51,7 @@
 param(
     [string]$Exe,
     [switch]$Strict,
-    [string]$Only = ''          # run a single cell by name: graceful | killed | refusal | replay | axis-graceful | axis-killed | swap-killed
+    [string]$Only = ''          # run a single cell by name: graceful | killed | refusal | replay | quit-capture | axis-graceful | axis-killed | swap-killed
 )
 
 $ErrorActionPreference = 'Stop'
@@ -256,6 +259,46 @@ Cell -Name 'replay' -Kill -Conf @('restore-commands = true') -Setup {
         Start-Sleep -Milliseconds 500
     }
     Check 'replay: the captured command was typed back into the pane (with the `& ` prefix the replay adds)' $typed "text=$text"
+}
+
+# The QUIT-TIME capture: SaveState(captureCommands: true) is reached from WM_DESTROY alone and runs
+# only with restore-commands on. The graceful cell above runs with it off and the replay cell is
+# killed, so the code the P3 round-1 fix rewrote was run by no cell (#234). This one: the toggle on,
+# a child running, NO `restore capture` for its pane, a clean close — the checkpoint the relaunch
+# reads must be the one WM_DESTROY wrote. CIM is warmed first by a capture aimed at the IDLE pane
+# (it writes null into that pane's slot and never touches the first pane's), so the quit path's 4 s
+# budget is not what this cell measures on a cold provider.
+Cell -Name 'quit-capture' -Conf @('restore-commands = true') -Setup {
+    param($s)
+    $sid = Sid $s
+    if (-not (Wait-Prompt $s $sid)) { throw 'the first shell never drew a prompt' }
+    $ctxText = 'quit-capture: WM_DESTROY fills the slot'
+    $set = Reply $s @('session', 'context', $ctxText, '--target', $sid)
+    Check 'quit-capture: session context replies with the value in effect' ($set.ok -and $set.result.context -eq $ctxText) ($set | ConvertTo-Json -Compress)
+    $idle = [string](Reply $s @('session', 'new', '--name', 'idle', '--no-select')).result
+    for ($i = 0; $i -lt 30 -and -not (Node $s $idle); $i++) { Start-Sleep -Milliseconds 200 }
+    if (-not (Start-Child $s $sid)) { throw 'the ping child never echoed in the first pane' }
+    $warm = Reply $s @('restore', 'capture', '--target', $idle)
+    $warmMine = @($warm.result.panes) | Where-Object { $_.pane -eq $sid }
+    Check 'quit-capture: the warming capture is scoped to the idle pane (the first pane is not in its reply)' `
+        ($warm.ok -and -not $warmMine -and @($warm.result.panes).Count -eq 1) ($warm | ConvertTo-Json -Compress -Depth 5)
+    Start-Sleep -Milliseconds 600
+    $raw = Get-Content -LiteralPath (StateFile $s).FullName -Raw
+    Check 'quit-capture: before the close the state file carries the context and NO ping command (nothing captured the first pane yet)' `
+        (($raw -match ('"Context":\s*"' + [regex]::Escape($ctxText) + '"')) -and ($raw -notmatch '(?i)"Command":\s*"[^"]*ping')) "file=$((StateFile $s).FullName)"
+    return @{ Sid = $sid; Idle = $idle; Context = $ctxText }
+} -Assert {
+    param($s, $ctx)
+    Start-Sleep -Seconds 3   # the restored shells come up; the tree is readable before they do
+    $n = Node $s $ctx.Sid
+    Check 'quit-capture: the context is back on the same session id' ($n -and $n.context -eq $ctx.Context) "node=$($n | ConvertTo-Json -Compress)"
+    Check 'quit-capture: capturedCommands names the child — the slot WM_DESTROY filled, with no restore capture having named that pane' `
+        ($n -and $n.PSObject.Properties['capturedCommands'] -and ("$($n.capturedCommands.($ctx.Sid))" -match $ChildPattern)) `
+        "capturedCommands=$($n.capturedCommands | ConvertTo-Json -Compress)"
+    $idle = Node $s $ctx.Idle
+    Check 'quit-capture: the idle session is back with no capture (its shell ran nothing, at the warm-up and at the quit)' `
+        ($idle -and -not ($idle.PSObject.Properties['capturedCommands'] -and $idle.capturedCommands.PSObject.Properties[$ctx.Idle])) `
+        "node=$($idle | ConvertTo-Json -Compress)"
 }
 
 # ---- P4: the split axis survives the restart ----


### PR DESCRIPTION
Closes #234 — the seven Minors and one pre-existing item revmux round 2 of #233 left behind, in one PR with its own round, as #228 (P2) and #244 (P4). One behaviour change (the title-bar budget); everything else is contract prose, a comment, a CLI guard and a test cell.

## Items

1. **`ISessionHost.RestoreCapture` Threading** now says what a hop that TIMES OUT means: ok:false, but the action stays queued and may still land when the loop resumes, and the reply says so — the wording `Program.ControlHost.cs` already carried.
2. **The empty-target rule, one rule everywhere**: null (omitted) = every real pane; a present but EMPTY target is refused by the server (`RestoreCaptureReply.EmptyTarget`, `ControlServer.cs:520`) before the host is asked, so the hosts' `""` arms are unreachable through the wire. Same words in `ISessionHost`, `README.md`, `docs/lite-parity.md`, the P3 plan — and (round finding) `HandleRestoreCapture`'s own summary, which had said "there is no server-side rule" two lines above the check.
3. **`DrawTitleBar` measures the pills FIRST** and takes them off `titleAvail` before the title and the context divide what is left (`titleShare`); the context reserves at most 40% of that and nothing at all when the reserve could not be drawn (the 20 px floor), so a title is never cut for a run that then does not appear. The pill strip stays anchored on the title's right edge. Before: the context's reserve was computed against the full budget and the pill strip consumed it, so a long title + a pill + a short context lost the context.
4. The title-bar comment no longer claims "the run never grows past `titleAvail`"; it explains the bell clamp (`rgLeft - bellW - 14`, the edge the budget was cut from) and why the right group never moves.
5. **The kill comment** says why the read completes: killing powershell closes the last write handle on its stdout, so the pending `ReadToEndAsync` sees EOF; the WMI provider host is the WMI service's child, never ours, and never held the pipe.
6. **`agwintermctl restore capture --target`** guard matches `session split` / `session swap`: a bare `--target` or `--target ''` is refused locally ("is empty", exit 2); `--target true` reaches the wire (a session may be named that).
7. **`restore-roundtrip.ps1` gains `quit-capture`**: restore-commands ON, a `ping -n 300` child in the first pane, a warming capture aimed at the IDLE pane (asserted scoped to it), the state file asserted to carry the context and NO ping command before a graceful close, then after the relaunch `capturedCommands[sid]` names the child and the idle session has none — the slot WM_DESTROY fills, run by a cell for the first time. Negative control: with the toggle OFF the same cell reads `capturedCommands=null`.
8. **(pre-existing)** The links that resolved one directory short were the P4 plan's (`2026-09-06-p4-splits.md:4-5`), not the P3 plan's; fixed there.

## Verification

- Pty tests 613/613; `restore-roundtrip.ps1 -Strict` all 8 cells; `win32-control.ps1 -Strict` all passed.
- CLI: `--target true` → connects; bare `--target` and `--target ''` → "is empty", exit 2.
- Title bar (PrintWindow captures, 1100 px window, scale 1, BROADCAST pill on, sidebar shown):
  - short title, context set vs not: first differing column at 356 px — right of the pill, which did not move;
  - a tiny context (`x`, under the 20 px floor): byte-identical to no context (nothing reserved, nothing drawn);
  - long title + pill + `note here`: title ellipsized, pill follows it, context DRAWN (it vanished before);
  - the long context on the long title: ellipsized inside its 40% reserve;
  - the right 220 DIP button group byte-identical across all five captures.

## Review

`.revmux/tasks/p3-leftovers/01-initial` on `68944b2`: **no Major, no Critical.** Two Minors, both confirmed and fixed in `04c3e2a`:
- the prose bound "a title that FITS is never shortened by a context" was stronger than the layout — the cut is at `titleShare − ctxReserve` (≥ 60% of the share); the comment and the qa criterion now state that bound as a biconditional (the strip moved iff the title shows the trimming sign). Layout unchanged.
- the warm-up capture could name the idle pane before its shell had a pid — a capture with no pids never runs powershell, so the warm-up was a no-op on a slow start; the cell now waits for the idle prompt first (cell re-run: all passed).

Pre-existing prose taken here: the `HandleRestoreCapture` summary (item 2 above) and the P3 plan's task-2 line (said the context is drawn BEFORE the pills). Pre-existing behaviour left for #246: the recents clock is outside the title budget and overdraws (and out-hit-tests) the right group's first button when the sidebar is hidden and the title is ellipsized; `RestoreCapture` reports success after a swallowed `SaveState` failure. Immaterial: `--target victim --target` (a duplicate) sends `true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k