### PR TITLE
fix: session.overlay per-open block completion and queued resize (#227)

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,9 @@ Thirteen of those answer a question a script would otherwise have to guess at:
   `open --block` answers the outcome of the overlay it opened — `closed` when that overlay was closed
   or replaced first, `exit 1` also when its program could not be started at all (a blocking open
   closes its pane as it replies, so to tell that from a program that ran and failed, open with
-  `--wait` instead, read the pane by the id the open returned, and close it by that id), and
+  `--wait` instead, poll `overlay result` for its `exit N`, read the pane by the id the open
+  returned, and close it by that id — a close whose overlay is already gone is refused, which is
+  the same end state), and
   `ok:false` with the status unknown when the window closed under it. `overlay result` stays one
   value per window, written by whichever session's overlay exits next.
 - `session restore` replies `{action, pane, session}` instead of the word "pinned": `pane` is the pane

--- a/README.md
+++ b/README.md
@@ -279,8 +279,10 @@ Thirteen of those answer a question a script would otherwise have to guess at:
   nothing to close, and nothing is what you asked for. Two replies are not refusals: a `resize` whose
   reply says the window did not run it within 15 s is still queued and may land later; and
   `open --block` answers the outcome of the overlay it opened — `closed` when that overlay was closed
-  or replaced first, `exit 1` also when its program could not be started at all (the reason is in the
-  pane), and `ok:false` with the status unknown when the window closed under it.
+  or replaced first, `exit 1` also when its program could not be started at all (a blocking open
+  closes its pane as it replies, so to tell that from a program that ran and failed, open with
+  `--wait` instead and read the pane), and `ok:false` with the status unknown when the window closed
+  under it.
 - `session restore` replies `{action, pane, session}` instead of the word "pinned": `pane` is the pane
   the target resolved to (a session name lands on its focused pane, a session id on the pane that
   carries that id while one does — pane 0 of a fresh session, either side after a `session swap` —

--- a/README.md
+++ b/README.md
@@ -276,7 +276,11 @@ Thirteen of those answer a question a script would otherwise have to guess at:
   overlay covers the whole session — the refusal names the session id to pass instead); and `resize`
   with no overlay open. `close` stays `ok` when the session resolves and
   has no overlay, or when the target is absent, empty or `active` while nothing is active — there is
-  nothing to close, and nothing is what you asked for.
+  nothing to close, and nothing is what you asked for. Two replies are not refusals: a `resize` whose
+  reply says the window did not run it within 15 s is still queued and may land later; and
+  `open --block` answers the outcome of the overlay it opened — `closed` when that overlay was closed
+  or replaced first, `exit 1` also when its program could not be started at all (the reason is in the
+  pane), and `ok:false` with the status unknown when the window closed under it.
 - `session restore` replies `{action, pane, session}` instead of the word "pinned": `pane` is the pane
   the target resolved to (a session name lands on its focused pane, a session id on the pane that
   carries that id while one does — pane 0 of a fresh session, either side after a `session swap` —

--- a/README.md
+++ b/README.md
@@ -281,8 +281,9 @@ Thirteen of those answer a question a script would otherwise have to guess at:
   `open --block` answers the outcome of the overlay it opened — `closed` when that overlay was closed
   or replaced first, `exit 1` also when its program could not be started at all (a blocking open
   closes its pane as it replies, so to tell that from a program that ran and failed, open with
-  `--wait` instead and read the pane), and `ok:false` with the status unknown when the window closed
-  under it.
+  `--wait` instead, read the pane by the id the open returned, and close it by that id), and
+  `ok:false` with the status unknown when the window closed under it. `overlay result` stays one
+  value per window, written by whichever session's overlay exits next.
 - `session restore` replies `{action, pane, session}` instead of the word "pinned": `pane` is the pane
   the target resolved to (a session name lands on its focused pane, a session id on the pane that
   carries that id while one does — pane 0 of a fresh session, either side after a `session swap` —

--- a/src/Agwinterm.Pty/AgentSkill.cs
+++ b/src/Agwinterm.Pty/AgentSkill.cs
@@ -184,8 +184,11 @@ public static class AgentSkill
           the pty-host down), and a blocking open closes its pane as it replies, so AFTER the call `exit 1` cannot be
           told from a program that ran and failed. When that distinction matters, do not block: open with `--wait`
           (the pane stays after the exit and the reply is its id), poll `overlay result` until it says `exit N`,
-          `session text --target <that id>` for the output or the start failure, then `overlay close --target <that id>`
-          (a bare `close` closes the ACTIVE session's overlay, which need not be yours). `overlay result` is ONE value
+          `session text --target <that id>` for the output or the start failure (`exit N` is written when the process
+          ends, not when its output is drained — the last lines can still be landing; read again if the text looks
+          cut off), then `overlay close --target <that id>` (a bare `close` closes the ACTIVE session's overlay, which
+          need not be yours; that close answers `ok:false` when the overlay is already gone — a key pressed on the
+          `--wait` prompt, a later open replacing it — which means closed, not failed; `tree` settles it). `overlay result` is ONE value
           per window — reset to `no overlay` by any open in the window, written by any session's overlay exit — so
           the poll is trustworthy only while yours is the only overlay in the window; `tree` shows which sessions
           have one.
@@ -196,7 +199,9 @@ public static class AgentSkill
           next; it ignores `--target`. Two overlays in one window make it name either one's exit.
         - What is REFUSED (`ok:false`, nothing happened): `open` with no command; `open` and `resize` whenever no
           session resolves (a `--target` that matches nothing, or no target while no session is active); a `close`
-          whose `--target` names something that does not exist; and `resize` on a session with no overlay open.
+          whose `--target` names something that does not exist; `open`, `close` and `resize` whose `--target` names
+          one pane of a split session (an overlay covers the whole session — the refusal names the session id to
+          pass instead); and `resize` on a session with no overlay open.
           One `resize` `ok:false` is NOT "nothing happened": the reply that says the window did not run the request
           within 15 s — that resize is still queued and may land when the window's loop resumes; read `tree`.
           `close` answers `ok` ("no overlay") when the session resolves and has no overlay, or when the target is

--- a/src/Agwinterm.Pty/AgentSkill.cs
+++ b/src/Agwinterm.Pty/AgentSkill.cs
@@ -181,7 +181,10 @@ public static class AgentSkill
         - `--block` waits for the program to exit and returns `exit N` (its exit code). Good for `lazygit`, `htop`, an editor, or any pick-a-thing helper you want to run and read the result of.
           The reply is the outcome of the overlay THIS call opened: `closed` when it was closed or replaced before its
           program exited. `exit 1` also covers a program that could not be started at all (the session's cwd gone,
-          the pty-host down) — the pane shows the reason; if `exit 1` matters to you, read the pane before branching.
+          the pty-host down), and a blocking open closes its pane as it replies, so AFTER the call `exit 1` cannot be
+          told from a program that ran and failed. When that distinction matters, do not block: open with `--wait`
+          (the pane stays after the exit and the reply is its id), poll `overlay result` until it says `exit N`,
+          `session text --target <that id>` for the output or the start failure, then `overlay close`.
           The window closing under a blocking open answers `ok:false` with the status unknown.
         - `agwintermctl session overlay close [--target <id>]`   — dismiss the overlay now.
         - `agwintermctl session overlay result`                 — the last overlay's `exit N` (or `no overlay`).

--- a/src/Agwinterm.Pty/AgentSkill.cs
+++ b/src/Agwinterm.Pty/AgentSkill.cs
@@ -179,11 +179,17 @@ public static class AgentSkill
           reply `resized N%` is always the N you asked for.
         - `--wait` keeps the panel after the program exits (shows "press any key to close") instead of auto-dismissing.
         - `--block` waits for the program to exit and returns `exit N` (its exit code). Good for `lazygit`, `htop`, an editor, or any pick-a-thing helper you want to run and read the result of.
+          The reply is the outcome of the overlay THIS call opened: `closed` when it was closed or replaced before its
+          program exited. `exit 1` also covers a program that could not be started at all (the session's cwd gone,
+          the pty-host down) — the pane shows the reason; if `exit 1` matters to you, read the pane before branching.
+          The window closing under a blocking open answers `ok:false` with the status unknown.
         - `agwintermctl session overlay close [--target <id>]`   — dismiss the overlay now.
         - `agwintermctl session overlay result`                 — the last overlay's `exit N` (or `no overlay`).
         - What is REFUSED (`ok:false`, nothing happened): `open` with no command; `open` and `resize` whenever no
           session resolves (a `--target` that matches nothing, or no target while no session is active); a `close`
           whose `--target` names something that does not exist; and `resize` on a session with no overlay open.
+          One `resize` `ok:false` is NOT "nothing happened": the reply that says the window did not run the request
+          within 15 s — that resize is still queued and may land when the window's loop resumes; read `tree`.
           `close` answers `ok` ("no overlay") when the session resolves and has no overlay, or when the target is
           absent, empty or `active` while nothing is active — closing nothing leaves "no overlay open" true. These used to
           answer `ok:true` with the failure as the result text; branch on `ok`.

--- a/src/Agwinterm.Pty/AgentSkill.cs
+++ b/src/Agwinterm.Pty/AgentSkill.cs
@@ -184,10 +184,16 @@ public static class AgentSkill
           the pty-host down), and a blocking open closes its pane as it replies, so AFTER the call `exit 1` cannot be
           told from a program that ran and failed. When that distinction matters, do not block: open with `--wait`
           (the pane stays after the exit and the reply is its id), poll `overlay result` until it says `exit N`,
-          `session text --target <that id>` for the output or the start failure, then `overlay close`.
+          `session text --target <that id>` for the output or the start failure, then `overlay close --target <that id>`
+          (a bare `close` closes the ACTIVE session's overlay, which need not be yours). `overlay result` is ONE value
+          per window — reset to `no overlay` by any open in the window, written by any session's overlay exit — so
+          the poll is trustworthy only while yours is the only overlay in the window; `tree` shows which sessions
+          have one.
           The window closing under a blocking open answers `ok:false` with the status unknown.
         - `agwintermctl session overlay close [--target <id>]`   — dismiss the overlay now.
-        - `agwintermctl session overlay result`                 — the last overlay's `exit N` (or `no overlay`).
+        - `agwintermctl session overlay result`                 — the last overlay's `exit N` (or `no overlay`): one value per
+          window, not per session — reset by any open in the window, written by whichever session's overlay exits
+          next; it ignores `--target`. Two overlays in one window make it name either one's exit.
         - What is REFUSED (`ok:false`, nothing happened): `open` with no command; `open` and `resize` whenever no
           session resolves (a `--target` that matches nothing, or no target while no session is active); a `close`
           whose `--target` names something that does not exist; and `resize` on a session with no overlay open.

--- a/src/Agwinterm.Pty/DeElevatedPty.cs
+++ b/src/Agwinterm.Pty/DeElevatedPty.cs
@@ -8,9 +8,11 @@ namespace Agwinterm.Pty;
 /// A ConPTY connection whose child shell runs at the interactive user's <b>Medium</b> integrity,
 /// spawned from an <b>elevated</b> agwinterm (de-elevation). This is the one direction Windows allows
 /// — dropping privileges, never raising them — so an elevated window can host both admin and normal
-/// sessions. It grabs explorer.exe's token and launches via <c>CreateProcessWithTokenW</c>
-/// (needs SeImpersonatePrivilege, which admins hold); Porta.Pty can't do this because it only calls
-/// plain <c>CreateProcess</c>.
+/// sessions. It derives a Medium-integrity primary token from THIS process's own token (SAFER:
+/// SaferCreateLevel + SaferComputeTokenFromLevel, then the integrity label) and launches via
+/// <c>CreateProcessAsUserW</c> — <c>CreateProcessWithTokenW</c> rejects the pseudoconsole attribute
+/// (error 87) — so no extra privilege is needed: the token is a restricted copy of the caller's.
+/// Porta.Pty can't do this because it only calls plain <c>CreateProcess</c>.
 /// </summary>
 internal sealed class DeElevatedPty : IPtyConnection
 {
@@ -61,7 +63,8 @@ internal sealed class DeElevatedPty : IPtyConnection
     }
 
     /// <summary>Spawn <paramref name="commandLine"/> de-elevated inside a fresh pseudoconsole. Throws on
-    /// failure (e.g. the caller isn't actually elevated, or explorer's token is unavailable).</summary>
+    /// failure (e.g. the SAFER token derivation fails, or <c>CreateProcessAsUserW</c> does — a missing
+    /// cwd, a command that does not exist); every such failure is prefixed "de-elevation:".</summary>
     public static DeElevatedPty Spawn(string commandLine, string? cwd, int cols, int rows)
     {
         IntPtr inPipeRead = IntPtr.Zero, inPipeWrite = IntPtr.Zero;

--- a/src/Agwinterm.Pty/ISessionHost.cs
+++ b/src/Agwinterm.Pty/ISessionHost.cs
@@ -371,10 +371,15 @@ public interface ISessionHost
     /// overlay (one an open has since replaced, or a close disposed, does not write it); a caller
     /// that runs overlays on two sessions at once reads the last such exit in the window, not its
     /// own. `result` skips the target check entirely. A blocking open whose window closes before the
-    /// program exits is a throw the server turns into ok:false (the status is unknown).
+    /// program exits — or before the open itself ran — is a throw the server turns into ok:false
+    /// (the status is unknown); an overlay whose program could not be started at all (the pty-host
+    /// down, the cwd gone) ends as "exit 1", not a wait without end.
     /// Resize resolves the target, checks for the overlay and writes the size in one queued UI action
     /// and replies from its result (#227), so the reply names a size that landed on an overlay that
-    /// existed when it did.
+    /// existed when it did; a hop that cannot be queued or run is a refusal. A hop that TIMES OUT
+    /// (a message loop that is alive but not pumping, 15 s) is ok:false too, but the action stays
+    /// queued and may still land when the loop resumes, and the reply says so rather than claiming
+    /// the size is unchanged.
     /// A FAILURE is signalled by prefixing <see cref="RefusePrefix"/>, which the server turns into
     /// ok:false: open with no command; open or resize whenever NO session resolves (a named target
     /// that matches nothing, or no target and no active session); close when a target other than

--- a/src/Agwinterm.Pty/ISessionHost.cs
+++ b/src/Agwinterm.Pty/ISessionHost.cs
@@ -359,18 +359,22 @@ public interface ISessionHost
     /// an ephemeral terminal over the target session; sizePercent 0 = full-region, 1..100 = a centered
     /// floating panel; wait = keep it after the program exits (press a key to close); block = wait for
     /// the program to exit and return its status. Returns the overlay pane id (open), "exit N" (block;
-    /// result), "closed", "resized N%", or "no overlay" (deliberately ok for close: a session that
-    /// resolves and has no overlay, or a target that is absent, empty or the word "active" while
+    /// result), "closed" (close; and block, when the overlay this call opened was closed or replaced
+    /// before its program exited), "resized N%", or "no overlay" (deliberately ok for close: a session
+    /// that resolves and has no overlay, or a target that is absent, empty or the word "active" while
     /// nothing is active — the guard is the app's `target != "active"`, so those three targets are one
-    /// case). The value `result` reads is ONE PER WINDOW, not per session or per overlay: it is "no
-    /// overlay" until the first open in that window, every open resets it to "no overlay", and the
-    /// exit of ANY overlay in the window — whichever session's, including one an open has since
-    /// replaced — writes "exit N" over it, so a caller that runs overlays on two sessions at once
-    /// reads the last exit in the window, not its own; `--block` waits on the same per-window signal
-    /// and then reads the same value, so it can return on another session's exit, answer "no overlay"
-    /// when an open lands between its wake-up and its read, or stay parked past its own program's
-    /// exit when that open's reset lands first (agwinterm #246 tracks keying value and signal to the
-    /// open that produced them). `result` skips the target check entirely.
+    /// case). A blocking open's reply is the outcome of THE OVERLAY THAT CALL OPENED and no other
+    /// (#227): two blocking opens in one window each get their own program's status. The value
+    /// `result` reads is different — ONE PER WINDOW, not per session or per overlay: "no overlay"
+    /// until the first open in that window, reset to "no overlay" by every open, and written with
+    /// "exit N" by the exit of whichever session's overlay exits while it is still that session's
+    /// overlay (one an open has since replaced, or a close disposed, does not write it); a caller
+    /// that runs overlays on two sessions at once reads the last such exit in the window, not its
+    /// own. `result` skips the target check entirely. A blocking open whose window closes before the
+    /// program exits is a throw the server turns into ok:false (the status is unknown).
+    /// Resize resolves the target, checks for the overlay and writes the size in one queued UI action
+    /// and replies from its result (#227), so the reply names a size that landed on an overlay that
+    /// existed when it did.
     /// A FAILURE is signalled by prefixing <see cref="RefusePrefix"/>, which the server turns into
     /// ok:false: open with no command; open or resize whenever NO session resolves (a named target
     /// that matches nothing, or no target and no active session); close when a target other than

--- a/src/Agwinterm.Pty/PtyHostServer.cs
+++ b/src/Agwinterm.Pty/PtyHostServer.cs
@@ -175,10 +175,12 @@ public sealed class PtyHostServer : IDisposable
             }
         };
         session.Exited += _ => CloseData(hosted);
-        // Await the spawn so a failure (bad exe, bad cwd) travels back as the create's error.
+        // Await the spawn so a failure (bad exe, bad cwd) travels back as the create's error — the
+        // throwing form: StartAsync would paint the reason into THIS process's emulator, which no
+        // client sees, and answer ok for a session that never ran (#227 r3).
         try
         {
-            session.StartAsync(c.App, c.Args.ToArray(), verbatimCommandLine: c.Verbatim,
+            session.StartOrThrowAsync(c.App, c.Args.ToArray(), verbatimCommandLine: c.Verbatim,
                     extraEnv: env, cwd: c.Cwd.Length > 0 ? c.Cwd : null, deElevate: c.DeElevate,
                     freshEnv: !c.FreshEnvOff)
                 .GetAwaiter().GetResult();

--- a/src/Agwinterm.Pty/TerminalSession.cs
+++ b/src/Agwinterm.Pty/TerminalSession.cs
@@ -199,9 +199,10 @@ public sealed class TerminalSession : ISession
                 : QuoteArg(app);
             IPtyConnection dc;
             try { dc = DeElevatedPty.Spawn(cmd, string.IsNullOrEmpty(cwd) ? Environment.CurrentDirectory : cwd, Cols, Rows); }
-            catch (Exception ex)
+            catch (Exception ex) when (paintFailure)
             {
                 // Surface the failure in the pane instead of leaving it dead (or crashing on the unobserved task).
+                // The pty-host's form (StartOrThrowAsync) lets it throw, the same as the ordinary spawn below.
                 var msg = $"\r\n\x1b[31m[agwinterm] could not start a non-elevated session:\x1b[0m\r\n  {ex.Message}\r\n";
                 lock (_sync) Emulator.Feed(System.Text.Encoding.UTF8.GetBytes(msg));
                 OutputReceived?.Invoke();

--- a/src/Agwinterm.Pty/TerminalSession.cs
+++ b/src/Agwinterm.Pty/TerminalSession.cs
@@ -230,8 +230,22 @@ public sealed class TerminalSession : ISession
             options.Environment = env;
         }
 
-        _connection = await PtyProvider.SpawnAsync(options, ct).ConfigureAwait(false);
-        var conn = _connection;
+        IPtyConnection conn;
+        try { conn = await PtyProvider.SpawnAsync(options, ct).ConfigureAwait(false); }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Same shape as the de-elevate branch above and ServerSession.StartAsync: a spawn that
+            // fails (the cwd gone, the app missing) surfaces IN the pane and ends as exit 1, with
+            // HasExited set and Exited NOT raised (the surface stays to show the reason). Before,
+            // the failure escaped as a faulted fire-and-forget task: a dead blank pane, and an
+            // overlay watcher keyed on HasExited never saw an end (#227 r2).
+            var msg = $"\r\n\x1b[31m[agwinterm] could not start the session:\x1b[0m\r\n  {ex.Message}\r\n";
+            lock (_sync) Emulator.Feed(System.Text.Encoding.UTF8.GetBytes(msg));
+            OutputReceived?.Invoke();
+            ExitCode = 1; HasExited = true;
+            return;
+        }
+        _connection = conn;
         _ = StartPump(conn.ReaderStream);
         // Watch for the child exiting so overlays (and anyone else) get the real ConPTY exit code,
         // reliably even for programs that finish faster than a PID poll could catch them.

--- a/src/Agwinterm.Pty/TerminalSession.cs
+++ b/src/Agwinterm.Pty/TerminalSession.cs
@@ -168,10 +168,28 @@ public sealed class TerminalSession : ISession
 
     /// <summary>Spawn an interactive shell and pump its output in the background until it exits or is disposed.
     /// When <paramref name="deElevate"/> is set, the shell runs at the interactive user's Medium integrity
-    /// (only valid from an elevated agwinterm) so an elevated window can host a normal session.</summary>
-    public async Task StartAsync(string app, string[] commandLine, bool verbatimCommandLine = false,
+    /// (only valid from an elevated agwinterm) so an elevated window can host a normal session.
+    /// A spawn that FAILS (the cwd gone, the app missing) is painted into this pane and ends it as
+    /// exit 1 with <see cref="HasExited"/> set and <see cref="Exited"/> NOT raised — the surface
+    /// stays to show the reason (#227 r2). The pty-host calls <see cref="StartOrThrowAsync"/>
+    /// instead, so the failure travels back to its client as the create's error.</summary>
+    public Task StartAsync(string app, string[] commandLine, bool verbatimCommandLine = false,
         IReadOnlyDictionary<string, string>? extraEnv = null, string? cwd = null, bool deElevate = false,
         bool freshEnv = true, CancellationToken ct = default)
+        => StartCoreAsync(app, commandLine, verbatimCommandLine, extraEnv, cwd, deElevate, freshEnv, ct, paintFailure: true);
+
+    /// <summary>The <see cref="StartAsync"/> form for a host that owns the failure: a spawn that fails
+    /// THROWS to the caller (PtyHostServer turns it into the create's error and rolls the session
+    /// back) instead of being painted here, where no client could read it — the host's emulator is
+    /// not what the client shows, and the client's own start catch is what paints the reason.</summary>
+    public Task StartOrThrowAsync(string app, string[] commandLine, bool verbatimCommandLine = false,
+        IReadOnlyDictionary<string, string>? extraEnv = null, string? cwd = null, bool deElevate = false,
+        bool freshEnv = true, CancellationToken ct = default)
+        => StartCoreAsync(app, commandLine, verbatimCommandLine, extraEnv, cwd, deElevate, freshEnv, ct, paintFailure: false);
+
+    private async Task StartCoreAsync(string app, string[] commandLine, bool verbatimCommandLine,
+        IReadOnlyDictionary<string, string>? extraEnv, string? cwd, bool deElevate,
+        bool freshEnv, CancellationToken ct, bool paintFailure)
     {
         if (deElevate)
         {
@@ -232,13 +250,14 @@ public sealed class TerminalSession : ISession
 
         IPtyConnection conn;
         try { conn = await PtyProvider.SpawnAsync(options, ct).ConfigureAwait(false); }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        catch (Exception ex) when (paintFailure && ex is not OperationCanceledException)
         {
             // Same shape as the de-elevate branch above and ServerSession.StartAsync: a spawn that
             // fails (the cwd gone, the app missing) surfaces IN the pane and ends as exit 1, with
             // HasExited set and Exited NOT raised (the surface stays to show the reason). Before,
             // the failure escaped as a faulted fire-and-forget task: a dead blank pane, and an
-            // overlay watcher keyed on HasExited never saw an end (#227 r2).
+            // overlay watcher keyed on HasExited never saw an end (#227 r2). Not for the pty-host
+            // (StartOrThrowAsync): there the throw IS the client's diagnostic.
             var msg = $"\r\n\x1b[31m[agwinterm] could not start the session:\x1b[0m\r\n  {ex.Message}\r\n";
             lock (_sync) Emulator.Feed(System.Text.Encoding.UTF8.GetBytes(msg));
             OutputReceived?.Invoke();

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -911,18 +911,25 @@ internal partial class Program
                             return id;
                         });
                         if (opened.StartsWith(ISessionHost.RefusePrefix, StringComparison.Ordinal)) return opened;
+                        // InvokeOnUi does not say whether its lambda ran: a SendMessage to a window
+                        // already destroyed returns at once with the previous caller's result, and a
+                        // lambda that threw leaves "". Neither is a refusal, so `done` is the proof
+                        // the open happened; without it the reply is the same throw as below.
+                        if (done is null) throw new InvalidOperationException(OverlayWindowGone);
                         // The wait ends with the pane's own outcome — "exit N", or "closed" when the
                         // overlay was closed or replaced before its program exited — or with the
                         // window going away (Dispose closes each pane without raising Exited, so the
                         // source would never complete; _uiGone is cancelled on WM_DESTROY's first line).
-                        try { done!.Task.Wait(Timeout.Infinite, _uiGone.Token); }
-                        catch (OperationCanceledException) { throw new InvalidOperationException("the window closed before the overlay's program exited; its exit status is unknown"); }
+                        try { done.Task.Wait(Timeout.Infinite, _uiGone.Token); }
+                        catch (OperationCanceledException) { throw new InvalidOperationException(OverlayWindowGone); }
                         return done.Task.Result;
                     }
                     return InvokeOnUi(() => { var s = FindSesForTarget(target); return s is null ? NoSessionRefusal : OverlayOpen(s, command!, sizePercent, wait); });
                 }
         }
     }
+
+    private const string OverlayWindowGone = "the window closed before the overlay's program exited; its exit status is unknown";
 
     public bool Notify(string? target, string? title, string body)
     {

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -864,18 +864,29 @@ internal partial class Program
                 }
             case "resize":
                 {
-                    var ses = FindSesForTarget(target);
-                    // Refusals, not strings: before P2's review both came back as ok:true "no
-                    // overlay", and a script branching on ok proceeded as if the resize had happened.
-                    // Same split as close: no session at all is not "open one first".
-                    if (ses is null) return NoSessionRefusal;
-                    if (ses.Overlay is null) return ISessionHost.RefusePrefix + "no overlay to resize on that target; open one first";
                     // No clamp: ControlServer.TryOverlaySize refused anything outside 0..100 before
                     // this ran, so the N reported is always the N the caller asked for. A clamp here
                     // could only hide a bug upstream now. 0 = full content region; 1..100 = centered panel.
                     int sp = sizePercent;
-                    PostVerb(() => { ses.OverlaySizePercent = sp; if (ReferenceEquals(_ovlOwner, ses)) RegridCover(); RequestRedraw(); });
-                    return $"resized {sp}%";
+                    // Resolve, check and write in ONE queued UI action and reply from its result
+                    // (#227): resolved on the pipe thread and written by a posted action, the check
+                    // and the write could straddle the overlay's exit — the exit's close (a posted
+                    // action ahead in the same queue) cleared OverlaySizePercent, the resize then
+                    // wrote N over a session with no overlay, and the tree showed `overlaySize` on
+                    // nothing while the reply said "resized". The refusals are the same as before:
+                    // no session at all is not "open one first" (before P2's review both came back
+                    // as ok:true "no overlay", and a script branching on ok proceeded as if the
+                    // resize had happened).
+                    return InvokeOnUiQueued(() =>
+                    {
+                        var ses = FindSesForTarget(target);
+                        if (ses is null) return NoSessionRefusal;
+                        if (ses.Overlay is null) return ISessionHost.RefusePrefix + "no overlay to resize on that target; open one first";
+                        ses.OverlaySizePercent = sp;
+                        if (ReferenceEquals(_ovlOwner, ses)) RegridCover();
+                        RequestRedraw();
+                        return $"resized {sp}%";
+                    });
                 }
             default: // "open"
                 {
@@ -884,11 +895,29 @@ internal partial class Program
                     if (string.IsNullOrWhiteSpace(command)) return ISessionHost.RefusePrefix + "overlay open needs a command; nothing opened";
                     if (block)
                     {
-                        // Open on the UI thread, then wait (on this pipe thread) for the program to exit.
-                        string opened = InvokeOnUi(() => { var s = FindSesForTarget(target); return s is null ? NoSessionRefusal : OverlayOpen(s, command!, sizePercent, false); });
+                        // Open on the UI thread, then wait (on this pipe thread) on the completion
+                        // source of THE PANE THIS CALL OPENED (#227): before, every blocking open in
+                        // the window waited on one event and then read one field, so a caller could
+                        // return on another session's exit, read "no overlay" after a later open's
+                        // reset, or stay parked past its own program's exit. The source is taken
+                        // inside the same UI hop as the open, so it is this open's pane and no other.
+                        TaskCompletionSource<string>? done = null;
+                        string opened = InvokeOnUi(() =>
+                        {
+                            var s = FindSesForTarget(target);
+                            if (s is null) return NoSessionRefusal;
+                            string id = OverlayOpen(s, command!, sizePercent, false);
+                            done = s.Overlay!.OverlayDone;
+                            return id;
+                        });
                         if (opened.StartsWith(ISessionHost.RefusePrefix, StringComparison.Ordinal)) return opened;
-                        _overlayDone.Wait();
-                        return _lastOverlayExit;   // "exit N"
+                        // The wait ends with the pane's own outcome — "exit N", or "closed" when the
+                        // overlay was closed or replaced before its program exited — or with the
+                        // window going away (Dispose closes each pane without raising Exited, so the
+                        // source would never complete; _uiGone is cancelled on WM_DESTROY's first line).
+                        try { done!.Task.Wait(Timeout.Infinite, _uiGone.Token); }
+                        catch (OperationCanceledException) { throw new InvalidOperationException("the window closed before the overlay's program exited; its exit status is unknown"); }
+                        return done.Task.Result;
                     }
                     return InvokeOnUi(() => { var s = FindSesForTarget(target); return s is null ? NoSessionRefusal : OverlayOpen(s, command!, sizePercent, wait); });
                 }

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -902,20 +902,27 @@ internal partial class Program
                         // reset, or stay parked past its own program's exit. The source is taken
                         // inside the same UI hop as the open, so it is this open's pane and no other.
                         TaskCompletionSource<string>? done = null;
+                        bool ran = false;
                         string opened = InvokeOnUi(() =>
                         {
+                            ran = true;
                             var s = FindSesForTarget(target);
                             if (s is null) return NoSessionRefusal;
                             string id = OverlayOpen(s, command!, sizePercent, false);
                             done = s.Overlay!.OverlayDone;
                             return id;
                         });
-                        if (opened.StartsWith(ISessionHost.RefusePrefix, StringComparison.Ordinal)) return opened;
                         // InvokeOnUi does not say whether its lambda ran: a SendMessage to a window
-                        // already destroyed returns at once with the previous caller's result, and a
-                        // lambda that threw leaves "". Neither is a refusal, so `done` is the proof
-                        // the open happened; without it the reply is the same throw as below.
-                        if (done is null) throw new InvalidOperationException(OverlayWindowGone);
+                        // already destroyed returns at once with the PREVIOUS caller's result on this
+                        // window — which may itself be a refusal, so the reply text is no proof of
+                        // anything. `ran` is: unset, the window was gone before the open, the same
+                        // throw as below. Set, the result is this call's own: a refusal is returned as
+                        // one; otherwise `done` is the pane's source, and its absence means OverlayOpen
+                        // threw midway (InvokeOnUi turns a throw into ""), which is not the window
+                        // going away and says so.
+                        if (!ran) throw new InvalidOperationException(OverlayWindowGone);
+                        if (opened.StartsWith(ISessionHost.RefusePrefix, StringComparison.Ordinal)) return opened;
+                        if (done is null) throw new InvalidOperationException("the open did not complete on the UI thread; whether an overlay opened is unknown — read tree");
                         // The wait ends with the pane's own outcome — "exit N", or "closed" when the
                         // overlay was closed or replaced before its program exited — or with the
                         // window going away (Dispose closes each pane without raising Exited, so the

--- a/src/Agwinterm.Win32/Program.Render.cs
+++ b/src/Agwinterm.Win32/Program.Render.cs
@@ -808,7 +808,7 @@ internal partial class Program
     {
         if (_coverKind != 3 || _ovlOwner is not { OverlayExited: true }) return;
         var (fx, fy, fw, fh) = CoverRect();
-        string msg = $"  exited ({_overlayExitCode}) — press any key to close  ";
+        string msg = $"  exited ({_ovlOwner.OverlayExitCode}) — press any key to close  ";
         float bh = 22f;
         brush.Color = WithA(ChromeAccent, 0.95f);
         rt.FillRectangle(new Rect(fx, fy + fh - bh, fw, bh), brush);

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -766,10 +766,10 @@ internal partial class Program
     private string OverlayOpen(Ses ses, string command, int sizePercent, bool wait, Dictionary<string, string>? extraEnv = null)
     {
         CloseOverlayOf(ses);                    // one overlay per session; replace any existing one
-        _overlayDone.Reset();
-        _lastOverlayExit = "no overlay"; _overlayExitCode = 0;
+        _lastOverlayExit = "no overlay"; _overlayExitCode = 0;   // the window-wide LAST exit (`overlay result`), reset by every open
         string id = ses.Id + ":overlay:" + Guid.NewGuid().ToString("N")[..6];
         var pane = CreatePane(id, ses.Ws, CwdOf(ses), ses.FontSize, command, shellWrap: true, extraEnv: extraEnv);
+        pane.OverlayDone = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
         ses.Overlay = pane;
         ses.OverlaySizePercent = sizePercent;   // validated at the control API (TryOverlaySize); in-app callers pass literals
         ses.OverlayWait = wait;
@@ -787,6 +787,10 @@ internal partial class Program
         if (pane is null) return;
         if (_coverKind == 3 && ReferenceEquals(_cover, pane)) { _cover = null; _coverKind = 0; _ovlOwner = null; SyncSession(); if (_active is not null) RegridSession(_active); }
         ses.Overlay = null; ses.OverlayExited = false; ses.OverlaySizePercent = 0; ses.OverlayWait = false;
+        // Closed (or replaced) before its program exited: release a `--block` caller with "closed"
+        // rather than parking it — Dispose ends the pty without raising Exited (ServerSession
+        // suppresses the event on its own teardown), so nothing else would. A no-op after an exit.
+        pane.OverlayDone?.TrySetResult("closed");
         try { pane.S.Dispose(); } catch { }
         RequestRedraw();
     }
@@ -799,9 +803,16 @@ internal partial class Program
     {
         void OnExit(int code)
         {
+            // This pane's own outcome first: a `--block` caller is released with its OWN program's
+            // status (#227), whatever other overlays in the window did meanwhile.
+            pane.OverlayDone?.TrySetResult($"exit {code}");
+            // The window-wide last exit is written only while this pane is still its session's
+            // overlay: a pane an open has since replaced (or a close disposed) must not stamp its
+            // code over the one `overlay result` now describes. Read here on the pty's thread and
+            // re-checked on the UI thread; a replacement landing between the two resets it anyway.
+            if (!ReferenceEquals(ses.Overlay, pane)) return;
             _overlayExitCode = code;
             _lastOverlayExit = $"exit {code}";
-            _overlayDone.Set();
             Post(() =>
             {
                 if (!ReferenceEquals(ses.Overlay, pane)) return;   // already replaced/closed

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -832,8 +832,11 @@ internal partial class Program
         // the session keeps its surface to show the failure — so nothing above would end this
         // overlay and a `--block` caller would wait forever (revmux r1). The start task completes
         // after that catch: an overlay whose program never ran ends like one that exited 1. A
-        // start task that FAULTS instead (a failure a backend let escape — cancellation is the
-        // one left today) is the same end; reading t.Exception marks the fault observed.
+        // start task that FAULTS instead (a failure a backend let escape) is the same end;
+        // reading t.Exception marks the fault observed. A CANCELLED start is NOT an end here
+        // (an async method that throws OperationCanceledException completes Canceled, with
+        // t.Exception null) — no call site passes a cancellable token, so none can happen today;
+        // whoever wires one through CreatePane must widen this guard or a --block waits forever.
         else pane.Start?.ContinueWith(t => { if (t.Exception is not null || pane.S.HasExited) OnExit(pane.S.ExitCode ?? 1); }, TaskScheduler.Default);
     }
 

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -831,8 +831,10 @@ internal partial class Program
         // A start that FAILS (pty-host down, cwd gone) sets HasExited without raising Exited —
         // the session keeps its surface to show the failure — so nothing above would end this
         // overlay and a `--block` caller would wait forever (revmux r1). The start task completes
-        // after that catch: an overlay whose program never ran ends like one that exited 1.
-        else pane.Start?.ContinueWith(_ => { if (pane.S.HasExited) OnExit(pane.S.ExitCode ?? 1); }, TaskScheduler.Default);
+        // after that catch: an overlay whose program never ran ends like one that exited 1. A
+        // start task that FAULTS instead (a failure a backend let escape — cancellation is the
+        // one left today) is the same end; reading t.Exception marks the fault observed.
+        else pane.Start?.ContinueWith(t => { if (t.Exception is not null || pane.S.HasExited) OnExit(pane.S.ExitCode ?? 1); }, TaskScheduler.Default);
     }
 
     /// <summary>App version for TERM_PROGRAM_VERSION — the entry assembly's informational version

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -141,21 +141,21 @@ internal partial class Program
             // --wait: run the command, then hold on "press any key" so a build/test/deploy's final
             // output (or an early failure) stays readable before the session closes (agterm #255 —
             // the session-surface counterpart of `overlay open --wait`).
-            _ = session.StartAsync("cmd.exe", new[] { "/c", command! + " & echo. & pause" }, verbatimCommandLine: true, extraEnv: env, cwd: cwd, freshEnv: _config.FreshEnv);
+            pane.Start = session.StartAsync("cmd.exe", new[] { "/c", command! + " & echo. & pause" }, verbatimCommandLine: true, extraEnv: env, cwd: cwd, freshEnv: _config.FreshEnv);
         else if (!string.IsNullOrWhiteSpace(command) && interactive)
             // Run the command in a fresh shell that STAYS OPEN afterwards (custom-command "new" mode):
             // the user's profile loads (oh-my-posh etc.), the command runs, then it's an interactive shell.
-            _ = session.StartAsync("powershell.exe", new[] { "-NoLogo", "-NoExit", "-Command", command! }, extraEnv: env, cwd: cwd, freshEnv: _config.FreshEnv);
+            pane.Start = session.StartAsync("powershell.exe", new[] { "-NoLogo", "-NoExit", "-Command", command! }, extraEnv: env, cwd: cwd, freshEnv: _config.FreshEnv);
         else if (!string.IsNullOrWhiteSpace(command) && shellWrap)
             // Run the whole command line through cmd so shell syntax works AND the child's exit code
             // propagates. Verbatim so it becomes exactly `cmd.exe /c <command>` (no extra quoting,
             // which cmd's /c quote-stripping rules would otherwise mangle).
-            _ = session.StartAsync("cmd.exe", new[] { "/c", command! }, verbatimCommandLine: true, extraEnv: env, cwd: cwd, freshEnv: _config.FreshEnv);
+            pane.Start = session.StartAsync("cmd.exe", new[] { "/c", command! }, verbatimCommandLine: true, extraEnv: env, cwd: cwd, freshEnv: _config.FreshEnv);
         else if (!string.IsNullOrWhiteSpace(command))
         {
             var argv = ParseArgv(command);
             if (argv.Length > 0)
-                _ = session.StartAsync(argv[0], argv[1..], extraEnv: env, cwd: cwd, freshEnv: _config.FreshEnv);
+                pane.Start = session.StartAsync(argv[0], argv[1..], extraEnv: env, cwd: cwd, freshEnv: _config.FreshEnv);
             else
                 LaunchShell(session, profileName, env, cwd, deElevate);
         }
@@ -766,14 +766,17 @@ internal partial class Program
     private string OverlayOpen(Ses ses, string command, int sizePercent, bool wait, Dictionary<string, string>? extraEnv = null)
     {
         CloseOverlayOf(ses);                    // one overlay per session; replace any existing one
-        _lastOverlayExit = "no overlay"; _overlayExitCode = 0;   // the window-wide LAST exit (`overlay result`), reset by every open
         string id = ses.Id + ":overlay:" + Guid.NewGuid().ToString("N")[..6];
         var pane = CreatePane(id, ses.Ws, CwdOf(ses), ses.FontSize, command, shellWrap: true, extraEnv: extraEnv);
         pane.OverlayDone = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
-        ses.Overlay = pane;
+        // The window-wide LAST exit (`overlay result`) is reset by every open, and the new pane
+        // becomes the session's overlay in the same locked step: an exit that lands on the pty
+        // thread either wrote before this (and is reset here) or sees the replacement and skips —
+        // never writes a replaced pane's code over the reset (WatchOverlayExit takes the lock).
+        lock (_overlayExitLock) { _lastOverlayExit = "no overlay"; ses.Overlay = pane; }
         ses.OverlaySizePercent = sizePercent;   // validated at the control API (TryOverlaySize); in-app callers pass literals
         ses.OverlayWait = wait;
-        ses.OverlayExited = false;
+        ses.OverlayExited = false; ses.OverlayExitCode = 0;
         if (ReferenceEquals(ses, _active)) { _cover = pane; _coverKind = 3; _ovlOwner = ses; SyncSession(); RegridCover(); }
         RequestRedraw();
         WatchOverlayExit(ses, pane);
@@ -786,7 +789,8 @@ internal partial class Program
         var pane = ses.Overlay;
         if (pane is null) return;
         if (_coverKind == 3 && ReferenceEquals(_cover, pane)) { _cover = null; _coverKind = 0; _ovlOwner = null; SyncSession(); if (_active is not null) RegridSession(_active); }
-        ses.Overlay = null; ses.OverlayExited = false; ses.OverlaySizePercent = 0; ses.OverlayWait = false;
+        lock (_overlayExitLock) ses.Overlay = null;   // the exit's guard reads this under the same lock
+        ses.OverlayExited = false; ses.OverlaySizePercent = 0; ses.OverlayWait = false;
         // Closed (or replaced) before its program exited: release a `--block` caller with "closed"
         // rather than parking it — Dispose ends the pty without raising Exited (ServerSession
         // suppresses the event on its own teardown), so nothing else would. A no-op after an exit.
@@ -801,27 +805,34 @@ internal partial class Program
     /// <summary>When an overlay's program exits, record its code and either close the overlay or (with --wait) mark it exited.</summary>
     private void WatchOverlayExit(Ses ses, Pane pane)
     {
+        int fired = 0;   // one-shot: the event, the already-exited check and the start watch can all see the end
         void OnExit(int code)
         {
+            if (Interlocked.Exchange(ref fired, 1) != 0) return;
             // This pane's own outcome first: a `--block` caller is released with its OWN program's
             // status (#227), whatever other overlays in the window did meanwhile.
             pane.OverlayDone?.TrySetResult($"exit {code}");
             // The window-wide last exit is written only while this pane is still its session's
             // overlay: a pane an open has since replaced (or a close disposed) must not stamp its
-            // code over the one `overlay result` now describes. Read here on the pty's thread and
-            // re-checked on the UI thread; a replacement landing between the two resets it anyway.
-            if (!ReferenceEquals(ses.Overlay, pane)) return;
-            _overlayExitCode = code;
-            _lastOverlayExit = $"exit {code}";
+            // code over the one `overlay result` now describes. Guard and write are one locked
+            // step against OverlayOpen's reset-and-assign and CloseOverlayOf's null-out, so there
+            // is no gap in which a replaced pane's exit lands after the replacement's reset. The
+            // post below is unconditional as before: its own guard runs on the UI thread.
+            lock (_overlayExitLock) { if (ReferenceEquals(ses.Overlay, pane)) _lastOverlayExit = $"exit {code}"; }
             Post(() =>
             {
                 if (!ReferenceEquals(ses.Overlay, pane)) return;   // already replaced/closed
-                if (ses.OverlayWait) { ses.OverlayExited = true; RequestRedraw(); }
+                if (ses.OverlayWait) { ses.OverlayExited = true; ses.OverlayExitCode = code; RequestRedraw(); }
                 else CloseOverlayOf(ses);
             });
         }
         pane.S.Exited += OnExit;
         if (pane.S.HasExited) OnExit(pane.S.ExitCode ?? 0);        // already gone before we subscribed
+        // A start that FAILS (pty-host down, cwd gone) sets HasExited without raising Exited —
+        // the session keeps its surface to show the failure — so nothing above would end this
+        // overlay and a `--block` caller would wait forever (revmux r1). The start task completes
+        // after that catch: an overlay whose program never ran ends like one that exited 1.
+        else pane.Start?.ContinueWith(_ => { if (pane.S.HasExited) OnExit(pane.S.ExitCode ?? 1); }, TaskScheduler.Default);
     }
 
     /// <summary>App version for TERM_PROGRAM_VERSION — the entry assembly's informational version

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -323,8 +323,9 @@ internal partial class Program : ISessionHost, IWindowHost
         // their own program's status; the window-wide last exit (`overlay result`) stays separate.
         public TaskCompletionSource<string>? OverlayDone;
         // The pane's StartAsync task (CreatePane's command branches). A start that FAILS sets
-        // HasExited without raising Exited — both session kinds keep the surface to show the
-        // failure — so a watcher that needs an end (WatchOverlayExit) observes this instead.
+        // HasExited without raising Exited — both session kinds catch the spawn failure and keep
+        // the surface to show it — so a watcher that needs an end (WatchOverlayExit) observes this
+        // instead, and treats a task that faulted anyway as the same end.
         public Task? Start;
         public float FontSize;     // per-pane font zoom (pt)
         public float Ratio = 1f;   // this pane's OWN share of the session's extent along its axis (width when vertical, height when horizontal); PaneLayout normalises by the sum

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -105,9 +105,8 @@ internal partial class Program : ISessionHost, IWindowHost
     private Pane? _quick;                // the single per-app quick terminal (lazy; kept alive)
     // Overlays (Wave B3): an ephemeral program run over a session; vanishes when the program exits.
     private Ses? _ovlOwner;              // the session whose overlay is the current cover (kind 3)
-    private string _lastOverlayExit = "no overlay"; // "exit N" once an overlay's program has exited
-    private int _overlayExitCode;        // the last overlay program's exit code
-    private readonly System.Threading.ManualResetEventSlim _overlayDone = new(false); // signalled on overlay exit (for --block)
+    private string _lastOverlayExit = "no overlay"; // "exit N" once an overlay's program has exited (`overlay result`, one per window)
+    private int _overlayExitCode;        // the last overlay program's exit code (the --wait banner)
     private static ControlServer? _control;
     // Update Claude Code workflow: one run at a time + the newest version the background check saw.
     private volatile bool _claudeUpdating;
@@ -318,6 +317,11 @@ internal partial class Program : ISessionHost, IWindowHost
         // local dictionary inside SaveState at quit, so every ordinary save wrote "" over the slot and a
         // crash / Stop-Process never filled it; one field, one writer per capture, one reader.
         public string? CapturedCommand;
+        // Overlay panes only (#227): completed once, with the outcome of THIS pane — "exit N" when its
+        // program exits, "closed" when the overlay is closed or replaced first. `overlay open --block`
+        // waits on the source of the pane it opened, so two blocking opens in one window each get
+        // their own program's status; the window-wide last exit (`overlay result`) stays separate.
+        public TaskCompletionSource<string>? OverlayDone;
         public float FontSize;     // per-pane font zoom (pt)
         public float Ratio = 1f;   // this pane's OWN share of the session's extent along its axis (width when vertical, height when horizontal); PaneLayout normalises by the sum
         public int ScrollOffset;   // lines scrolled up from the live bottom (0 = live; clamped to HistoryCount)

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -106,7 +106,7 @@ internal partial class Program : ISessionHost, IWindowHost
     // Overlays (Wave B3): an ephemeral program run over a session; vanishes when the program exits.
     private Ses? _ovlOwner;              // the session whose overlay is the current cover (kind 3)
     private string _lastOverlayExit = "no overlay"; // "exit N" once an overlay's program has exited (`overlay result`, one per window)
-    private int _overlayExitCode;        // the last overlay program's exit code (the --wait banner)
+    private readonly object _overlayExitLock = new(); // orders an exit's write of _lastOverlayExit against an open's reset (see WatchOverlayExit)
     private static ControlServer? _control;
     // Update Claude Code workflow: one run at a time + the newest version the background check saw.
     private volatile bool _claudeUpdating;
@@ -322,6 +322,10 @@ internal partial class Program : ISessionHost, IWindowHost
         // waits on the source of the pane it opened, so two blocking opens in one window each get
         // their own program's status; the window-wide last exit (`overlay result`) stays separate.
         public TaskCompletionSource<string>? OverlayDone;
+        // The pane's StartAsync task (CreatePane's command branches). A start that FAILS sets
+        // HasExited without raising Exited — both session kinds keep the surface to show the
+        // failure — so a watcher that needs an end (WatchOverlayExit) observes this instead.
+        public Task? Start;
         public float FontSize;     // per-pane font zoom (pt)
         public float Ratio = 1f;   // this pane's OWN share of the session's extent along its axis (width when vertical, height when horizontal); PaneLayout normalises by the sum
         public int ScrollOffset;   // lines scrolled up from the live bottom (0 = live; clamped to HistoryCount)
@@ -369,6 +373,7 @@ internal partial class Program : ISessionHost, IWindowHost
         public int OverlaySizePercent; // 0 = full content region; 1..100 = centered floating panel
         public bool OverlayWait;   // keep the overlay after its program exits (press a key to close)
         public bool OverlayExited; // the overlay's program has exited and it's awaiting a key
+        public int OverlayExitCode;   // that program's exit code (the --wait banner) — per session, so another session's open cannot reset it
         // Wave F2: per-session background watermark (a faint image drawn behind the terminal of every pane).
         public string? BgPath;      // absolute path to the copied image under AppDir\backgrounds (null = none)
         public int BgOpacity = 15;  // 0..100 (drawn opacity of the watermark)

--- a/tests/Agwinterm.Pty.Tests/ServerSessionTests.cs
+++ b/tests/Agwinterm.Pty.Tests/ServerSessionTests.cs
@@ -267,7 +267,11 @@ public class ServerSessionTests : IDisposable
         await s.StartAsync("cmd.exe", new[] { "/c", "exit 0" }, verbatimCommandLine: true, cwd: cwd, deElevate: true);
         Assert.True(s.HasExited);
         Assert.Equal(1, s.ExitCode);
-        Assert.Contains("failed to start", GridText(s));
+        string grid = GridText(s);
+        Assert.Contains("failed to start", grid);
+        // Only DeElevatedPty.Fail stamps this prefix: proves the flag reached the host's de-elevate branch
+        // (the ordinary spawn fails a missing cwd too, with a different message).
+        Assert.Contains("de-elevation", grid);
         await Task.Delay(300);
         Assert.False(exitedRaised);
     }

--- a/tests/Agwinterm.Pty.Tests/ServerSessionTests.cs
+++ b/tests/Agwinterm.Pty.Tests/ServerSessionTests.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using Agwinterm.Core;
 using Agwinterm.Pty;
 
@@ -250,10 +249,26 @@ public class ServerSessionTests : IDisposable
         await s.StartAsync("cmd.exe", new[] { "/c", "exit 0" }, verbatimCommandLine: true, cwd: cwd);
         Assert.True(s.HasExited);
         Assert.Equal(1, s.ExitCode);
-        var sb = new StringBuilder();
-        for (int r = 0; r < s.Rows; r++) sb.AppendLine(s.SnapshotRow(r));
-        Assert.Contains("failed to start", sb.ToString());
+        Assert.Contains("failed to start", GridText(s));
         await Task.Delay(300);   // an Exited via the data pipe's EOF would arrive after the create reply
+        Assert.False(exitedRaised);
+    }
+
+    /// <summary>The de-elevate spawn (its own branch, its own catch) must keep the same host
+    /// contract (#227 r4): a failed DeElevatedPty.Spawn — the missing cwd fails CreateProcessAsUserW
+    /// whether or not this test process is elevated — is the create's error, not an ok.</summary>
+    [Fact]
+    public async Task StartFailure_DeElevatedIntoAMissingCwd_ReachesTheClientAsTheReason()
+    {
+        string cwd = Path.Combine(Path.GetTempPath(), "agwinterm-gone-" + Guid.NewGuid().ToString("N"));
+        using var s = _backend.Create(Guid.NewGuid().ToString(), 80, 24);
+        bool exitedRaised = false;
+        s.Exited += _ => exitedRaised = true;
+        await s.StartAsync("cmd.exe", new[] { "/c", "exit 0" }, verbatimCommandLine: true, cwd: cwd, deElevate: true);
+        Assert.True(s.HasExited);
+        Assert.Equal(1, s.ExitCode);
+        Assert.Contains("failed to start", GridText(s));
+        await Task.Delay(300);
         Assert.False(exitedRaised);
     }
 }

--- a/tests/Agwinterm.Pty.Tests/ServerSessionTests.cs
+++ b/tests/Agwinterm.Pty.Tests/ServerSessionTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Agwinterm.Core;
 using Agwinterm.Pty;
 
@@ -232,5 +233,27 @@ public class ServerSessionTests : IDisposable
         await s.StartAsync("definitely-not-a-real-exe-agw.exe", Array.Empty<string>());
         Assert.True(WaitFor(() => s.HasExited, 10000));
         Assert.Equal(1, s.ExitCode);
+    }
+
+    /// <summary>The failure must travel back over the wire as the create's ERROR (#227 r3): the
+    /// host's own spawn catch would paint into an emulator no client sees and answer ok for a
+    /// session that never ran. The proof is the reason in the REPLICA's grid — only the client's
+    /// start catch writes it, and that runs only when create errs — with Exited not raised (the
+    /// surface stays, as in-process).</summary>
+    [Fact]
+    public async Task StartFailure_IntoAMissingCwd_ReachesTheClientAsTheReason()
+    {
+        string cwd = Path.Combine(Path.GetTempPath(), "agwinterm-gone-" + Guid.NewGuid().ToString("N"));
+        using var s = _backend.Create(Guid.NewGuid().ToString(), 80, 24);
+        bool exitedRaised = false;
+        s.Exited += _ => exitedRaised = true;
+        await s.StartAsync("cmd.exe", new[] { "/c", "exit 0" }, verbatimCommandLine: true, cwd: cwd);
+        Assert.True(s.HasExited);
+        Assert.Equal(1, s.ExitCode);
+        var sb = new StringBuilder();
+        for (int r = 0; r < s.Rows; r++) sb.AppendLine(s.SnapshotRow(r));
+        Assert.Contains("failed to start", sb.ToString());
+        await Task.Delay(300);   // an Exited via the data pipe's EOF would arrive after the create reply
+        Assert.False(exitedRaised);
     }
 }

--- a/tests/Agwinterm.Pty.Tests/TerminalSessionStartFailureTests.cs
+++ b/tests/Agwinterm.Pty.Tests/TerminalSessionStartFailureTests.cs
@@ -1,0 +1,26 @@
+using System.Text;
+using Agwinterm.Pty;
+
+namespace Agwinterm.Pty.Tests;
+
+/// <summary>An in-process session whose spawn FAILS (the cwd is gone) ends the way a pty-host
+/// session's failed start does: the reason painted in the pane, ExitCode 1, HasExited true, and
+/// StartAsync returning normally — not a faulted task with a pane that never ends (#227 r2).</summary>
+public class TerminalSessionStartFailureTests
+{
+    [Fact]
+    public async Task StartAsync_WithAMissingCwd_EndsAsExit1InsteadOfFaulting()
+    {
+        string cwd = Path.Combine(Path.GetTempPath(), "agwinterm-gone-" + Guid.NewGuid().ToString("N"));
+        using var s = new TerminalSession(100, 24);
+        bool exitedRaised = false;
+        s.Exited += _ => exitedRaised = true;
+        await s.StartAsync("cmd.exe", new[] { "/c", "exit 0" }, verbatimCommandLine: true, cwd: cwd);
+        Assert.True(s.HasExited);
+        Assert.Equal(1, s.ExitCode);
+        Assert.False(exitedRaised);   // the pane keeps its surface to show the failure; watchers use HasExited
+        var sb = new StringBuilder();
+        for (int r = 0; r < s.Rows; r++) sb.AppendLine(s.SnapshotRow(r));
+        Assert.Contains("could not start", sb.ToString());
+    }
+}

--- a/tests/integration/win32-control.ps1
+++ b/tests/integration/win32-control.ps1
@@ -797,10 +797,22 @@ for ($i = 0; $i -lt 60; $i++) { & '__CTL__' session overlay resize --size-percen
         }
         Check 'recipe: overlay result reaches "exit 7" while the --wait overlay stays' ($recipeResult.ok -and $recipeResult.result -eq 'exit 7') "$($recipeResult | ConvertTo-Json -Compress)"
         $recipeNode = Get-SessionSnapshot $recipeId
-        $recipeText = Invoke-Ctl @('session', 'text', '--target', $recipeOvl)
+        # "exit N" is written on process exit, not on output drain: poll the text like the skill says to.
+        $recipeText = $null
+        for ($i = 0; $i -lt 30; $i++) {
+            $recipeText = Invoke-Ctl @('session', 'text', '--target', $recipeOvl)
+            if ($recipeText.ok -and ("$($recipeText.result)" -match 'recipe-marker')) { break }
+            Start-Sleep -Milliseconds 200
+        }
         Check 'recipe: session text --target <overlay id> reads the overlay pane after its exit' ($recipeNode.overlay -and $recipeText.ok -and ("$($recipeText.result)" -match 'recipe-marker')) "overlay=$($recipeNode.overlay) $($recipeText | ConvertTo-Json -Compress)"
         $recipeClose = Invoke-Ctl @('session', 'overlay', 'close', '--target', $recipeOvl)
-        $recipeAfter = Get-SessionSnapshot $recipeId
+        # "closed" means queued (PostVerb); tree reads the state directly, so poll for it like the resize block.
+        $recipeAfter = $null
+        for ($i = 0; $i -lt 30; $i++) {
+            $recipeAfter = Get-SessionSnapshot $recipeId
+            if ($recipeAfter -and -not $recipeAfter.overlay) { break }
+            Start-Sleep -Milliseconds 200
+        }
         Check 'recipe: overlay close --target <overlay id> closes that session''s overlay' ($recipeClose.ok -and $recipeClose.result -eq 'closed' -and $recipeAfter -and -not $recipeAfter.overlay) "$($recipeClose | ConvertTo-Json -Compress) overlay=$($recipeAfter.overlay)"
         try { Invoke-Ctl @('session', 'close', $recipeId) | Out-Null } catch { }
 

--- a/tests/integration/win32-control.ps1
+++ b/tests/integration/win32-control.ps1
@@ -779,6 +779,31 @@ for ($i = 0; $i -lt 60; $i++) { & '__CTL__' session overlay resize --size-percen
             ($goneEnded -and $goneReply -and $goneReply.ok -and $goneReply.result -eq 'exit 1') "ended=$goneEnded reply=$($goneReply | ConvertTo-Json -Compress)"
         try { Invoke-Ctl @('session', 'close', $goneId) | Out-Null } catch { }
 
+        # #227 r4: the skill's recipe for telling a start failure from a failed program, step by
+        # step against the code: open --wait (reply = the overlay pane id, the pane survives the
+        # exit), overlay result becomes "exit N", session text by that id reaches the overlay pane,
+        # overlay close --target <that id> closes THAT session's overlay (not the active one).
+        $recipeMade = Invoke-Ctl @('session', 'new', '--name', 'p2-227-recipe', '--no-select')
+        $recipeId = [string]$recipeMade.result
+        for ($i = 0; $i -lt 30 -and -not (Get-SessionSnapshot $recipeId); $i++) { Start-Sleep -Milliseconds 200 }
+        $recipeOpen = Invoke-Ctl @('session', 'overlay', 'open', 'echo recipe-marker & exit 7', '--wait', '--target', $recipeId)
+        $recipeOvl = [string]$recipeOpen.result
+        Check 'recipe: overlay open --wait replies the overlay pane id' ($recipeOpen.ok -and $recipeOvl -like "$recipeId*overlay*") "$($recipeOpen | ConvertTo-Json -Compress)"
+        $recipeResult = $null
+        for ($i = 0; $i -lt 50; $i++) {
+            $recipeResult = Invoke-Ctl @('session', 'overlay', 'result')
+            if ($recipeResult.ok -and $recipeResult.result -eq 'exit 7') { break }
+            Start-Sleep -Milliseconds 200
+        }
+        Check 'recipe: overlay result reaches "exit 7" while the --wait overlay stays' ($recipeResult.ok -and $recipeResult.result -eq 'exit 7') "$($recipeResult | ConvertTo-Json -Compress)"
+        $recipeNode = Get-SessionSnapshot $recipeId
+        $recipeText = Invoke-Ctl @('session', 'text', '--target', $recipeOvl)
+        Check 'recipe: session text --target <overlay id> reads the overlay pane after its exit' ($recipeNode.overlay -and $recipeText.ok -and ("$($recipeText.result)" -match 'recipe-marker')) "overlay=$($recipeNode.overlay) $($recipeText | ConvertTo-Json -Compress)"
+        $recipeClose = Invoke-Ctl @('session', 'overlay', 'close', '--target', $recipeOvl)
+        $recipeAfter = Get-SessionSnapshot $recipeId
+        Check 'recipe: overlay close --target <overlay id> closes that session''s overlay' ($recipeClose.ok -and $recipeClose.result -eq 'closed' -and $recipeAfter -and -not $recipeAfter.overlay) "$($recipeClose | ConvertTo-Json -Compress) overlay=$($recipeAfter.overlay)"
+        try { Invoke-Ctl @('session', 'close', $recipeId) | Out-Null } catch { }
+
         # sidebar.width must move the divider, not just a number. The unit tests see the fake host
         # only; here the proof is live geometry: the active session's measured width (session.metrics,
         # columns x cell width) shrinks when the sidebar widens, because the grid derives from the

--- a/tests/integration/win32-control.ps1
+++ b/tests/integration/win32-control.ps1
@@ -696,13 +696,14 @@ try {
         # #227 (2): resize resolves, checks and writes in ONE queued UI action. Fired against an
         # overlay whose program exits under it: two hammer processes resize without pause for the
         # program's whole life while this loop resizes and reads the tree between calls. The
-        # discriminating assertion is the one #227 names — once the tree has shown the overlay
-        # gone, no LATER resize may answer "resized" — and the persistent one: the node carries no
-        # `overlaySize` once the overlay is gone. The old code's lie needed a resize to straddle
-        # the exit's close (its pipe-thread check passing, its posted write landing after the
-        # close cleared the size); the hammers make that straddle likely, not certain — the
-        # stale-size state it leaves is what the last check catches. Every reply must still be
-        # "resized N%" or the "open one first" refusal.
+        # regression guard is the LAST check: the node carries no `overlaySize` once the overlay
+        # is gone. The old code's lie needed a resize to straddle the exit's close (its pipe-thread
+        # check passing while the close was posted but not yet run, its posted write landing after
+        # the close cleared the size); the hammers make that straddle likely, not certain, and the
+        # stale size it leaves is what that check catches. The middle check is a LIVENESS check,
+        # not a guard: the old code refused after the tree showed no overlay too (both read the
+        # same field), so it proves only that this loop outlived the overlay and that the shape
+        # held to the end. Every reply must be "resized N%" or the "open one first" refusal.
         $resizeTarget = $blockIds[1]
         Invoke-Ctl @('session', 'overlay', 'open', 'ping -n 3 127.0.0.1 >nul & exit 0', '--size-percent', '40', '--target', $resizeTarget) | Out-Null
         $hammerScript = @'
@@ -748,10 +749,35 @@ for ($i = 0; $i -lt 60; $i++) { & '__CTL__' session overlay resize --size-percen
         $refusedCount = @($resizeReplies | Where-Object { -not $_.ok }).Count
         Check 'resize under an exiting overlay answers resized-or-refused only, and both happened' `
             ($resizeBad.Count -eq 0 -and $resizedCount -gt 0 -and $refusedCount -gt 0) "resized=$resizedCount refused=$refusedCount bad=$($resizeBad -join ' | ')"
-        Check 'and no resize after the tree showed the overlay gone answered resized' ($seenGone -and $resizeAfterGone.Count -eq 0) "seenGone=$seenGone after=$($resizeAfterGone -join ' | ')"
+        Check 'and the loop outlived the overlay (liveness; every resize after the tree showed it gone was refused)' ($seenGone -and $resizeAfterGone.Count -eq 0) "seenGone=$seenGone after=$($resizeAfterGone -join ' | ')"
         Check 'and once the overlay is gone the session carries no overlaySize' `
             ($resizeNode -and -not $resizeNode.overlay -and -not $resizeNode.PSObject.Properties['overlaySize']) "$($resizeNode | ConvertTo-Json -Compress -Depth 3)"
         foreach ($id in $blockIds) { try { Invoke-Ctl @('session', 'close', $id) | Out-Null } catch { } }
+
+        # #227 r2: an overlay whose program cannot be STARTED ends a blocking open as "exit 1" on
+        # the in-process backend too (the default), not a wait without end. The fixture is a
+        # session whose launch dir is deleted under it: its own process moved to C:\ first so the
+        # directory can go, it reports no OSC 7 (cmd), so the overlay is spawned in the dead dir.
+        $goneDir = Join-Path ([IO.Path]::GetTempPath()) ("agwinterm-gone-" + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $goneDir | Out-Null
+        $goneMade = Invoke-Ctl @('session', 'new', '--name', 'p2-227-gone', '--cwd', $goneDir, '--command', 'cmd.exe /c cd /d C:\ & ping -n 60 127.0.0.1 >nul', '--no-select')
+        $goneId = [string]$goneMade.result
+        for ($i = 0; $i -lt 30 -and -not (Get-SessionSnapshot $goneId); $i++) { Start-Sleep -Milliseconds 200 }
+        $goneRemoved = $false
+        for ($i = 0; $i -lt 25 -and -not $goneRemoved; $i++) {
+            try { Remove-Item -LiteralPath $goneDir -Recurse -Force -ErrorAction Stop; $goneRemoved = $true } catch { Start-Sleep -Milliseconds 200 }
+        }
+        Check 'fixture: the launch dir of the p2-227-gone session could be deleted' $goneRemoved "$goneDir"
+        $goneFile = Join-Path ([IO.Path]::GetTempPath()) ("agwinterm-block-gone-" + [guid]::NewGuid().ToString('N') + '.json')
+        $goneProc = Start-Process $ctl -ArgumentList @('session', 'overlay', 'open', '"cmd /c exit 0"', '--block', '--target', $goneId, '--pipe', $pipe, '--json') -NoNewWindow -PassThru -RedirectStandardOutput $goneFile
+        $goneEnded = $goneProc.WaitForExit(15000)
+        if (-not $goneEnded) { try { $goneProc.Kill() } catch { } }
+        $goneReply = $null
+        try { $goneReply = (Get-Content -LiteralPath $goneFile -Raw) | ConvertFrom-Json } catch { }
+        try { Remove-Item -LiteralPath $goneFile -Force -ErrorAction SilentlyContinue } catch { }
+        Check 'a blocking open whose program cannot start (cwd gone) answers "exit 1" instead of waiting forever' `
+            ($goneEnded -and $goneReply -and $goneReply.ok -and $goneReply.result -eq 'exit 1') "ended=$goneEnded reply=$($goneReply | ConvertTo-Json -Compress)"
+        try { Invoke-Ctl @('session', 'close', $goneId) | Out-Null } catch { }
 
         # sidebar.width must move the divider, not just a number. The unit tests see the fake host
         # only; here the proof is live geometry: the active session's measured width (session.metrics,

--- a/tests/integration/win32-control.ps1
+++ b/tests/integration/win32-control.ps1
@@ -628,6 +628,98 @@ try {
         $bareClose = Invoke-Ctl @('session', 'overlay', 'close')
         Check 'an untargeted overlay close with nothing open stays ok' ($bareClose.ok -and $bareClose.result -eq 'no overlay') "$($bareClose | ConvertTo-Json -Compress)"
 
+        # #227 (1): `overlay open --block` answers the exit of THE OVERLAY IT OPENED. Before, every
+        # blocking open in the window waited on one event and read one field, so concurrent blocks
+        # on different sessions could return each other's code, "no overlay", or never. Three
+        # --no-select fixtures (one overlay per session), three blocking opens in flight at once,
+        # each running `exit <n>` with its own n, each reply must carry its own n. The opens are
+        # separate ctl processes so the pipe threads really overlap; --json replies land in files.
+        $blockIds = @()
+        foreach ($n in 1, 2, 3) {
+            $made = Invoke-Ctl @('session', 'new', '--name', "p2-227-$n", '--no-select')
+            $blockIds += [string]$made.result
+        }
+        foreach ($id in $blockIds) { for ($i = 0; $i -lt 30 -and -not (Get-SessionSnapshot $id); $i++) { Start-Sleep -Milliseconds 200 } }
+        $blockCodes = @{ }; $blockCodes[$blockIds[0]] = 11; $blockCodes[$blockIds[1]] = 22; $blockCodes[$blockIds[2]] = 33
+        $blockProcs = @{ }
+        foreach ($id in $blockIds) {
+            $outFile = Join-Path ([IO.Path]::GetTempPath()) ("agwinterm-block-" + [guid]::NewGuid().ToString('N') + '.json')
+            # Each program waits ~1.5 s before exiting so all three opens are parked at the same time.
+            $blockProcs[$id] = @{
+                File = $outFile
+                Proc = Start-Process $ctl -ArgumentList @('session', 'overlay', 'open', "`"ping -n 3 127.0.0.1 >nul & exit $($blockCodes[$id])`"",
+                    '--block', '--target', $id, '--pipe', $pipe, '--json') -NoNewWindow -PassThru -RedirectStandardOutput $outFile
+            }
+        }
+        $blockReplies = @{ }
+        foreach ($id in $blockIds) {
+            $p = $blockProcs[$id].Proc
+            if (-not $p.WaitForExit(30000)) { try { $p.Kill() } catch { } }
+            $raw = ''
+            try { $raw = [IO.File]::ReadAllText($blockProcs[$id].File) } catch { }
+            try { $blockReplies[$id] = $raw | ConvertFrom-Json } catch { $blockReplies[$id] = [pscustomobject]@{ __raw = $raw } }
+            try { Remove-Item -LiteralPath $blockProcs[$id].File -Force -ErrorAction SilentlyContinue } catch { }
+        }
+        foreach ($id in $blockIds) {
+            $r = $blockReplies[$id]
+            Check "overlay open --block on $id answers its OWN program's exit ($($blockCodes[$id]))" `
+                ($r.ok -and $r.result -eq "exit $($blockCodes[$id])") "$($r | ConvertTo-Json -Compress)"
+        }
+        $lastExit = Invoke-Ctl @('session', 'overlay', 'result')
+        Check 'and overlay result (the window-wide last exit) names one of the three' `
+            ($lastExit.ok -and ($lastExit.result -in @('exit 11', 'exit 22', 'exit 33'))) "$($lastExit | ConvertTo-Json -Compress)"
+
+        # A blocking open whose overlay is REPLACED before its program exits is released with
+        # "closed" — its own outcome — not parked, and not handed the replacement's code. Dispose
+        # ends the pty without raising Exited, so before #227 nothing released it at all.
+        $replacedFile = Join-Path ([IO.Path]::GetTempPath()) ("agwinterm-block-" + [guid]::NewGuid().ToString('N') + '.json')
+        $replacedProc = Start-Process $ctl -ArgumentList @('session', 'overlay', 'open', "`"ping -n 60 127.0.0.1 >nul & exit 44`"",
+            '--block', '--target', $blockIds[0], '--pipe', $pipe, '--json') -NoNewWindow -PassThru -RedirectStandardOutput $replacedFile
+        $replacedUp = $false
+        for ($i = 0; $i -lt 30 -and -not $replacedUp; $i++) {
+            $node = Get-SessionSnapshot $blockIds[0]
+            $replacedUp = $node -and $node.overlay
+            if (-not $replacedUp) { Start-Sleep -Milliseconds 200 }
+        }
+        $replacer = Invoke-Ctl @('session', 'overlay', 'open', 'exit 55', '--block', '--target', $blockIds[0])
+        $replacedDone = $replacedProc.WaitForExit(10000)
+        if (-not $replacedDone) { try { $replacedProc.Kill() } catch { } }
+        $replacedRaw = ''
+        try { $replacedRaw = [IO.File]::ReadAllText($replacedFile) } catch { }
+        try { $replaced = $replacedRaw | ConvertFrom-Json } catch { $replaced = [pscustomobject]@{ __raw = $replacedRaw } }
+        try { Remove-Item -LiteralPath $replacedFile -Force -ErrorAction SilentlyContinue } catch { }
+        Check 'a blocking open whose overlay was replaced returns "closed" (released, its own outcome)' `
+            ($replacedUp -and $replacedDone -and $replaced.ok -and $replaced.result -eq 'closed') "up=$replacedUp done=$replacedDone reply=$($replaced | ConvertTo-Json -Compress)"
+        Check 'and the replacing blocking open returns its own exit (55)' `
+            ($replacer.ok -and $replacer.result -eq 'exit 55') "$($replacer | ConvertTo-Json -Compress)"
+
+        # #227 (2): resize resolves, checks and writes in ONE queued UI action. Fired in a loop
+        # against an overlay whose program exits under it, each reply is either "resized N%" (the
+        # overlay existed when the size landed) or the "open one first" refusal — never a reply that
+        # says resized while the write went to a session with no overlay. The proof afterwards: the
+        # session's tree node carries no `overlaySize` once the overlay is gone.
+        $resizeTarget = $blockIds[1]
+        Invoke-Ctl @('session', 'overlay', 'open', 'ping -n 2 127.0.0.1 >nul & exit 0', '--size-percent', '40', '--target', $resizeTarget) | Out-Null
+        $resizeReplies = @(); $resizeBad = @()
+        for ($i = 0; $i -lt 60; $i++) {
+            $r = Invoke-Ctl @('session', 'overlay', 'resize', '--size-percent', (30 + ($i % 50)), '--target', $resizeTarget)
+            $resizeReplies += $r
+            $okShape = ($r.ok -and ("$($r.result)" -match '^resized \d+%$')) -or ((-not $r.ok) -and ("$($r.error)" -match 'open one first'))
+            if (-not $okShape) { $resizeBad += ($r | ConvertTo-Json -Compress) }
+            Start-Sleep -Milliseconds 30
+        }
+        $resizeNode = $null
+        for ($i = 0; $i -lt 30; $i++) {
+            $resizeNode = Get-SessionSnapshot $resizeTarget
+            if ($resizeNode -and -not $resizeNode.overlay) { break }
+            Start-Sleep -Milliseconds 200
+        }
+        $resizedCount = @($resizeReplies | Where-Object { $_.ok }).Count
+        Check 'resize under an exiting overlay answers resized-or-refused only' ($resizeBad.Count -eq 0 -and $resizedCount -gt 0) "resized=$resizedCount bad=$($resizeBad -join ' | ')"
+        Check 'and once the overlay is gone the session carries no overlaySize' `
+            ($resizeNode -and -not $resizeNode.overlay -and -not $resizeNode.PSObject.Properties['overlaySize']) "$($resizeNode | ConvertTo-Json -Compress -Depth 3)"
+        foreach ($id in $blockIds) { try { Invoke-Ctl @('session', 'close', $id) | Out-Null } catch { } }
+
         # sidebar.width must move the divider, not just a number. The unit tests see the fake host
         # only; here the proof is live geometry: the active session's measured width (session.metrics,
         # columns x cell width) shrinks when the sidebar widens, because the grid derives from the

--- a/tests/integration/win32-control.ps1
+++ b/tests/integration/win32-control.ps1
@@ -693,20 +693,50 @@ try {
         Check 'and the replacing blocking open returns its own exit (55)' `
             ($replacer.ok -and $replacer.result -eq 'exit 55') "$($replacer | ConvertTo-Json -Compress)"
 
-        # #227 (2): resize resolves, checks and writes in ONE queued UI action. Fired in a loop
-        # against an overlay whose program exits under it, each reply is either "resized N%" (the
-        # overlay existed when the size landed) or the "open one first" refusal — never a reply that
-        # says resized while the write went to a session with no overlay. The proof afterwards: the
-        # session's tree node carries no `overlaySize` once the overlay is gone.
+        # #227 (2): resize resolves, checks and writes in ONE queued UI action. Fired against an
+        # overlay whose program exits under it: two hammer processes resize without pause for the
+        # program's whole life while this loop resizes and reads the tree between calls. The
+        # discriminating assertion is the one #227 names — once the tree has shown the overlay
+        # gone, no LATER resize may answer "resized" — and the persistent one: the node carries no
+        # `overlaySize` once the overlay is gone. The old code's lie needed a resize to straddle
+        # the exit's close (its pipe-thread check passing, its posted write landing after the
+        # close cleared the size); the hammers make that straddle likely, not certain — the
+        # stale-size state it leaves is what the last check catches. Every reply must still be
+        # "resized N%" or the "open one first" refusal.
         $resizeTarget = $blockIds[1]
-        Invoke-Ctl @('session', 'overlay', 'open', 'ping -n 2 127.0.0.1 >nul & exit 0', '--size-percent', '40', '--target', $resizeTarget) | Out-Null
-        $resizeReplies = @(); $resizeBad = @()
-        for ($i = 0; $i -lt 60; $i++) {
+        Invoke-Ctl @('session', 'overlay', 'open', 'ping -n 3 127.0.0.1 >nul & exit 0', '--size-percent', '40', '--target', $resizeTarget) | Out-Null
+        $hammerScript = @'
+for ($i = 0; $i -lt 60; $i++) { & '__CTL__' session overlay resize --size-percent (30 + ($i % 50)) --target '__TARGET__' --pipe '__PIPE__' --json }
+'@
+        $hammerScript = $hammerScript.Replace('__CTL__', $ctl.Replace("'", "''")).Replace('__TARGET__', $resizeTarget).Replace('__PIPE__', $pipe)
+        $hammerEncoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($hammerScript))
+        $hammers = @()
+        foreach ($h in 1, 2) {
+            $hFile = Join-Path ([IO.Path]::GetTempPath()) ("agwinterm-hammer-" + [guid]::NewGuid().ToString('N') + '.txt')
+            $hammers += @{ File = $hFile; Proc = Start-Process pwsh -ArgumentList @('-NoLogo', '-NoProfile', '-EncodedCommand', $hammerEncoded) -NoNewWindow -PassThru -RedirectStandardOutput $hFile }
+        }
+        $resizeReplies = @(); $resizeBad = @(); $resizeAfterGone = @(); $seenGone = $false
+        for ($i = 0; $i -lt 40; $i++) {
             $r = Invoke-Ctl @('session', 'overlay', 'resize', '--size-percent', (30 + ($i % 50)), '--target', $resizeTarget)
             $resizeReplies += $r
             $okShape = ($r.ok -and ("$($r.result)" -match '^resized \d+%$')) -or ((-not $r.ok) -and ("$($r.error)" -match 'open one first'))
             if (-not $okShape) { $resizeBad += ($r | ConvertTo-Json -Compress) }
-            Start-Sleep -Milliseconds 30
+            if ($seenGone -and $r.ok) { $resizeAfterGone += ($r | ConvertTo-Json -Compress) }
+            $node = Get-SessionSnapshot $resizeTarget
+            if ($node -and -not $node.overlay) { $seenGone = $true }
+        }
+        foreach ($h in $hammers) {
+            if (-not $h.Proc.WaitForExit(60000)) { try { $h.Proc.Kill() } catch { } }
+            try {
+                foreach ($line in [IO.File]::ReadAllLines($h.File)) {
+                    if (-not $line.Trim()) { continue }
+                    try { $hr = $line | ConvertFrom-Json } catch { $resizeBad += $line; continue }
+                    $resizeReplies += $hr
+                    $okShape = ($hr.ok -and ("$($hr.result)" -match '^resized \d+%$')) -or ((-not $hr.ok) -and ("$($hr.error)" -match 'open one first'))
+                    if (-not $okShape) { $resizeBad += $line }
+                }
+            } catch { }
+            try { Remove-Item -LiteralPath $h.File -Force -ErrorAction SilentlyContinue } catch { }
         }
         $resizeNode = $null
         for ($i = 0; $i -lt 30; $i++) {
@@ -715,7 +745,10 @@ try {
             Start-Sleep -Milliseconds 200
         }
         $resizedCount = @($resizeReplies | Where-Object { $_.ok }).Count
-        Check 'resize under an exiting overlay answers resized-or-refused only' ($resizeBad.Count -eq 0 -and $resizedCount -gt 0) "resized=$resizedCount bad=$($resizeBad -join ' | ')"
+        $refusedCount = @($resizeReplies | Where-Object { -not $_.ok }).Count
+        Check 'resize under an exiting overlay answers resized-or-refused only, and both happened' `
+            ($resizeBad.Count -eq 0 -and $resizedCount -gt 0 -and $refusedCount -gt 0) "resized=$resizedCount refused=$refusedCount bad=$($resizeBad -join ' | ')"
+        Check 'and no resize after the tree showed the overlay gone answered resized' ($seenGone -and $resizeAfterGone.Count -eq 0) "seenGone=$seenGone after=$($resizeAfterGone -join ' | ')"
         Check 'and once the overlay is gone the session carries no overlaySize' `
             ($resizeNode -and -not $resizeNode.overlay -and -not $resizeNode.PSObject.Properties['overlaySize']) "$($resizeNode | ConvertTo-Json -Compress -Depth 3)"
         foreach ($id in $blockIds) { try { Invoke-Ctl @('session', 'close', $id) | Out-Null } catch { } }


### PR DESCRIPTION
Closes #227. Also takes the overlay items collected on #246 while #228 shipped (cross-session `--block` release, a replaced overlay stamping `overlay result`, a replaced/closed overlay never releasing its blocking caller).

## What changed

**`overlay open --block` answers the outcome of the overlay it opened.** Every blocking open in a window used to wait on one `ManualResetEventSlim` and then read one field, so concurrent blocks on different sessions could return each other's exit code, read `no overlay` after a later open's reset, or stay parked past their own program's exit — and an overlay closed or replaced before its program exited never released its caller at all (`ServerSession.Dispose` ends the pty without raising `Exited`).

Each overlay pane now carries its own `TaskCompletionSource<string>` (`Pane.OverlayDone`): the program's exit completes it with `exit N`, `CloseOverlayOf` (close, replacement) with `closed`, and the blocking open waits on the source of the pane it opened — captured inside the same UI hop as the open — cancelled by `_uiGone` when the window closes (a throw → `ok:false`, "its exit status is unknown").

**`overlay result` (window-wide last exit) is written only by an exit of a pane that is still its session's overlay**, so a replaced pane no longer stamps its code over the one `result` now describes.

**`overlay resize` resolves, checks and writes in one `InvokeOnUiQueued` action and replies from its result** (the `SessionContext` shape), instead of checking on the pipe thread and writing from a later posted action that could land after the overlay's exit had cleared the size — which left `overlaySize` on a session with no overlay while the reply said `resized`.

Contract: `ISessionHost.SessionOverlay` doc rewritten for the three points.

## Evidence

Rebuilt Release; `tests/integration/win32-control.ps1 -Strict`:

```
  PASS  overlay open --block on 06876215-… answers its OWN program's exit (11)
  PASS  overlay open --block on f4de8da6-… answers its OWN program's exit (22)
  PASS  overlay open --block on 55a69c4e-… answers its OWN program's exit (33)
  PASS  and overlay result (the window-wide last exit) names one of the three
  PASS  a blocking open whose overlay was replaced returns "closed" (released, its own outcome)
  PASS  and the replacing blocking open returns its own exit (55)
  PASS  resize under an exiting overlay answers resized-or-refused only
  PASS  and once the overlay is gone the session carries no overlaySize
Win32 control-host integration: all passed
```

The three `--block` opens run as separate `agwintermctl` processes (`ping -n 3 127.0.0.1 >nul & exit 11|22|33` on three `--no-select` fixtures) so the pipe threads really overlap; the replaced-block check opens a 60 s program with `--block`, waits for `overlay:true` in the tree, then opens `exit 55` with `--block` on the same session.

- `dotnet test tests/Agwinterm.Pty.Tests`: 613/613
- `tests/conformance/conformance.ps1 -Strict`: all passed
- revmux (`.revmux/tasks/p2-overlay-227/`): five rounds. r1 → `8c29626`; r2 (Major: the in-process backend faulted on a spawn failure) → `9589456`; r3 (Major: that catch swallowed the pty-host's create error; the skill's "read the pane" after a blocking `exit 1` was impossible) → `811984e`; r4 (Major: the de-elevate branch still swallowed; the recipe's poll and close were not scoped to the overlay's id) → `3c92290`; **r5 clean** — its three Minors (refused close of an already-gone overlay, the de-elevate test's distinguishing assertion, the recipe check's post-close poll) and the prose of its pre-existing items landed in `1f05a42`. Pre-existing behaviour it named — `exit N` is published before the overlay's output is drained — goes to #246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k
