### PR TITLE
feat: P13 passive session HUD and nine-position placement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,11 @@ jobs:
         timeout-minutes: 10
         run: ./tests/integration/win32-control.ps1 -Strict
 
+      - name: Passive HUD integration
+        shell: pwsh
+        timeout-minutes: 5
+        run: ./tests/integration/hud-ui.ps1 -Strict
+
       - name: Test (Core + Pty)
         # One retry for the known .NET 10 test-host #118 pathology under named-pipe churn, which
         # manifests two ways: a native CRASH ("Test Run Aborted") OR a DEADLOCK that hangs the run

--- a/README.md
+++ b/README.md
@@ -229,6 +229,9 @@ agwintermctl session type "npm test`n"       # type into the active session
 say "hi"
 "@ | agwintermctl session type --stdin   # text with quotes/newlines: stdin as bytes (see below)
 agwintermctl session overlay open "git diff" --size-percent 60
+agwintermctl session hud "Reviewing" --spinner --position top-right  # passive status, shell stays usable
+agwintermctl session hud update "Ready"                             # replace message in place
+agwintermctl session hud close
 agwintermctl session overlay open "lazygit" --pane right    # over the right pane only; the left pane stays live
 agwintermctl session overlay text --pane right --all        # the overlay's own screen + scrollback (session text reads the shell under it)
 agwintermctl session restore "npm run dev" --target <pane>   # re-run on every restart; reply names the pane

--- a/docs/agterm-parity.md
+++ b/docs/agterm-parity.md
@@ -115,7 +115,7 @@ reaches. The agliteterm mirrors are the per-batch `P<n>-lite` plans, tracked in
 
 Nothing left here: the control-API items closed with P1–P5. What remains of the overlay verbs is
 agterm's `--cwd`, `--follow` and `--background-color` on `open`, deliberately left out of P5
-(tracked as #139 / #88), and `session.hud` below.
+(tracked as #139 / #88). P13 adds `session.hud` in agwinterm (see below).
 
 ---
 
@@ -127,9 +127,12 @@ conversation picker, backlog picker, SQLite browser. Nothing here can do that wi
 picker binary of its own.
 **The biggest single capability gap.** Size: large.
 
-### 2. `session.hud` and `--position`
+### 2. `session.hud` and `--position` — implemented in P13
 **agterm 0.22.0 / 0.24.0.** A transient overlay for status an agent wants seen without printing into
-the terminal, anchored to one of nine positions. Size: medium.
+the terminal, anchored to one of nine positions. Agwinterm now draws a passive native
+HUD with detail, spinners, colors and bounded width; it leaves terminal input and geometry
+unchanged. See [session-hud.md](session-hud.md) for targeting, replacement and validation.
+The agliteterm mirror remains owed in P17; the shared conformance floor is unchanged.
 
 ### 3. Quick terminal: screen percentage, and a global hotkey
 **agterm 0.24.0 / 0.25.0.** Sizes as 40–90% of the screen, and a system-wide hotkey summons it over

--- a/docs/plans/2026-09-03-parity-batches.md
+++ b/docs/plans/2026-09-03-parity-batches.md
@@ -277,6 +277,12 @@ remain. The former blanket “every verb except images” sentence was not an ac
 A transient overlay for status an agent wants seen without printing into the terminal, anchored to
 one of nine positions.
 
+Implemented by [the P13 plan](2026-09-09-p13-session-hud.md): native passive drawing,
+`session.hud.open/update/close`, CLI shorthand, detail/spinners/colors and bounded width.
+See [the API contract](../session-hud.md). Dedicated dispatcher/layout tests and an owned-process
+Win32 fixture cover placement, click/type-through, targeting and overlay lifecycle. The lite mirror
+remains P17 work; this batch does not expand shared conformance or publish a release.
+
 ### P14 · agwinterm · quick terminal
 Size as 40–90% of the screen · a system-wide hotkey that summons it over any app
 

--- a/docs/plans/2026-09-09-p13-session-hud.md
+++ b/docs/plans/2026-09-09-p13-session-hud.md
@@ -1,0 +1,47 @@
+# P13 — passive session HUD
+
+Boris requested P13 end-to-end on 2026-09-09. Codex owns `agwinterm-p13`,
+branch `feat/p13-session-hud`, base e0e5282. Claude's parked worktree is untouched.
+
+## Scope
+
+Implement the roadmap's agwinterm HUD, using agterm v0.26.0's HUD API as the reference:
+`session.hud.open/update/close`, CLI `session hud [open] MESSAGE`, `update MESSAGE`,
+`close`. Nine positions plus top/bottom aliases, detail, five spinner styles/none,
+optional background/text colors and width percent. Open replaces an existing HUD;
+update requires one and replaces the spec except for the original background color.
+Close is idempotent and never closes a program overlay. No expiry is implied:
+transient means until closed/replaced/session teardown, never persisted.
+
+The HUD is session-wide native drawing, not another terminal or process. Keyboard,
+mouse, selection, terminal geometry/history, focus and notification state are unchanged.
+An active program overlay refuses HUD open/update. Opening a session-wide program
+overlay replaces the HUD; overlay close and the ordinary close shortcut dismiss it.
+Pane overlays may coexist underneath. Scratch/quick covers and dashboard obscure it.
+Explicit auxiliary-cover or split-pane-only targets refuse rather than widen silently;
+use the owning session id. Unknown targets/options/invalid types change nothing.
+
+Tree exposes the effective `hud` object with normalized position/spinner, effective
+width limit and retained background. Input text is at most 256 normalized Unicode
+scalars per field, nonblank message, no control characters. Plain text only. Requested
+width 1..100 is visibly bounded to 10..80%; height follows wrapped content, capped at
+80%. Off-center anchors retain a 10% edge margin; content is clipped on tiny windows.
+Colors use six hexadecimal digits (optional #). Rendering uses DirectWrite Unicode
+layout and Direct2D, with a window-owned animation timer and no helper filesystem.
+
+## Validation / delivery
+
+Pure validation, all nine layouts and spinner tests; dispatcher refusal/state tests;
+Win32 integration covering all anchors, update/close/replacement, stable terminal text
+and geometry, typing through the panel, split and auxiliary targeting, and lifecycle.
+Build/Core+Pty tests plus exact-head Windows CI. Local GUI runs require canonical suite
+token through exact owned-process exit; use a dedicated HUD fixture that does not touch
+clipboard/shared configuration. Existing full integration remains on disposable CI.
+Visually inspect the actual rendered panel. One broad Codex-only revmux review, batched
+fixes, narrow confirmation only as needed. Merge only the tested head; no release/tag.
+
+Update the agterm tracker and record that lite's Wave-3 mirror is still owed (P17).
+Do not expand the shared conformance floor ahead of that mirror: P13's executable
+contract coverage is agwinterm-only integration plus dispatcher tests for now.
+
+Reference: https://github.com/umputun/agterm/tree/v0.26.0/agtermCore/Sources/agtermCore

--- a/docs/session-hud.md
+++ b/docs/session-hud.md
@@ -1,0 +1,77 @@
+# Passive session HUD (P13)
+
+A HUD displays short status text over a session without writing to its terminal, changing
+its dimensions, taking keyboard focus, capturing the mouse or changing notification badges.
+It is native presentation: no shell, helper process, temporary message file or restore state.
+
+```powershell
+agwintermctl session hud "Preparing review" --detail "Reading the diff" --spinner --position top-right
+agwintermctl session hud update "Review ready" --text-color '#80ff80'
+agwintermctl session hud close
+```
+
+`open` is optional before the message. Use explicit `open` for a message that is literally
+`open`, `update` or `close`. `--target ID` and `--window ID` use normal control routing.
+Use the owning **session** id, not the secondary split pane or an auxiliary cover's id.
+A session name is accepted; an ambiguous/unknown target refuses. With `--target active`,
+an active scratch/quick/program cover refuses; name the session explicitly instead.
+
+## Options and state
+
+- `--detail TEXT`: optional second text block.
+- `--position`: `top-left`, `top-center`, `top-right`, `center-left`, `center`,
+  `center-right`, `bottom-left`, `bottom-center`, `bottom-right`. Default `center`.
+  `top` and `bottom` normalize to `top-center` and `bottom-center`.
+- `--spinner`: animate the default ASCII bar. `--spinner-style` accepts `bar`, `braille`,
+  `circle`, `blocks`, `dot` or `none`; an explicit style wins over the flag.
+- `--size-percent N`: requested width 1–100, bounded to 10–80% of the content area;
+  tree read-back reports the bounded value. Omitted width fits the text within those
+  limits. Height fits wrapped text up to 80%; it is not an independently settable size.
+- `--background-color HEX` / `--text-color HEX`: six hex digits, optional `#`.
+  Otherwise the current theme's background/foreground is used. On **update**, the
+  original background is retained; a newly supplied valid background is ignored.
+  Open again to change it. Text color can change on each update.
+
+Message and detail each allow 256 Unicode scalars after NFC normalization. The message
+must be nonblank; control characters, including newline/tab/escape, are refused. Text is
+plain, not ANSI/Markdown. DirectWrite wraps Unicode; small windows may clip content.
+The nine anchors apply to the whole session's content rectangle, not the focused split.
+An off-center anchor holds a 10% edge margin on the corresponding axis.
+
+Open replaces an existing HUD. Update requires an existing HUD and replaces its whole
+specification except background: omitted detail/spinner/position/width/text color reset
+to their defaults. Close is idempotent on a valid session, but unknown targets refuse.
+There is no automatic timeout. Transient means it is not restored: close, replacement,
+session teardown or app exit ends it. A crashed agent may leave its HUD until closed.
+
+## Program overlays and input
+
+A session-wide program overlay owns the same logical slot: HUD open/update refuse while
+that program is present. HUD close never kills it. Opening a session-wide program overlay
+replaces a HUD, and `session overlay close` also dismisses a HUD. The ordinary close
+shortcut dismisses the HUD before closing a pane. Pane overlays may remain underneath;
+scratch/quick covers and the dashboard obscure the HUD while shown.
+
+The HUD itself is not a terminal surface. `session text/copy/type/paste` continue to
+address their normal terminal targets. A HUD cannot be read with `overlay text`, resized
+with `overlay resize`, or awaited with `overlay --block`; inspect `tree` instead.
+
+## Wire API
+
+`session.hud.open`, `session.hud.update`, `session.hud.close`. Open/update args:
+`message`, optional `detail`, `spinner` (style string), `position`, `size-percent`,
+`color` (background), `text-color`. Close accepts no display arguments. Invalid types,
+unknown arguments and unsupported options refuse before mutation. Replies are
+`{session, hud}` inside the usual `ok/result` envelope; close reports `hud:null`.
+The session's `tree` node includes the same `hud` object while set:
+`message`, `detail`, `spinner`, `backgroundColor`, `textColor`, `sizePercent`, `position`.
+Absent optional values are null; no HUD means the tree omits `hud`.
+
+This is the native Win32 implementation. Hosts without HUD support explicitly refuse.
+The shared lite conformance floor is unchanged until the Wave-3 mirror; lite does not
+yet implement these verbs. No release/tag is included in P13.
+
+Reference: [agterm v0.26.0 HUD implementation](https://github.com/umputun/agterm/blob/v0.26.0/agtermCore/Sources/agtermCore/Hud.swift).
+The nine positions, passive behavior and replacement semantics follow that interface;
+rendering is native rather than an auxiliary terminal, and pane/cover targeting is refused
+instead of silently widening to the whole session.

--- a/docs/session-hud.md
+++ b/docs/session-hud.md
@@ -14,7 +14,8 @@ agwintermctl session hud close
 `open`, `update` or `close`. `--target ID` and `--window ID` use normal control routing.
 Use the owning **session** id, not the secondary split pane or an auxiliary cover's id.
 A session name is accepted; an ambiguous/unknown target refuses. With `--target active`,
-an active scratch/quick/program cover refuses; name the session explicitly instead.
+an active scratch/quick/session-wide program cover refuses; name the session explicitly instead.
+Pane overlays may coexist, including on the focused pane. Empty target/window selectors refuse.
 
 ## Options and state
 
@@ -59,7 +60,7 @@ with `overlay resize`, or awaited with `overlay --block`; inspect `tree` instead
 ## Wire API
 
 `session.hud.open`, `session.hud.update`, `session.hud.close`. Open/update args:
-`message`, optional `detail`, `spinner` (style string), `position`, `size-percent`,
+`message`, optional `detail`, `spinner` (style string), `position`, `size-percent` (JSON integer),
 `color` (background), `text-color`. Close accepts no display arguments. Invalid types,
 unknown arguments and unsupported options refuse before mutation. Replies are
 `{session, hud}` inside the usual `ok/result` envelope; close reports `hud:null`.

--- a/src/Agwinterm.Ctl/Program.cs
+++ b/src/Agwinterm.Ctl/Program.cs
@@ -48,6 +48,9 @@ using System.Text.Json;
 //   agwintermctl session metrics [<pane-id>] [--json] (live cell + pane pixel metrics)
 //   agwintermctl session text [--all|--lines N] [--target ID]   (N reaches into scrollback; --all = the whole
 //       buffer, screen + scrollback; default = screen; --all with --lines is refused)
+//   agwintermctl session hud [open|update] <message...> [--detail TEXT] [--spinner|--spinner-style STYLE]
+//       [--position ANCHOR] [--size-percent N] [--background-color HEX] [--text-color HEX] [--target ID]
+//   agwintermctl session hud close [--target ID]   (see docs/session-hud.md)
 //   agwintermctl session overlay open <command...> [--pane left|right] [--wait|--block] [--size-percent N] [--target ID]
 //   agwintermctl session overlay close|result|copy [--pane left|right] [--target ID]
 //   agwintermctl session overlay text [--all|--lines N] [--pane left|right] [--target ID]
@@ -122,7 +125,7 @@ for (int i = 0; i < args.Length; i++)
     else if (a.StartsWith("--"))
     {
         string key = a[2..];
-        bool takes = i + 1 < args.Length && !args[i + 1].StartsWith("--");
+        bool takes = !key.Equals("spinner", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length && !args[i + 1].StartsWith("--");
         string val = takes ? args[++i] : "true";
         options[key] = val;
         if (takes) { valued.Add(key); bareLast.Remove(key); } else bareLast.Add(key);
@@ -203,6 +206,34 @@ switch (area)
         target = DefaultTarget();
         switch (sub)
         {
+            case "hud":
+            {
+                string action = rest.Count > 0 && rest[0] is "open" or "update" or "close" ? rest[0] : "open";
+                if (rest.Count > 0 && rest[0] is "open" or "update" or "close") rest.RemoveAt(0);
+                string[] allowed = ["target", "window", "pipe", "socket", "detail", "spinner", "spinner-style", "position", "size-percent", "background-color", "text-color"];
+                foreach (var key in options.Keys)
+                {
+                    if (!allowed.Contains(key, StringComparer.OrdinalIgnoreCase)) { Console.Error.WriteLine("hud: unknown option --" + key); return 2; }
+                    if (!key.Equals("spinner", StringComparison.OrdinalIgnoreCase) && bareLast.Contains(key)) { Console.Error.WriteLine("hud: --" + key + " needs a value"); return 2; }
+                }
+                if (action == "close" && (rest.Count != 0 || options.Keys.Any(k => !new[] { "target", "window", "pipe", "socket" }.Contains(k, StringComparer.OrdinalIgnoreCase))))
+                { Console.Error.WriteLine("hud close takes no message or display options"); return 2; }
+                if (action != "close")
+                {
+                    cargs["message"] = string.Join(' ', rest);
+                    foreach (var key in new[] { "detail", "position", "size-percent", "text-color" })
+                        if (Opt(key) is { } value) cargs[key] = value;
+                    if (Opt("background-color") is { } bg) cargs["color"] = bg;
+                    if (Opt("spinner-style") is { } style) cargs["spinner"] = style;
+                    else if (options.ContainsKey("spinner")) cargs["spinner"] = "bar";
+                }
+                using var hudArgs = JsonDocument.Parse(JsonSerializer.Serialize(cargs));
+                if (!Agwinterm.Pty.SessionHuds.TryParse(action, hudArgs.RootElement, out _, out var error))
+                { Console.Error.WriteLine(error); return 2; }
+                cmd = "session.hud." + action;
+                target = DefaultTarget();
+                break;
+            }
             case "new":
                 if (Opt("cwd") is { } cwd) cargs["cwd"] = cwd;
                 if (Opt("name") is { } name) cargs["name"] = name;

--- a/src/Agwinterm.Ctl/Program.cs
+++ b/src/Agwinterm.Ctl/Program.cs
@@ -215,14 +215,22 @@ switch (area)
                 {
                     if (!allowed.Contains(key, StringComparer.OrdinalIgnoreCase)) { Console.Error.WriteLine("hud: unknown option --" + key); return 2; }
                     if (!key.Equals("spinner", StringComparison.OrdinalIgnoreCase) && bareLast.Contains(key)) { Console.Error.WriteLine("hud: --" + key + " needs a value"); return 2; }
+                    if ((key.Equals("target", StringComparison.OrdinalIgnoreCase) || key.Equals("window", StringComparison.OrdinalIgnoreCase)) && options[key].Length == 0)
+                    { Console.Error.WriteLine("hud: --" + key + " must not be empty"); return 2; }
                 }
                 if (action == "close" && (rest.Count != 0 || options.Keys.Any(k => !new[] { "target", "window", "pipe", "socket" }.Contains(k, StringComparer.OrdinalIgnoreCase))))
                 { Console.Error.WriteLine("hud close takes no message or display options"); return 2; }
                 if (action != "close")
                 {
                     cargs["message"] = string.Join(' ', rest);
-                    foreach (var key in new[] { "detail", "position", "size-percent", "text-color" })
+                    foreach (var key in new[] { "detail", "position", "text-color" })
                         if (Opt(key) is { } value) cargs[key] = value;
+                    if (Opt("size-percent") is { } width)
+                    {
+                        if (!int.TryParse(width, System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out int n))
+                        { Console.Error.WriteLine("hud: size-percent must be a whole number in 1..100"); return 2; }
+                        cargs["size-percent"] = n;
+                    }
                     if (Opt("background-color") is { } bg) cargs["color"] = bg;
                     if (Opt("spinner-style") is { } style) cargs["spinner"] = style;
                     else if (options.ContainsKey("spinner")) cargs["spinner"] = "bar";

--- a/src/Agwinterm.Pty/AgentSkill.cs
+++ b/src/Agwinterm.Pty/AgentSkill.cs
@@ -199,6 +199,17 @@ public static class AgentSkill
           The slot moves with its pane (a swap, a split close of the other pane) and dies with it (split
           close, split off, the shell exiting when that removes the pane - a single-pane session keeps an
           exited shell on screen, and its overlay with it - session close, the window closing).
+        - `agwintermctl session hud [open] "message" [--detail "text"] [--spinner] [--position top-right] [--target <session id>]`
+          — passive session-wide text; shell input, mouse, history and dimensions are unchanged. Nine anchors:
+          top-left/top-center/top-right, center-left/center/center-right, bottom-left/bottom-center/bottom-right;
+          top/bottom aliases normalize, default center. Optional --size-percent 1..100 bounds width to 10..80%,
+          --spinner-style bar|braille|circle|blocks|dot|none, --background-color and --text-color #rrggbb.
+          `hud update "message"` replaces the whole spec except its original background; omitted options reset.
+          `hud close` dismisses only the HUD. Open replaces a HUD but refuses over a program overlay; program
+          overlay open replaces a HUD. Overlay close/the ordinary close shortcut dismiss a HUD too. Tree's hud
+          object is its read-back. No timeout or persistence. Max 256 normalized Unicode scalars per text field,
+          no control characters, nonblank message. Split-pane-only/auxiliary ids refuse: name the owning session.
+          Scratch/quick/dashboard obscure it. See docs/session-hud.md for exact wire fields and clipping limits.
         - `agwintermctl session overlay open "<command>" [--pane left|right] [--size-percent N] [--wait] [--block] [--target <id>]`
           — run `<command>` in a throwaway terminal over the session (or, with `--pane`, over that one pane's box); it vanishes when the program exits, leaving the session untouched. Returns the overlay id.
           `--size-percent N` (1..100) makes it a centered floating panel over a dimmed session (default = full content region). The session gets a `* (overlay)` tag in `tree`.

--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -169,6 +169,13 @@ public sealed class ControlServer : IDisposable
             JsonElement args = root.TryGetProperty("args", out var a) ? a : default;
             // --window <id|prefix|active>: content verbs act on the resolved window (default = frontmost).
             string? windowSel = root.TryGetProperty("window", out var wv) && wv.ValueKind == JsonValueKind.String ? wv.GetString() : null;
+            if (cmd.StartsWith("session.hud.", StringComparison.Ordinal))
+            {
+                if ((root.TryGetProperty("target", out var ht) && ht.ValueKind is not (JsonValueKind.String or JsonValueKind.Null)) ||
+                    (root.TryGetProperty("window", out var hw) && hw.ValueKind is not (JsonValueKind.String or JsonValueKind.Null)))
+                    return Err("hud: target and window must be string selectors");
+                if (windowSel is not null && _windows is null) return Err("hud: window routing is unavailable in this host");
+            }
 
             // App-level, window-agnostic verbs first.
             switch (cmd)
@@ -241,6 +248,14 @@ public sealed class ControlServer : IDisposable
                         ? Ok("moved") : Err("not found");
                 case "session.rename": return host.SessionRename(target, GetString(args, "name") ?? "") ? Ok("renamed") : Err("session not found / blank name");
                 case "session.context": return HandleSessionContext(host, target, args);
+                case "session.hud.open": case "session.hud.update": case "session.hud.close":
+                    {
+                        string action = cmd[12..];
+                        if (!SessionHuds.TryParse(action, args, out var hud, out var hudError)) return Err(hudError!);
+                        string reply = host.SessionHud(target, action, hud);
+                        return reply.StartsWith(ISessionHost.RefusePrefix, StringComparison.Ordinal)
+                            ? Err(reply[ISessionHost.RefusePrefix.Length..]) : OkRaw(reply);
+                    }
                 case "session.seen": return host.SessionSeen(target) ? Ok("seen") : Err("session not found");
                 case "broadcast": return Ok(host.BroadcastOp(GetString(args, "op") ?? "toggle"));
                 case "session.readonly": return Ok(host.ReadOnlyOp(target, GetString(args, "op") ?? "toggle"));
@@ -434,6 +449,7 @@ public sealed class ControlServer : IDisposable
                   // absent field, and would have to guess which of the two absence meant.
                   .Append(",\"statusChangedAt\":").Append(n.StatusChangedAt.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 if (n.Overlay) sb.Append(",\"overlay\":true");
+                if (n.Hud is { } hud) sb.Append(",\"hud\":").Append(JsonSerializer.Serialize(hud, SessionHuds.JsonOptions));
                 if (n.Flagged) sb.Append(",\"flagged\":true");
                 if (n.Background) sb.Append(",\"background\":true");
                 if (n.Notifications > 0) sb.Append(",\"notifications\":").Append(n.Notifications);

--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -174,6 +174,7 @@ public sealed class ControlServer : IDisposable
                 if ((root.TryGetProperty("target", out var ht) && ht.ValueKind is not (JsonValueKind.String or JsonValueKind.Null)) ||
                     (root.TryGetProperty("window", out var hw) && hw.ValueKind is not (JsonValueKind.String or JsonValueKind.Null)))
                     return Err("hud: target and window must be string selectors");
+                if (target == "" || windowSel == "") return Err("hud: target and window selectors must not be empty");
                 if (windowSel is not null && _windows is null) return Err("hud: window routing is unavailable in this host");
             }
 

--- a/src/Agwinterm.Pty/ISessionHost.cs
+++ b/src/Agwinterm.Pty/ISessionHost.cs
@@ -21,7 +21,7 @@ public sealed record SessionSnapshot(string Id, string Name, bool Active, AgentS
     IReadOnlyList<double>? SplitRatios = null, IReadOnlyList<string>? PaneIds = null,
     IReadOnlyList<string>? RestoreCommands = null, long StatusChangedAt = 0,
     string? Context = null, IReadOnlyList<string>? CapturedCommands = null,
-    string? Axis = null, IReadOnlyList<string>? PaneOverlays = null);
+    string? Axis = null, IReadOnlyList<string>? PaneOverlays = null, HudSpec? Hud = null);
 
 /// <summary>A workspace (with its sessions) for the control-API tree.</summary>
 public sealed record WorkspaceSnapshot(string Id, string Name, bool Active, IReadOnlyList<SessionSnapshot> Sessions);
@@ -72,6 +72,10 @@ public sealed record PaneMetricsSnapshot(int Cols, int Rows, int CellWidth, int 
 /// </summary>
 public interface ISessionHost
 {
+    /// <summary>Passive session-wide HUD. The host returns JSON {session,hud}, or RefusePrefix.
+    /// Resolve and mutate together on the UI thread; do not change focus, terminal input or geometry.</summary>
+    string SessionHud(string? target, string action, HudSpec? spec)
+        => RefusePrefix + "session HUD is unavailable in this host";
     /// <summary>Marker a host puts in front of a verb's result to mean "refused, and here is why" —
     /// the control server turns it into an ok:false error. Needed where the host returns a string
     /// rather than a bool, so a refusal cannot be mistaken for a result.</summary>

--- a/src/Agwinterm.Pty/SessionHuds.cs
+++ b/src/Agwinterm.Pty/SessionHuds.cs
@@ -1,0 +1,98 @@
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+
+namespace Agwinterm.Pty;
+
+public sealed record HudSpec(string Message, string? Detail, string Spinner, string? BackgroundColor,
+    string? TextColor, int? SizePercent, string Position);
+
+/// <summary>Host-independent HUD validation, read-back and bounded nine-anchor geometry.</summary>
+public static class SessionHuds
+{
+    public const int MaxTextLength = 256;
+    public static readonly string[] Positions = ["top-left", "top-center", "top-right", "center-left",
+        "center", "center-right", "bottom-left", "bottom-center", "bottom-right"];
+    public static readonly string[] Spinners = ["none", "bar", "braille", "circle", "blocks", "dot"];
+    public static readonly JsonSerializerOptions JsonOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+    public static bool TryParse(string action, JsonElement args, out HudSpec? spec, out string? error)
+    {
+        spec = null; error = null;
+        if (action is not ("open" or "update" or "close")) { error = "hud: expected open, update or close"; return false; }
+        if (args.ValueKind is not (JsonValueKind.Object or JsonValueKind.Undefined))
+        { error = "hud: args must be an object"; return false; }
+        var values = new Dictionary<string, string>(StringComparer.Ordinal);
+        int? width = null;
+        if (args.ValueKind == JsonValueKind.Object)
+        foreach (var field in args.EnumerateObject())
+        {
+            if (action == "close") { error = "hud close takes no display options"; return false; }
+            if (field.Name == "size-percent")
+            {
+                var raw = field.Value.ValueKind == JsonValueKind.String ? field.Value.GetString() : field.Value.GetRawText();
+                if (!int.TryParse(raw, NumberStyles.None, CultureInfo.InvariantCulture, out int n) || n is < 1 or > 100)
+                { error = "hud: size-percent must be a whole number in 1..100"; return false; }
+                width = Math.Clamp(n, 10, 80); continue;
+            }
+            if (field.Name is not ("message" or "detail" or "spinner" or "color" or "text-color" or "position"))
+            { error = "hud: unknown option '" + field.Name + "'"; return false; }
+            if (field.Value.ValueKind != JsonValueKind.String)
+            { error = "hud: '" + field.Name + "' must be text"; return false; }
+            values[field.Name] = field.Value.GetString()!;
+        }
+        if (action == "close") return true;
+        string Read(string key, string fallback = "") => values.GetValueOrDefault(key, fallback);
+        string message = Read("message"), detail = Read("detail");
+        if (string.IsNullOrWhiteSpace(message)) { error = "hud requires a nonblank message"; return false; }
+        foreach (var value in new[] { message, detail })
+        {
+            if (value.Any(char.IsControl)) { error = "hud text must not contain control characters"; return false; }
+            // Normalize validates UTF-16 too; malformed Unicode is a refusal, never a render exception.
+            try
+            {
+                if (value.Normalize().EnumerateRunes().Count() > MaxTextLength)
+                { error = "hud text exceeds 256 Unicode scalars"; return false; }
+            }
+            catch (ArgumentException) { error = "hud text is not valid Unicode"; return false; }
+        }
+        string position = Read("position", "center") switch { "top" => "top-center", "bottom" => "bottom-center", var p => p };
+        if (!Positions.Contains(position)) { error = "hud: invalid position; use " + string.Join('|', Positions) + " (top/bottom aliases accepted)"; return false; }
+        string spinner = Read("spinner", "none");
+        if (!Spinners.Contains(spinner)) { error = "hud: invalid spinner; use " + string.Join('|', Spinners); return false; }
+        foreach (string key in new[] { "color", "text-color" })
+        {
+            if (!values.TryGetValue(key, out string? color)) continue;
+            string digits = color.StartsWith('#') ? color[1..] : color;
+            if (digits.Length != 6 || !digits.All(char.IsAsciiHexDigit))
+            { error = "hud: " + key + " must be #rrggbb"; return false; }
+            values[key] = "#" + digits.ToLowerInvariant();
+        }
+        spec = new(message.Normalize(), string.IsNullOrEmpty(detail) ? null : detail.Normalize(), spinner,
+            values.GetValueOrDefault("color"), values.GetValueOrDefault("text-color"), width, position);
+        return true;
+    }
+
+    public static string Reply(string session, HudSpec? hud) => JsonSerializer.Serialize(new { session, hud }, JsonOptions);
+    public readonly record struct Box(float X, float Y, float Width, float Height);
+    public static Box Place(float x, float y, float width, float height, float neededWidth, float neededHeight, HudSpec spec)
+    {
+        width = Math.Max(0, width); height = Math.Max(0, height);
+        float w = spec.SizePercent is { } n ? width * n / 100 : Math.Clamp(neededWidth, width * .1f, width * .8f);
+        float h = Math.Clamp(neededHeight, 0, height * .8f);
+        int i = Array.IndexOf(Positions, spec.Position); if (i < 0) i = 4;
+        static float Offset(float extent, float size, int band) => band switch
+        { 0 => extent * .1f, 2 => extent * .9f - size, _ => (extent - size) / 2 };
+        return new(x + Offset(width, w, i % 3), y + Offset(height, h, i / 3), w, h);
+    }
+
+    public static string Frame(string spinner, long milliseconds)
+    {
+        string[] frames = spinner switch {
+            "bar" => ["|", "/", "-", "\\"], "braille" => ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"],
+            "circle" => ["◐", "◓", "◑", "◒"], "blocks" => ["▁", "▃", "▄", "▅", "▆", "▇", "▆", "▅", "▄", "▃"],
+            "dot" => ["●", " "], _ => [""] };
+        int interval = spinner switch { "braille" or "blocks" => 80, "circle" => 120, "dot" => 450, _ => 100 };
+        return frames[(int)((Math.Max(0, milliseconds) / interval) % frames.Length)];
+    }
+}

--- a/src/Agwinterm.Pty/SessionHuds.cs
+++ b/src/Agwinterm.Pty/SessionHuds.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using System.Text;
 using System.Text.Json;
 
@@ -30,8 +29,7 @@ public static class SessionHuds
             if (action == "close") { error = "hud close takes no display options"; return false; }
             if (field.Name == "size-percent")
             {
-                var raw = field.Value.ValueKind == JsonValueKind.String ? field.Value.GetString() : field.Value.GetRawText();
-                if (!int.TryParse(raw, NumberStyles.None, CultureInfo.InvariantCulture, out int n) || n is < 1 or > 100)
+                if (field.Value.ValueKind != JsonValueKind.Number || !field.Value.TryGetInt32(out int n) || n is < 1 or > 100)
                 { error = "hud: size-percent must be a whole number in 1..100"; return false; }
                 width = Math.Clamp(n, 10, 80); continue;
             }
@@ -74,6 +72,26 @@ public static class SessionHuds
     }
 
     public static string Reply(string session, HudSpec? hud) => JsonSerializer.Serialize(new { session, hud }, JsonOptions);
+
+    public sealed record Target(string Id, string Name, IEnumerable<string> SurfaceIds);
+
+    /// <summary>HUD-only session routing, shared with the contract fake. Exact session IDs win;
+    /// other surface IDs never widen, and a prefix must identify one owning session's own ID.</summary>
+    public static string? ResolveTarget(string target, IEnumerable<Target> candidates, IEnumerable<string> standaloneIds)
+    {
+        if (string.IsNullOrEmpty(target)) return null;
+        var sessions = candidates.ToArray();
+        var standalone = standaloneIds.ToArray();
+        if (sessions.Any(s => s.Id == target)) return target;
+        if (sessions.Any(s => s.SurfaceIds.Contains(target)) || standalone.Contains(target)) return null;
+        var prefixes = sessions.Where(s => s.Id.StartsWith(target, StringComparison.Ordinal) ||
+            s.SurfaceIds.Any(id => id.StartsWith(target, StringComparison.Ordinal))).ToArray();
+        if (standalone.Any(id => id.StartsWith(target, StringComparison.Ordinal))) return null;
+        if (prefixes.Length != 0)
+            return prefixes.Length == 1 && prefixes[0].Id.StartsWith(target, StringComparison.Ordinal) ? prefixes[0].Id : null;
+        var named = sessions.Where(s => string.Equals(s.Name, target, StringComparison.OrdinalIgnoreCase)).ToArray();
+        return named.Length == 1 ? named[0].Id : null;
+    }
     public readonly record struct Box(float X, float Y, float Width, float Height);
     public static Box Place(float x, float y, float width, float height, float neededWidth, float neededHeight, HudSpec spec)
     {

--- a/src/Agwinterm.Win32/Program.Chrome.cs
+++ b/src/Agwinterm.Win32/Program.Chrome.cs
@@ -600,6 +600,7 @@ internal partial class Program
             _workspaces.Remove(ws);
             if (_workspaces.Count == 0) _workspaces.Add(new Workspace { Id = Guid.NewGuid().ToString(), Name = "workspace 1" });
         }
+        RefreshHudTimer(); // a removed workspace may have owned the last animated HUD
         foreach (var s in sessions) { try { s.S.Dispose(); } catch { } }
         if (hadActive)
         {

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -207,7 +207,7 @@ internal partial class Program
                         // panes and the slots ride on them, so `["right"]` becomes `["left"]` by
                         // construction. Empty = the server omits the key.
                         PaneOverlays: s.Panes.Select((p, i) => (p, i)).Where(t => t.p.Overlay.Term is not null)
-                                             .Select(t => OverlayPanes.Word(t.i)).ToList());
+                                             .Select(t => OverlayPanes.Word(t.i)).ToList(), Hud: s.Hud);
                 }).ToList()
             )).ToList();
     }
@@ -923,7 +923,7 @@ internal partial class Program
                     // close in an empty window is not contract-dependent on a session existing.
                     var ses = FindSesForTarget(target);
                     if (ses is null && !string.IsNullOrEmpty(target) && target != "active") return NoSessionRefusal;
-                    if (ses is null || ses.Overlay.Term is null) return "no overlay";
+                    if (ses is null || (ses.Overlay.Term is null && ses.Hud is null)) return "no overlay";
                     PostVerb(() => CloseOverlayOf(ses));
                     return "closed";
                 }

--- a/src/Agwinterm.Win32/Program.Hud.cs
+++ b/src/Agwinterm.Win32/Program.Hud.cs
@@ -1,0 +1,114 @@
+using System.Globalization;
+using System.Numerics;
+using Agwinterm.Pty;
+using Vortice.Direct2D1;
+using Vortice.DirectWrite;
+using Vortice.Mathematics;
+using static Agwinterm.Win32.Win32;
+
+namespace Agwinterm.Win32;
+
+internal partial class Program
+{
+    private const int HudTimer = 14;
+
+    public string SessionHud(string? target, string action, HudSpec? spec) => InvokeOnUiQueued(() =>
+    {
+        // Session identity must be explicit if a split/auxiliary pane was named. A HUD is not
+        // a pane overlay and has no PTY id of its own. Resolve/check/write in this same UI hop.
+        var ses = FindSesForTarget(target);
+        if (ses is null) return ISessionHost.RefusePrefix + "hud: no session matches that target";
+        if (string.IsNullOrEmpty(target) || target == "active")
+        {
+            if (_cover is not null) return ISessionHost.RefusePrefix + "hud: active surface is a cover; pass the session id";
+        }
+        else if (FindControlPane(target) is { } resolved &&
+                 (!ses.Panes.Contains(resolved.pane) ||
+                  (ses.Panes.Count > 1 && target != ses.Id && !ses.Id.StartsWith(target, StringComparison.Ordinal) &&
+                   ses.Panes.Any(p => p.Id == target || p.Id.StartsWith(target, StringComparison.Ordinal)))))
+            return ISessionHost.RefusePrefix + "hud: target names a pane or cover; pass the owning session id";
+
+        if (action == "close") ClearHud(ses); // never touches a program overlay
+        else
+        {
+            if (ses.Overlay.Term is not null) return ISessionHost.RefusePrefix + "hud: a program overlay occupies the slot";
+            if (action == "update" && ses.Hud is null) return ISessionHost.RefusePrefix + "hud: no HUD to update";
+            if (spec is null) return ISessionHost.RefusePrefix + "hud: missing message specification";
+            lock (_workspaces) ses.Hud = action == "update" ? spec with { BackgroundColor = ses.Hud!.BackgroundColor } : spec;
+            RefreshHudTimer(); RequestRedraw();
+        }
+        return SessionHuds.Reply(ses.Id, ses.Hud);
+    });
+
+    private void ClearHud(Ses ses)
+    {
+        if (ses.Hud is null) return;
+        lock (_workspaces) ses.Hud = null;
+        RefreshHudTimer(); RequestRedraw();
+    }
+
+    private void RefreshHudTimer()
+    {
+        bool spinning;
+        lock (_workspaces) spinning = _workspaces.Any(w => w.Sessions.Any(s => s.Hud is { Spinner: not "none" }));
+        if (spinning) SetTimer(_hwnd, (IntPtr)HudTimer, 80, IntPtr.Zero);
+        else KillTimer(_hwnd, (IntPtr)HudTimer);
+    }
+
+    private void HudTick()
+    {
+        if (!_dashboardOpen && _cover is null && _active?.Hud is { Spinner: not "none" }) RequestRedraw();
+    }
+
+    private void DrawHud(ID2D1HwndRenderTarget rt, ID2D1SolidColorBrush brush, HudSpec hud)
+    {
+        var (x, y, w, h) = ContentArea();
+        if (w < 2 || h < 2) return;
+        float spinnerWidth = hud.Spinner == "none" ? 0 : 24;
+        float maxWidth = Math.Max(1, w * .8f - 24 - spinnerWidth);
+        using var measure = _dwrite.CreateTextLayout(hud.Message, _uiFont, maxWidth, 10000);
+        measure.WordWrapping = WordWrapping.Wrap;
+        float naturalWidth = measure.Metrics.Width;
+        if (hud.Detail is { } detail)
+        {
+            using var detailMeasure = _dwrite.CreateTextLayout(detail, _uiSmall, maxWidth, 10000);
+            detailMeasure.WordWrapping = WordWrapping.Wrap;
+            naturalWidth = Math.Max(naturalWidth, detailMeasure.Metrics.Width);
+        }
+        var initial = SessionHuds.Place(x, y, w, h, naturalWidth + 24 + spinnerWidth, 0, hud);
+        float textWidth = Math.Max(1, initial.Width - 24 - spinnerWidth);
+        using var title = _dwrite.CreateTextLayout(hud.Message, _uiFont, textWidth, 10000);
+        title.WordWrapping = WordWrapping.Wrap; title.ParagraphAlignment = ParagraphAlignment.Near;
+        using var subtitle = _dwrite.CreateTextLayout(hud.Detail ?? "", _uiSmall, textWidth, 10000);
+        subtitle.WordWrapping = WordWrapping.Wrap; subtitle.ParagraphAlignment = ParagraphAlignment.Near;
+        float titleHeight = title.Metrics.Height;
+        float detailHeight = hud.Detail is null ? 0 : subtitle.Metrics.Height + 6;
+        var box = SessionHuds.Place(x, y, w, h, naturalWidth + 24 + spinnerWidth, titleHeight + detailHeight + 24, hud);
+        var rect = new Rect(box.X, box.Y, box.Width, box.Height);
+        rt.PushAxisAlignedClip(rect, AntialiasMode.PerPrimitive);
+        try
+        {
+            static Color4 ColorOf(string? hex, Color4 fallback)
+            {
+                if (hex is null) return fallback;
+                uint n = uint.Parse(hex.AsSpan(1), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+                return new Color4(((n >> 16) & 255) / 255f, ((n >> 8) & 255) / 255f, (n & 255) / 255f, 1);
+            }
+            brush.Color = ColorOf(hud.BackgroundColor, C4(_theme.DefaultBackground));
+            rt.FillRectangle(rect, brush);
+            brush.Color = ChromeAccent; rt.DrawRectangle(rect, brush, 1);
+            var fg = ColorOf(hud.TextColor, C4(_theme.DefaultForeground));
+            brush.Color = fg;
+            if (spinnerWidth > 0)
+                rt.DrawText(SessionHuds.Frame(hud.Spinner, Environment.TickCount64), _uiFont,
+                    new Rect(box.X + 10, box.Y + 12, spinnerWidth, titleHeight), brush, DrawTextOptions.Clip);
+            rt.DrawTextLayout(new Vector2(box.X + 12 + spinnerWidth, box.Y + 12), title, brush, DrawTextOptions.Clip);
+            if (hud.Detail is not null)
+            {
+                brush.Color = WithA(fg, .75f);
+                rt.DrawTextLayout(new Vector2(box.X + 12 + spinnerWidth, box.Y + 18 + titleHeight), subtitle, brush, DrawTextOptions.Clip);
+            }
+        }
+        finally { rt.PopAxisAlignedClip(); }
+    }
+}

--- a/src/Agwinterm.Win32/Program.Hud.cs
+++ b/src/Agwinterm.Win32/Program.Hud.cs
@@ -16,18 +16,16 @@ internal partial class Program
     {
         // Session identity must be explicit if a split/auxiliary pane was named. A HUD is not
         // a pane overlay and has no PTY id of its own. Resolve/check/write in this same UI hop.
-        var ses = FindSesForTarget(target);
+        var ses = target is null or "active" ? _active : FindSessionByExactId(
+            SessionHuds.ResolveTarget(target, AllSessions().Select(s => new SessionHuds.Target(s.Id, s.Name,
+                s.Panes.Select(p => p.Id).Concat(s.Panes.Select(p => p.Overlay.Term?.Id).OfType<string>())
+                    .Concat(new[] { s.Scratch?.Id, s.Overlay.Term?.Id }.OfType<string>()))),
+                new[] { _quick?.Id }.OfType<string>()) ?? "");
         if (ses is null) return ISessionHost.RefusePrefix + "hud: no session matches that target";
-        if (string.IsNullOrEmpty(target) || target == "active")
+        if (target is null or "active")
         {
             if (_cover is not null) return ISessionHost.RefusePrefix + "hud: active surface is a cover; pass the session id";
         }
-        else if (FindControlPane(target) is { } resolved &&
-                 (!ses.Panes.Contains(resolved.pane) ||
-                  (ses.Panes.Count > 1 && target != ses.Id && !ses.Id.StartsWith(target, StringComparison.Ordinal) &&
-                   ses.Panes.Any(p => p.Id == target || p.Id.StartsWith(target, StringComparison.Ordinal)))))
-            return ISessionHost.RefusePrefix + "hud: target names a pane or cover; pass the owning session id";
-
         if (action == "close") ClearHud(ses); // never touches a program overlay
         else
         {

--- a/src/Agwinterm.Win32/Program.Input.cs
+++ b/src/Agwinterm.Win32/Program.Input.cs
@@ -128,7 +128,7 @@ internal partial class Program
             case "duplicate_session": DuplicateSession(_active); break;
             case "reopen_session": ReopenMostRecent(); break;
             case "new_workspace": CreateWorkspace(Guid.NewGuid().ToString(), null); break;
-            // Ctrl+Shift+W: the cover first (an overlay closes, scratch/quick hide), then the focused
+            // Ctrl+Shift+W: the cover first (an overlay closes, scratch/quick hide), then the HUD, then the focused
             // pane's own overlay (P5 — agterm's Cmd+W closes the overlay before it would close the pane),
             // then the pane.
             case "close_session": case "close_pane":

--- a/src/Agwinterm.Win32/Program.Input.cs
+++ b/src/Agwinterm.Win32/Program.Input.cs
@@ -134,6 +134,7 @@ internal partial class Program
             case "close_session": case "close_pane":
                 if (_coverKind == 3) CloseActiveOverlay();
                 else if (_cover is not null) HideCover();
+                else if (_active is { Hud: not null } hudOwner) ClearHud(hudOwner);
                 else if (FocusedPaneWithOverlay() is { } fpo) ClosePaneOverlay(_active!, fpo);
                 else CloseActivePane();
                 break;

--- a/src/Agwinterm.Win32/Program.Render.cs
+++ b/src/Agwinterm.Win32/Program.Render.cs
@@ -619,6 +619,7 @@ internal partial class Program
         // and title bar still render below.
         if (_dashboardOpen) DrawDashboard(rt, brush);
         else DrawWindowContent(rt, brush);
+        if (!_dashboardOpen && _cover is null && _active?.Hud is { } hud) DrawHud(rt, brush, hud);
         if (!_windowActive && _config.UnfocusedDim > 0)   // dim the content region when the window isn't focused
         {
             var (dx, dy, dw, dh) = ContentArea();

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -875,6 +875,7 @@ internal partial class Program
     /// The pane slots are <see cref="ClosePaneOverlay"/>'s.</summary>
     private void CloseOverlayOf(Ses ses)
     {
+        ClearHud(ses);
         var slot = ses.Overlay;
         var term = slot.Term;
         if (term is null) return;

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -871,7 +871,7 @@ internal partial class Program
         return id;
     }
 
-    /// <summary>Tear down a session's SESSION-WIDE overlay (hiding its cover if shown, disposing its PTY).
+    /// <summary>Clear the session-wide HUD/program-overlay slot. A program's cover is hidden and its PTY disposed.
     /// The pane slots are <see cref="ClosePaneOverlay"/>'s.</summary>
     private void CloseOverlayOf(Ses ses)
     {

--- a/src/Agwinterm.Win32/Program.WndProc.cs
+++ b/src/Agwinterm.Win32/Program.WndProc.cs
@@ -181,6 +181,7 @@ internal partial class Program
                 return IntPtr.Zero;
 
             case WM_TIMER:
+                if ((int)wParam == HudTimer) { HudTick(); return IntPtr.Zero; }
                 if ((int)wParam == 2) { _toastText = null; _toastTarget = null; KillTimer(hwnd, (IntPtr)2); InvalidateRect(hwnd, IntPtr.Zero, false); return IntPtr.Zero; }
                 if ((int)wParam == SelAutoTimer) { SelAutoscrollTick(); return IntPtr.Zero; }
                 if ((int)wParam == HoverTimer) { HoverTick(); return IntPtr.Zero; }

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -383,6 +383,7 @@ internal partial class Program : ISessionHost, IWindowHost
         // active. Per session, so another session's open cannot reset its exit. The per-PANE slots are
         // Pane.Overlay (P5); the type is the same.
         public readonly OverlaySlot Overlay = new();
+        public HudSpec? Hud;      // passive session-wide presentation, never restored or a PTY
         // Wave F2: per-session background watermark (a faint image drawn behind the terminal of every pane).
         public string? BgPath;      // absolute path to the copied image under AppDir\backgrounds (null = none)
         public int BgOpacity = 15;  // 0..100 (drawn opacity of the watermark)

--- a/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
+++ b/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
@@ -455,13 +455,14 @@ internal sealed class FakeSessionHost : ISessionHost
     public bool SessionReorder(string? target, string dir) => Find(target) is not null;
     public bool SessionToWorkspace(string? target, string workspace) { var s = Find(target); var w = FindWs(workspace); if (s is null || w is null) return false; Workspaces.First(x => x.Sessions.Contains(s)).Sessions.Remove(s); w.Sessions.Add(s); return true; }
     public bool SessionRename(string? target, string name) { var s = FindSes(target); if (s is null || string.IsNullOrWhiteSpace(name)) return false; s.Name = name; return true; }
-    // Real, not a stub: resolves as rename does (FindSes, so a cover id lands on its session and an
-    // unknown target is the app's "session not found"), stores what the server already validated,
-    // and replies with the value read back off the session — the app's InvokeOnUiQueued reply.
     public string SessionHud(string? target, string action, HudSpec? spec)
     {
-        var s = FindSes(target);
+        var all = Workspaces.SelectMany(w => w.Sessions).ToArray();
+        var id = target is null or "active" ? ActiveSess?.Id : SessionHuds.ResolveTarget(target,
+            all.Select(s => new SessionHuds.Target(s.Id, s.Name, s.PaneIds.Concat(s.CoverPanes.Select(c => c.Id)))), []);
+        var s = all.FirstOrDefault(s => s.Id == id);
         if (s is null) return ISessionHost.RefusePrefix + "hud: no session matches that target";
+        if ((target is null or "active") && (QuickVisible || s.Overlay)) return ISessionHost.RefusePrefix + "hud: active surface is a cover";
         if (action == "close") s.Hud = null;
         else
         {
@@ -472,6 +473,9 @@ internal sealed class FakeSessionHost : ISessionHost
         return SessionHuds.Reply(s.Id, s.Hud);
     }
 
+    // Real, not a stub: resolves as rename does (FindSes, so a cover id lands on its session and an
+    // unknown target is the app's "session not found"), stores what the server already validated,
+    // and replies with the value read back off the session — the app's InvokeOnUiQueued reply.
     public string SessionContext(string? target, string? context)
     {
         var s = FindSes(target);

--- a/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
+++ b/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
@@ -23,6 +23,7 @@ internal sealed class FakeSessionHost : ISessionHost
         /// <summary>session.context — what the app keeps in Ses.Context. Read back through the tree,
         /// so a test asserts a set the way a caller does and a refusal the way it must: unchanged.</summary>
         public string? Context;
+        public HudSpec? Hud;
         public int Notifications, PaneCount = 1, FocusedPane, OverlaySize;
         public List<double> Ratios = new() { 1.0 };
         /// <summary>The split's orientation — what the app keeps in Ses.Axis: one of <see cref="SplitAxes"/>'
@@ -319,7 +320,7 @@ internal sealed class FakeSessionHost : ISessionHost
                 Context: s.Context,
                 CapturedCommands: s.PaneIds.Select(id => s.Captured.TryGetValue(id, out var c) ? c : "").ToList(),   // the slot, "" = none, parallel to PaneIds
                 Axis: s.Axis,
-                PaneOverlays: s.PaneOverlayWords());   // the open pane slots as words; empty = the tree omits the key (P5)
+                PaneOverlays: s.PaneOverlayWords(), Hud: s.Hud);
         }).ToList())).ToList();
 
     public WindowStateSnapshot WindowState() =>
@@ -457,6 +458,20 @@ internal sealed class FakeSessionHost : ISessionHost
     // Real, not a stub: resolves as rename does (FindSes, so a cover id lands on its session and an
     // unknown target is the app's "session not found"), stores what the server already validated,
     // and replies with the value read back off the session — the app's InvokeOnUiQueued reply.
+    public string SessionHud(string? target, string action, HudSpec? spec)
+    {
+        var s = FindSes(target);
+        if (s is null) return ISessionHost.RefusePrefix + "hud: no session matches that target";
+        if (action == "close") s.Hud = null;
+        else
+        {
+            if (s.Overlay) return ISessionHost.RefusePrefix + "hud: a program overlay occupies the slot";
+            if (action == "update" && s.Hud is null) return ISessionHost.RefusePrefix + "hud: no HUD to update";
+            s.Hud = action == "update" ? spec! with { BackgroundColor = s.Hud!.BackgroundColor } : spec;
+        }
+        return SessionHuds.Reply(s.Id, s.Hud);
+    }
+
     public string SessionContext(string? target, string? context)
     {
         var s = FindSes(target);
@@ -783,7 +798,8 @@ internal sealed class FakeSessionHost : ISessionHost
         {
             case "close":
                 if (s is null) return named ? NoOverlaySession : "no overlay";
-                if (!s.Overlay) return "no overlay";
+                if (!s.Overlay && s.Hud is null) return "no overlay";
+                s.Hud = null;
                 s.Overlay = false; s.OverlaySize = 0; return "closed";
             case "resize":
                 if (s is null) return NoOverlaySession;
@@ -797,7 +813,7 @@ internal sealed class FakeSessionHost : ISessionHost
             default:
                 if (string.IsNullOrWhiteSpace(command)) return ISessionHost.RefusePrefix + "overlay open needs a command; nothing opened";
                 if (s is null) return NoOverlaySession;
-                s.Overlay = true; s.OverlaySize = sizePercent; return s.Id;
+                s.Hud = null; s.Overlay = true; s.OverlaySize = sizePercent; return s.Id;
         }
     }
 

--- a/tests/Agwinterm.Pty.Tests/RustPtyHostTests.cs
+++ b/tests/Agwinterm.Pty.Tests/RustPtyHostTests.cs
@@ -151,17 +151,20 @@ public class RustPtyHostTests : IDisposable
     {
         if (ExePath is null) return;
         using var client = Start();
-        // Non-interactive: the colour line, 14 scroll fillers and a READY marker are all produced by
-        // -Command — no typing, so no ConPTY input-echo races and no dependence on how fast an
-        // interactive PowerShell spins up on a cold runner (input typed while the shell initializes
-        // can be silently discarded; this starved the test on CI). Single-quoted so the argument
-        // carries no embedded double quotes through the host's command-line quoting.
-        const string script =
+        string gateName = @"Local\agwinterm-color-" + Guid.NewGuid().ToString("N");
+        using var outputGate = new EventWaitHandle(false, EventResetMode.ManualReset, gateName);
+        // Same create/attach barrier as ServerSessionTests (#258): synthetic output must start
+        // after the host installed the sink, not race its scheduling. No interactive input echo.
+        string script = $"$g=[Threading.EventWaitHandle]::OpenExisting('{gateName}'); if (-not $g.WaitOne(60000)) {{ exit 41 }}; $g.Dispose(); " +
             "$e=[char]27; Write-Host ($e+'[31mCOLORLINE'+$e+'[0m'); 1..14|%{'.'}; 'SCROLL-READY'; Start-Sleep 3600";
         string id = client.Create(Guid.NewGuid().ToString(), 60, 10, "powershell.exe",
                                   new[] { "-NoLogo", "-NoProfile", "-Command", script });
         using (var first = client.Attach(id))
+        {
+            Assert.True(WaitFor(() => client.List().Any(s => s.Id == id && s.Attached), 10000), "Rust host never attached the output sink");
+            outputGate.Set();
             Assert.Contains("SCROLL-READY", ReadUntil(first.Data, "SCROLL-READY", 60000));
+        }
         Thread.Sleep(300);   // small grace for the host emulator to ingest the final bytes
 
         using var second = client.Attach(id, repaint: true);

--- a/tests/Agwinterm.Pty.Tests/ServerSessionTests.cs
+++ b/tests/Agwinterm.Pty.Tests/ServerSessionTests.cs
@@ -178,15 +178,20 @@ public class ServerSessionTests : IDisposable
     public async Task Reattach_PreservesScrollbackColors()
     {
         string paneId = Guid.NewGuid().ToString();
-        var gen1 = _backend.Create(paneId, 60, 10);
-        // Non-interactive (same rationale as RustPtyHostTests): the colour line, scroll fillers and
-        // READY marker are all produced by -Command, so the test never depends on interactive
-        // typing echo or cold-start readline latency (both flaked on cold CI runners).
-        const string script =
+        using var gen1 = _backend.Create(paneId, 60, 10);
+        string gateName = @"Local\agwinterm-color-" + Guid.NewGuid().ToString("N");
+        using var outputGate = new EventWaitHandle(false, EventResetMode.ManualReset, gateName);
+        // Create starts the child BEFORE Attach installs its output sink. A fast -Command can
+        // otherwise emit the entire fixture into that gap (#258). Gate synthetic output on the
+        // host's Attached acknowledgement; no timing sleep or interactive command echo is involved.
+        string script = $"$g=[Threading.EventWaitHandle]::OpenExisting('{gateName}'); if (-not $g.WaitOne(60000)) {{ exit 41 }}; $g.Dispose(); " +
             "$e=[char]27; Write-Host ($e+'[31mCOLORLINE'+$e+'[0m'); 1..14|%{'.'}; 'SCROLL-READY'; Start-Sleep 3600";
         await gen1.StartAsync("powershell.exe", new[] { "-NoLogo", "-NoProfile", "-Command", script });
+        using (var probe = PtyHostClient.Connect(_appId))
+            Assert.True(WaitFor(() => probe.List().Any(s => s.Id == paneId && s.Attached), 10000), "host never attached the output sink");
+        outputGate.Set();
         Assert.True(WaitFor(() => GridText(gen1).Contains("SCROLL-READY"), 60000),
-                    "PS -Command output never reached the replica emulator");
+                    "gated PS output never reached the replica; exited=" + gen1.HasExited + "; grid:\n" + GridText(gen1));
         gen1.Detach();
 
         using var gen2 = (ServerSession)_backend.Create(paneId, 60, 10);

--- a/tests/Agwinterm.Pty.Tests/SessionHudTests.cs
+++ b/tests/Agwinterm.Pty.Tests/SessionHudTests.cs
@@ -1,0 +1,121 @@
+using System.Text.Json;
+using Agwinterm.Pty;
+namespace Agwinterm.Pty.Tests;
+
+public class SessionHudTests
+{
+    private static JsonElement Call(ControlServer server, string action, object? args = null, string target = "s1")
+        => JsonDocument.Parse(server.Dispatch(JsonSerializer.Serialize(new { cmd = "session.hud." + action, target, args = args ?? new { } }))).RootElement;
+    private static HudSpec Spec(string position = "center", int? width = null) => new("title", null, "none", null, null, width, position);
+    private static JsonElement Tree(ControlServer server) => JsonDocument.Parse(server.Dispatch("{\"cmd\":\"tree\"}"))
+        .RootElement.GetProperty("result").GetProperty("workspaces")[0].GetProperty("sessions")[0];
+
+    [Fact] public void OpenUpdateClose_ReadBackAndBackgroundLifetime()
+    {
+        var host = new FakeSessionHost(); var server = new ControlServer(host);
+        Assert.False(Tree(server).TryGetProperty("hud", out _));
+        Assert.True(Call(server, "open", new { message = "building", detail = "tests", spinner = "bar", color = "AaBBcc", position = "top" }).GetProperty("ok").GetBoolean());
+        var hud = Tree(server).GetProperty("hud");
+        Assert.Equal("top-center", hud.GetProperty("position").GetString());
+        Assert.Equal("#aabbcc", hud.GetProperty("backgroundColor").GetString());
+        Assert.Equal("bar", hud.GetProperty("spinner").GetString());
+        Assert.True(Call(server, "update", new { message = "ready", color = "#000000" }).GetProperty("ok").GetBoolean());
+        hud = Tree(server).GetProperty("hud");
+        Assert.Equal("#aabbcc", hud.GetProperty("backgroundColor").GetString());
+        Assert.Equal("center", hud.GetProperty("position").GetString());
+        Assert.Equal("none", hud.GetProperty("spinner").GetString());
+        Assert.Equal(JsonValueKind.Null, hud.GetProperty("detail").ValueKind);
+        Assert.True(Call(server, "close").GetProperty("ok").GetBoolean());
+        Assert.True(Call(server, "close").GetProperty("ok").GetBoolean());
+        Assert.False(Tree(server).TryGetProperty("hud", out _));
+        Assert.False(Call(server, "update", new { message = "not open" }).GetProperty("ok").GetBoolean());
+    }
+
+    [Theory]
+    [InlineData("{}")] [InlineData("{\"message\":\" \"}")]
+    [InlineData("{\"message\":1}")] [InlineData("{\"message\":\"a\\nb\"}")]
+    [InlineData("{\"message\":\"ok\",\"detail\":false}")]
+    [InlineData("{\"message\":\"ok\",\"spinner\":true}")]
+    [InlineData("{\"message\":\"ok\",\"spinner\":\"bad\"}")]
+    [InlineData("{\"message\":\"ok\",\"position\":\"north\"}")]
+    [InlineData("{\"message\":\"ok\",\"size-percent\":1.5}")]
+    [InlineData("{\"message\":\"ok\",\"size-percent\":101}")]
+    [InlineData("{\"message\":\"ok\",\"size-percent\":0}")]
+    [InlineData("{\"message\":\"ok\",\"size-percent\":null}")]
+    [InlineData("{\"message\":\"ok\",\"color\":\"#ffff\"}")]
+    [InlineData("{\"message\":\"ok\",\"text-color\":\"bad\"}")]
+    [InlineData("{\"message\":\"ok\",\"pane\":\"right\"}")]
+    [InlineData("{\"message\":\"ok\",\"window\":\"silently-ignored\"}")]
+    [InlineData("[]")]
+    public void InvalidUpdatePreservesLiveHud(string raw)
+    {
+        var host = new FakeSessionHost(); var server = new ControlServer(host);
+        Call(server, "open", new { message = "keep" });
+        using var args = JsonDocument.Parse(raw);
+        var result = Call(server, "update", args.RootElement);
+        Assert.False(result.GetProperty("ok").GetBoolean(), result.ToString());
+        Assert.Equal("keep", host.ActiveSess!.Hud!.Message);
+    }
+
+    [Fact] public void UnknownTargetAndProgramOverlayNeverMutate()
+    {
+        var host = new FakeSessionHost(); var server = new ControlServer(host);
+        Assert.False(Call(server, "open", new { message = "x" }, "missing").GetProperty("ok").GetBoolean());
+        host.ActiveSess!.Overlay = true;
+        Assert.False(Call(server, "open", new { message = "x" }).GetProperty("ok").GetBoolean());
+        Assert.True(Call(server, "close").GetProperty("ok").GetBoolean());
+        Assert.True(host.ActiveSess.Overlay); Assert.Null(host.ActiveSess.Hud);
+        Assert.False(Call(server, "close", new { message = "not ignored" }).GetProperty("ok").GetBoolean());
+    }
+
+    [Fact] public void UnicodeCeilingIsNormalizedScalarCount()
+    {
+        var server = new ControlServer(new FakeSessionHost());
+        Assert.True(Call(server, "open", new { message = string.Concat(Enumerable.Repeat("e\u0301", 256)) }).GetProperty("ok").GetBoolean());
+        Assert.True(Call(server, "open", new { message = string.Concat(Enumerable.Repeat("😀", 256)) }).GetProperty("ok").GetBoolean());
+        Assert.False(Call(server, "open", new { message = new string('x', 257) }).GetProperty("ok").GetBoolean());
+        Assert.False(Call(server, "open", new { message = "x", detail = new string('x', 257) }).GetProperty("ok").GetBoolean());
+    }
+
+    [Theory] [InlineData(1, 10)] [InlineData(50, 50)] [InlineData(100, 80)]
+    public void WidthReadBackIsEffective(int requested, int effective)
+    {
+        using var args = JsonDocument.Parse("{\"message\":\"x\",\"size-percent\":" + requested + "}");
+        Assert.True(SessionHuds.TryParse("open", args.RootElement, out var spec, out _));
+        Assert.Equal(effective, spec!.SizePercent);
+    }
+
+    [Fact] public void AllNineAnchorsRespectMarginsAndStayBounded()
+    {
+        for (int i = 0; i < 9; ++i)
+        foreach (float width in new[] { 0f, 1f, 25f, 800f })
+        foreach (float height in new[] { 0f, 1f, 15f, 600f })
+        {
+            var b = SessionHuds.Place(10, 20, width, height, width * .25f, height * .2f, Spec(SessionHuds.Positions[i]));
+            Assert.InRange(b.X, 10, 10 + width); Assert.InRange(b.Y, 20, 20 + height);
+            Assert.True(b.X + b.Width <= 10 + width + .001f); Assert.True(b.Y + b.Height <= 20 + height + .001f);
+            float expectedX = (i % 3) switch { 0 => .1f, 1 => .375f, _ => .65f };
+            Assert.Equal(10 + width * expectedX, b.X, 3);
+            var huge = SessionHuds.Place(0, 0, width, height, 9999, 9999, Spec(SessionHuds.Positions[i]));
+            Assert.Equal(width * .8f, huge.Width, 3); Assert.Equal(height * .8f, huge.Height, 3);
+        }
+    }
+
+    [Fact] public void EverySpinnerHasChangingFramesAndNoneIsStatic()
+    {
+        Assert.Equal("", SessionHuds.Frame("none", 2000));
+        foreach (var spinner in SessionHuds.Spinners.Where(s => s != "none"))
+            Assert.True(Enumerable.Range(0, 20).Select(i => SessionHuds.Frame(spinner, i * 100)).Distinct().Count() > 1);
+    }
+
+    [Theory]
+    [InlineData("\"target\":false")] [InlineData("\"target\":[]")]
+    [InlineData("\"window\":123")] [InlineData("\"window\":\"unavailable\"")]
+    public void MalformedOrUnsupportedRoutingNeverFallsBackToActive(string routing)
+    {
+        var host = new FakeSessionHost(); var server = new ControlServer(host);
+        var result = JsonDocument.Parse(server.Dispatch("{\"cmd\":\"session.hud.open\",\"args\":{\"message\":\"wrong\"}," + routing + "}"));
+        Assert.False(result.RootElement.GetProperty("ok").GetBoolean());
+        Assert.Null(host.ActiveSess!.Hud);
+    }
+}

--- a/tests/Agwinterm.Pty.Tests/SessionHudTests.cs
+++ b/tests/Agwinterm.Pty.Tests/SessionHudTests.cs
@@ -42,6 +42,7 @@ public class SessionHudTests
     [InlineData("{\"message\":\"ok\",\"size-percent\":101}")]
     [InlineData("{\"message\":\"ok\",\"size-percent\":0}")]
     [InlineData("{\"message\":\"ok\",\"size-percent\":null}")]
+    [InlineData("{\"message\":\"ok\",\"size-percent\":\"50\"}")]
     [InlineData("{\"message\":\"ok\",\"color\":\"#ffff\"}")]
     [InlineData("{\"message\":\"ok\",\"text-color\":\"bad\"}")]
     [InlineData("{\"message\":\"ok\",\"pane\":\"right\"}")]
@@ -111,11 +112,55 @@ public class SessionHudTests
     [Theory]
     [InlineData("\"target\":false")] [InlineData("\"target\":[]")]
     [InlineData("\"window\":123")] [InlineData("\"window\":\"unavailable\"")]
+    [InlineData("\"target\":\"\"")] [InlineData("\"window\":\"\"")]
     public void MalformedOrUnsupportedRoutingNeverFallsBackToActive(string routing)
     {
         var host = new FakeSessionHost(); var server = new ControlServer(host);
         var result = JsonDocument.Parse(server.Dispatch("{\"cmd\":\"session.hud.open\",\"args\":{\"message\":\"wrong\"}," + routing + "}"));
         Assert.False(result.RootElement.GetProperty("ok").GetBoolean());
         Assert.Null(host.ActiveSess!.Hud);
+    }
+
+    [Theory] [InlineData("open")] [InlineData("update")] [InlineData("close")]
+    public void PaneAndCoverIdsNeverWidenEvenAfterOriginalPaneCloses(string action)
+    {
+        var host = new FakeSessionHost(); var server = new ControlServer(host); var s = host.ActiveSess!;
+        Call(server, "open", new { message = "keep" });
+        s.AddPane(); string pane = s.PaneIds[1], cover = s.AddCoverPane();
+        foreach (var target in new[] { pane, pane[..5], cover })
+        {
+            Assert.False(Call(server, action, action == "close" ? null : new { message = "wrong" }, target).GetProperty("ok").GetBoolean());
+            Assert.Equal("keep", s.Hud!.Message);
+        }
+        s.RemovePane(0);
+        Assert.False(Call(server, action, action == "close" ? null : new { message = "wrong" }, pane).GetProperty("ok").GetBoolean());
+        Assert.Equal("keep", s.Hud!.Message);
+        Assert.True(Call(server, action, action == "close" ? null : new { message = "right" }, s.Id).GetProperty("ok").GetBoolean());
+    }
+
+    [Theory] [InlineData("open")] [InlineData("update")] [InlineData("close")]
+    public void AmbiguousOwnersRefuseWithoutChangingEitherSession(string action)
+    {
+        var host = new FakeSessionHost(); var server = new ControlServer(host);
+        var other = new FakeSessionHost.Sess { Id = "s10", Name = "other" }.Seed();
+        host.ActiveWs.Sessions.Add(other);
+        Call(server, "open", new { message = "first" }, "s1");
+        Call(server, "open", new { message = "second" }, "s10");
+        Assert.False(Call(server, action, action == "close" ? null : new { message = "wrong" }, "s").GetProperty("ok").GetBoolean());
+        Assert.Equal("first", host.ActiveSess!.Hud!.Message); Assert.Equal("second", other.Hud!.Message);
+        Assert.True(Call(server, "update", new { message = "named" }, "OTHER").GetProperty("ok").GetBoolean());
+        Assert.Equal("first", host.ActiveSess.Hud.Message); Assert.Equal("named", other.Hud.Message);
+    }
+
+    [Theory]
+    [InlineData("abc", "abc")] [InlineData("ab", "abc")] [InlineData("a", null)]
+    [InlineData("pane-a", null)] [InlineData("pane", null)] [InlineData("abc:scratch:x", null)]
+    [InlineData("first", "abc")] [InlineData("quick:x", null)] [InlineData("qui", null)]
+    [InlineData("missing", null)] [InlineData("", null)]
+    public void SessionSelectorMatrix(string target, string? expected)
+    {
+        SessionHuds.Target[] choices = [new("abc", "first", ["abc", "pane-a", "abc:scratch:x"]), new("axz", "second", ["axz", "pane-b"])];
+        Assert.Equal(expected, SessionHuds.ResolveTarget(target, choices, ["quick:x"]));
+        Assert.Null(SessionHuds.ResolveTarget("duplicate", [new("a", "duplicate", []), new("b", "duplicate", [])], []));
     }
 }

--- a/tests/integration/hud-ui.ps1
+++ b/tests/integration/hud-ui.ps1
@@ -1,0 +1,252 @@
+# Dedicated P13 fixture: private app-data, no clipboard/registry writes, exact owned job teardown.
+param([string]$Exe="$PSScriptRoot/../../src/Agwinterm.Win32/bin/x64/Release/net10.0-windows/win-x64/Agwinterm.Win32.exe",
+      [string]$TokenOwner=$env:AGWINTERM_TEST_OWNER,[switch]$Strict)
+$ErrorActionPreference='Stop'
+$PSNativeCommandUseErrorActionPreference=$false
+$root=[IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
+$run='hud-ui-'+(Get-Date -Format yyyyMMddTHHmmss)+'-'+[guid]::NewGuid().ToString('N').Substring(0,6)
+$artifact=Join-Path $root ".revmux/$run"
+New-Item -ItemType Directory $artifact|Out-Null
+Start-Transcript (Join-Path $artifact 'transcript.log')|Out-Null
+$hub='C:/Users/boris/AI/bin/suite-token.py';$lease=$null;$job=$null;$cleanup=$true;$checks=0;$failed=0
+function Check([string]$name,[bool]$ok,[string]$detail='') {
+    $script:checks++;if($ok){"PASS $name"}else{$script:failed++;"FAIL $name : $detail"}
+}
+try {
+    if(Test-Path $hub){
+        if([string]::IsNullOrWhiteSpace($TokenOwner)){throw 'Local HUD tests require -TokenOwner'}
+        $raw=& python $hub acquire --owner $TokenOwner --run $run --worktree $root --holder-pid $PID --purpose 'P13 private HUD UI acceptance'
+        $state=$raw|ConvertFrom-Json
+        if($LASTEXITCODE-ne 0 -or -not $state.ok){throw "Suite token unavailable: $raw"}
+        $lease=$state
+        $lease|ConvertTo-Json -Depth 5|Set-Content (Join-Path $artifact 'lease.json')
+    }elseif($env:CI-ne 'true'){throw 'No canonical suite token helper on local desktop'}
+    if(-not (Test-Path -LiteralPath $Exe)){throw "Build this worktree first: $Exe"}
+    Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+public sealed class HudOwnedJob {
+    [StructLayout(LayoutKind.Sequential)] struct IO { public ulong a,b,c,d,e,f; }
+    [StructLayout(LayoutKind.Sequential)] struct BASIC { public long a,b; public uint flags; public UIntPtr min,max; public uint active; public UIntPtr affinity; public uint priority,schedule; }
+    [StructLayout(LayoutKind.Sequential)] struct LIMIT { public BASIC basic; public IO io; public UIntPtr a,b,c,d; }
+    [StructLayout(LayoutKind.Sequential)] struct ACCOUNT { public long a,b,c,d; public uint faults,total,active,terminated; }
+    [StructLayout(LayoutKind.Sequential,CharSet=CharSet.Unicode)] struct STARTUP {
+        public int cb; public string reserved,desktop,title; public int x,y,w,h,xc,yc,fill,flags;
+        public short show,reserved2; public IntPtr reservedPtr,input,output,error;
+    }
+    [StructLayout(LayoutKind.Sequential)] struct PROCESS { public IntPtr process,thread; public uint pid,tid; }
+    [StructLayout(LayoutKind.Sequential)] public struct RECT { public int left,top,right,bottom; }
+    [StructLayout(LayoutKind.Sequential)] struct GUI { public int size,flags; public IntPtr active,focus,capture,menu,move,caret; public RECT rect; }
+    [DllImport("kernel32.dll",CharSet=CharSet.Unicode,SetLastError=true)] static extern IntPtr CreateJobObjectW(IntPtr a,string n);
+    [DllImport("kernel32.dll",SetLastError=true)] static extern bool SetInformationJobObject(IntPtr j,int c,ref LIMIT l,int n);
+    [DllImport("kernel32.dll",SetLastError=true)] static extern bool QueryInformationJobObject(IntPtr j,int c,out ACCOUNT a,int n,IntPtr r);
+    [DllImport("kernel32.dll",CharSet=CharSet.Unicode,SetLastError=true)] static extern bool CreateProcessW(string app,StringBuilder cmd,IntPtr pa,IntPtr ta,bool inherit,uint flags,IntPtr env,string cwd,ref STARTUP si,out PROCESS pi);
+    [DllImport("kernel32.dll",SetLastError=true)] static extern bool AssignProcessToJobObject(IntPtr j,IntPtr p);
+    [DllImport("kernel32.dll")] static extern uint ResumeThread(IntPtr t);
+    [DllImport("kernel32.dll")] static extern bool TerminateProcess(IntPtr p,uint e);
+    [DllImport("kernel32.dll")] static extern bool TerminateJobObject(IntPtr j,uint e);
+    [DllImport("kernel32.dll")] static extern uint WaitForSingleObject(IntPtr h,uint ms);
+    [DllImport("kernel32.dll")] static extern bool CloseHandle(IntPtr h);
+    [DllImport("user32.dll")] public static extern bool PostMessageW(IntPtr h,uint m,IntPtr w,IntPtr l);
+    [DllImport("user32.dll")] public static extern IntPtr SendMessageW(IntPtr h,uint m,IntPtr w,IntPtr l);
+    [DllImport("user32.dll")] public static extern bool GetClientRect(IntPtr h,out RECT r);
+    [DllImport("user32.dll")] public static extern bool PrintWindow(IntPtr h,IntPtr dc,uint f);
+    [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
+    [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h,out uint pid);
+    [DllImport("user32.dll")] static extern bool GetGUIThreadInfo(uint t,ref GUI info);
+    public static IntPtr InputWindow(IntPtr h,bool capture) {
+        uint pid;uint t=GetWindowThreadProcessId(h,out pid);var info=new GUI {size=Marshal.SizeOf<GUI>()};
+        if(!GetGUIThreadInfo(t,ref info))throw new Exception("GetGUIThreadInfo");return capture?info.capture:info.focus;
+    }
+    IntPtr job,process; public uint Pid { get; private set; }
+    public void Start(string exe,string args,string cwd) {
+        job=CreateJobObjectW(IntPtr.Zero,null); if(job==IntPtr.Zero)throw new Exception("CreateJobObject");
+        var limit=new LIMIT(); limit.basic.flags=0x2000; // kill-on-close, no breakaway permission
+        if(!SetInformationJobObject(job,9,ref limit,Marshal.SizeOf<LIMIT>()))throw new Exception("Job limits");
+        var si=new STARTUP { cb=Marshal.SizeOf<STARTUP>(),flags=1,show=4 }; // shown without activation
+        PROCESS pi;
+        if(!CreateProcessW(exe,new StringBuilder("\""+exe+"\" "+args),IntPtr.Zero,IntPtr.Zero,false,4,IntPtr.Zero,cwd,ref si,out pi))
+            throw new Exception("CreateProcess: "+Marshal.GetLastWin32Error());
+        process=pi.process; Pid=pi.pid;
+        try {
+            if(!AssignProcessToJobObject(job,process)) { TerminateProcess(process,1); throw new Exception("AssignProcessToJobObject"); }
+            if(ResumeThread(pi.thread)==uint.MaxValue)throw new Exception("ResumeThread");
+        } finally { CloseHandle(pi.thread); }
+    }
+    public uint Count() {
+        ACCOUNT a; if(!QueryInformationJobObject(job,1,out a,Marshal.SizeOf<ACCOUNT>(),IntPtr.Zero))throw new Exception("Job accounting");
+        return a.active;
+    }
+    public void Finish() {
+        if(job==IntPtr.Zero)return;
+        if(process!=IntPtr.Zero && WaitForSingleObject(process,5000)!=0)TerminateJobObject(job,1);
+        for(int i=0;i<100 && Count()!=0;i++)Thread.Sleep(100);
+        if(Count()!=0) { TerminateJobObject(job,1); for(int i=0;i<100 && Count()!=0;i++)Thread.Sleep(100); }
+        if(Count()!=0)throw new Exception("Owned job still contains live processes; retain suite token");
+        if(process!=IntPtr.Zero){CloseHandle(process);process=IntPtr.Zero;}
+        CloseHandle(job);job=IntPtr.Zero;
+    }
+    public static int[] Bounds(int[] pixels,int width,int color) {
+        int left=width,top=pixels.Length/width,right=-1,bottom=-1,count=0;
+        for(int i=0;i<pixels.Length;i++)if((pixels[i]&0xffffff)==color){int x=i%width,y=i/width;left=Math.Min(left,x);right=Math.Max(right,x);top=Math.Min(top,y);bottom=Math.Max(bottom,y);count++;}
+        return new[]{left,top,right,bottom,count};
+    }
+}
+'@
+    $pipe='p13-'+[guid]::NewGuid().ToString('N')
+    $appId='agwinterm-'+$run
+    $appDir=Join-Path ([Environment]::GetFolderPath('LocalApplicationData')) $appId
+    if(Test-Path -LiteralPath $appDir){throw 'Private app directory already exists'}
+    New-Item -ItemType Directory $appDir|Out-Null
+    # Every pane uses a harmless cmd /d shell: never the user's PowerShell profile or agent hooks.
+    @{default='HUD-test';profiles=@(@{name='HUD-test';command='cmd.exe';args=@('/d');cwd=$artifact})}|ConvertTo-Json -Depth 5|Set-Content (Join-Path $appDir 'profiles.json')
+    @('session-host = in-process','claude-update-check = false','update-check = false','fresh-env = false','copy-on-select = false')|Set-Content (Join-Path $appDir 'agwinterm.conf')
+    $savedEnv=@{}
+    foreach($name in 'AGWINTERM_APP_ID','AGWINTERM_PIPE','AGWINTERM_SESSION_ID','AGWINTERM_PANE_ID','AGWINTERM_DUMP','AGWINTERM_PERF','AGWINTERM_IMGLOG'){
+        $savedEnv[$name]=[Environment]::GetEnvironmentVariable($name)
+        [Environment]::SetEnvironmentVariable($name,$null)
+    }
+    $env:AGWINTERM_APP_ID=$appId+'-fallback'
+    $job=[HudOwnedJob]::new()
+    $job.Start([IO.Path]::GetFullPath($Exe),"--app-id $appId --pipe $pipe --no-restore",$root)
+    function Rpc([string]$verb,$params=@{},[string]$target='active',[switch]$AllowError){
+        $client=[IO.Pipes.NamedPipeClientStream]::new('.',$pipe,[IO.Pipes.PipeDirection]::InOut)
+        try {
+            $client.Connect(1500)
+            $writer=[IO.StreamWriter]::new($client);$writer.AutoFlush=$true
+            $reader=[IO.StreamReader]::new($client)
+            $writer.WriteLine((@{cmd=$verb;args=$params;target=$target}|ConvertTo-Json -Compress -Depth 8))
+            $read=$reader.ReadLineAsync();if(-not $read.Wait(15000)){throw 'HUD RPC deadline exceeded'}
+            $answer=$read.Result|ConvertFrom-Json
+            if($AllowError){return $answer}
+            if(-not $answer.ok){throw "$verb : $($answer.error)"};return $answer.result
+        }finally{$client.Dispose()}
+    }
+    $ready=$false
+    for($i=0;$i-lt 60;$i++){try{$null=Rpc 'ping';$ready=$true;break}catch{Start-Sleep -Milliseconds 200}}
+    if(-not $ready){throw 'Private app did not answer'}
+    if(Test-Path ($appDir+'-fallback')){throw 'App ignored --app-id'}
+    $proc=[Diagnostics.Process]::GetProcessById($job.Pid);$hwnd=[IntPtr]::Zero
+    for($i=0;$i-lt 50 -and $hwnd-eq [IntPtr]::Zero;$i++){$proc.Refresh();$hwnd=$proc.MainWindowHandle;if($hwnd-eq [IntPtr]::Zero){Start-Sleep -Milliseconds 100}}
+    [uint32]$windowPid=0;[void][HudOwnedJob]::GetWindowThreadProcessId($hwnd,[ref]$windowPid)
+    if($hwnd-eq [IntPtr]::Zero -or $windowPid-ne $job.Pid){throw 'No owned GUI handle'}
+    $session=[string](Rpc 'tree').workspaces[0].sessions[0].id
+    function Node([string]$id=$session){@((Rpc 'tree').workspaces|ForEach-Object sessions)|Where-Object id -eq $id|Select-Object -First 1}
+    function Shot([string]$name){
+        Start-Sleep -Milliseconds 160
+        $r=[HudOwnedJob+RECT]::new();[void][HudOwnedJob]::GetClientRect($hwnd,[ref]$r)
+        $bitmap=[Drawing.Bitmap]::new($r.right,$r.bottom)
+        $graphics=[Drawing.Graphics]::FromImage($bitmap)
+        try {
+            $dc=$graphics.GetHdc();try{if(-not [HudOwnedJob]::PrintWindow($hwnd,$dc,3)){throw 'PrintWindow failed'}}finally{$graphics.ReleaseHdc($dc)}
+            $bitmap.Save((Join-Path $artifact "$name.png"))
+            $rect=[Drawing.Rectangle]::new(0,0,$bitmap.Width,$bitmap.Height)
+            $bits=$bitmap.LockBits($rect,[Drawing.Imaging.ImageLockMode]::ReadOnly,[Drawing.Imaging.PixelFormat]::Format32bppArgb)
+            try {
+                $pixels=[int[]]::new($bitmap.Width*$bitmap.Height)
+                [Runtime.InteropServices.Marshal]::Copy($bits.Scan0,$pixels,0,$pixels.Length)
+                return ,([HudOwnedJob]::Bounds($pixels,$bitmap.Width,0x125a9f))
+            }finally{$bitmap.UnlockBits($bits)}
+        }finally{$graphics.Dispose();$bitmap.Dispose()}
+    }
+    $ctl=Join-Path $root 'src/Agwinterm.Ctl/bin/Release/net10.0-windows/agwintermctl.exe'
+    $null=& $ctl session hud --spinner 'CLI HUD' --detail 'private acceptance' --target $session --pipe $pipe --json
+    Check 'CLI default open accepts spinner before message' ($LASTEXITCODE-eq 0 -and (Node).hud.message-eq 'CLI HUD')
+    $null=Rpc 'session.hud.close' @{} $session
+    for($i=0;$i-lt 50 -and ([string](Rpc 'session.text' @{} $session))-notmatch '>'; $i++){Start-Sleep -Milliseconds 100}
+    $text=Rpc 'session.text' @{all=$true} $session;$metrics=Rpc 'session.metrics' @{} $session|ConvertTo-Json -Compress
+    $positions=@('top-left','top-center','top-right','center-left','center','center-right','bottom-left','bottom-center','bottom-right')
+    $focusBefore=[HudOwnedJob]::InputWindow($hwnd,$false)
+    $boxes=@()
+    foreach($position in $positions){
+        $null=Rpc 'session.hud.open' @{message='Building P13 — 中文';detail='HUD does not take keyboard focus';position=$position;color='#125a9f';'size-percent'=35} $session
+        Check "readback anchor $position" ((Node).hud.position-eq $position)
+        $b=Shot $position;$boxes+=,$b
+        Check "painted anchor $position" ($b[4]-gt 500)
+    }
+    Check 'nine placements have three increasing horizontal anchors' ($boxes[0][0]-lt $boxes[1][0] -and $boxes[1][0]-lt $boxes[2][0])
+    Check 'nine placements have three increasing vertical anchors' ($boxes[0][1]-lt $boxes[3][1] -and $boxes[3][1]-lt $boxes[6][1])
+    Check 'HUD never enters terminal text' ((Rpc 'session.text' @{all=$true} $session)-ceq $text)
+    Check 'HUD never resizes the terminal' ((Rpc 'session.metrics' @{} $session|ConvertTo-Json -Compress)-ceq $metrics)
+    Check 'HUD leaves window input focus unchanged' ([HudOwnedJob]::InputWindow($hwnd,$false)-eq $focusBefore)
+    $null=Rpc 'session.hud.update' @{message='Ready';'text-color'='#ffdd00'} $session
+    Check 'update replaces defaults but retains background' ((Node).hud.position-eq 'center' -and (Node).hud.backgroundColor-eq '#125a9f' -and (Node).hud.detail-eq $null)
+    $updatedBox=Shot 'updated'
+    # Copy-on-select is disabled in this private instance; the drag never writes the clipboard.
+    $mx=[int](($updatedBox[0]+$updatedBox[2])/2);$my=[int](($updatedBox[1]+$updatedBox[3])/2)
+    $point=($my-shl 16)-bor $mx
+    [void][HudOwnedJob]::SendMessageW($hwnd,0x201,[IntPtr]1,[IntPtr]$point)
+    Check 'mouse press through HUD reaches terminal selection capture' ([HudOwnedJob]::InputWindow($hwnd,$true)-eq $hwnd)
+    [void][HudOwnedJob]::SendMessageW($hwnd,0x202,[IntPtr]::Zero,[IntPtr]$point)
+    $null=Rpc 'selection.clear' @{} $session
+    $before=Node|ConvertTo-Json -Depth 6 -Compress
+    foreach($bad in @(@{message='x';position='north'},@{message="bad`nline"},@{message='x';'size-percent'=101},@{message='x';spinner=$true})){
+        $a=Rpc 'session.hud.update' $bad $session -AllowError
+        Check 'invalid update refuses and preserves live spec' (-not $a.ok -and (Node|ConvertTo-Json -Depth 6 -Compress)-ceq $before)
+    }
+    $sink=Join-Path $artifact 'typed-through.txt'
+    # ConPTY advertises win32-input mode. Pin this fixture to legacy char input before posting
+    # printable WM_CHAR and an actual Enter WM_KEYDOWN (WM_CHAR deliberately ignores controls).
+    $null=Rpc 'session.write' @{text=([string][char]27+'[?9001l')} $session
+    foreach($c in ("echo WORKED>`"$sink`"").ToCharArray()){[void][HudOwnedJob]::SendMessageW($hwnd,0x102,[IntPtr][int]$c,[IntPtr]1)}
+    [void][HudOwnedJob]::SendMessageW($hwnd,0x100,[IntPtr]13,[IntPtr]1)
+    for($i=0;$i-lt 50 -and -not (Test-Path $sink);$i++){Start-Sleep -Milliseconds 100}
+    Check 'posted human characters execute underneath HUD' ((Test-Path $sink) -and (Get-Content $sink -Raw).Trim()-eq 'WORKED')
+    $split=[string](Rpc 'session.split' @{op='on'} $session)
+    $a=Rpc 'session.hud.open' @{message='must refuse'} $split -AllowError
+    Check 'split-pane target refuses rather than widening' (-not $a.ok -and (Node).hud.message-eq 'Ready')
+    $null=Rpc 'session.hud.open' @{message='Whole split'} $session
+    Check 'session id still addresses whole split HUD' ((Node).hud.message-eq 'Whole split')
+    $paneOverlay=Rpc 'session.overlay' @{action='open';pane='left';command='cmd /d /k'} $session
+    Check 'pane overlay coexists under session HUD' ((Node).hud.message-eq 'Whole split' -and (Node).paneOverlays.Count-eq 1)
+    $null=Rpc 'session.overlay' @{action='close';pane='left'} $session
+    $other=[string](Rpc 'session.new' @{name='hud-background';'no-select'=$true})
+    for($i=0;$i-lt 50 -and $null-eq (Node $other);$i++){Start-Sleep -Milliseconds 50}
+    $null=Rpc 'session.hud.open' @{message='Background status';spinner='dot'} $other
+    Check 'background HUD targets only named session without selecting it' ((Node).active -and -not (Node $other).active -and (Node $other).hud.message-eq 'Background status')
+    $null=Rpc 'session.close' @{} $other
+    $null=Rpc 'session.scratch' @{op='on'} $session
+    $a=Rpc 'session.hud.open' @{message='wrong surface'} -AllowError
+    Check 'active auxiliary cover refuses HUD' (-not $a.ok)
+    $null=Rpc 'session.scratch' @{op='off'} $session
+    $overlay=Rpc 'session.overlay' @{action='open';command='cmd /d /k echo HUD-OVERLAY'} $session
+    Check 'program overlay replaces HUD' ($null-eq (Node).hud -and (Node).overlay)
+    $a=Rpc 'session.hud.open' @{message='must not replace program'} $session -AllowError
+    Check 'HUD cannot replace program overlay' (-not $a.ok -and (Node).overlay)
+    $null=Rpc 'session.hud.close' @{} $session
+    Check 'HUD close leaves program overlay alone' ([bool](Node).overlay)
+    $null=Rpc 'session.overlay' @{action='close'} $session
+    $null=Rpc 'session.hud.open' @{message='close through overlay'} $session
+    $null=Rpc 'session.overlay' @{action='close'} $session
+    for($i=0;$i-lt 50 -and $null-ne (Node).hud;$i++){Start-Sleep -Milliseconds 50}
+    Check 'overlay close removes passive HUD' ($null-eq (Node).hud)
+    $null=Rpc 'session.hud.close' @{} $session
+    Check 'close absent HUD is idempotent' ($null-eq (Node).hud)
+    $a=Rpc 'session.hud.close' @{} 'not-a-session' -AllowError
+    Check 'unknown close target refuses' (-not $a.ok)
+    $null=Rpc 'session.hud.open' @{message='transient';spinner='bar'} $session
+    Check 'HUD creates no extra terminal panes' ((Node).paneCount-eq 2)
+    $null=Rpc 'session.close' @{} $session
+    for($i=0;$i-lt 50 -and $null-ne (Node);$i++){Start-Sleep -Milliseconds 50}
+    Check 'session close removes HUD state' ($null-eq (Node))
+}catch{$failed++;"FAIL fixture: $($_.Exception.Message)"}
+finally {
+    if($job){
+        try{
+            if($hwnd){[void][HudOwnedJob]::PostMessageW($hwnd,0x10,[IntPtr]::Zero,[IntPtr]::Zero)}
+            $job.Finish();'Cleanup: owned job has zero live processes; no name-based cleanup.'
+        }catch{$cleanup=$false;"CLEANUP INCOMPLETE: $_"}
+    }
+    if($savedEnv){foreach($name in $savedEnv.Keys){[Environment]::SetEnvironmentVariable($name,$savedEnv[$name])}}
+    if($cleanup){'Clipboard/registry untouched; only private app-data retained for evidence; no queued launches.'}
+    if($lease -and $cleanup){
+        $raw=& python $hub release --owner $lease.owner --token $lease.token --cleanup-confirmed
+        $raw|Set-Content (Join-Path $artifact 'release.json');$raw
+        if($LASTEXITCODE-ne 0){$cleanup=$false}
+    }
+    "hud-ui: $checks checks, $failed failed; cleanup complete: $cleanup; artifacts $artifact"
+    Stop-Transcript|Out-Null
+}
+if(-not $cleanup){exit 2};if($failed){exit 1};exit 0

--- a/tests/integration/hud-ui.ps1
+++ b/tests/integration/hud-ui.ps1
@@ -60,7 +60,7 @@ public sealed class HudOwnedJob {
         uint pid;uint t=GetWindowThreadProcessId(h,out pid);var info=new GUI {size=Marshal.SizeOf<GUI>()};
         if(!GetGUIThreadInfo(t,ref info))throw new Exception("GetGUIThreadInfo");return capture?info.capture:info.focus;
     }
-    IntPtr job,process; public uint Pid { get; private set; }
+    IntPtr job,process; bool assigned; public uint Pid { get; private set; }
     public void Start(string exe,string args,string cwd) {
         job=CreateJobObjectW(IntPtr.Zero,null); if(job==IntPtr.Zero)throw new Exception("CreateJobObject");
         var limit=new LIMIT(); limit.basic.flags=0x2000; // kill-on-close, no breakaway permission
@@ -71,7 +71,8 @@ public sealed class HudOwnedJob {
             throw new Exception("CreateProcess: "+Marshal.GetLastWin32Error());
         process=pi.process; Pid=pi.pid;
         try {
-            if(!AssignProcessToJobObject(job,process)) { TerminateProcess(process,1); throw new Exception("AssignProcessToJobObject"); }
+            if(!AssignProcessToJobObject(job,process))throw new Exception("AssignProcessToJobObject");
+            assigned=true;
             if(ResumeThread(pi.thread)==uint.MaxValue)throw new Exception("ResumeThread");
         } finally { CloseHandle(pi.thread); }
     }
@@ -81,7 +82,10 @@ public sealed class HudOwnedJob {
     }
     public void Finish() {
         if(job==IntPtr.Zero)return;
-        if(process!=IntPtr.Zero && WaitForSingleObject(process,5000)!=0)TerminateJobObject(job,1);
+        if(process!=IntPtr.Zero && WaitForSingleObject(process,5000)!=0) {
+            if(assigned)TerminateJobObject(job,1);else TerminateProcess(process,1);
+            if(WaitForSingleObject(process,10000)!=0)throw new Exception("Owned primary process still live; retain suite token");
+        }
         for(int i=0;i<100 && Count()!=0;i++)Thread.Sleep(100);
         if(Count()!=0) { TerminateJobObject(job,1); for(int i=0;i<100 && Count()!=0;i++)Thread.Sleep(100); }
         if(Count()!=0)throw new Exception("Owned job still contains live processes; retain suite token");
@@ -103,6 +107,7 @@ public sealed class HudOwnedJob {
     # Every pane uses a harmless cmd /d shell: never the user's PowerShell profile or agent hooks.
     @{default='HUD-test';profiles=@(@{name='HUD-test';command='cmd.exe';args=@('/d');cwd=$artifact})}|ConvertTo-Json -Depth 5|Set-Content (Join-Path $appDir 'profiles.json')
     @('session-host = in-process','claude-update-check = false','update-check = false','fresh-env = false','copy-on-select = false')|Set-Content (Join-Path $appDir 'agwinterm.conf')
+    'map f12 = close_pane'|Set-Content (Join-Path $appDir 'keymap.conf')
     $savedEnv=@{}
     foreach($name in 'AGWINTERM_APP_ID','AGWINTERM_PIPE','AGWINTERM_SESSION_ID','AGWINTERM_PANE_ID','AGWINTERM_DUMP','AGWINTERM_PERF','AGWINTERM_IMGLOG'){
         $savedEnv[$name]=[Environment]::GetEnvironmentVariable($name)
@@ -152,8 +157,12 @@ public sealed class HudOwnedJob {
         }finally{$graphics.Dispose();$bitmap.Dispose()}
     }
     $ctl=Join-Path $root 'src/Agwinterm.Ctl/bin/Release/net10.0-windows/agwintermctl.exe'
-    $null=& $ctl session hud --spinner 'CLI HUD' --detail 'private acceptance' --target $session --pipe $pipe --json
-    Check 'CLI default open accepts spinner before message' ($LASTEXITCODE-eq 0 -and (Node).hud.message-eq 'CLI HUD')
+    $null=& $ctl session hud --spinner 'CLI HUD' --detail 'private acceptance' --size-percent 35 --target $session --pipe $pipe --json
+    Check 'CLI default open accepts spinner before message and numeric width' ($LASTEXITCODE-eq 0 -and (Node).hud.message-eq 'CLI HUD' -and (Node).hud.sizePercent-eq 35)
+    foreach($selector in 'target','window'){
+        $null=& $ctl session hud close "--$selector" '' --pipe $pipe --json
+        Check "CLI empty $selector refuses without clearing HUD" ($LASTEXITCODE-eq 2 -and (Node).hud.message-eq 'CLI HUD')
+    }
     $null=Rpc 'session.hud.close' @{} $session
     for($i=0;$i-lt 50 -and ([string](Rpc 'session.text' @{} $session))-notmatch '>'; $i++){Start-Sleep -Milliseconds 100}
     $text=Rpc 'session.text' @{all=$true} $session;$metrics=Rpc 'session.metrics' @{} $session|ConvertTo-Json -Compress
@@ -201,6 +210,8 @@ public sealed class HudOwnedJob {
     Check 'session id still addresses whole split HUD' ((Node).hud.message-eq 'Whole split')
     $paneOverlay=Rpc 'session.overlay' @{action='open';pane='left';command='cmd /d /k'} $session
     Check 'pane overlay coexists under session HUD' ((Node).hud.message-eq 'Whole split' -and (Node).paneOverlays.Count-eq 1)
+    [void][HudOwnedJob]::SendMessageW($hwnd,0x100,[IntPtr]123,[IntPtr]1) # private F12 binding: ordinary close action
+    Check 'ordinary close shortcut removes HUD but preserves panes and pane overlay' ($null-eq (Node).hud -and (Node).paneCount-eq 2 -and (Node).paneOverlays.Count-eq 1)
     $null=Rpc 'session.overlay' @{action='close';pane='left'} $session
     $other=[string](Rpc 'session.new' @{name='hud-background';'no-select'=$true})
     for($i=0;$i-lt 50 -and $null-eq (Node $other);$i++){Start-Sleep -Milliseconds 50}
@@ -228,6 +239,14 @@ public sealed class HudOwnedJob {
     Check 'unknown close target refuses' (-not $a.ok)
     $null=Rpc 'session.hud.open' @{message='transient';spinner='bar'} $session
     Check 'HUD creates no extra terminal panes' ((Node).paneCount-eq 2)
+    $survivor=Rpc 'session.split.close' @{} $session
+    foreach($action in 'open','update','close'){
+        $hudArgs=if($action-eq 'close'){@{}}else{@{message='wrong'}}
+        $answer=Rpc "session.hud.$action" $hudArgs $survivor -AllowError
+        Check "$action refuses surviving secondary pane id" (-not $answer.ok -and (Node).hud.message-eq 'transient')
+    }
+    $null=Rpc 'session.hud.update' @{message='session identity survives'} $session
+    Check 'owning session id remains usable without its original pane' ((Node).hud.message-eq 'session identity survives')
     $null=Rpc 'session.close' @{} $session
     for($i=0;$i-lt 50 -and $null-ne (Node);$i++){Start-Sleep -Milliseconds 50}
     Check 'session close removes HUD state' ($null-eq (Node))


### PR DESCRIPTION
## P13: passive session HUD

Implements the Wave-3 agwinterm batch: `session.hud.open/update/close`, CLI shorthand, nine anchors, detail, five spinner styles, colors and bounded width. Native rendering creates no terminal/helper and leaves typing, mouse selection, focus and terminal geometry unchanged. Includes strict validation, tree readback and program-overlay lifecycle rules.

Lite's mirror remains P17; no canonical shared-contract expansion or release/tag.

## Gates

- Release build passed; 49 HUD dispatcher/layout/validation tests passed.
- Full Core+Pty on fix head: 246 + 750 passed, 0 skipped. Initial candidate encountered tracked #118 native test-host AV locally; its single retry and CI passed. Fix-head local tests passed first attempt.
- Owned-process Win32 fixture: 51/51 checks passed, including nine painted placements, typing/click-through, split/background/cover targeting, ordinary close shortcut, surviving secondary pane refusal and overlay lifecycle.
- Local run `hud-ui-20260909T145331-16e2fa` (sources committed unchanged as `28853d1`): owned primary exited and job zero live processes, no queued launches, clipboard/registry untouched; canonical suite-token generation 100 released after proof. Screenshots inspected.
- Broad Codex-only revmux: 4/4 sources, no degradation. Three major targeting defects and six minor items addressed in one fix commit; one immaterial API-encapsulation item deferred. Detailed disposition in PR comment. Claude is unavailable; no cross-vendor review claimed.
- Narrow Codex-only confirmation passed: 2/2 reviewers, zero findings, no degradation. Both examined the frozen fix diff and related code; no third review round.
- Both CI attempts at `28853d1` passed all integration (HUD 51/51) but failed the same #258 readiness assertion. No further blind rerun: test-only `61907c8` gates both C#/Rust color-fixture emissions until their own host data sink is Attached. Detach/adopt and attributed-history assertions remain unchanged. [Investigation and residual production concern](https://github.com/yeroo/agwinterm/issues/258#issuecomment-5601717249).
- Built the Rust host locally, then verified both affected tests, five further repetitions each (10/10), and full Core246/Pty750. Earlier local runs without that binary did not exercise Rust-host tests; CI always builds it.
- The extra narrow Codex-only review of this CI blocker passed: 2/2 reviewers, no findings or degradation. [Exact-head CI at `61907c8`](https://github.com/yeroo/agwinterm/actions/runs/34350293176) passed all gates, including conformance, existing Win32 integration, HUD51, Core246 and Pty750. No check bypass or test weakening.

Plan: `docs/plans/2026-09-09-p13-session-hud.md`. API: `docs/session-hud.md`.
