### PR TITLE
docs: record P7/P9-lite delivery and review stopping rule

### DIFF
--- a/docs/lite-parity.md
+++ b/docs/lite-parity.md
@@ -216,8 +216,8 @@ program inside, the chord closing the focused pane's overlay first, the slot mov
 on a swap and dying with its pane — all mirrored. What differs, each recorded in the P5-lite plan:
 
 - **(a)** the session-wide slot is a popup over the window, not a cover inside the content region
-  (P2-lite, unchanged); `copy` on it is always `no selection` — the popup paints no selection and
-  takes no drag (the selection gap above; P6-lite keeps it refusing `selection all`).
+  (P2-lite, unchanged). The former no-selection limitation closed in P7-lite: popup selection
+  paints, takes a drag, and copies its own cells.
 - **(b)** `session text` and `overlay text` default to the WHOLE buffer (scrollback + screen) —
   `--all` is the explicit spelling of lite's bare form, `--lines N` the last N lines of that text
   and `--lines 0` the screen — where agwinterm's and agterm's bare `session text` is the screen
@@ -277,15 +277,15 @@ products. What differs, each recorded in the P6-lite plan:
   difference any more.
 - **(b)** `selection finalize` never answers `finalized (copy-on-select off)`: lite's
   release-copies rule has no off switch (a `CopyOnSelect` knob is P10's, the configuration surface).
-- **(c)** `selection all` on any popup (overlay, quick or scratch — all three share `paintPopup`)
-  is refused `the popup paints no selection`; agwinterm's covers take a selection. P7-lite paints
+- **(c)** Before P7, `selection all` on any popup (overlay, quick or scratch — all three share `paintPopup`)
+  was refused `the popup paints no selection`; agwinterm's covers take a selection. P7-lite paints
   one and lifts this.
 - **(d)** `selection copy`'s clipboard write is posted to the UI thread; the reply counts the text
   posted. A caller reading the clipboard right after waits for the window's next message (the
   suites' 300 ms). When that enqueue fails, `copy` and `finalize` refuse `the clipboard write could
   not be queued; selection unchanged` — the selection is kept for a retry.
-- **(e)** the alt-screen pin covers the VERB; the wheel and the drag still reach main-screen
-  history until P7-lite.
+- **(e)** The P6 alt-screen pin initially covered only the verb. P7-lite extends it to wheel,
+  drag and keyboard selection; none of those routes enters main-screen history from the alt screen.
 - and `copied N chars` counts differently on non-ASCII text: lite counts UTF-8 bytes, agwinterm
   UTF-16 code units (`string.Length`). Same N for ASCII.
 - **(f)** `session.paste` reports what happened in agwinterm only (#256, rounds 8-9): `pasted` when
@@ -309,6 +309,21 @@ shape coverage, not proof that a selection was made — the value is the shell's
 compared, so a no-op `selected all` followed by an empty copy would pass; that proof, and the copy
 itself (`copied N chars`), is each product's own honesty suite's, on a fixture whose content is known.
 
+### Mirrored: P7-lite keyboard and mouse selection shipped
+
+agliteterm [#50](https://github.com/yeroo/agliteterm/pull/50) merged on 2026-09-08 as `1e0903a`.
+Ctrl+Shift+M enters mark mode; arrows/Home/End extend it, Enter or Ctrl+C copies, and Escape cancels.
+Ctrl+Shift+A selects all. Both bindings can be cleared or rebound. Double/triple-click selects a
+word/line; release copies; dragging past a main-screen edge autoscrolls. Posted wheel messages work.
+Frame, split, pane-overlay and overlay/quick/scratch popup surfaces share the selection rules;
+alternate screens stay pinned to their own grid. Captured drags are cancelled on invalidation.
+
+The P6 contract mirror is in step. Local Strict selection acceptance and GitHub Windows CI both
+passed 70 selection checks, and the complete `run-all.ps1 -Strict` passed in CI. The local fixture
+held the shared suite token through owned-process teardown and whole-format clipboard/touched-HKCU
+restoration. Legacy fixture hardening remains [lite #51](https://github.com/yeroo/agliteterm/issues/51);
+those older full-suite fixtures are confined to the disposable CI runner until hardened.
+
 ---
 
 ## Where agliteterm is AHEAD
@@ -325,10 +340,8 @@ Not a one-way list, and these should move the other way.
   elsewhere, so that reply is a guess. lite (P2-lite, its #24) answers `selected` only when
   `GetForegroundWindow` is the window afterwards, and a string starting `not raised:` otherwise —
   still `ok`, the contract's shape, so one script works against both. **agwinterm should copy this.**
-- **Splits scroll into main-screen history on the alt screen.** lite's renderer and hit-test derive
-  their row from the same offset on either screen; agwinterm pins the alt screen to 0. Both are
-  self-consistent (highlight and clipboard agree either way), so this is a difference to decide about
-  rather than a defect — see `qa/product.md` in the lite repo.
+- **Alternate-screen history difference resolved.** Boris chose pinning to the alternate grid.
+  P6-lite applied that rule to selection verbs; P7-lite applied it to wheel, drag and mark mode.
 - ~~**An unknown workspace is refused, not silently swapped** for the active one on `session.new`.
   agwinterm falls back.~~ **Matched in batch P2** (agwinterm **#226**): agwinterm now refuses an
   unknown `--workspace`
@@ -345,13 +358,9 @@ and the list should grow as more turn up.
 
 | Feature | Notes |
 | --- | --- |
-| Mark mode (keyboard selection) | agwinterm: Ctrl+Shift+M, arrows, Enter copies |
-| Select All | no equivalent |
-| Drag-autoscroll | dragging past the pane edge does not extend the selection |
 | Configurable scrollback | lite does not call `agwcore_emu_set_scrollback`; the cap is the core default |
 | Images / graphics | see the `image.*` verbs above |
 | Dashboard, quick-terminal parity, multi-window | agwinterm has a window library; lite has one window plus popups |
-| Wheel over the pane | a posted `WM_MOUSEWHEEL` does not reach lite's handler (harness finding, 0.17.11) |
 
 ---
 

--- a/docs/lite-parity.md
+++ b/docs/lite-parity.md
@@ -25,18 +25,18 @@ purpose justifies it.
 
 ---
 
-## Control API: 41 verbs agliteterm does not answer
+## Control API: remaining gaps and batch status
 
 Grouped by what they cost an agent, not alphabetically. The four `selection.*` verbs — the
 sharpest gap, the one where a QA setup step silently did nothing — closed in P6-lite (see
 "Mirrored: what P6 owed lite" below).
 
 ### Reading and driving a pane
-`session.search` · `session.focus` · `session.switch` · `session.resize` · `session.background` ·
-`session.readonly` · `session.bind` · `session.restore` · `session.write`
-
-`session.write` is in flight (agliteterm #15). `session.readonly` matters most of the rest: it is how
-you stop stray keys reaching a running agent.
+`session.focus` shipped in P4-lite; `session.write` is also implemented (display injection, not
+shell input). P9-lite [#52](https://github.com/yeroo/agliteterm/pull/52) implements `session.search`,
+`session.switch`, `session.resize`, `session.readonly`, `session.bind` and `session.restore`;
+its status and deliberate differences are recorded below. `session.background` remains refused:
+lite draws no images, and adding a watermark pipeline is outside this batch.
 
 ### Images
 `image.show` · `image.sixel` · `image.clear` · `image.frame`
@@ -119,8 +119,8 @@ verb:
   later batch; lite's verb count is 43 with it.
 
 `session.new`'s **refusal** of an unknown workspace needed no mirror — lite had it first, which is
-why decision 1 went that way. `session.restore`'s pane reply stays agwinterm-only until **P9**
-brings the verb to lite at all. The conformance steps for `session new --workspace
+why decision 1 went that way. P9-lite implements `session.restore` and its pane reply.
+The conformance steps for `session new --workspace
 no-such-workspace`, `--size-percent`, `sidebar width` and the two sidebar refusals landed in the
 sibling contract PR (#229) right after #226; agliteterm's `test/control-api.json` is that file
 again and `check-contract` is in step. Until the agwinterm release that carries #226 is tagged, lite's
@@ -139,11 +139,10 @@ lite's README and its shipped skill text rather than left for a reader to trip o
   could not be "dimmed". The sidebar row — lite's one per-session text surface — draws the context
   dimmed after the name in its post-paint pass, beside the pennant and the unread pill it already
   draws, and the badges do not move (`qa/persistence.md` there has the capture).
-- **`replayOnRestore` is a constant `false`.** lite restores a session's LAUNCH spec at the next
-  start and never types a slot back (`session.restore` is P9), so the truthful answer is `false`;
-  a toggle with nothing behind it, or `true`, would be the lie P2 existed to end. The shape is the
-  contract's, so one script reads both products; the field starts reporting a toggle when P9 lands
-  the replay. The capture itself is in-process (one Toolhelp32 snapshot plus the PEB read lite
+- **`replayOnRestore` is a constant `false`.** It describes replay of captured `K` commands, which
+  lite never types back. P9's explicit `R` pins and `B` bindings are separate and do not change
+  this answer. A future captured-command replay setting belongs to the configuration batch.
+  The capture itself is in-process (one Toolhelp32 snapshot plus the PEB read lite
   already does for a shell's cwd — milliseconds, no child process, so none of the CIM query's
   timeout-and-kill semantics), with agwinterm's default denylist frozen as a constant: lite has no
   `restore-denylist.conf`.
@@ -187,8 +186,8 @@ Both products' P3 checks run for real since agwinterm **0.17.12** (2026-09-05). 
   but empty one (only an OMITTED `--target` means every real pane) or a pane that is never restored
   is refused with nothing written; a process query that fails is a refusal, not an empty answer for
   every pane. `tree --json` reads the slots back as `capturedCommands`,
-  keyed by pane id like `restoreCommands`. Lite has no `session.restore` yet (that is **P9**), so
-  this lands the slot and the verb first and the pin later.
+  keyed by pane id like `restoreCommands`. P3 landed captured slots first; P9 adds explicit pins
+  separately, not as an instruction to replay captures.
 
 The conformance steps for both (the `session context` set and `--clear` steps, the `restore capture`
 step pinning the reply keys, and the two errors-block refusals) landed in the sibling contract PR
@@ -296,11 +295,12 @@ products. What differs, each recorded in the P6-lite plan:
   `the pane's process has exited` (a single-pane session keeps the exited surface; the exit is
   observed a moment after it happens, so a paste right after a child dies can still be `pasted`) — and
   `paste failed: <why>` when the write threw: that one comes after the payload was picked (the
-  clipboard may have been read) and says nothing about how much landed. lite's `session.paste` answers
-  `pasted` whatever happened — on an exited pane, on an empty payload (it writes only a non-empty
-  one to a live handle) — and lite has no read-only pane (`session readonly` is in its "does NOT
-  have" list). The lite mirror of the replies is a follow-up with the P6 paste leftovers in #257;
-  the contract's paste step stays shape-only until both products answer alike.
+  clipboard may have been read) and says nothing about how much landed. Outside its refusals,
+  lite's `session.paste` still answers `pasted` on an exited pane or an empty payload (it writes only a non-empty
+  one to a live handle). P9 adds the read-only refusal before clipboard access, but does not mirror
+  the empty/exited/write-failure outcomes yet. Those remain [lite #53](https://github.com/yeroo/agliteterm/issues/53); agwinterm #257
+  separately tracks missing-session refusals on `readonly` and `search`. The contract's paste
+  step stays shape-only until both products answer alike.
 
 The contract's P6 steps (#256) are shape-only and run on the no-selection arm of `copy` and
 `finalize` on purpose: the Windows clipboard is shared with the user and with every other sandbox on
@@ -323,6 +323,44 @@ passed 70 selection checks, and the complete `run-all.ps1 -Strict` passed in CI.
 held the shared suite token through owned-process teardown and whole-format clipboard/touched-HKCU
 restoration. Legacy fixture hardening remains [lite #51](https://github.com/yeroo/agliteterm/issues/51);
 those older full-suite fixtures are confined to the disposable CI runner until hardened.
+
+### Mirrored: P9-lite driving a pane shipped
+
+agliteterm [#52](https://github.com/yeroo/agliteterm/pull/52) merged on 2026-09-08 as `190e514`,
+from tested candidate `c77b256`. Guarded local acceptance and Windows CI each passed 188 combined
+selection/driving checks; 30 pure driving checks and the complete Strict suite passed. The final
+Codex-only confirmation reported no findings from two healthy independent reviewers. CI evidence:
+[run 34215226185](https://github.com/yeroo/agliteterm/actions/runs/34215226185).
+
+- **Human-input gate.** `readonly` blocks keys, paste and reporting mouse input on the addressed
+  surface, while API typing/display writes and terminal replies remain allowed. Blocked keys
+  preserve scrollback and working status. The flag resets on restart; status shows READ-ONLY.
+- **Explicit replay.** `restore` pins a command; `bind` supplies a verbatim command that wins over
+  the pin. Additive `R`/`B` state fields preserve quotes, backslashes and Unicode. Replay waits
+  2500 ms (not a shell-readiness proof), re-resolves current state, and skips adopted or gone shells.
+  Captured `K` commands never replay. Lite accepts a session id/name for binding to its own shell;
+  agwinterm uses pane-id resolution and lower-cases binding text. Lite saves before replying;
+  agwinterm posts the update.
+- **Split and navigation.** `resize` persists slot-0's ratio as `G`, clamps to 0.05..0.95, validates
+  growth against the axis, and refuses unavailable geometry before mutation. Lite accepts a numeric
+  ratio string as well as a JSON number. `switch` previews a snapshot of recency without changing
+  it; commit updates recency, cancel restores the origin. Unnamed replies use `session N` instead
+  of agwinterm's empty name. Next/previous key bindings still walk tree order, not MRU.
+- **Search.** The verb searches the active surface (a valid target does not redirect it), maps
+  Unicode scalars to cells, paints current/other matches and shows FIND status. Alternate-screen
+  search excludes main history. Counts refresh on a search call; stale row highlights are suppressed.
+  A find bar/Ctrl+F and mouse divider drag remain follow-ups, not shipped features.
+- **Refusals.** Lite refuses unknown `readonly`/`switch` operations and missing `readonly`/`search`
+  targets with `ok:false`; agwinterm still toggles on an unknown readonly op or returns success
+  strings for the other cases (missing-session follow-up: [#257](https://github.com/yeroo/agwinterm/issues/257)).
+  Both now refuse read-only API paste; the older P9 plan predates agwinterm #256's fix. Lite's
+  remaining paste outcome differences are listed under P6 above.
+
+Unknown-operation refusals and binding-command case preservation are tracked in
+[agwinterm #259](https://github.com/yeroo/agwinterm/issues/259), separately from #257.
+
+No new canonical contract steps are added by P9: the existing shared floor is unchanged. A later
+contract batch follows the remaining agwinterm honesty fixes, with the usual lite mirror update.
 
 ---
 

--- a/docs/plans/2026-09-03-parity-batches.md
+++ b/docs/plans/2026-09-03-parity-batches.md
@@ -187,6 +187,13 @@ the posted `WM_MOUSEWHEEL` that never reaches lite's handler (harness finding, 0
 
 Same model as P6, different surface — split because it is UI work with a different test shape.
 
+**Shipped:** agliteterm [#50](https://github.com/yeroo/agliteterm/pull/50), 2026-09-08,
+main `1e0903a`. Mark mode, seeded/rebindable Select All, word/line mouse selection, drag-autoscroll,
+posted wheel handling and alternate-screen pinning work on frame and popup surfaces. The merged
+P6 contract is mirrored. Local Strict selection acceptance and disposable Windows CI both passed
+70 checks; the full Strict suite also passed. Clipboard/registry and owned-process cleanup are
+guarded in the selection fixture. Remaining legacy shared-desktop fixture safety is lite #51.
+
 ### P8 · lite · mirror Wave 1 — dissolved into per-batch mirrors
 `surface.cursor` · `statusChangedAt` · `version` → **P1-lite — shipped** (agliteterm #20,
 2026-09-04, six revmux rounds; plan `docs/plans/completed/2026-09-03-p1-lite-mirror.md` there) ·

--- a/docs/plans/2026-09-03-parity-batches.md
+++ b/docs/plans/2026-09-03-parity-batches.md
@@ -6,7 +6,7 @@ plan, one branch, one PR — run with review steps disabled, then reviewed by re
 
 Each `P<n>` becomes its own plan file in this directory when it is its turn, and moves to
 `completed/` when it ships; expanding all of them up front would just produce stale plans. A batch
-without a **Shipped** line below has not started.
+without a status line below is backlog; **Ready** is not **Shipped**.
 
 ## The rules the split obeys
 
@@ -22,9 +22,13 @@ without a **Shipped** line below has not started.
   two merges. P8 below is therefore dissolved into those per-batch mirrors.
 - **A batch is a theme, not a size quota.** Items travel together when they share a test area or a
   format change, so one revmux round covers them coherently.
-- **Every batch exits the same way:** its own tests, the QA cases in `qa/` (both products have them),
-  the full suite green, then revmux — **two rounds minimum**; the second round is where criticals have
-  historically surfaced.
+- **Every batch exits the same way:** its own tests, applicable QA acceptance and the full suite
+  green, with independent review. Boris's 2026-09-08 stopping rule is one full review, batched
+  fixes and one narrow confirmation when needed. More rounds require a correctness, safety or
+  acceptance blocker, or a substantive new change; cosmetic findings do not hold a merge.
+  During Claude's rate-limit outage Codex leads, with Codex-only independent revmux reviewers.
+  Shared-desktop tests still require the suite token through proven cleanup; unsafe legacy
+  fixtures run only on disposable CI runners until hardened.
 - **A release follows every agwinterm batch that adds a verb.** agliteterm's CI proves the contract
   against the *released* `agwintermctl` (its `fetch-native.ps1` takes the `latest` release), so a lite
   mirror cannot go green until the verb it mirrors has shipped in a CLI. Only `*.*.9` / `*.*.18` /
@@ -90,7 +94,8 @@ additive keys only, no version field, every loaded value validated. Round-4 left
 (#227 / #228) remain, in `SessionOverlay`. Mirror: agliteterm P3-lite — **shipped** as agliteterm
 #28 (2026-09-05; plan `docs/plans/2026-09-05-p3-lite-mirror.md` there): `session.context` as a `C`
 line type after the `S` lines, `restore.capture` as a `K` line with an in-process Toolhelp32 + PEB
-query instead of the CIM one, `replayOnRestore` a constant `false` until P9 lands the replay, and a
+query instead of the CIM one, `replayOnRestore` a constant `false` for captured commands (P9's
+explicit pin/binding replay is separate), and a
 hidden pane refusing `session context` (the three divergences are in `docs/lite-parity.md`); its
 checks SKIP against the released `agwintermctl` until the release that carries #233 + #235 is tagged.
 
@@ -209,6 +214,14 @@ merges.
 `session.readonly` **first** — it is how you stop stray keys reaching a running agent — then
 `session.focus` · `session.switch` · `session.resize` · `session.background` · `session.search` ·
 `session.bind` · `session.restore`
+
+**Shipped:** agliteterm [#52](https://github.com/yeroo/agliteterm/pull/52), main `190e514`, tested
+candidate `c77b256` (2026-09-08). Six verbs implemented; `focus` already shipped in P4-lite and `background`
+remains refused because lite draws no images. Guarded local acceptance passed 188 combined P7/P9
+checks, pure driving checks passed 30, and the final two-reviewer Codex-only confirmation was clean.
+The full Strict Windows CI suite passed, including the same 188 checks. Explicit pins/bindings replay on fresh
+restored shells, never adopted shells; captured commands do not replay. Differences and remaining
+find-bar/divider-drag work are recorded in `docs/lite-parity.md`.
 
 ### P10 · lite · the configuration surface
 `config.get/list/set` · `theme.list/set` · `omp.list/set` · `font` · `settings.open` ·


### PR DESCRIPTION
## Summary

- Record P7-lite selection delivery and P9-lite pane-driving delivery with tested revisions, acceptance evidence and merge links.
- Remove the selection/focus/write/drive gaps those batches closed and distinguish explicit pin/binding replay from captured-command replay.
- Record remaining deliberate differences and concrete follow-ups: lite #51 (legacy fixture safety), lite #53 (paste outcomes), agwinterm #257 (missing-session refusals) and #259 (unknown operations/binding case).
- Apply Boris's delegated review stopping rule: batch fixes, use narrow confirmation when needed, and do not block delivery on cosmetic rounds. Codex-only independent review during Claude's outage; shared-suite token/cleanup and CI gates remain mandatory.

## Verification

Documentation only: checked the descriptions against lite's tested P9 source, agwinterm main, local test transcripts and independent Codex review archives. `git diff --check` passes. No additional broad review round for this status update. CI remains required for this PR; no local shared-desktop tests were launched for documentation.

No source/contract changes, no release/tag, and no changes to Claude's checkout.

Codex-Session: 01a0773e-4780-78f2-bab8-078213f0f84e
