### PR TITLE
docs: P11-lite commands, installers and agent lifecycle parity

### DIFF
--- a/docs/lite-parity.md
+++ b/docs/lite-parity.md
@@ -453,9 +453,12 @@ companion status update must not merge before the implementation and its gates.
   optional launcher wrapper generates an explicit conversation UUID for a bare invocation.
 - YOLO is explicit and requires lite's per-process PowerShell prompt bridge. Default PowerShell
   launches load it without profile edits; existing/adopted/explicit-argv shells need an explicit load.
-  Input is reserved while interruption is pending. The prompt may claim a quoted resume argv only
-  after retained descendants exited, no shell children remain and the prompt proves sole attached
-  console ownership, including late orphans; it never appends commands to a draft.
+  Input is reserved while interruption is pending; only one Ctrl+C is queued. The host-readline
+  boundary may claim a quoted resume argv only after retained descendants exited, no shell children
+  remain and the shell proves sole attached console ownership, including late orphans. It returns the
+  command to PowerShell's normal pipeline, never executes inside the prompt or appends to a draft.
+  Ordinary input delegates to the prior readline function; unsupported alias/script readers are untouched
+  and do not register the bridge.
   Readonly/covered/custom-conflicting/changed panes refuse or cancel. Timeout has no relaunch fallback.
   Interrupt writes are bounded/cancellable; lease offers and acknowledgements are retryable and
   expire, using globally unique authorization IDs across UI adoption. A still-unresolved Windows

--- a/docs/lite-parity.md
+++ b/docs/lite-parity.md
@@ -457,11 +457,15 @@ companion status update must not merge before the implementation and its gates.
   after retained descendants exited, no shell children remain and the prompt proves sole attached
   console ownership, including late orphans; it never appends commands to a draft.
   Readonly/covered/custom-conflicting/changed panes refuse or cancel. Timeout has no relaunch fallback.
+  Interrupt writes are bounded/cancellable; lease offers and acknowledgements are retryable and
+  expire. Receipt notification and binding persistence do not block authorization replies.
 - Claude update runs visibly in an owned overlay. Only a proven newer version requests safe restarts
   of the originally verified eligible panes using that executable/script, preserving conversation and
   explicit startup permission arguments (not interactive mode changes). Fail/no-op/unknown versions
   restart nothing. Queue/dispatch/persistence and successful
   agent startup are distinct outcomes, reported through `agent.update` / `agent.restart` events.
+  Five-minute supervision expiry retains updater exclusion until the owned command ends, without
+  authorizing late restarts.
 
 Detailed behavior: [lite agent integration](https://github.com/yeroo/agliteterm/blob/main/docs/agent-integration.md).
 Tests use private fake agents, redirected files and owned processes, never the user's real Claude CLI.

--- a/docs/lite-parity.md
+++ b/docs/lite-parity.md
@@ -446,18 +446,21 @@ companion status update must not merge before the implementation and its gates.
 - `app.update` exposes lite's existing verified release updater and refuses developer/portable copies.
   Queued does not mean downloaded, verified or installed. No release/tag is part of the batch.
 - Adoption requires a birth-verified live Claude descendant with one explicit conversation UUID,
-  either native claude.exe or node.exe with the exact installed Claude Code cli.js path suffix.
-  Bare/continue/headless/ambiguous/inaccessible evidence refuses; no newest-folder transcript fallback.
+  either native claude.exe or node.exe with an absolute installed Claude Code cli.js path suffix.
+  Bare/continue/headless/fork-session/unknown-arity/ambiguous/inaccessible evidence refuses;
+  no newest-folder transcript fallback. Initial positional prompts are not replayed on resume.
   Existing bindings and permission modes are preserved. Lite pane IDs are not Claude UUIDs, so its
   optional launcher wrapper generates an explicit conversation UUID for a bare invocation.
 - YOLO is explicit and requires lite's per-process PowerShell prompt bridge. Default PowerShell
   launches load it without profile edits; existing/adopted/explicit-argv shells need an explicit load.
   Input is reserved while interruption is pending. The prompt may claim a quoted resume argv only
-  after retained descendants exited and no shell children remain; it never appends commands to a draft.
+  after retained descendants exited, no shell children remain and the prompt proves sole attached
+  console ownership, including late orphans; it never appends commands to a draft.
   Readonly/covered/custom-conflicting/changed panes refuse or cancel. Timeout has no relaunch fallback.
 - Claude update runs visibly in an owned overlay. Only a proven newer version requests safe restarts
   of the originally verified eligible panes using that executable/script, preserving conversation and
-  permission mode. Fail/no-op/unknown versions restart nothing. Queue/dispatch/persistence and successful
+  explicit startup permission arguments (not interactive mode changes). Fail/no-op/unknown versions
+  restart nothing. Queue/dispatch/persistence and successful
   agent startup are distinct outcomes, reported through `agent.update` / `agent.restart` events.
 
 Detailed behavior: [lite agent integration](https://github.com/yeroo/agliteterm/blob/main/docs/agent-integration.md).

--- a/docs/lite-parity.md
+++ b/docs/lite-parity.md
@@ -453,12 +453,15 @@ companion status update must not merge before the implementation and its gates.
   optional launcher wrapper generates an explicit conversation UUID for a bare invocation.
 - YOLO is explicit and requires lite's per-process PowerShell prompt bridge. Default PowerShell
   launches load it without profile edits; existing/adopted/explicit-argv shells need an explicit load.
-  Input is reserved while interruption is pending; only one Ctrl+C is queued. The host-readline
+  Input is reserved while exit is pending; one documented Ctrl+D exit key is queued, not Ctrl+C
+  cancellation. Unsupported/rebound exit behavior times out without forced termination. The host-readline
   boundary may claim a quoted resume argv only after retained descendants exited, no shell children
   remain and the shell proves sole attached console ownership, including late orphans. It returns the
   command to PowerShell's normal pipeline, never executes inside the prompt or appends to a draft.
   Ordinary input delegates to the prior readline function; unsupported alias/script readers are untouched
   and do not register the bridge.
+  Compatibility limit: bridge probes change the delegated reader's `$?`/predictor status, not the
+  preceding command's exit code or `$LASTEXITCODE`; preserving that side channel is a follow-up.
   Readonly/covered/custom-conflicting/changed panes refuse or cancel. Timeout has no relaunch fallback.
   Interrupt writes are bounded/cancellable; lease offers and acknowledgements are retryable and
   expire, using globally unique authorization IDs across UI adoption. A still-unresolved Windows

--- a/docs/lite-parity.md
+++ b/docs/lite-parity.md
@@ -458,13 +458,18 @@ companion status update must not merge before the implementation and its gates.
   console ownership, including late orphans; it never appends commands to a draft.
   Readonly/covered/custom-conflicting/changed panes refuse or cancel. Timeout has no relaunch fallback.
   Interrupt writes are bounded/cancellable; lease offers and acknowledgements are retryable and
-  expire. Receipt notification and binding persistence do not block authorization replies.
-- Claude update runs visibly in an owned overlay. Only a proven newer version requests safe restarts
+  expire, using globally unique authorization IDs across UI adoption. A still-unresolved Windows
+  cancellation retains the pane's input gate until completion and emits an event; no late resume.
+  Receipt notification and binding persistence do not block authorization replies or overwrite newer bindings.
+- Claude update owns its helper/descendants in a native job and displays a log in an overlay viewer.
+  Closing the viewer does not stop the updater; closing the app kills its owned job (possibly partial).
+  Only a proven newer version requests safe restarts
   of the originally verified eligible panes using that executable/script, preserving conversation and
   explicit startup permission arguments (not interactive mode changes). Fail/no-op/unknown versions
   restart nothing. Queue/dispatch/persistence and successful
   agent startup are distinct outcomes, reported through `agent.update` / `agent.restart` events.
-  Five-minute supervision expiry retains updater exclusion until the owned command ends, without
+  Five-minute supervision expiry retains updater exclusion until the owned job is empty, even if the viewer
+  closes, without
   authorizing late restarts.
 
 Detailed behavior: [lite agent integration](https://github.com/yeroo/agliteterm/blob/main/docs/agent-integration.md).

--- a/docs/lite-parity.md
+++ b/docs/lite-parity.md
@@ -59,15 +59,14 @@ not the full app's terminal-theme catalog; custom profiles have the explicit sub
 P10 does not claim complete appearance/profile-schema parity.
 
 ### Commands and installers
-`command.list` · `command.run` · `command.leader` · `install.cli` · `install.hooks` ·
-`install.shell` · `app.update`
-
-lite has `install.skill` only.
+P11 [lite #59](https://github.com/yeroo/agliteterm/pull/59) implements `command.list/run/leader`,
+`install.cli/hooks/shell` and `app.update`, in addition to the existing `install.skill`.
+The command modes, installer safety boundary and deliberate differences are recorded below.
 
 ### Agent integration
-`claude.adopt` · `claude.yolo` · `claude.update`
-
-Adoption is the interesting one: pointing the terminal at an already-running Claude session.
+P11 [lite #59](https://github.com/yeroo/agliteterm/pull/59) implements `claude.adopt/yolo/update`.
+Adoption requires exact process conversation evidence; restart uses a guarded PowerShell prompt bridge.
+This is not a claim of identical unsafe-fallback behavior; the explicit differences follow below.
 
 ### Everything else
 `broadcast` · `notify` · `dashboard` · `restore.clear` · `workspace.move`
@@ -426,6 +425,44 @@ agliteterm [#57](https://github.com/yeroo/agliteterm/pull/57) adds four verbs an
 
 Local acceptance and independent Codex-only review/CI evidence are tracked in the PR. The
 implementation and its required gates must land before this status update.
+
+---
+
+### P11-lite commands, installers and agent integration
+
+[Lite #59](https://github.com/yeroo/agliteterm/pull/59) delivers the complete P11 batch as one PR.
+Its required review/integration/CI gates and token-release evidence are recorded in the PR; this
+companion status update must not merge before the implementation and its gates.
+
+- Custom commands support send/new/overlay/detached, complete ASCII-case-insensitive labels, AGW
+  context tokens/environment, palette entries, actual key bindings and two-second leader state.
+  Lite refuses the whole invalid reload and retains the last catalog; it only accepts its implemented
+  actions. New/overlay use PowerShell, detached uses the system cmd.exe. Oversized host arguments refuse.
+- CLI/hooks/shell installers are opt-in and idempotent, preserve unrelated profile/settings/PATH data,
+  and atomically replace changed existing files with unique backups. Partial multi-file failures
+  report completed writes; they are not a transaction. Codex TOML is never rewritten. The profile
+  target is Windows PowerShell, not PowerShell 7. Shared CLI versions may intercept `install cli`
+  locally; use the lite pipe verb or bundled helper for an unambiguous lite PATH installation.
+- `app.update` exposes lite's existing verified release updater and refuses developer/portable copies.
+  Queued does not mean downloaded, verified or installed. No release/tag is part of the batch.
+- Adoption requires a birth-verified live Claude descendant with one explicit conversation UUID,
+  either native claude.exe or node.exe with the exact installed Claude Code cli.js path suffix.
+  Bare/continue/headless/ambiguous/inaccessible evidence refuses; no newest-folder transcript fallback.
+  Existing bindings and permission modes are preserved. Lite pane IDs are not Claude UUIDs, so its
+  optional launcher wrapper generates an explicit conversation UUID for a bare invocation.
+- YOLO is explicit and requires lite's per-process PowerShell prompt bridge. Default PowerShell
+  launches load it without profile edits; existing/adopted/explicit-argv shells need an explicit load.
+  Input is reserved while interruption is pending. The prompt may claim a quoted resume argv only
+  after retained descendants exited and no shell children remain; it never appends commands to a draft.
+  Readonly/covered/custom-conflicting/changed panes refuse or cancel. Timeout has no relaunch fallback.
+- Claude update runs visibly in an owned overlay. Only a proven newer version requests safe restarts
+  of the originally verified eligible panes using that executable/script, preserving conversation and
+  permission mode. Fail/no-op/unknown versions restart nothing. Queue/dispatch/persistence and successful
+  agent startup are distinct outcomes, reported through `agent.update` / `agent.restart` events.
+
+Detailed behavior: [lite agent integration](https://github.com/yeroo/agliteterm/blob/main/docs/agent-integration.md).
+Tests use private fake agents, redirected files and owned processes, never the user's real Claude CLI.
+Full Strict suite remains a disposable Windows CI gate; local integration uses the shared suite token.
 
 ---
 

--- a/docs/plans/2026-09-03-parity-batches.md
+++ b/docs/plans/2026-09-03-parity-batches.md
@@ -242,10 +242,16 @@ icons or elevation. Font targeting is excluded under Boris's fixed-strike/no-zoo
 Current behavior, rollback limits and product differences are recorded in `docs/lite-parity.md`.
 
 ### P11 · lite · commands, installers, agent integration
-`command.list/run/leader` · `install.cli/hooks/shell` · `app.update` · `claude.adopt/yolo/update`
+P11 [lite #59](https://github.com/yeroo/agliteterm/pull/59) implements `command.list/run/leader`,
+`install.cli/hooks/shell`, `app.update` and `claude.adopt/yolo/update` as one delivery. Custom commands
+cover all four modes, palette and leader bindings. Installers preserve unrelated data and retain
+backups; Codex configuration is suggested, not rewritten. Agent adoption requires exact live process
+identity, and restarts use a guarded PowerShell prompt bridge after proven descendant exit, never
+a newest-folder guess or fixed-delay command injection. Failed/no-op updates restart nothing.
 
-lite ships `install.skill` only. `claude.adopt` — pointing the terminal at an already-running Claude
-session — is the interesting one.
+Compatibility differences, prompt-bridge requirements and asynchronous outcome semantics are in
+`docs/lite-parity.md`. The implementation PR records Codex-only independent review and integration/CI
+gates; it must merge before this companion status update. No release/tag is part of P11.
 
 ### P12 · lite · the remainder
 `broadcast` · `notify` · `dashboard` · `restore.clear` · `workspace.move`


### PR DESCRIPTION
## P11-lite companion status

Update the batch plan and lite parity tracker for the complete P11 implementation in yeroo/agliteterm#59.
Records commands/leader/palette, opt-in installers, update gating, exact agent identity and prompt-bridge
restart safety, along with explicit compatibility limits. No canonical contract or source changes.

Implementation https://github.com/yeroo/agliteterm/pull/59 is merged as
`8a5fc125d537073f5e961f39016c1da45ecb0d36` after its review/integration/exact-head CI gates.
Dependency ordering and this companion's exact-head CI gate are satisfied.

Companion candidate: `0a9550b45cfe1dd8730200eee96b24c140c478fa`.
Exact-head Windows CI passed (attempt 3, 6m1s): https://github.com/yeroo/agwinterm/actions/runs/34271732642.
The implementation's final guarded combined local suite passed **404/404** at `3eb0b11`; all 39 retained
descendants exited, clipboard/touched registry restored, no queued launches, suite token generation 83
released. Exact-head full Windows CI passed: https://github.com/yeroo/agliteterm/actions/runs/34272365065.
Codex-only review and direct final-fix verification are recorded in implementation PR #59.
Graceful exit uses documented Ctrl+D; full schema coverage and delegated-reader `$?` preservation are
explicitly nonblocking follow-ups yeroo/agliteterm#60 and #61, not hidden or reported fixed.

CI attempt 1 failed on restore.capture's process-query timeout; the code/tests are unchanged from the
last green 36590ec candidate (only docs/lite-parity.md differs). Attempt 2 passed conformance but failed
the unchanged floating-cover mouse fixture's 10-second readiness check. Attempt 3 passed every stage,
including both previously failing stages; neither failed attempt is presented as passing evidence or bypassed.

No release or tag is part of this delivery.
