### PR TITLE
release: 0.17.14

### DIFF
--- a/installer/agwinterm.iss
+++ b/installer/agwinterm.iss
@@ -2,7 +2,7 @@
 ; Build via installer\build.ps1 (publishes to stage\ then runs ISCC on this file).
 
 #define AppName    "agwinterm"
-#define AppVersion "0.17.13"
+#define AppVersion "0.17.14"
 #define AppExe     "Agwinterm.Win32.exe"
 #define AppPublisher "Boris Kudriashov"
 ; The main app defaults new sessions to the Rust pty-host as a first-run seed only (it never


### PR DESCRIPTION
Version bump to **0.17.14** — the P5 release: overlays stop being session-wide. Not a package checkpoint (`patch % 9 != 0`): GitHub Releases + Scoop only; winget/choco wait for 0.17.18. **agliteterm's CI stays red until this ships** (its suites skip the P5 checks with *"this agwintermctl predates agwinterm #250"*, and a skip fails `run-all -Strict`).

**Since v0.17.13**
- **#250 — P5, pane overlays** (three revmux rounds): `session overlay open|close|result --pane left|right` — left = pane 0, right = pane 1 whatever the axis; the flag omitted is the session-wide slot, byte for byte; `session overlay copy` / `text [--all|--lines N]` (agterm's `{text}` shape), `session text --all`, `paneOverlays` in `tree --json`; the slot lives on the pane, so a swap moves it by construction; a pane overlay's own id reaches it from anywhere and, on `session overlay` itself, names its slot; refusal words (`pane not visible`, `pane overlay already open`, `no overlay`, `overlay still running`, `no overlay result`, the two-panes disagreement) in one place for host, server, CLI and the test fake. Recorded divergences: the bare `overlay result` stays window-wide; `--size-percent` beside `--pane` and `resize --pane` are refused at both ends. Leftover: #251 (wheel routing by the focused surface).
- **#252** — the contract steps for those.

Merge order: #252 first (so the tag carries the contract), then this; tag `v0.17.14` on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k
