### PR TITLE
fix: P2 round-4 leftovers (#228)

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,9 @@ Thirteen of those answer a question a script would otherwise have to guess at:
   full content region. `resized N%` is always the N that was asked for. The verb's other failures
   are refusals too: `open` with no command; `open` and `resize` whenever no session resolves (a
   `--target` that matches nothing, or no target and no active session); a `close` whose `--target`
-  names nothing; and `resize` with no overlay open. `close` stays `ok` when the session resolves and
+  names nothing; `open`, `close` and `resize` whose `--target` names one pane of a split session (an
+  overlay covers the whole session — the refusal names the session id to pass instead); and `resize`
+  with no overlay open. `close` stays `ok` when the session resolves and
   has no overlay, or when the target is absent, empty or `active` while nothing is active — there is
   nothing to close, and nothing is what you asked for.
 - `session restore` replies `{action, pane, session}` instead of the word "pinned": `pane` is the pane

--- a/README.md
+++ b/README.md
@@ -273,8 +273,8 @@ Thirteen of those answer a question a script would otherwise have to guess at:
   are refusals too: `open` with no command; `open` and `resize` whenever no session resolves (a
   `--target` that matches nothing, or no target and no active session); a `close` whose `--target`
   names nothing; and `resize` with no overlay open. `close` stays `ok` when the session resolves and
-  has no overlay, or when no target was given — there is nothing to close, and nothing is what you
-  asked for.
+  has no overlay, or when the target is absent, empty or `active` while nothing is active — there is
+  nothing to close, and nothing is what you asked for.
 - `session restore` replies `{action, pane, session}` instead of the word "pinned": `pane` is the pane
   the target resolved to (a session name lands on its focused pane, a session id on the pane that
   carries that id while one does — pane 0 of a fresh session, either side after a `session swap` —

--- a/src/Agwinterm.Pty/AgentSkill.cs
+++ b/src/Agwinterm.Pty/AgentSkill.cs
@@ -184,8 +184,8 @@ public static class AgentSkill
         - What is REFUSED (`ok:false`, nothing happened): `open` with no command; `open` and `resize` whenever no
           session resolves (a `--target` that matches nothing, or no target while no session is active); a `close`
           whose `--target` names something that does not exist; and `resize` on a session with no overlay open.
-          `close` answers `ok` ("no overlay") in two cases — the session resolves and has no overlay, or no target
-          was given and nothing is active — because closing nothing leaves "no overlay open" true. These used to
+          `close` answers `ok` ("no overlay") when the session resolves and has no overlay, or when the target is
+          absent, empty or `active` while nothing is active — closing nothing leaves "no overlay open" true. These used to
           answer `ok:true` with the failure as the result text; branch on `ok`.
 
         ## Notify the user (desktop notification)

--- a/src/Agwinterm.Pty/ISessionHost.cs
+++ b/src/Agwinterm.Pty/ISessionHost.cs
@@ -145,8 +145,10 @@ public interface ISessionHost
     /// <summary>Rename a session: sets its custom name (shown in the sidebar and title bar). Resolves
     /// the target the way every content verb does (exact pane, exact session, pane prefix, session
     /// prefix / name — a scratch or overlay cover id lands on the session it covers). False when no
-    /// session resolves, the name is blank, or the window is closing and the rename could not be
-    /// queued (#228 item 5: the post's result is the reply, not a constant true).</summary>
+    /// session resolves or the name is blank. A rename the window could not queue (it is closing) is
+    /// a throw, not a false — the server reads false as "session not found", and Dispatch turns the
+    /// throw into ok:false with the real reason (#228 item 5: every verb that posts to the UI thread
+    /// answers with the post's outcome, never a constant true; nothing was applied when it says so).</summary>
     bool SessionRename(string? target, string name);
 
     /// <summary>
@@ -354,13 +356,15 @@ public interface ISessionHost
     /// Overlay control. action = open|close|resize|result. For open: run <paramref name="command"/> in
     /// an ephemeral terminal over the target session; sizePercent 0 = full-region, 1..100 = a centered
     /// floating panel; wait = keep it after the program exits (press a key to close); block = wait for
-    /// the program to exit and return its status. Returns the session id (open), "exit N"
-    /// (block/result), "closed", "resized N%", or "no overlay" (deliberately ok, two states: close on
-    /// a session that resolves and has no overlay, and an untargeted close that resolves no session).
+    /// the program to exit and return its status. Returns the session id (open), "exit N" (block;
+    /// result once any overlay's program has exited — before that, result is "no overlay"), "closed",
+    /// "resized N%", or "no overlay" (deliberately ok, three states for close: a session that resolves
+    /// and has no overlay, and a target that is absent, empty or the word "active" while nothing is
+    /// active — the guard is the app's `target != "active"`, and those three targets are one case).
     /// A FAILURE is signalled by prefixing <see cref="RefusePrefix"/>, which the server turns into
     /// ok:false: open with no command; open or resize whenever NO session resolves (a named target
-    /// that matches nothing, or no target and no active session); close only when a non-empty,
-    /// non-"active" target resolves to nothing; resize with no overlay open. A second host that
+    /// that matches nothing, or no target and no active session); close only when a target other than
+    /// absent, empty or "active" resolves to nothing; resize with no overlay open. A second host that
     /// returns those as plain strings reproduces the ok:true-on-failure P2 removed.
     /// </summary>
     string SessionOverlay(string? target, string action, string? command, int sizePercent, bool wait, bool block);

--- a/src/Agwinterm.Pty/ISessionHost.cs
+++ b/src/Agwinterm.Pty/ISessionHost.cs
@@ -145,8 +145,9 @@ public interface ISessionHost
     /// <summary>Rename a session: sets its custom name (shown in the sidebar and title bar). Resolves
     /// the target the way every content verb does (exact pane, exact session, pane prefix, session
     /// prefix / name — a scratch or overlay cover id lands on the session it covers). False when no
-    /// session resolves or the name is blank. A rename the window could not queue (it is closing) is
-    /// a throw, not a false — the server reads false as "session not found", and Dispatch turns the
+    /// session resolves or the name is blank. A rename the window could not queue (it is closing, or
+    /// its message queue refused the wake-up) is a throw, not a false — the server reads false as
+    /// "session not found", and Dispatch turns the
     /// throw into ok:false with the real reason (#228 item 5: every verb that posts to the UI thread
     /// answers with the post's outcome, never a constant true; nothing was applied when it says so).</summary>
     bool SessionRename(string? target, string name);
@@ -356,11 +357,14 @@ public interface ISessionHost
     /// Overlay control. action = open|close|resize|result. For open: run <paramref name="command"/> in
     /// an ephemeral terminal over the target session; sizePercent 0 = full-region, 1..100 = a centered
     /// floating panel; wait = keep it after the program exits (press a key to close); block = wait for
-    /// the program to exit and return its status. Returns the session id (open), "exit N" (block;
-    /// result once any overlay's program has exited — before that, result is "no overlay"), "closed",
-    /// "resized N%", or "no overlay" (deliberately ok, three states for close: a session that resolves
-    /// and has no overlay, and a target that is absent, empty or the word "active" while nothing is
-    /// active — the guard is the app's `target != "active"`, and those three targets are one case).
+    /// the program to exit and return its status. Returns the overlay pane id (open), "exit N" (block;
+    /// result when the most recently opened overlay's program has exited — result is "no overlay"
+    /// before any overlay has been opened, while the current one is still running, and again after a
+    /// new open resets it; the value is one per window, not per session, so an open on any session
+    /// resets it), "closed", "resized N%", or "no overlay" (deliberately ok for close: a session that
+    /// resolves and has no overlay, or a target that is absent, empty or the word "active" while
+    /// nothing is active — the guard is the app's `target != "active"`, so those three targets are one
+    /// case).
     /// A FAILURE is signalled by prefixing <see cref="RefusePrefix"/>, which the server turns into
     /// ok:false: open with no command; open or resize whenever NO session resolves (a named target
     /// that matches nothing, or no target and no active session); close only when a target other than

--- a/src/Agwinterm.Pty/ISessionHost.cs
+++ b/src/Agwinterm.Pty/ISessionHost.cs
@@ -173,8 +173,9 @@ public interface ISessionHost
     /// <para><b>Threading</b>: the write is applied on the UI thread through the FIFO queued hop (the
     /// same queue every posted action travels), and the calling pipe thread waits for it, so the
     /// reply describes a state that exists. A hop that cannot be queued or run (the window is
-    /// closing, or a message loop that never pumps within the bound) throws, which the server turns
-    /// into ok:false — never ok:true for a write that did not land. The session is resolved INSIDE
+    /// closing, its message queue refused the wake-up, or a message loop that never pumps within the
+    /// bound) throws, which the server turns into ok:false — never ok:true for a write that did not
+    /// land. The session is resolved INSIDE
     /// the hop so a session closed between the request and the write is refused, not written to.</para>
     /// </summary>
     string SessionContext(string? target, string? context);
@@ -358,18 +359,23 @@ public interface ISessionHost
     /// an ephemeral terminal over the target session; sizePercent 0 = full-region, 1..100 = a centered
     /// floating panel; wait = keep it after the program exits (press a key to close); block = wait for
     /// the program to exit and return its status. Returns the overlay pane id (open), "exit N" (block;
-    /// result when the most recently opened overlay's program has exited — result is "no overlay"
-    /// before any overlay has been opened, while the current one is still running, and again after a
-    /// new open resets it; the value is one per window, not per session, so an open on any session
-    /// resets it), "closed", "resized N%", or "no overlay" (deliberately ok for close: a session that
+    /// result), "closed", "resized N%", or "no overlay" (deliberately ok for close: a session that
     /// resolves and has no overlay, or a target that is absent, empty or the word "active" while
     /// nothing is active — the guard is the app's `target != "active"`, so those three targets are one
-    /// case).
+    /// case). The value `result` reads is ONE PER WINDOW, not per session or per overlay: it is "no
+    /// overlay" until the first open in that window, every open resets it to "no overlay", and the
+    /// exit of ANY overlay in the window — whichever session's, including one an open has since
+    /// replaced — writes "exit N" over it, so a caller that runs overlays on two sessions at once
+    /// reads the last exit in the window, not its own; `--block` waits on the same per-window signal
+    /// and can return on another session's exit (agwinterm #246 tracks keying both to the open that
+    /// produced them). `result` skips the target check entirely.
     /// A FAILURE is signalled by prefixing <see cref="RefusePrefix"/>, which the server turns into
     /// ok:false: open with no command; open or resize whenever NO session resolves (a named target
     /// that matches nothing, or no target and no active session); close only when a target other than
-    /// absent, empty or "active" resolves to nothing; resize with no overlay open. A second host that
-    /// returns those as plain strings reproduces the ok:true-on-failure P2 removed.
+    /// absent, empty or "active" resolves to nothing; open, close and resize whenever the target names
+    /// one pane of a multi-pane session (the overlay covers the whole session; the app's
+    /// OverlayTargetRefusal); resize with no overlay open. A second host that returns those as plain
+    /// strings reproduces the ok:true-on-failure P2 removed.
     /// </summary>
     string SessionOverlay(string? target, string action, string? command, int sizePercent, bool wait, bool block);
 
@@ -475,7 +481,9 @@ public interface ISessionHost
 
     /// <summary>Apply an oh-my-posh theme (by name or .omp.json path) live to the active session's shell
     /// (re-inits oh-my-posh and re-applies the OSC-7 prompt wrap). When <paramref name="persist"/>, also
-    /// save it to config so new sessions launch with it. Returns an ack / "not found".</summary>
+    /// save it to config so new sessions launch with it. Returns an ack / "not found". A change the
+    /// window could not queue (it is closing, or its message queue refused the wake-up) is a throw the
+    /// server turns into ok:false with the reason, never the ack (#228 item 5).</summary>
     string OmpSet(string nameOrPath, bool persist);
 }
 

--- a/src/Agwinterm.Pty/ISessionHost.cs
+++ b/src/Agwinterm.Pty/ISessionHost.cs
@@ -367,11 +367,13 @@ public interface ISessionHost
     /// exit of ANY overlay in the window — whichever session's, including one an open has since
     /// replaced — writes "exit N" over it, so a caller that runs overlays on two sessions at once
     /// reads the last exit in the window, not its own; `--block` waits on the same per-window signal
-    /// and can return on another session's exit (agwinterm #246 tracks keying both to the open that
-    /// produced them). `result` skips the target check entirely.
+    /// and then reads the same value, so it can return on another session's exit, answer "no overlay"
+    /// when an open lands between its wake-up and its read, or stay parked past its own program's
+    /// exit when that open's reset lands first (agwinterm #246 tracks keying value and signal to the
+    /// open that produced them). `result` skips the target check entirely.
     /// A FAILURE is signalled by prefixing <see cref="RefusePrefix"/>, which the server turns into
     /// ok:false: open with no command; open or resize whenever NO session resolves (a named target
-    /// that matches nothing, or no target and no active session); close only when a target other than
+    /// that matches nothing, or no target and no active session); close when a target other than
     /// absent, empty or "active" resolves to nothing; open, close and resize whenever the target names
     /// one pane of a multi-pane session (the overlay covers the whole session; the app's
     /// OverlayTargetRefusal); resize with no overlay open. A second host that returns those as plain
@@ -481,9 +483,11 @@ public interface ISessionHost
 
     /// <summary>Apply an oh-my-posh theme (by name or .omp.json path) live to the active session's shell
     /// (re-inits oh-my-posh and re-applies the OSC-7 prompt wrap). When <paramref name="persist"/>, also
-    /// save it to config so new sessions launch with it. Returns an ack / "not found". A change the
-    /// window could not queue (it is closing, or its message queue refused the wake-up) is a throw the
-    /// server turns into ok:false with the reason, never the ack (#228 item 5).</summary>
+    /// save it to config so new sessions launch with it. Returns an ack, or "oh-my-posh theme not
+    /// found: NAME" — a plain string the server sends as ok:true, so a caller must match the text
+    /// (agwinterm #246 tracks making it a refusal). A change the window could not queue (it is
+    /// closing, or its message queue refused the wake-up) is a throw the server turns into ok:false
+    /// with the reason, never the ack (#228 item 5).</summary>
     string OmpSet(string nameOrPath, bool persist);
 }
 

--- a/src/Agwinterm.Pty/IWindowHost.cs
+++ b/src/Agwinterm.Pty/IWindowHost.cs
@@ -20,6 +20,10 @@ public interface IWindowHost
     /// <summary>Create a new (seeded) window; returns its id.</summary>
     string WindowNew(string? name);
 
+    // Every window verb below applies its change on the UI thread through a posted action. False
+    // means the selector named no window (the server replies "window not found"); a change the app
+    // could not queue — the window is closing, or its message queue refused the wake-up — is a THROW,
+    // which the server turns into ok:false with that reason, never the ack (#228 item 5).
     /// <summary>Raise/focus a window (restoring it if minimized). False if not found.</summary>
     bool WindowSelect(string? selector);
     /// <summary>Close a window (its entry + per-window file are kept, marked not-open). False if not found.</summary>

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -32,12 +32,13 @@ internal partial class Program
             return _windowIndex.Select(m => new WindowSnapshot(m.Id, m.Name, m.IsOpen, m.Id == _frontmostId)).ToList();
     }
 
-    // The window verbs post on the window they RESOLVED, and the ones that resolve none (new, or a
-    // meta that may be closed) on a window that is not closing: every window shares the one UI
-    // thread, so any live one runs the action, but the refusal PostVerb raises names the window it
-    // was posted on — posting on Frontmost while Frontmost sits inside its WM_DESTROY (Frontmost is
-    // reassigned only near the end of it) refused `window close --target B` as "the window is
-    // closing" about a healthy B, and `window new` with a healthy window one line away.
+    // The window verbs all post on ONE window that is not closing — Frontmost, or the first live
+    // window while Frontmost sits inside its WM_DESTROY (it is reassigned only near the end of it).
+    // Every window shares the one UI thread, so any live one runs the action; one queue keeps the
+    // verbs FIFO across windows (`window select A`, `select B`, `select A` on per-window queues could
+    // drain A's two before B's one); and a refusal is raised only when NO window is live, so "the
+    // window is closing" is true of every window, where posting on Frontmost refused `window close
+    // --target B` as "closing" about a healthy B.
     private static Program LiveWindow()
     {
         var f = Frontmost;
@@ -68,7 +69,7 @@ internal partial class Program
     {
         var p = ResolveOpen(selector);
         if (p is null) return false;
-        p.PostVerb(() => { if (IsIconic(p._hwnd)) ShowWindow(p._hwnd, SW_RESTORE); SetForegroundWindow(p._hwnd); });
+        LiveWindow().PostVerb(() => { if (IsIconic(p._hwnd)) ShowWindow(p._hwnd, SW_RESTORE); SetForegroundWindow(p._hwnd); });
         return true;
     }
 
@@ -76,7 +77,7 @@ internal partial class Program
     {
         var p = ResolveOpen(selector);
         if (p is null) return false;
-        p.PostVerb(() => DestroyWindow(p._hwnd)); // WM_DESTROY does teardown + index bookkeeping
+        LiveWindow().PostVerb(() => DestroyWindow(p._hwnd)); // WM_DESTROY does teardown + index bookkeeping
         return true;
     }
 
@@ -119,7 +120,7 @@ internal partial class Program
     {
         var p = ResolveOpen(selector);
         if (p is null || w <= 0 || h <= 0) return false;
-        p.PostVerb(() => { SetWindowPos(p._hwnd, IntPtr.Zero, 0, 0, w, h, SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE); p.SaveState(); });
+        LiveWindow().PostVerb(() => { SetWindowPos(p._hwnd, IntPtr.Zero, 0, 0, w, h, SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE); p.SaveState(); });
         return true;
     }
 
@@ -127,7 +128,7 @@ internal partial class Program
     {
         var p = ResolveOpen(selector);
         if (p is null) return false;
-        p.PostVerb(() => { SetWindowPos(p._hwnd, IntPtr.Zero, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE); p.SaveState(); });
+        LiveWindow().PostVerb(() => { SetWindowPos(p._hwnd, IntPtr.Zero, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE); p.SaveState(); });
         return true;
     }
 
@@ -135,7 +136,7 @@ internal partial class Program
     {
         var p = ResolveOpen(selector);
         if (p is null) return false;
-        p.PostVerb(() => { ShowWindow(p._hwnd, IsZoomed(p._hwnd) ? SW_RESTORE : SW_MAXIMIZE); p.SaveState(); });
+        LiveWindow().PostVerb(() => { ShowWindow(p._hwnd, IsZoomed(p._hwnd) ? SW_RESTORE : SW_MAXIMIZE); p.SaveState(); });
         return true;
     }
 
@@ -438,7 +439,8 @@ internal partial class Program
     // quick terminal on nothing). The write goes through the FIFO queued hop rather than Post(...);
     // return true, because the reply carries the value IN EFFECT, read back off the session after the
     // write — P2's session.restore round found that Post-and-return reports the value REQUESTED. A
-    // hop that cannot be queued (the window is closing) or that the window closes under throws, which
+    // hop that cannot be queued (the window is closing, or its message queue refused the wake-up —
+    // NothingApplied names which) or that the window closes under throws, which
     // Dispatch turns into ok:false with nothing applied. A hop that TIMES OUT (15 s, a message loop
     // that is alive but not pumping) is ok:false too, but the action stays queued and may still run
     // when the loop resumes — the reply says so, in InvokeOnUiQueued's own words (revmux r1).

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -32,10 +32,23 @@ internal partial class Program
             return _windowIndex.Select(m => new WindowSnapshot(m.Id, m.Name, m.IsOpen, m.Id == _frontmostId)).ToList();
     }
 
+    // The window verbs post on the window they RESOLVED, and the ones that resolve none (new, or a
+    // meta that may be closed) on a window that is not closing: every window shares the one UI
+    // thread, so any live one runs the action, but the refusal PostVerb raises names the window it
+    // was posted on — posting on Frontmost while Frontmost sits inside its WM_DESTROY (Frontmost is
+    // reassigned only near the end of it) refused `window close --target B` as "the window is
+    // closing" about a healthy B, and `window new` with a healthy window one line away.
+    private static Program LiveWindow()
+    {
+        var f = Frontmost;
+        if (!f._uiGone.IsCancellationRequested) return f;
+        lock (_windowIndex) return _byId.Values.FirstOrDefault(w => !w._uiGone.IsCancellationRequested) ?? f;
+    }
+
     public string WindowNew(string? name)
     {
         string id = Guid.NewGuid().ToString();
-        Frontmost.PostVerb(() =>
+        LiveWindow().PostVerb(() =>
         {
             var m = new WinMeta { Id = id, Name = name ?? "", IsOpen = true };
             CascadeGeometry(m);
@@ -55,7 +68,7 @@ internal partial class Program
     {
         var p = ResolveOpen(selector);
         if (p is null) return false;
-        Frontmost.PostVerb(() => { if (IsIconic(p._hwnd)) ShowWindow(p._hwnd, SW_RESTORE); SetForegroundWindow(p._hwnd); });
+        p.PostVerb(() => { if (IsIconic(p._hwnd)) ShowWindow(p._hwnd, SW_RESTORE); SetForegroundWindow(p._hwnd); });
         return true;
     }
 
@@ -63,7 +76,7 @@ internal partial class Program
     {
         var p = ResolveOpen(selector);
         if (p is null) return false;
-        Frontmost.PostVerb(() => DestroyWindow(p._hwnd)); // WM_DESTROY does teardown + index bookkeeping
+        p.PostVerb(() => DestroyWindow(p._hwnd)); // WM_DESTROY does teardown + index bookkeeping
         return true;
     }
 
@@ -72,7 +85,7 @@ internal partial class Program
         var target = ResolveMeta(selector);
         if (target is null) return false;
         lock (_windowIndex) if (_windowIndex.Count <= 1) return false; // never delete the last window
-        Frontmost.PostVerb(() =>
+        LiveWindow().PostVerb(() =>
         {
             Program? open; lock (_windowIndex) _byId.TryGetValue(target.Id, out open);
             if (open is not null) DestroyWindow(open._hwnd);
@@ -93,7 +106,7 @@ internal partial class Program
         if (string.IsNullOrWhiteSpace(name)) return false;
         var target = ResolveMeta(selector);
         if (target is null) return false;
-        Frontmost.PostVerb(() =>
+        LiveWindow().PostVerb(() =>
         {
             lock (_windowIndex) target.Name = name;
             if (_byId.TryGetValue(target.Id, out var p)) { p.WinName = name; p.RequestRedraw(); }
@@ -106,7 +119,7 @@ internal partial class Program
     {
         var p = ResolveOpen(selector);
         if (p is null || w <= 0 || h <= 0) return false;
-        Frontmost.PostVerb(() => { SetWindowPos(p._hwnd, IntPtr.Zero, 0, 0, w, h, SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE); p.SaveState(); });
+        p.PostVerb(() => { SetWindowPos(p._hwnd, IntPtr.Zero, 0, 0, w, h, SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE); p.SaveState(); });
         return true;
     }
 
@@ -114,7 +127,7 @@ internal partial class Program
     {
         var p = ResolveOpen(selector);
         if (p is null) return false;
-        Frontmost.PostVerb(() => { SetWindowPos(p._hwnd, IntPtr.Zero, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE); p.SaveState(); });
+        p.PostVerb(() => { SetWindowPos(p._hwnd, IntPtr.Zero, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE); p.SaveState(); });
         return true;
     }
 
@@ -122,7 +135,7 @@ internal partial class Program
     {
         var p = ResolveOpen(selector);
         if (p is null) return false;
-        Frontmost.PostVerb(() => { ShowWindow(p._hwnd, IsZoomed(p._hwnd) ? SW_RESTORE : SW_MAXIMIZE); p.SaveState(); });
+        p.PostVerb(() => { ShowWindow(p._hwnd, IsZoomed(p._hwnd) ? SW_RESTORE : SW_MAXIMIZE); p.SaveState(); });
         return true;
     }
 

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -35,7 +35,7 @@ internal partial class Program
     public string WindowNew(string? name)
     {
         string id = Guid.NewGuid().ToString();
-        Frontmost.Post(() =>
+        Frontmost.PostVerb(() =>
         {
             var m = new WinMeta { Id = id, Name = name ?? "", IsOpen = true };
             CascadeGeometry(m);
@@ -55,7 +55,7 @@ internal partial class Program
     {
         var p = ResolveOpen(selector);
         if (p is null) return false;
-        Frontmost.Post(() => { if (IsIconic(p._hwnd)) ShowWindow(p._hwnd, SW_RESTORE); SetForegroundWindow(p._hwnd); });
+        Frontmost.PostVerb(() => { if (IsIconic(p._hwnd)) ShowWindow(p._hwnd, SW_RESTORE); SetForegroundWindow(p._hwnd); });
         return true;
     }
 
@@ -63,7 +63,7 @@ internal partial class Program
     {
         var p = ResolveOpen(selector);
         if (p is null) return false;
-        Frontmost.Post(() => DestroyWindow(p._hwnd)); // WM_DESTROY does teardown + index bookkeeping
+        Frontmost.PostVerb(() => DestroyWindow(p._hwnd)); // WM_DESTROY does teardown + index bookkeeping
         return true;
     }
 
@@ -72,7 +72,7 @@ internal partial class Program
         var target = ResolveMeta(selector);
         if (target is null) return false;
         lock (_windowIndex) if (_windowIndex.Count <= 1) return false; // never delete the last window
-        Frontmost.Post(() =>
+        Frontmost.PostVerb(() =>
         {
             Program? open; lock (_windowIndex) _byId.TryGetValue(target.Id, out open);
             if (open is not null) DestroyWindow(open._hwnd);
@@ -93,7 +93,7 @@ internal partial class Program
         if (string.IsNullOrWhiteSpace(name)) return false;
         var target = ResolveMeta(selector);
         if (target is null) return false;
-        Frontmost.Post(() =>
+        Frontmost.PostVerb(() =>
         {
             lock (_windowIndex) target.Name = name;
             if (_byId.TryGetValue(target.Id, out var p)) { p.WinName = name; p.RequestRedraw(); }
@@ -106,7 +106,7 @@ internal partial class Program
     {
         var p = ResolveOpen(selector);
         if (p is null || w <= 0 || h <= 0) return false;
-        Frontmost.Post(() => { SetWindowPos(p._hwnd, IntPtr.Zero, 0, 0, w, h, SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE); p.SaveState(); });
+        Frontmost.PostVerb(() => { SetWindowPos(p._hwnd, IntPtr.Zero, 0, 0, w, h, SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE); p.SaveState(); });
         return true;
     }
 
@@ -114,7 +114,7 @@ internal partial class Program
     {
         var p = ResolveOpen(selector);
         if (p is null) return false;
-        Frontmost.Post(() => { SetWindowPos(p._hwnd, IntPtr.Zero, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE); p.SaveState(); });
+        Frontmost.PostVerb(() => { SetWindowPos(p._hwnd, IntPtr.Zero, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE); p.SaveState(); });
         return true;
     }
 
@@ -122,7 +122,7 @@ internal partial class Program
     {
         var p = ResolveOpen(selector);
         if (p is null) return false;
-        Frontmost.Post(() => { ShowWindow(p._hwnd, IsZoomed(p._hwnd) ? SW_RESTORE : SW_MAXIMIZE); p.SaveState(); });
+        Frontmost.PostVerb(() => { ShowWindow(p._hwnd, IsZoomed(p._hwnd) ? SW_RESTORE : SW_MAXIMIZE); p.SaveState(); });
         return true;
     }
 
@@ -302,7 +302,7 @@ internal partial class Program
             ws ??= ActiveWorkspace();
         }
         string id = Guid.NewGuid().ToString();
-        Post(() =>
+        PostVerb(() =>
         {
             // The resolve above ran on the pipe thread; this runs on the UI thread some milliseconds
             // later, and in between the user (or a posted workspace.delete) can have removed `ws`
@@ -338,7 +338,7 @@ internal partial class Program
     {
         var ses = Find(target);
         if (ses is null) return false;
-        Post(() => SetActive(ses));
+        PostVerb(() => SetActive(ses));
         return true;
     }
 
@@ -346,14 +346,14 @@ internal partial class Program
     {
         var ses = Find(target);
         if (ses is null) return false;
-        Post(() => CloseSessionInternal(ses));
+        PostVerb(() => CloseSessionInternal(ses));
         return true;
     }
 
     public string NewWorkspace(string? name)
     {
         string id = Guid.NewGuid().ToString();
-        Post(() => CreateWorkspace(id, name));
+        PostVerb(() => CreateWorkspace(id, name));
         return id;
     }
 
@@ -364,11 +364,11 @@ internal partial class Program
         {
             var ses = Find(target);
             if (ses is null) return false;
-            Post(() => ChangeFontSizeOf(ses, delta));
+            PostVerb(() => ChangeFontSizeOf(ses, delta));
             return true;
         }
         if (FindControlPane(target) is not { } targetPane) return false;
-        Post(() => ZoomPane(targetPane, delta));
+        PostVerb(() => ZoomPane(targetPane, delta));
         return true;
     }
 
@@ -376,7 +376,7 @@ internal partial class Program
     /// most-recently-used), close it, and optionally pin a font size. (agterm #202 CLI.)</summary>
     public bool Dashboard(bool close, string? ids, int fontSize)
     {
-        Post(() =>
+        PostVerb(() =>
         {
             if (close) { CloseDashboard(); return; }
             List<Ses>? list = null;
@@ -389,13 +389,13 @@ internal partial class Program
     }
 
     // ---- Wave A1 verbs ----
-    public void SessionGo(string dir) => Post(() => SessionGoInternal(dir));
+    public void SessionGo(string dir) => PostVerb(() => SessionGoInternal(dir));
 
     public bool SessionReorder(string? target, string dir)
     {
         var s = Find(target);
         if (s is null) return false;
-        Post(() => { lock (_workspaces) ReorderInList(s.Ws.Sessions, s, dir); RequestRedraw(); SaveState(); });
+        PostVerb(() => { lock (_workspaces) ReorderInList(s.Ws.Sessions, s, dir); RequestRedraw(); SaveState(); });
         return true;
     }
 
@@ -403,7 +403,7 @@ internal partial class Program
     {
         var s = Find(target); var ws = FindWs(workspace);
         if (s is null || ws is null) return false;
-        Post(() => MoveSession(s, ws));
+        PostVerb(() => MoveSession(s, ws));
         return true;
     }
 
@@ -411,10 +411,13 @@ internal partial class Program
     {
         var ses = FindSesForTarget(target);
         if (ses is null || string.IsNullOrWhiteSpace(name)) return false;
-        // The post's result IS the reply (#228 item 5): a rename racing the window's WM_DESTROY used
-        // to answer ok with the action stranded in the queue. The rename does not touch Context —
-        // the name and the context are two fields, and rename edits one of them.
-        return Post(() => { ses.Name = name; ses.CustomName = name; RequestRedraw(); SaveState(); }); // CustomName drives the title bar
+        // The post's result IS the reply (#228 item 5), as for every verb that posts: a rename racing
+        // the window's WM_DESTROY used to answer ok with the action stranded in the queue; in P3 it
+        // returned the post's false, which the server read back as "session not found"; PostVerb's
+        // throw names the real reason. The rename does not touch Context — the name and the context
+        // are two fields, and rename edits one of them.
+        PostVerb(() => { ses.Name = name; ses.CustomName = name; RequestRedraw(); SaveState(); }); // CustomName drives the title bar
+        return true;
     }
 
     // session.context (P3). Resolution is rename's (FindSesForTarget: exact pane, exact session, pane
@@ -444,7 +447,7 @@ internal partial class Program
     {
         var ws = FindWs(target);
         if (ws is null || string.IsNullOrWhiteSpace(name)) return false;
-        Post(() => { ws.Name = name; RequestRedraw(); SaveState(); });
+        PostVerb(() => { ws.Name = name; RequestRedraw(); SaveState(); });
         return true;
     }
 
@@ -452,7 +455,7 @@ internal partial class Program
     public string DuplicateSession(string? target)
     {
         string id = Guid.NewGuid().ToString();
-        Post(() => DuplicateSession(FindSesForTarget(target), id));
+        PostVerb(() => DuplicateSession(FindSesForTarget(target), id));
         return id;
     }
 
@@ -461,7 +464,7 @@ internal partial class Program
     {
         var ws = string.IsNullOrEmpty(target) ? ActiveWorkspace() : FindWs(target);
         if (ws is null) return false;
-        Post(() => { lock (_workspaces) ws.Expanded = expand; RequestRedraw(); SaveState(); });
+        PostVerb(() => { lock (_workspaces) ws.Expanded = expand; RequestRedraw(); SaveState(); });
         return true;
     }
 
@@ -469,7 +472,7 @@ internal partial class Program
     {
         var ws = FindWs(target);
         if (ws is null) return false;
-        Post(() => DeleteWorkspace(ws));
+        PostVerb(() => DeleteWorkspace(ws));
         return true;
     }
 
@@ -477,7 +480,7 @@ internal partial class Program
     {
         var ws = FindWs(target);
         if (ws is null) return false;
-        Post(() => { var s = ws.Sessions.FirstOrDefault(); if (s is not null) SetActive(s); });
+        PostVerb(() => { var s = ws.Sessions.FirstOrDefault(); if (s is not null) SetActive(s); });
         return true;
     }
 
@@ -485,7 +488,7 @@ internal partial class Program
     {
         var ws = FindWs(target);
         if (ws is null) return false;
-        Post(() => { lock (_workspaces) ReorderInList(_workspaces, ws, dir); RequestRedraw(); SaveState(); });
+        PostVerb(() => { lock (_workspaces) ReorderInList(_workspaces, ws, dir); RequestRedraw(); SaveState(); });
         return true;
     }
 
@@ -630,16 +633,16 @@ internal partial class Program
     public bool ThemeSet(string name)
     {
         if (!_allThemes.Any(t => string.Equals(t.Name, name, StringComparison.OrdinalIgnoreCase))) return false;
-        Post(() => CommitTheme(FindTheme(name)));
+        PostVerb(() => CommitTheme(FindTheme(name)));
         return true;
     }
 
-    public string KeymapReload() { Post(ReloadKeymap); return "keymap reload requested"; }
+    public string KeymapReload() { PostVerb(ReloadKeymap); return "keymap reload requested"; }
 
     public string ConfigSet(string key, string value) => InvokeOnUi(() => ConfigSetInternal(key, value));
     public string ConfigGet(string key) => InvokeOnUi(() => ConfigValue(key.Trim().ToLowerInvariant()));
     public string ConfigList() => InvokeOnUi(() => string.Join("\n", ConfigKeys.Select(k => $"{k} = {ConfigValue(k)}")));
-    public string SettingsOpen() { Post(OpenSettingsWindow); return "settings opened"; }
+    public string SettingsOpen() { PostVerb(OpenSettingsWindow); return "settings opened"; }
 
     public string ProfilesList() => InvokeOnUi(() => string.Join("\n", _profileCfg.Profiles.Select(p =>
         $"{(p.Name.Equals(_profileCfg.Default, StringComparison.OrdinalIgnoreCase) ? "*" : " ")} {p.Name}\t{p.Command}{(p.Args is { Length: > 0 } a ? " " + string.Join(" ", a) : "")}")));
@@ -651,7 +654,7 @@ internal partial class Program
         catch (Exception ex) { return "error: " + ex.Message; }
     }
 
-    public void SidebarOp(string op) => Post(() => SidebarOpInternal(op));
+    public void SidebarOp(string op) => PostVerb(() => SidebarOpInternal(op));
 
     // "<visible|hidden> <tree|flagged> <width>": the width is _sidebarWShown, the one in effect when
     // shown — beside "hidden" it is the width the next show will use, not a claim that it is on screen.
@@ -701,7 +704,7 @@ internal partial class Program
     {
         var ses = FindSesForTarget(target);
         if (ses is null) return false;
-        Post(() => { ClearUnread(ses); RequestRedraw(); });
+        PostVerb(() => { ClearUnread(ses); RequestRedraw(); });
         return true;
     }
 
@@ -790,11 +793,11 @@ internal partial class Program
     {
         var ses = FindSesForTarget(target);
         if (ses is null) return false;
-        Post(() => ScratchOp(ses, op));
+        PostVerb(() => ScratchOp(ses, op));
         return true;
     }
 
-    public void Quick(string op) => Post(() => QuickOp(op));
+    public void Quick(string op) => PostVerb(() => QuickOp(op));
 
     /// <summary>An overlay covers a whole SESSION. When the caller named one pane of a split, that
     /// is not what they asked for - say so rather than widen it in silence and blank the pane the
@@ -838,7 +841,7 @@ internal partial class Program
                     var ses = FindSesForTarget(target);
                     if (ses is null && !string.IsNullOrEmpty(target) && target != "active") return NoSessionRefusal;
                     if (ses?.Overlay is null) return "no overlay";
-                    Post(() => CloseOverlayOf(ses));
+                    PostVerb(() => CloseOverlayOf(ses));
                     return "closed";
                 }
             case "resize":
@@ -853,7 +856,7 @@ internal partial class Program
                     // this ran, so the N reported is always the N the caller asked for. A clamp here
                     // could only hide a bug upstream now. 0 = full content region; 1..100 = centered panel.
                     int sp = sizePercent;
-                    Post(() => { ses.OverlaySizePercent = sp; if (ReferenceEquals(_ovlOwner, ses)) RegridCover(); RequestRedraw(); });
+                    PostVerb(() => { ses.OverlaySizePercent = sp; if (ReferenceEquals(_ovlOwner, ses)) RegridCover(); RequestRedraw(); });
                     return $"resized {sp}%";
                 }
             default: // "open"
@@ -878,16 +881,16 @@ internal partial class Program
     {
         var ses = FindSesForTarget(target);
         if (ses is null) return false;
-        Post(() => OnNotified(ses.ActivePane, title ?? "", body));
+        PostVerb(() => OnNotified(ses.ActivePane, title ?? "", body));
         return true;
     }
 
     public bool SessionFlag(string? target, string op)
     {
-        if (op == "clear") { Post(() => FlagOp(null, "clear")); return true; } // clear is global; no target needed
+        if (op == "clear") { PostVerb(() => FlagOp(null, "clear")); return true; } // clear is global; no target needed
         var ses = FindSesForTarget(target);
         if (ses is null) return false;
-        Post(() => FlagOp(ses, op));
+        PostVerb(() => FlagOp(ses, op));
         return true;
     }
 
@@ -899,7 +902,7 @@ internal partial class Program
         var hit = FindPaneById(target!);
         if (hit is null) return false;
         string? val = string.IsNullOrWhiteSpace(agent) || agent.Equals("none", StringComparison.OrdinalIgnoreCase) ? null : agent.ToLowerInvariant();
-        Post(() => { hit.Value.pane.AgentResume = val; SaveState(); });
+        PostVerb(() => { hit.Value.pane.AgentResume = val; SaveState(); });
         return true;
     }
 
@@ -1073,7 +1076,7 @@ internal partial class Program
         return SetBackground(ses, path!, opacity, mode);
     });
 
-    public void WorkspaceFocus(string op) => Post(() => WorkspaceFocusOp(op));
+    public void WorkspaceFocus(string op) => PostVerb(() => WorkspaceFocusOp(op));
 
     public string SessionSwitch(string op) => InvokeOnUi(() => SwitchOp(op));
 

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -36,9 +36,12 @@ internal partial class Program
     // window while Frontmost sits inside its WM_DESTROY (it is reassigned only near the end of it).
     // Every window shares the one UI thread, so any live one runs the action; one queue keeps the
     // verbs FIFO across windows (`window select A`, `select B`, `select A` on per-window queues could
-    // drain A's two before B's one); and a refusal is raised only when NO window is live, so "the
-    // window is closing" is true of every window, where posting on Frontmost refused `window close
-    // --target B` as "closing" about a healthy B.
+    // drain A's two before B's one), at the price Post's doc names: the queue belongs to the window
+    // it was posted on, so a verb about a healthy B is stranded if that window is torn down first
+    // (true is best-effort; a verb that must know goes through InvokeOnUiQueued). A refusal is the
+    // withdrawn post's reason (NothingApplied): no window live — "the window is closing", true of
+    // every window then, where posting on Frontmost refused `window close --target B` as "closing"
+    // about a healthy B — or a live window's message queue refusing the wake-up.
     private static Program LiveWindow()
     {
         var f = Frontmost;

--- a/src/Agwinterm.Win32/Program.Services.cs
+++ b/src/Agwinterm.Win32/Program.Services.cs
@@ -705,7 +705,7 @@ internal partial class Program
     {
         string? path = Agwinterm.Pty.OmpThemes.Resolve(nameOrPath);
         if (path is null) return "oh-my-posh theme not found: " + nameOrPath;
-        Post(() => ApplyOmp(path, persist));
+        PostVerb(() => ApplyOmp(path, persist));   // a control verb: the post's outcome is the reply (#228 item 5)
         return "oh-my-posh theme set: " + nameOrPath;
     }
 

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -1813,13 +1813,37 @@ internal partial class Program
     }
 
     /// <summary>Run an action on the UI thread (pipe callbacks arrive on a background thread).
-    /// Returns whether the wake-up message was posted — false once the window is gone, when the
-    /// action sits in the queue and nothing will ever run it.</summary>
+    /// Returns whether the action ran or will run. False means the wake-up message could not be
+    /// posted — the window is gone, or a live window's posted-message quota refused it — AND the
+    /// action was withdrawn from the queue before any drain could reach it, so nothing will ever run
+    /// it (#228 item 4; before, a quota failure left it queued for the next successful post to run
+    /// after the caller had been told nothing was applied). The same withdrawal covers a window that
+    /// is INSIDE its WM_DESTROY when the post lands: the hwnd is still valid, so PostMessageW says
+    /// yes, but no message posted to it is dispatched again — <see cref="_uiGone"/> (cancelled on
+    /// WM_DESTROY's first line) is the tell. True on a failed post only when a drain woken by an
+    /// earlier post had already taken the action, in which case it did run. The pty callbacks
+    /// (bell, notify, progress, exit) discard the value on purpose: they have no reply to give and a
+    /// window that is going away has nothing left to show. A control verb never discards it — see
+    /// <see cref="PostVerb"/>.</summary>
     private bool Post(Action a)
     {
-        _uiActions.Enqueue(a);
-        return PostMessageW(_hwnd, WM_APP_ACTION, IntPtr.Zero, IntPtr.Zero);
+        var slot = new UiAction(a);
+        _uiActions.Enqueue(slot);
+        bool posted = PostMessageW(_hwnd, WM_APP_ACTION, IntPtr.Zero, IntPtr.Zero);
+        if (posted && !_uiGone.IsCancellationRequested) return true;
+        return !slot.TryWithdraw();   // withdrawn: nothing will run it; not withdrawable: the drain has it
     }
+
+    /// <summary>A control verb's <see cref="Post"/>: a wake-up that could not be posted IS the reply
+    /// (#228 item 5). The throw is what Dispatch turns into ok:false, worded as
+    /// <see cref="InvokeOnUiQueued{T}"/>'s post-failure exit, and it is true — the action was
+    /// withdrawn. Before, every verb that posted ran <c>Post(...); return true;</c> and a <c>session.close</c>
+    /// racing the window's WM_DESTROY answered ok with the action stranded.</summary>
+    private void PostVerb(Action a)
+    {
+        if (!Post(a)) throw new InvalidOperationException(NothingAppliedRefusal);
+    }
+    private const string NothingAppliedRefusal = "the window is closing; nothing was applied";
 
     // Synchronous UI-thread invoke that is FIFO with everything already Post()ed. InvokeOnUi below
     // rides SendMessageW, and Windows dispatches a sent message AHEAD of messages already posted, so
@@ -1843,7 +1867,7 @@ internal partial class Program
             try { tcs.TrySetResult(fn()); }
             catch (Exception ex) { tcs.TrySetException(ex); }
         });
-        if (!posted) throw new InvalidOperationException("the window is closing; nothing was applied");
+        if (!posted) throw new InvalidOperationException(NothingAppliedRefusal);
         try
         {
             if (!tcs.Task.Wait((int)UiQueuedTimeout.TotalMilliseconds, _uiGone.Token))

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -761,7 +761,8 @@ internal partial class Program
     // ---- Overlays (Wave B3): an ephemeral program run over a session ----
 
     /// <summary>Open an overlay on a session: run <paramref name="command"/> in an ephemeral terminal over it.
-    /// sizePercent 0 = full content region; 1..100 = a centered floating panel. Returns "id PID".</summary>
+    /// sizePercent 0 = full content region; 1..100 = a centered floating panel. Returns the overlay
+    /// pane id.</summary>
     private string OverlayOpen(Ses ses, string command, int sizePercent, bool wait, Dictionary<string, string>? extraEnv = null)
     {
         CloseOverlayOf(ses);                    // one overlay per session; replace any existing one
@@ -1813,18 +1814,22 @@ internal partial class Program
     }
 
     /// <summary>Run an action on the UI thread (pipe callbacks arrive on a background thread).
-    /// Returns whether the action ran or will run. False means the wake-up message could not be
-    /// posted — the window is gone, or a live window's posted-message quota refused it — AND the
-    /// action was withdrawn from the queue before any drain could reach it, so nothing will ever run
-    /// it (#228 item 4; before, a quota failure left it queued for the next successful post to run
-    /// after the caller had been told nothing was applied). The same withdrawal covers a window that
-    /// is INSIDE its WM_DESTROY when the post lands: the hwnd is still valid, so PostMessageW says
-    /// yes, but no message posted to it is dispatched again — <see cref="_uiGone"/> (cancelled on
-    /// WM_DESTROY's first line) is the tell. True on a failed post only when a drain woken by an
-    /// earlier post had already taken the action, in which case it did run. The pty callbacks
-    /// (bell, notify, progress, exit) discard the value on purpose: they have no reply to give and a
-    /// window that is going away has nothing left to show. A control verb never discards it — see
-    /// <see cref="PostVerb"/>.</summary>
+    /// False is authoritative: the wake-up message could not be posted — the window is gone, or a
+    /// live window's posted-message quota refused it — AND the action was withdrawn from the queue
+    /// before any drain could reach it, so nothing will ever run it (#228 item 4; before, a quota
+    /// failure left it queued for the next successful post to run after the caller had been told
+    /// nothing was applied). The same withdrawal covers a window that is INSIDE its WM_DESTROY when
+    /// the post lands: the hwnd is still valid, so PostMessageW says yes, but no message posted to it
+    /// is dispatched again — <see cref="_uiGone"/> (cancelled on WM_DESTROY's first line) is the
+    /// tell. True is best-effort: the wake-up was accepted by a window that was not closing when the
+    /// poster looked, which a WM_DESTROY landing right after (or a WM_CLOSE already queued ahead of
+    /// the wake-up) can still strand — the poster has answered by then and no poster-side check can
+    /// close that gap; a verb that must KNOW its action ran goes through
+    /// <see cref="InvokeOnUiQueued{T}"/>, which waits for it. True on a failed post only when a drain
+    /// woken by an earlier post had already taken the action, in which case it did run. The pty
+    /// callbacks (bell, notify, progress, clipboard, exit) discard the value on purpose: they have no
+    /// reply to give and a window that is going away has nothing left to show. A control verb never
+    /// discards it — see <see cref="PostVerb"/>.</summary>
     private bool Post(Action a)
     {
         var slot = new UiAction(a);
@@ -1835,15 +1840,21 @@ internal partial class Program
     }
 
     /// <summary>A control verb's <see cref="Post"/>: a wake-up that could not be posted IS the reply
-    /// (#228 item 5). The throw is what Dispatch turns into ok:false, worded as
-    /// <see cref="InvokeOnUiQueued{T}"/>'s post-failure exit, and it is true — the action was
-    /// withdrawn. Before, every verb that posted ran <c>Post(...); return true;</c> and a <c>session.close</c>
-    /// racing the window's WM_DESTROY answered ok with the action stranded.</summary>
+    /// (#228 item 5). The throw is what Dispatch turns into ok:false, worded by what the poster knows
+    /// (<see cref="NothingApplied"/>), and it is true — the action was withdrawn. Before, every verb
+    /// that posted ran <c>Post(...); return true;</c> and a <c>session.close</c> racing the window's
+    /// WM_DESTROY answered ok with the action stranded.</summary>
     private void PostVerb(Action a)
     {
-        if (!Post(a)) throw new InvalidOperationException(NothingAppliedRefusal);
+        if (!Post(a)) throw new InvalidOperationException(NothingApplied());
     }
-    private const string NothingAppliedRefusal = "the window is closing; nothing was applied";
+    /// <summary>Why a post was withdrawn, as far as this side can tell: the window is closing
+    /// (<see cref="_uiGone"/> cancelled), or a live window's message queue refused the wake-up — the
+    /// posted-message quota, which a caller may retry once the queue drains. Both end "nothing was
+    /// applied", which is what the withdrawal guarantees.</summary>
+    private string NothingApplied() => _uiGone.IsCancellationRequested
+        ? "the window is closing; nothing was applied"
+        : "the window's message queue refused the request (posted-message quota); nothing was applied";
 
     // Synchronous UI-thread invoke that is FIFO with everything already Post()ed. InvokeOnUi below
     // rides SendMessageW, and Windows dispatches a sent message AHEAD of messages already posted, so
@@ -1867,7 +1878,7 @@ internal partial class Program
             try { tcs.TrySetResult(fn()); }
             catch (Exception ex) { tcs.TrySetException(ex); }
         });
-        if (!posted) throw new InvalidOperationException(NothingAppliedRefusal);
+        if (!posted) throw new InvalidOperationException(NothingApplied());
         try
         {
             if (!tcs.Task.Wait((int)UiQueuedTimeout.TotalMilliseconds, _uiGone.Token))

--- a/src/Agwinterm.Win32/Program.WndProc.cs
+++ b/src/Agwinterm.Win32/Program.WndProc.cs
@@ -173,7 +173,7 @@ internal partial class Program
 
             case WM_APP_ACTION:
                 while (_uiActions.TryDequeue(out var act))
-                    try { act(); } catch (Exception ex) { Perf($"uiaction ex: {ex.Message}"); }
+                    try { act.RunIfQueued(); } catch (Exception ex) { Perf($"uiaction ex: {ex.Message}"); }
                 return IntPtr.Zero;
 
             case WM_APP_SYNC:

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -127,8 +127,22 @@ internal partial class Program : ISessionHost, IWindowHost
     private const float DividerW = 6f;                       // THICKNESS of the gutter between panes, along the session's axis (a column gap on a vertical split, a row gap on a horizontal one)
     private bool _divDragging;                        // dragging a pane divider
     private int _divLeft;                             // index of the pane BEFORE the divider being dragged (the left pane on a vertical split, the top pane on a horizontal one)
-    // Actions queued from the pipe (background) thread to run on the UI thread.
-    private readonly System.Collections.Concurrent.ConcurrentQueue<Action> _uiActions = new();
+    // Actions queued from the pipe (background) thread to run on the UI thread. Each sits in a slot
+    // the poster can WITHDRAW when its wake-up message could not be posted (#228 item 4): the drain
+    // takes a slot or the poster withdraws it, never both, so "nothing was applied" is true whenever
+    // Post says so — also on a live window whose posted-message quota refused the wake-up, where a
+    // later drain used to run the stranded action after the caller had been told nothing did.
+    private readonly System.Collections.Concurrent.ConcurrentQueue<UiAction> _uiActions = new();
+    private sealed class UiAction
+    {
+        private readonly Action _run; private int _state;   // 0 queued, 1 taken by the drain, 2 withdrawn
+        public UiAction(Action run) => _run = run;
+        /// <summary>The drain's side: runs the action unless it was withdrawn. Exceptions are the caller's.</summary>
+        public void RunIfQueued() { if (Interlocked.CompareExchange(ref _state, 1, 0) == 0) _run(); }
+        /// <summary>The poster's side: true when the action was still queued and will now never run;
+        /// false when the drain already took it (an earlier wake-up reached it first).</summary>
+        public bool TryWithdraw() => Interlocked.CompareExchange(ref _state, 2, 0) == 0;
+    }
     /// <summary>Cancelled in WM_DESTROY: every pipe thread parked in InvokeOnUiQueued wakes and
     /// answers "window closed" instead of waiting for a message loop that will never run its action.</summary>
     private readonly CancellationTokenSource _uiGone = new();

--- a/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
+++ b/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
@@ -545,9 +545,10 @@ internal sealed class FakeSessionHost : ISessionHost
         // absent, empty or "active" resolves to nothing (`named`), and is ok ("no overlay") for those
         // three with nothing active, or on a session that exists and has no overlay — idempotent,
         // the conformance contract closes with nothing open; resize with no overlay open is a
-        // refusal. NOT mirrored: `result` (no arm — it falls into open's "needs a command" refusal,
-        // where the app answers its last exit), and the app's refusal of a target that names one
-        // pane of a split session (OverlayTargetRefusal); a test of either needs the app.
+        // refusal. NOT mirrored: open's reply (the fake answers the SESSION id; the app answers the
+        // overlay pane id, `<session>:overlay:<hex>`), `result` (no arm — it falls into open's "needs
+        // a command" refusal, where the app answers its last exit), and the app's refusal of a target
+        // that names one pane of a split session (OverlayTargetRefusal); a test of any needs the app.
         const string noSession = ISessionHost.RefusePrefix + "no session matches that target; nothing opened, resized or closed";
         var s = FindSes(target);
         bool named = !string.IsNullOrEmpty(target) && target != "active";

--- a/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
+++ b/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
@@ -539,10 +539,12 @@ internal sealed class FakeSessionHost : ISessionHost
     public string SessionOverlay(string? target, string action, string? command, int sizePercent, bool wait, bool block)
     {
         // As the app, in the app's ORDER and WORDING (the suite asserts wording, so the two hosts
-        // must not drift): open checks the command before the session; a named target that resolves
-        // to no session is refused by open, resize and close alike; close on a session that exists
-        // and has no overlay is idempotent ok ("no overlay" — the conformance contract closes with
-        // nothing open); resize with no overlay open is a refusal.
+        // must not drift), and as ISessionHost.SessionOverlay reads: open checks the command before
+        // the session; open and resize are refused whenever NO session resolves; close is refused
+        // only when a target other than absent, empty or "active" resolves to nothing (`named`), and
+        // is ok ("no overlay") for those three with nothing active, or on a session that exists and
+        // has no overlay — idempotent, the conformance contract closes with nothing open; resize
+        // with no overlay open is a refusal.
         const string noSession = ISessionHost.RefusePrefix + "no session matches that target; nothing opened, resized or closed";
         var s = FindSes(target);
         bool named = !string.IsNullOrEmpty(target) && target != "active";

--- a/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
+++ b/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
@@ -539,12 +539,15 @@ internal sealed class FakeSessionHost : ISessionHost
     public string SessionOverlay(string? target, string action, string? command, int sizePercent, bool wait, bool block)
     {
         // As the app, in the app's ORDER and WORDING (the suite asserts wording, so the two hosts
-        // must not drift), and as ISessionHost.SessionOverlay reads: open checks the command before
-        // the session; open and resize are refused whenever NO session resolves; close is refused
-        // only when a target other than absent, empty or "active" resolves to nothing (`named`), and
-        // is ok ("no overlay") for those three with nothing active, or on a session that exists and
-        // has no overlay — idempotent, the conformance contract closes with nothing open; resize
-        // with no overlay open is a refusal.
+        // must not drift), for open, close and resize — the cases ISessionHost.SessionOverlay's
+        // refusal list names: open checks the command before the session; open and resize are
+        // refused whenever NO session resolves; close is refused only when a target other than
+        // absent, empty or "active" resolves to nothing (`named`), and is ok ("no overlay") for those
+        // three with nothing active, or on a session that exists and has no overlay — idempotent,
+        // the conformance contract closes with nothing open; resize with no overlay open is a
+        // refusal. NOT mirrored: `result` (no arm — it falls into open's "needs a command" refusal,
+        // where the app answers its last exit), and the app's refusal of a target that names one
+        // pane of a split session (OverlayTargetRefusal); a test of either needs the app.
         const string noSession = ISessionHost.RefusePrefix + "no session matches that target; nothing opened, resized or closed";
         var s = FindSes(target);
         bool named = !string.IsNullOrEmpty(target) && target != "active";

--- a/tests/Agwinterm.Pty.Tests/OverlaySizeTests.cs
+++ b/tests/Agwinterm.Pty.Tests/OverlaySizeTests.cs
@@ -120,7 +120,7 @@ public class OverlaySizeTests
         var (server, host) = New();
         var r = Open(server, "40");
         Assert.True(Ok(r));
-        Assert.Equal(host.ActiveSess!.Id, Result(r));   // the fake answers the session id, as the app's "id" reply does
+        Assert.Equal(host.ActiveSess!.Id, Result(r));   // the fake answers the session id (the app answers the overlay pane id — not mirrored, see FakeSessionHost.SessionOverlay); this pins the fake's shape only
     }
 
     [Fact]

--- a/tests/Agwinterm.Pty.Tests/OverlaySizeTests.cs
+++ b/tests/Agwinterm.Pty.Tests/OverlaySizeTests.cs
@@ -115,7 +115,7 @@ public class OverlaySizeTests
     }
 
     [Fact]
-    public void Open_RepliesWithTheOverlayId_ShapeUnchanged()
+    public void Open_RepliesWithTheFakesSessionId_ShapeUnchanged()
     {
         var (server, host) = New();
         var r = Open(server, "40");


### PR DESCRIPTION
Closes #228 — the Minors of P2's revmux round 4 (`.revmux/tasks/p2-honesty/04-after-fix3`). Items 3 and the rename half of 5 were taken by P3 (#233); this PR takes 1, 2, 4 and the rest of 5, plus what its own rounds found.

## Behaviour (failure path only)

- **A UI action whose wake-up could not be posted is withdrawn, not left queued** (item 4). `Post` wraps each action in a `UiAction` slot with an Interlocked state (queued / taken by the drain / withdrawn): when `PostMessageW` fails, or the window is already inside its WM_DESTROY (`_uiGone` cancelled on its first line), the poster withdraws the slot; the drain and the poster can never both get it. Before, a failed post on a live window (posted-message quota) left the action for the NEXT successful post to run after the caller had been told nothing was applied.
- **Every control verb that posts answers with the post's outcome** (item 5). The 39 `Post(...); return true;` sites in `Program.ControlHost.cs` and `omp.set` in `Program.Services.cs` go through `PostVerb`, which throws when the post was withdrawn; Dispatch turns that into ok:false with the reason `NothingApplied()` picks — "the window is closing; nothing was applied" when `_uiGone` is cancelled, "the window's message queue refused the request (posted-message quota); nothing was applied" on a live window (retryable). `SessionRename` no longer returns the post's bool (the server read false as "session not found").
- **Window verbs post on `LiveWindow()`** — Frontmost, or the first live window while Frontmost sits inside its WM_DESTROY — so `window close --target B` is no longer refused as "closing" about a healthy B, and one queue keeps the verbs FIFO across windows.

## Prose

- Overlay close's ok states named once, everywhere (interface, AgentSkill, README, the fake): a session with no overlay, or a target that is absent, empty or `active` while nothing is active (item 1). `result`'s value documented as what the per-window fields do (one per window, reset by every open, written by any overlay's exit). The refusal list gains the pane-of-a-split refusal. The fake's comment claims only what it mirrors (item 2). `IWindowHost`, `OmpSet`, `SessionContext` and `SessionRename` docs name the throw.

## Verification

- Pty tests 613/613; `tests/integration/win32-control.ps1 -Strict` and `tests/conformance/conformance.ps1 -Strict` all passed on the rebuilt Release build, after each commit.
- The withdrawn-post path was not reached from outside: a CLI round trip is too coarse to land inside a WM_DESTROY, the single-window pipe dies with the process, and the two-window race probe sees `renamed` then "window not found". Verified by construction (the CAS makes taken/withdrawn exclusive) and by the suites.

## Review record (revmux, `--min-confidence 60`)

| round | subject | result |
|---|---|---|
| `01-initial` | `5ba111d` | 1 Major (`omp.set` outside the ControlHost sweep still constant-ok), 7 Minors → `79ce09e` |
| `02-after-fix1` | `79ce09e` | 1 Major (r1's `result` sentence promised per-open semantics the per-window fields do not have → documented as they are, behaviour filed on #246), 3 Minors, 1 immaterial taken (per-window queues broke cross-window FIFO) → `584ab67` |
| `03-after-fix2` | `584ab67` | **clean** — 4 prose Minors → `ccbdfd5`; pre-existing behaviour → #246 |

Filed on #246 from these rounds: overlay exit state is per window (cross-session `--block` release, replaced-overlay stamp, `--block`'s post-wait read, `ServerSession.Dispose` suppressing the exit); `omp.set` "not found" as ok:true.

Codex (`codex-agwinterm`) is reviewing the branch in parallel per Boris; its findings, if any, land as follow-up commits before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k
