### PR TITLE
feat: detached quick terminal and opt-in global hotkey (P14)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,11 @@ jobs:
         timeout-minutes: 5
         run: ./tests/integration/hud-ui.ps1 -Strict
 
+      - name: Detached quick terminal integration
+        shell: pwsh
+        timeout-minutes: 5
+        run: ./tests/integration/hud-ui.ps1 -Suite Quick -Strict
+
       - name: Test (Core + Pty)
         # One retry for the known .NET 10 test-host #118 pathology under named-pipe churn, which
         # manifests two ways: a native CRASH ("Test Run Aborted") OR a DEADLOCK that hangs the run

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A Windows homage to [umputun's **agterm**](https://github.com/umputun/agterm).
 
 agwinterm exists because of **[umputun](https://github.com/umputun)** and his terminal
 **[agterm](https://github.com/umputun/agterm)**. agterm's design — a terminal that treats AI coding
-agents as first-class citizens, with per-session status, a sidebar of workspaces, a quick terminal,
+agents as first-class citizens, with per-session status, a sidebar of workspaces, a [detached quick terminal](docs/quick-terminal.md),
 and a language-agnostic control socket — is the blueprint this project follows on Windows.
 
 This is an **independent, from-scratch implementation** written in C# on a native Win32/Direct2D

--- a/docs/plans/2026-09-09-p14-quick-terminal.md
+++ b/docs/plans/2026-09-09-p14-quick-terminal.md
@@ -1,0 +1,42 @@
+# P14 — detached quick terminal
+
+Authority: Boris requested P14, P15, P16 and P17 sequentially on 2026-09-09.
+Codex owns implementation and merge during Claude's outage. Base: ae4d52c (P13).
+Next: P15 navigation/keymap polish, P16 control.pick, P17 lite mirror; each starts
+after its predecessor's exact-head tests/review/CI and merge. No release/install.
+
+## Contract
+
+- One lazy, app-level, non-restored quick shell in a detached tool window, not a
+  library window. Normal windows, their geometry and their PTY sizes are untouched.
+- `quick-terminal-size = 70` controls both dimensions, 40–90 percent of the usable
+  monitor area under the pointer. Read on show and live size changes. DPI-aware.
+- Ctrl+backtick, toolbar, and keymap `quick_terminal` toggle this same panel.
+  Human summons dismiss on blur; API `quick on` pins it without taking focus. Hiding keeps
+  the shell; shell exit discards it; closing the last library window disposes it.
+- `quick-terminal-hotkey =` is opt-in with no default reservation. Accept one
+  Ctrl/Alt (optional Shift) chord with letter/digit, F1–F11 or backtick. No Win,
+  F12, unmodified or Shift-only chords. Register with MOD_NOREPEAT, once per app.
+  Live registration conflicts refuse without changing the old binding/config;
+  startup conflicts show a warning. Unregister at shutdown. No hooks or forced
+  foreground workarounds; Windows may decline focus to background API callers.
+- `--window quick` addresses the auxiliary surface once created; no quick entry
+  is persisted or returned by the library list. Normal window read-back reports
+  the shared panel's visibility. A quick shell inherits this explicit window
+  selector, not a fabricated library identity.
+
+Source: upstream agterm v0.26.0 `agterm/Views/QuickTerminal.swift` (detached,
+app-level, pointer monitor, human blur/control pin), adapted to Windows.
+Win32 constraints: [RegisterHotKey](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-registerhotkey),
+[SetForegroundWindow](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setforegroundwindow).
+
+## Acceptance / safety
+
+Parser/config bounds and geometry unit checks; owned-window integration for
+singleton identity, screen sizing, no normal-window resize, hide/show shell
+survival, close/exit, live hotkey conflict preservation/release and pin/blur.
+Actual foreground/key injection is disposable CI only. Local GUI tests require
+the canonical suite token and retained kill-on-close job ownership proof.
+One Codex-only broad revmux, batch substantive findings, narrow confirmation
+only when needed; exact-head green CI then normal PR merge. Do not defer bugs
+that violate the contract; do not churn additional rounds on cosmetic minors.

--- a/docs/quick-terminal.md
+++ b/docs/quick-terminal.md
@@ -1,0 +1,46 @@
+# Quick terminal
+
+P14 detaches the quick shell from the main window. There is one per app, shared
+by all library windows. Ctrl+backtick, the Quick toolbar button, a `quick_terminal`
+keymap action, and an optional global chord toggle the same panel. Human summons
+dismiss when focus moves elsewhere; hiding keeps the shell and working directory.
+Closing the shell discards it; the next summon starts a fresh shell in home.
+Closing the last library window disposes the quick shell. It is never restored.
+
+```text
+quick-terminal-size = 70
+quick-terminal-hotkey = ctrl+alt+backtick
+```
+
+Size is 40–90% of both usable monitor dimensions, centered on the monitor under
+the pointer. It does not resize normal sessions. The Appearance settings slider
+and `config set quick-terminal-size 60` apply live. Out-of-range live writes refuse;
+hand-edited numeric values clamp when loading the config.
+
+The global hotkey defaults to empty: no system chord is claimed until enabled.
+It accepts Ctrl/Alt (optional Shift) with a letter, digit, F1–F11 or `backtick`.
+Win, F12, unmodified and Shift-only chords are refused. Conflicts refuse without
+changing the current binding or saved value; startup conflicts warn. Empty disables
+and releases the binding. Holding the key does not repeatedly toggle the panel.
+
+`agwintermctl quick on|off|toggle` controls visibility. API shows stay pinned and
+do **not** take keyboard focus. A human summon requests focus through normal Windows
+policy; the app does not override the OS's foreground restrictions.
+
+```powershell
+agwintermctl quick on
+agwintermctl session type "echo hello`r" --window quick --target active
+agwintermctl session text --window quick --target active
+agwintermctl quick off
+```
+
+`--window quick` addresses the auxiliary host, not a library window. Its shell
+inherits that selector and its unique `quick:...` pane id. Explicit quick pane ids
+or the `quick:` prefix route content verbs to the same host from normal windows.
+Text/input/selection/images/font/read-only and config verbs work there; workspace,
+split, restore and normal-window UI mutations refuse rather than creating a hidden
+session tree. `window.state.quickTerminalVisible` reports shared visibility from
+any window. `window list` never includes the auxiliary host.
+
+P17 will mirror this shipped contract to lite; the shared conformance floor is
+unchanged until that mirror. No clipboard or registry policy is changed by P14.

--- a/docs/quick-terminal.md
+++ b/docs/quick-terminal.md
@@ -37,7 +37,9 @@ agwintermctl quick off
 `--window quick` addresses the auxiliary host, not a library window. Its shell
 inherits that selector and its unique `quick:...` pane id. Explicit quick pane ids
 or the `quick:` prefix route content verbs to the same host from normal windows.
-Text/input/selection/images/font/read-only and config verbs work there; workspace,
+Text/input/selection/images/font/search/read-only and config verbs work there;
+surface-local keymap actions (including leader bindings) and custom commands in
+`send` or `detached` mode work too. Workspace,
 split, restore and normal-window UI mutations refuse rather than creating a hidden
 session tree. `window.state.quickTerminalVisible` reports shared visibility from
 any window. `window list` never includes the auxiliary host.

--- a/qa/p14-quick-terminal.md
+++ b/qa/p14-quick-terminal.md
@@ -1,0 +1,51 @@
+# P14 acceptance and review record
+
+Initial revision: `7a758dc` (base `ae4d52c`). Codex owns this batch and merge.
+Plan: [P14](../docs/plans/2026-09-09-p14-quick-terminal.md).
+
+## Independent review
+
+Archive: `.revmux/tasks/feat-p14-quick-terminal/01-initial/` in the P14 worktree.
+Profile `codex-only`; runner, four reviewers, synthesis and verification all Codex.
+4 expected / 4 reported, no degraded source; each produced findings and used tools.
+Verified result: 5 Major, 8 Minor, 1 Immaterial. No open questions/pre-existing list.
+
+One fix batch, not repeated broad/polish rounds:
+
+- bugs+impl-1: atomic same-directory config replacement; failed writes preserve old bytes.
+- bugs+impl-2: quick DPI changes update render scale without scaling its physical frame twice.
+- arch+quality-1, docs+tests-2: retain actual old OS registration through persistence;
+  failed persistence releases only provisional registration. Track rare failed cleanup.
+- arch+quality-2: surface-local keymaps, leader bindings and send/detached custom commands
+  remain usable; tree-dependent actions refuse/notify instead of creating hidden sessions.
+- adversarial-2: config writes use the exception-propagating queued UI bridge.
+- bugs+impl-3, docs+tests-1: active quick font targeting uses its surface, not a library session.
+- bugs+impl-4: keyboard scrollback derives its page size from ActiveSurface.
+- adversarial-3: system caret follows the quick surface, despite no library session.
+- docs+tests-3: disposable-CI two-window singleton/survivor check and shutdown hotkey check.
+- docs+tests-5/6: teardown/render comments corrected while touching those functions.
+- Immaterial arch+quality-4: removed the unused forwarding helper in the same batch.
+
+Author checks also cover owned-modal focus, key-up cleanup, final-row hit-testing,
+font-family regrid, and the existing CI capture's new explicit quick-window routing.
+
+## Tests before focused confirmation
+
+- Initial Core 265, Pty 761 passed (includes 19 new Core / 11 protocol checks).
+- Fix batch Core 265, Pty 760 passed; one fake-only command.run refusal case replaced
+  by the real-window send/new-mode checks after enabling surface-local commands.
+- Initial private quick fixture: 32/32; HUD regression: 51/51.
+- Fix private quick fixture: 47/47, including save failure with valid and invalid
+  desired prior bindings, exact bytes preserved, native reservations, font/search,
+  keymap/custom command, posted logical DPI/focus, caret, exit and shutdown.
+- A new search fixture initially failed because an emulator-injected marker could be
+  overwritten by pending ConPTY resize output. It now waits for real shell output.
+- Actual OS hotkey injection, focus loss and two-library-window tests are CI-only;
+  never injected on Boris's shared desktop. Local DPI/focus checks are explicitly logical.
+
+Latest local receipts: token 103 (32 quick), 104 (51 HUD), 105 (43 quick),
+106 (46/47, failed marker check), 107 (47 quick). All released after retained-job
+proof of zero live processes and exact temporary hotkey cleanup. Clipboard and
+registry untouched. Private app-data and transcripts retained, no queued launches.
+
+Focused review and exact-head CI remain merge gates; neither is claimed complete here.

--- a/qa/p14-quick-terminal.md
+++ b/qa/p14-quick-terminal.md
@@ -48,4 +48,21 @@ Latest local receipts: token 103 (32 quick), 104 (51 HUD), 105 (43 quick),
 proof of zero live processes and exact temporary hotkey cleanup. Clipboard and
 registry untouched. Private app-data and transcripts retained, no queued launches.
 
-Focused review and exact-head CI remain merge gates; neither is claimed complete here.
+## Focused confirmation and final send guard
+
+Round `02-after-fix` reviewed `7a758dc...d87314f`: 2/2 healthy Codex sources,
+2 confirmed Majors, no other findings/questions. Both expose send-command false success:
+no quick shell, or a read-only surface. One guard in RunCommandText now refuses either
+before Send, on normal and quick windows; write exceptions already propagate through
+the queued API bridge. Keymap commands display the refusal. Regression coverage includes
+lazy/closed quick, named/raw readonly sends, a subsequent accepted-write fence and the
+normal-window readonly path. A further narrow round is justified by this delivery blocker,
+not cosmetic residue.
+
+`d87314f` passed [CI](https://github.com/yeroo/agwinterm/actions/runs/34357718306):
+conformance and Win32 integration, HUD 51, quick 51, Core 265 and Pty 760.
+The send-guard candidate built cleanly and passed 53/53 local quick checks; token 108
+was released after zero owned processes and exact hotkey cleanup. Evidence:
+`.revmux/quick-ui-20260909T165817-a9963b`. Narrow review and exact-head CI remain gates.
+The pre-existing process-wide UIA provider limitation is tracked in
+[#267](https://github.com/yeroo/agwinterm/issues/267); full quick UIA parity is not claimed.

--- a/src/Agwinterm.Core/QuickTerminal.cs
+++ b/src/Agwinterm.Core/QuickTerminal.cs
@@ -1,0 +1,41 @@
+namespace Agwinterm.Core;
+
+/// <summary>Platform-neutral quick-panel policy; modifiers use the Win32 hotkey bit values.</summary>
+public readonly record struct QuickHotkey(uint Modifiers, uint Key)
+{
+    public static bool TryParse(string text, out QuickHotkey chord)
+    {
+        chord = default;
+        if (string.IsNullOrWhiteSpace(text)) return true; // disabled
+        var parts = text.Trim().ToLowerInvariant().Split('+', StringSplitOptions.TrimEntries);
+        uint mods = 0;
+        for (int i = 0; i < parts.Length - 1; i++)
+        {
+            uint bit = parts[i] switch { "alt" => 1u, "ctrl" => 2u, "shift" => 4u, _ => 0u };
+            if (bit == 0 || (mods & bit) != 0) return false;
+            mods |= bit;
+        }
+        if ((mods & 3) == 0) return false;
+        string key = parts[^1];
+        uint vk = key.Length == 1 && (key[0] is >= 'a' and <= 'z' or >= '0' and <= '9')
+            ? char.ToUpperInvariant(key[0])
+            : key == "backtick" ? 0xC0u
+            : key.StartsWith('f') && int.TryParse(key.AsSpan(1), out int f) && f is >= 1 and <= 11
+                ? (uint)(0x6F + f) : 0;
+        if (vk == 0) return false;
+        chord = new(mods, vk);
+        return true;
+    }
+}
+
+public static class QuickTerminalGeometry
+{
+    public const int DefaultPercent = 70;
+    public static (int X, int Y, int Width, int Height) Frame(int x, int y, int width, int height, int percent)
+    {
+        int p = Math.Clamp(percent, 40, 90);
+        int w = Math.Max(1, (int)((long)Math.Max(1, width) * p / 100));
+        int h = Math.Max(1, (int)((long)Math.Max(1, height) * p / 100));
+        return (x + (width - w) / 2, y + (height - h) / 2, w, h);
+    }
+}

--- a/src/Agwinterm.Core/TerminalConfig.cs
+++ b/src/Agwinterm.Core/TerminalConfig.cs
@@ -196,6 +196,8 @@ public sealed class TerminalConfig
     public bool ShowSplitButton { get; set; } = true;
     public bool ShowDashboardButton { get; set; } = true;
     public bool ShowQuickButton { get; set; } = true;
+    public int QuickTerminalSize { get; set; } = QuickTerminalGeometry.DefaultPercent;
+    public string QuickTerminalHotkey { get; set; } = "";
 
     /// <summary>Show the title-bar attention bell (hidden entirely when off). On by default.</summary>
     public bool AttentionButton { get; set; } = true;
@@ -381,6 +383,12 @@ public sealed class TerminalConfig
         show-split-button = true
         show-dashboard-button = true
         show-quick-button = true
+
+        # Detached quick terminal: percent of the pointer monitor's usable width and height (40..90).
+        quick-terminal-size = 70
+        # Optional SYSTEM-WIDE shortcut; empty claims nothing. Example: ctrl+alt+backtick.
+        # Ctrl/Alt required; optional Shift; letter/digit, F1..F11 or backtick. No Win or F12.
+        quick-terminal-hotkey =
         attention-button = true
 
         # Terminal bell (BEL, 0x07): audible (system beep) | visual (brief window flash) | both | none.
@@ -472,6 +480,8 @@ public sealed class TerminalConfig
                 case "show-split-button": cfg.ShowSplitButton = ParseBool(val, cfg.ShowSplitButton); break;
                 case "show-dashboard-button": cfg.ShowDashboardButton = ParseBool(val, cfg.ShowDashboardButton); break;
                 case "show-quick-button": cfg.ShowQuickButton = ParseBool(val, cfg.ShowQuickButton); break;
+                case "quick-terminal-size": if (int.TryParse(val, out var qp)) cfg.QuickTerminalSize = Math.Clamp(qp, 40, 90); break;
+                case "quick-terminal-hotkey": cfg.QuickTerminalHotkey = val; break;
                 case "attention-button": cfg.AttentionButton = ParseBool(val, cfg.AttentionButton); break;
                 case "status-color-active": if (val.Length > 0) cfg.StatusColorActive = val; break;
                 case "status-color-blocked": if (val.Length > 0) cfg.StatusColorBlocked = val; break;

--- a/src/Agwinterm.Pty/AgentSkill.cs
+++ b/src/Agwinterm.Pty/AgentSkill.cs
@@ -180,7 +180,7 @@ public static class AgentSkill
 
         ## Scratch & quick terminals
         - `agwintermctl session scratch on|off|toggle [--target <id>]` — a per-session extra shell drawn over that session's content (opens in the session's cwd; stays alive when hidden; not restored)
-        - `agwintermctl quick on|off|toggle`                     — the window's single throwaway shell, dropped over the active session (opens in the home dir; stays alive when hidden; not restored)
+        - `agwintermctl quick on|off|toggle` — one app-level detached shell (home dir; stays alive when hidden; not restored). API shows stay pinned without taking focus; human toggles dismiss on blur. `--window quick --target active` addresses its surface. `quick-terminal-size` is 40–90% of the pointer monitor's work area; `quick-terminal-hotkey` is opt-in, empty by default. See `docs/quick-terminal.md`.
 
         ## Overlays (run a program over a session — or over ONE pane of it — ephemerally)
         The rule, quoted from `ISessionHost.SessionOverlay` (the CLI header quotes it too):

--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -204,6 +204,16 @@ public sealed class ControlServer : IDisposable
             if (windowSel is not null && _windows is not null && _windows.ResolveWindow(windowSel) is null)
                 return Err("window not found: " + windowSel);
 
+            host = host.AuxiliaryTarget(target) ?? host;
+
+            if (host.IsQuickSurface && cmd is not ("quick" or "window.state" or "tree"
+                or "session.write" or "session.type" or "session.text" or "session.copy" or "session.status"
+                or "session.metrics" or "surface.cursor" or "font" or "selection.all" or "selection.clear"
+                or "selection.copy" or "selection.finalize" or "session.paste" or "session.readonly"
+                or "config.get" or "config.list" or "config.set"
+                or "image.show" or "image.sixel" or "image.clear" or "image.frame" or "image.frameshm"))
+                return Err("quick terminal has no workspace/session tree; target a library window for this command");
+
             switch (cmd)
             {
                 case "tree": return HandleTree(host);
@@ -299,7 +309,11 @@ public sealed class ControlServer : IDisposable
                 case "keymap.reload": return Ok(host.KeymapReload());
                 case "restore.clear": return Ok(host.RestoreClear());
                 case "restore.capture": return HandleRestoreCapture(host, target);
-                case "config.set": return Ok(host.ConfigSet(GetString(args, "key") ?? "", GetString(args, "value") ?? ""));
+                case "config.set":
+                    {
+                        string reply = host.ConfigSet(GetString(args, "key") ?? "", GetString(args, "value") ?? "");
+                        return reply.StartsWith("error:", StringComparison.Ordinal) ? Err(reply[6..].TrimStart()) : HostReply(reply);
+                    }
                 case "config.get": return Ok(host.ConfigGet(GetString(args, "key") ?? ""));
                 case "config.list": return Ok(host.ConfigList());
                 case "settings.open": return Ok(host.SettingsOpen());
@@ -327,7 +341,12 @@ public sealed class ControlServer : IDisposable
                 case "session.paste": return HostReply(host.SessionPaste(target, GetString(args, "text")));
                 case "session.search": return Ok(host.SessionSearch(target, GetString(args, "query"), GetString(args, "action")));
                 case "session.scratch": return host.SessionScratch(target, GetString(args, "op") ?? "toggle") ? Ok("scratch") : Err("session not found");
-                case "quick": host.Quick(GetString(args, "op") ?? "toggle"); return Ok("quick");
+                case "quick":
+                    {
+                        string op = GetString(args, "op") ?? "toggle";
+                        if (op is not ("on" or "off" or "toggle")) return Err("quick: op must be on, off or toggle");
+                        host.Quick(op); return Ok("quick");
+                    }
                 case "session.overlay": return HandleSessionOverlay(host, target, args);   // the guards and their order: see the method
                 case "notify":
                     return host.Notify(target, GetString(args, "title"), GetString(args, "body") ?? "")

--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -210,7 +210,7 @@ public sealed class ControlServer : IDisposable
                 or "session.write" or "session.type" or "session.text" or "session.copy" or "session.status"
                 or "session.metrics" or "surface.cursor" or "font" or "selection.all" or "selection.clear"
                 or "selection.copy" or "selection.finalize" or "session.paste" or "session.readonly"
-                or "config.get" or "config.list" or "config.set"
+                or "config.get" or "config.list" or "config.set" or "session.search" or "command.run"
                 or "image.show" or "image.sixel" or "image.clear" or "image.frame" or "image.frameshm"))
                 return Err("quick terminal has no workspace/session tree; target a library window for this command");
 
@@ -378,7 +378,7 @@ public sealed class ControlServer : IDisposable
                     {
                         string? nameOrCmd = GetString(args, "name") ?? GetString(args, "command");
                         if (string.IsNullOrWhiteSpace(nameOrCmd)) return Err("command.run needs args.name or args.command");
-                        return Ok(host.CommandRun(nameOrCmd!, GetString(args, "mode")));
+                        return HostReply(host.CommandRun(nameOrCmd!, GetString(args, "mode")));
                     }
                 case "command.list": return Ok(host.CommandList());
                 case "command.leader": return Ok(host.CommandLeader(GetString(args, "op") ?? "state"));

--- a/src/Agwinterm.Pty/ISessionHost.cs
+++ b/src/Agwinterm.Pty/ISessionHost.cs
@@ -72,6 +72,10 @@ public sealed record PaneMetricsSnapshot(int Cols, int Rows, int CellWidth, int 
 /// </summary>
 public interface ISessionHost
 {
+    /// <summary>A detached quick surface has no workspace/library tree to mutate.</summary>
+    bool IsQuickSurface => false;
+    /// <summary>Route an explicit app-level auxiliary pane id to its detached owner, if any.</summary>
+    ISessionHost? AuxiliaryTarget(string? target) => null;
     /// <summary>Passive session-wide HUD. The host returns JSON {session,hud}, or RefusePrefix.
     /// Resolve and mutate together on the UI thread; do not change focus, terminal input or geometry.</summary>
     string SessionHud(string? target, string action, HudSpec? spec)

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -390,6 +390,11 @@ internal partial class Program
         int delta = op switch { "inc" => 1, "dec" => -1, _ => 0 }; // reset otherwise
         if (string.IsNullOrEmpty(target) || target == "active")
         {
+            if (_isQuickWindow) return InvokeOnUiQueued(() =>
+            {
+                if (ActiveSurface() is not { } p) return false;
+                ZoomPane((p, null, true), delta); return true;
+            });
             var ses = Find(target);
             if (ses is null) return false;
             PostVerb(() => ChangeFontSizeOf(ses, delta));
@@ -668,7 +673,7 @@ internal partial class Program
 
     public string KeymapReload() { PostVerb(ReloadKeymap); return "keymap reload requested"; }
 
-    public string ConfigSet(string key, string value) => InvokeOnUi(() => ConfigSetInternal(key, value));
+    public string ConfigSet(string key, string value) => InvokeOnUiQueued(() => ConfigSetInternal(key, value));
     public string ConfigGet(string key) => InvokeOnUi(() => ConfigValue(key.Trim().ToLowerInvariant()));
     public string ConfigList() => InvokeOnUi(() => string.Join("\n", ConfigKeys.Select(k => $"{k} = {ConfigValue(k)}")));
     public string SettingsOpen() { PostVerb(OpenSettingsWindow); return "settings opened"; }
@@ -826,7 +831,7 @@ internal partial class Program
     // searches the active session.)
     public string SessionSearch(string? target, string? query, string? action) => InvokeOnUi(() =>
     {
-        if (_active is null) return "no session";
+        if (ActiveSurface() is null) return "no session";
         if (action == "close") { CloseSearch(); return "closed"; }
         if (!_searchActive) _searchActive = true;
         if (!string.IsNullOrEmpty(query)) { _searchQuery = query!; RecomputeSearch(); _searchCur = 0; ScrollToMatch(); }
@@ -845,7 +850,7 @@ internal partial class Program
         return true;
     }
 
-    public void Quick(string op) => PostVerb(() => QuickOp(op, control: true));
+    public void Quick(string op) => InvokeOnUiQueued(() => { QuickOp(op, control: true); return 0; });
 
     /// <summary>An overlay covers a whole SESSION. When the caller named one pane of a split, that
     /// is not what they asked for - say so rather than widen it in silence and blank the pane the
@@ -1392,13 +1397,14 @@ internal partial class Program
 
     public string SessionSwitch(string op) => InvokeOnUi(() => SwitchOp(op));
 
-    public string CommandRun(string nameOrCommand, string? mode) => InvokeOnUi(() =>
+    public string CommandRun(string nameOrCommand, string? mode) => InvokeOnUiQueued(() =>
     {
         var cmd = _commands.FirstOrDefault(c => string.Equals(c.Label, nameOrCommand, StringComparison.OrdinalIgnoreCase));
         string text = cmd?.Text ?? nameOrCommand;
         // A configured command uses its mode unless overridden; a raw command defaults to a new session.
         string useMode = mode ?? cmd?.Mode ?? "new";
         string expanded = RunCommandText(text, useMode);
+        if (expanded.StartsWith(ISessionHost.RefusePrefix, StringComparison.Ordinal)) return expanded;
         return $"{useMode}: {expanded}";
     });
 

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -17,11 +17,15 @@ namespace Agwinterm.Win32;
 /// <summary>Control-API host: the IWindowHost + ISessionHost bridges the control server drives.</summary>
 internal partial class Program
 {
+    public bool IsQuickSurface => _isQuickWindow;
+    public ISessionHost? AuxiliaryTarget(string? target) => target?.StartsWith("quick:", StringComparison.Ordinal) == true
+        && _quickHost?._quick is { } q && q.Id.StartsWith(target, StringComparison.Ordinal) ? _quickHost : null;
     // ---- IWindowHost bridge (Wave F1b): app-level window management for the control API. Content
     // verbs resolve through ResolveWindow(--window); window.* verbs act on the library. These use
     // static library state + Frontmost, so they work regardless of which instance the server holds. ----
     public ISessionHost? ResolveWindow(string? selector)
     {
+        if (selector == "quick") return _quickHost;
         if (string.IsNullOrEmpty(selector) || selector == "active") return Frontmost;
         return ResolveOpen(selector);
     }
@@ -218,7 +222,7 @@ internal partial class Program
         var a = _active;
         return new WindowStateSnapshot(
             SidebarVisible: _sidebarW > 0, Fullscreen: _fullscreen, Maximized: IsZoomed(_hwnd),
-            QuickTerminalVisible: _coverKind == 2 && _cover is not null && ReferenceEquals(_cover, _quick),
+            QuickTerminalVisible: _quickHost?._quickVisible == true,
             // ActiveSession is the NAME; session.context is not a name and is not folded in — it is read from the tree (P3).
             ActiveWorkspace: a?.Ws.Name, ActiveSession: a is null ? null : (a.CustomName ?? a.Name));
     }
@@ -841,7 +845,7 @@ internal partial class Program
         return true;
     }
 
-    public void Quick(string op) => PostVerb(() => QuickOp(op));
+    public void Quick(string op) => PostVerb(() => QuickOp(op, control: true));
 
     /// <summary>An overlay covers a whole SESSION. When the caller named one pane of a split, that
     /// is not what they asked for - say so rather than widen it in silence and blank the pane the

--- a/src/Agwinterm.Win32/Program.Input.cs
+++ b/src/Agwinterm.Win32/Program.Input.cs
@@ -202,7 +202,12 @@ internal partial class Program
         => System.Threading.Tasks.Task.Run(() => { string r = installer(); Post(() => ShowToast(r)); });
 
     /// <summary>Run a configured custom command per its mode (send|new|overlay|detached), expanding {AGW_*}.</summary>
-    private void RunCustomCommand(Keymap.CmdDef cmd) => RunCommandText(cmd.Text, cmd.Mode);
+    private void RunCustomCommand(Keymap.CmdDef cmd)
+    {
+        string result = RunCommandText(cmd.Text, cmd.Mode);
+        if (result.StartsWith(ISessionHost.RefusePrefix, StringComparison.Ordinal))
+            ShowToast(result[ISessionHost.RefusePrefix.Length..]);
+    }
 
     /// <summary>Run an arbitrary command string in a mode, expanding {AGW_*} tokens and injecting $AGW_*
     /// env from the active session. Returns the expanded command line (for the control API / observability).</summary>
@@ -227,6 +232,14 @@ internal partial class Program
                 RunDetached(expanded, CommandCwd(ctx), AgwEnv(ctx));
                 break;
             default: // send — type it into the active session, as if the user typed it + Enter
+                // Send's human-key path may quietly reject input. A command acknowledgement must
+                // instead report that refusal, for library and quick surfaces alike. These checks
+                // and Send run together on the UI thread; an exit/write race throws through the
+                // queued CommandRun bridge and becomes an API error, not a successful empty write.
+                var surface = ActiveSurface();
+                if (surface is null || _session is null || surface.S.HasExited)
+                    return ISessionHost.RefusePrefix + "no live pane for send command";
+                if (surface.ReadOnly) return ISessionHost.RefusePrefix + "pane is read-only";
                 Send(expanded.Replace("\r", "").Replace("\n", "") + "\r");
                 break;
         }

--- a/src/Agwinterm.Win32/Program.Input.cs
+++ b/src/Agwinterm.Win32/Program.Input.cs
@@ -1158,7 +1158,7 @@ internal partial class Program
         // F1 help overlay: modal while open; plain F1 opens it from the shell prompt (full-screen
         // TUIs on the alt screen — Far, vim — keep their own F1).
         if (_helpOpen) return HelpKey(vk);
-        if (vk == 0x70 /* F1 */ && !ctrl && !alt && !shift)
+        if (!_isQuickWindow && vk == 0x70 /* F1 */ && !ctrl && !alt && !shift)
         {
             var helpSurf = ActiveSurface();
             bool altScreen = helpSurf is not null && helpSurf.S.Emulator.IsAltScreen;
@@ -1166,13 +1166,13 @@ internal partial class Program
         }
 
         // Dashboard grid overlay (agterm #202): Ctrl+Shift+D toggles it; while open it owns the keyboard.
-        if (ctrl && shift && !alt && vk == 0x44 /* D */) { ToggleDashboard(); return true; }
+        if (!_isQuickWindow && ctrl && shift && !alt && vk == 0x44 /* D */) { ToggleDashboard(); return true; }
         if (_dashboardOpen) return DashboardKey(vk);
 
         // Focus zones (F6): the sidebar zone owns the keyboard while active; plain F6 from the terminal
         // lifts focus out to the sidebar (the accessible "leave the terminal" gesture).
         if (_chromeFocus) return SidebarZoneKey(vk);
-        if (vk == 0x75 /* F6 */ && !ctrl && !alt && !shift) { EnterChromeFocus(); return true; }
+        if (!_isQuickWindow && vk == 0x75 /* F6 */ && !ctrl && !alt && !shift) { EnterChromeFocus(); return true; }
 
         // Leader/prefix sequence (tmux-style). When pending, the next chord resolves against the leader
         // bindings; Esc / timeout cancels; modifier-only keydowns stay pending. Checked before the normal
@@ -1189,7 +1189,7 @@ internal partial class Program
                 return true;
             }
         }
-        if (_leader is not null && Keymap.ChordFor(vk, ctrl, alt, shift) == _leader) { BeginLeader(); return true; }
+        if (!_isQuickWindow && _leader is not null && Keymap.ChordFor(vk, ctrl, alt, shift) == _leader) { BeginLeader(); return true; }
 
         // Shift+PageUp/PageDown (and Home/End) scroll this pane's scrollback; never reach the PTY.
         if (shift && !ctrl && !alt && _active is not null)
@@ -1238,7 +1238,7 @@ internal partial class Program
         // Ctrl+Tab / Ctrl+Shift+Tab drive the MRU session walk (needs WM_KEYUP to commit, so it lives
         // here rather than the keymap dispatch). Honoured only while the chord is still bound to the
         // session-cycle action (default) — a user rebind of the chord falls through to keymap dispatch.
-        if (ctrl && !alt && vk == VK_TAB)
+        if (!_isQuickWindow && ctrl && !alt && vk == VK_TAB)
         {
             string mruChord = shift ? "ctrl+shift+tab" : "ctrl+tab";
             if (!_keymap.TryGetValue(mruChord, out var mruAct) || mruAct is "next_session" or "previous_session")
@@ -1250,6 +1250,8 @@ internal partial class Program
         string? chord = Keymap.ChordFor(vk, ctrl, alt, shift);
         if (chord is not null && _keymap.TryGetValue(chord, out var action))
         {
+            if (_isQuickWindow && action is not ("quick_terminal" or "close_cover" or "close_pane" or "close_session"
+                or "select_all" or "copy_selection" or "paste" or "mark_mode")) return true;
             // close_cover only applies while a cover is up, or the focused pane holds an overlay (P5)
             // — otherwise its chord (typically a bare Escape) falls through so the key still reaches
             // the terminal.

--- a/src/Agwinterm.Win32/Program.Input.cs
+++ b/src/Agwinterm.Win32/Program.Input.cs
@@ -114,6 +114,7 @@ internal partial class Program
     /// <summary>Dispatch a keymap action id (or "command:&lt;Label&gt;") to the matching behavior.</summary>
     private void RunAction(string action)
     {
+        if (_isQuickWindow && !QuickActionAllowed(action)) { ShowToast("This action needs a library window"); return; }
         if (action.StartsWith("command:", StringComparison.OrdinalIgnoreCase))
         {
             string label = action["command:".Length..];
@@ -208,6 +209,9 @@ internal partial class Program
     private string RunCommandText(string text, string? mode)
     {
         var ctx = _active;
+        mode = (mode ?? "send").ToLowerInvariant();
+        if (_isQuickWindow && mode is not ("send" or "detached"))
+            return ISessionHost.RefusePrefix + "quick terminal commands support send or detached mode only";
         string expanded = ExpandAgwTokens(text, ctx);
         switch ((mode ?? "send").ToLowerInvariant())
         {
@@ -220,7 +224,7 @@ internal partial class Program
                 else ShowToast("no session for overlay command");
                 break;
             case "detached":
-                RunDetached(expanded, RawCwdOf(ctx), AgwEnv(ctx));
+                RunDetached(expanded, CommandCwd(ctx), AgwEnv(ctx));
                 break;
             default: // send — type it into the active session, as if the user typed it + Enter
                 Send(expanded.Replace("\r", "").Replace("\n", "") + "\r");
@@ -237,6 +241,13 @@ internal partial class Program
         return live.Length > 0 ? live : (ses.StartCwd ?? "");
     }
 
+    private string CommandCwd(Ses? ses)
+    {
+        if (!_isQuickWindow || ActiveSurface() is not { } p) return RawCwdOf(ses);
+        string live = PrettyCwd(SafeCwd(p));
+        return live.Length > 0 ? live : p.StartCwd ?? "";
+    }
+
     /// <summary>Best-effort path to agwintermctl.exe (next to us), else just "agwintermctl" (assume PATH).</summary>
     private static string CtlPath()
     {
@@ -251,7 +262,7 @@ internal partial class Program
     private Dictionary<string, string> AgwValues(Ses? ses)
     {
         var surface = ActiveSurface();
-        string paneName = "";
+        string paneName = _isQuickWindow && surface is not null ? "quick" : "";
         if (surface is not null && ses is not null)
         {
             if (_coverKind == 1 && ReferenceEquals(surface, ses.Scratch)) paneName = "scratch";
@@ -272,7 +283,7 @@ internal partial class Program
             ["AGW_SESSION"] = ses?.Name ?? "",
             ["AGW_SESSION_ID"] = ses?.Id ?? "",
             ["AGW_WORKSPACE"] = ses?.Ws.Name ?? "",
-            ["AGW_CWD"] = RawCwdOf(ses),
+            ["AGW_CWD"] = CommandCwd(ses),
             ["AGW_PANE_ID"] = surface?.Id ?? ses?.ActivePane.Id ?? "",
             ["AGW_PANE"] = paneName,
             ["AGW_APP"] = CtlPath(),
@@ -581,7 +592,7 @@ internal partial class Program
     /// which kind it is.</summary>
     private (Pane pane, float ox, float oy, float cw, float ch)? PaneAt(int px, int py)
     {
-        if (px < (int)_sidebarW || py < (int)TitleBarH || py >= ClientH() - (int)FooterH) return null;
+        if (px < (int)_sidebarW || py < (int)TitleBarH || py >= ClientH() - (_isQuickWindow ? 0 : (int)FooterH)) return null;
         if (_cover is not null) { var (cx, cy, _, _) = CoverRect(); var (_, ccw, cch) = Metrics(_cover.FontSize); return (_cover, cx, cy, ccw, cch); }
         if (_active is null) return null;
         if (PaneAlongAxisAt(_active, px, py) is { } hit)
@@ -1158,7 +1169,7 @@ internal partial class Program
         // F1 help overlay: modal while open; plain F1 opens it from the shell prompt (full-screen
         // TUIs on the alt screen — Far, vim — keep their own F1).
         if (_helpOpen) return HelpKey(vk);
-        if (!_isQuickWindow && vk == 0x70 /* F1 */ && !ctrl && !alt && !shift)
+        if (vk == 0x70 /* F1 */ && !ctrl && !alt && !shift)
         {
             var helpSurf = ActiveSurface();
             bool altScreen = helpSurf is not null && helpSurf.S.Emulator.IsAltScreen;
@@ -1189,12 +1200,12 @@ internal partial class Program
                 return true;
             }
         }
-        if (!_isQuickWindow && _leader is not null && Keymap.ChordFor(vk, ctrl, alt, shift) == _leader) { BeginLeader(); return true; }
+        if (_leader is not null && Keymap.ChordFor(vk, ctrl, alt, shift) == _leader) { BeginLeader(); return true; }
 
         // Shift+PageUp/PageDown (and Home/End) scroll this pane's scrollback; never reach the PTY.
-        if (shift && !ctrl && !alt && _active is not null)
+        if (shift && !ctrl && !alt && ActiveSurface() is { } scrollPane)
         {
-            int page = Math.Max(1, _active.ActivePane.S.Rows - 1);
+            int page = Math.Max(1, scrollPane.S.Rows - 1);
             switch (vk)
             {
                 case VK_PRIOR: return ScrollActivePane(page);        // Shift+PageUp — older
@@ -1250,8 +1261,6 @@ internal partial class Program
         string? chord = Keymap.ChordFor(vk, ctrl, alt, shift);
         if (chord is not null && _keymap.TryGetValue(chord, out var action))
         {
-            if (_isQuickWindow && action is not ("quick_terminal" or "close_cover" or "close_pane" or "close_session"
-                or "select_all" or "copy_selection" or "paste" or "mark_mode")) return true;
             // close_cover only applies while a cover is up, or the focused pane holds an overlay (P5)
             // — otherwise its chord (typically a bare Escape) falls through so the key still reaches
             // the terminal.

--- a/src/Agwinterm.Win32/Program.Quick.cs
+++ b/src/Agwinterm.Win32/Program.Quick.cs
@@ -13,6 +13,7 @@ internal partial class Program
     private IntPtr _quickPreviousForeground;
     private static QuickHotkey _registeredQuickChord;
     private static int _quickHotkeyId;
+    private static readonly HashSet<int> _quickHotkeyReservations = new();
     private const uint QuickHotkeyMessage = 0x0312;
 
     [DllImport("user32.dll", SetLastError = true)]
@@ -26,6 +27,9 @@ internal partial class Program
     private static extern bool IsWindow(IntPtr hwnd);
     [DllImport("user32.dll")] private static extern IntPtr GetForegroundWindow();
     [DllImport("user32.dll")] private static extern IntPtr GetCapture();
+    [DllImport("user32.dll")] private static extern IntPtr GetAncestor(IntPtr hwnd, uint flags);
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)] private static extern bool IsWindowEnabled(IntPtr hwnd);
 
     private static Program EnsureQuickHost()
     {
@@ -37,20 +41,39 @@ internal partial class Program
 
     // Acquire the replacement BEFORE releasing the current chord. Two alternating IDs avoid
     // RegisterHotKey's same-ID accumulation rule; conflicts cannot silently unbind the old key.
-    private static string? SetQuickHotkey(string value)
+    private static string? SetQuickHotkey(string value, Action? persist = null)
     {
         if (!QuickHotkey.TryParse(value, out var chord))
             return "error: quick-terminal-hotkey requires Ctrl/Alt, optional Shift, and a letter/digit, F1-F11 or backtick";
-        if (chord == _registeredQuickChord) return null;
         var host = EnsureQuickHost();
+        foreach (int extra in _quickHotkeyReservations.Where(id => id != _quickHotkeyId).ToArray())
+        {
+            if (!UnregisterHotKey(host._hwnd, extra)) return "error: previous provisional hotkey cleanup is incomplete";
+            _quickHotkeyReservations.Remove(extra);
+        }
+        if (chord == _registeredQuickChord) { persist?.Invoke(); return null; }
         int next = _quickHotkeyId == 0x514 ? 0x515 : 0x514;
         if (chord.Key != 0 && !RegisterHotKey(host._hwnd, next, chord.Modifiers | 0x4000, chord.Key))
             return $"error: quick-terminal-hotkey unavailable (Win32 {Marshal.GetLastWin32Error()}); previous binding retained";
+        if (chord.Key != 0) _quickHotkeyReservations.Add(next);
+        try { persist?.Invoke(); } // old registration remains reserved throughout the atomic save
+        catch (Exception ex)
+        {
+            bool clean = chord.Key == 0 || UnregisterHotKey(host._hwnd, next);
+            if (clean) _quickHotkeyReservations.Remove(next);
+            return "error: could not save quick-terminal-hotkey: " + ex.Message
+                + (clean ? "; previous binding retained" : "; provisional hotkey cleanup failed (reservation retained for retry/shutdown)");
+        }
         if (_quickHotkeyId != 0 && !UnregisterHotKey(host._hwnd, _quickHotkeyId))
         {
-            if (chord.Key != 0) UnregisterHotKey(host._hwnd, next);
-            return "error: could not release previous quick-terminal-hotkey; config unchanged";
+            // Persistence succeeded, but Windows refused cleanup. Keep both ids tracked and
+            // report partial application explicitly; never claim that the saved file is unchanged.
+            _registeredQuickChord = chord;
+            _quickHotkeyId = chord.Key == 0 ? 0 : next;
+            _config.QuickTerminalHotkey = value;
+            return "error: hotkey config saved, but previous OS reservation could not be released; restart to retry cleanup";
         }
+        _quickHotkeyReservations.Remove(_quickHotkeyId);
         _quickHotkeyId = chord.Key == 0 ? 0 : next;
         _registeredQuickChord = chord;
         return null;
@@ -73,8 +96,7 @@ internal partial class Program
         var host = EnsureQuickHost();
         if (!pin && !global && !host._quickVisible && host._quickAutoHiddenAt != 0
             && Environment.TickCount64 - host._quickAutoHiddenAt < 300) return;
-        if (pin) host._quickPinned = true; // an API show also pins an already-visible human summon
-        if (host._quickVisible) return;
+        if (host._quickVisible) { if (pin) host._quickPinned = true; return; }
         host._quickAutoHiddenAt = 0;
         host._quickPreviousForeground = GetForegroundWindow();
         host.PositionQuick();
@@ -82,7 +104,7 @@ internal partial class Program
         host._quick ??= host.CreatePane("quick:" + Guid.NewGuid().ToString("N")[..6],
             new Workspace { Id = "", Name = "" }, Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), (float)_config.FontSize);
         host._cover = host._quick; host._coverKind = 2; host.SyncSession(); host.RegridCover();
-        host._quickVisible = true;
+        host._quickPinned = pin; host._quickVisible = true;
         ShowWindow(host._hwnd, SW_SHOWNOACTIVATE);
         if (!pin) SetForegroundWindow(host._hwnd); // human summons only; scripts do not seize focus
         host.RequestRedraw();
@@ -95,6 +117,7 @@ internal partial class Program
         bool restoreFocus = !blur && GetForegroundWindow() == _hwnd;
         _quickVisible = false; _quickPinned = false;
         _quickAutoHiddenAt = blur ? Environment.TickCount64 : 0;
+        ReleaseQuickKeys(); CancelLeader(); CloseSearch();
         _selecting = false; _selPane = null; StopSelAutoscroll();
         if (GetCapture() == _hwnd) ReleaseCapture();
         ShowWindow(_hwnd, 0 /* SW_HIDE */);
@@ -106,11 +129,38 @@ internal partial class Program
     private static void DestroyQuickHost()
     {
         if (_quickHost is not { } host) return;
-        if (_quickHotkeyId != 0) UnregisterHotKey(host._hwnd, _quickHotkeyId);
+        foreach (int id in _quickHotkeyReservations) UnregisterHotKey(host._hwnd, id);
+        _quickHotkeyReservations.Clear();
         _quickHotkeyId = 0; _registeredQuickChord = default;
         host._quick?.S.Dispose(); host._quick = null; host._cover = null; host._session = null;
         DestroyWindow(host._hwnd);
         host._brush?.Dispose(); host._rt?.Dispose();
         _quickHost = null;
+    }
+
+    private void ReleaseQuickKeys()
+    {
+        int[] keys = _win32KeysDown.ToArray();
+        _win32KeysDown.Clear(); _kittyAteChar = false;
+        // Exit can race focus loss. Releasing best-effort key state must never prevent hiding
+        // the panel or dropping its system caret when the PTY has already closed.
+        try
+        {
+            if (_quick is { } p && !p.S.HasExited && p.S.Emulator.Win32InputMode)
+                foreach (int vk in keys)
+                    p.S.Write(System.Text.Encoding.UTF8.GetBytes($"\x1b[{vk};{MapVirtualKeyW((uint)vk, 0)};0;0;0;1_"));
+        }
+        catch (InvalidOperationException) { }
+        catch (System.IO.IOException) { }
+    }
+
+    private bool QuickActionAllowed(string action)
+    {
+        if (action.StartsWith("command:", StringComparison.OrdinalIgnoreCase))
+            return _commands.Any(c => string.Equals(c.Label, action[8..], StringComparison.OrdinalIgnoreCase)
+                && c.Mode is "send" or "detached");
+        return action is "quick_terminal" or "close_cover" or "close_pane" or "close_session"
+            or "select_all" or "copy_selection" or "paste" or "mark_mode" or "toggle_search"
+            or "previous_prompt" or "next_prompt" or "toggle_read_only";
     }
 }

--- a/src/Agwinterm.Win32/Program.Quick.cs
+++ b/src/Agwinterm.Win32/Program.Quick.cs
@@ -1,0 +1,116 @@
+using System.Runtime.InteropServices;
+using Agwinterm.Core;
+using static Agwinterm.Win32.Win32;
+
+namespace Agwinterm.Win32;
+
+internal partial class Program
+{
+    private bool _isQuickWindow;
+    private static Program? _quickHost;
+    private bool _quickVisible, _quickPinned;
+    private long _quickAutoHiddenAt;
+    private IntPtr _quickPreviousForeground;
+    private static QuickHotkey _registeredQuickChord;
+    private static int _quickHotkeyId;
+    private const uint QuickHotkeyMessage = 0x0312;
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool RegisterHotKey(IntPtr hwnd, int id, uint modifiers, uint key);
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool UnregisterHotKey(IntPtr hwnd, int id);
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool IsWindow(IntPtr hwnd);
+    [DllImport("user32.dll")] private static extern IntPtr GetForegroundWindow();
+    [DllImport("user32.dll")] private static extern IntPtr GetCapture();
+
+    private static Program EnsureQuickHost()
+    {
+        if (_quickHost is not null) return _quickHost;
+        var host = new Program { Id = "quick", WinName = "Quick terminal", _isQuickWindow = true, _sidebarW = 0 };
+        host.Boot(_hInstance);
+        return _quickHost = host;
+    }
+
+    // Acquire the replacement BEFORE releasing the current chord. Two alternating IDs avoid
+    // RegisterHotKey's same-ID accumulation rule; conflicts cannot silently unbind the old key.
+    private static string? SetQuickHotkey(string value)
+    {
+        if (!QuickHotkey.TryParse(value, out var chord))
+            return "error: quick-terminal-hotkey requires Ctrl/Alt, optional Shift, and a letter/digit, F1-F11 or backtick";
+        if (chord == _registeredQuickChord) return null;
+        var host = EnsureQuickHost();
+        int next = _quickHotkeyId == 0x514 ? 0x515 : 0x514;
+        if (chord.Key != 0 && !RegisterHotKey(host._hwnd, next, chord.Modifiers | 0x4000, chord.Key))
+            return $"error: quick-terminal-hotkey unavailable (Win32 {Marshal.GetLastWin32Error()}); previous binding retained";
+        if (_quickHotkeyId != 0 && !UnregisterHotKey(host._hwnd, _quickHotkeyId))
+        {
+            if (chord.Key != 0) UnregisterHotKey(host._hwnd, next);
+            return "error: could not release previous quick-terminal-hotkey; config unchanged";
+        }
+        _quickHotkeyId = chord.Key == 0 ? 0 : next;
+        _registeredQuickChord = chord;
+        return null;
+    }
+
+    private void PositionQuick()
+    {
+        GetCursorPos(out POINT pointer);
+        IntPtr monitor = MonitorFromPoint(pointer, MONITOR_DEFAULTTONEAREST);
+        var info = new MONITORINFO { cbSize = Marshal.SizeOf<MONITORINFO>() };
+        if (!GetMonitorInfoW(monitor, ref info)) return;
+        var r = info.rcWork;
+        var f = QuickTerminalGeometry.Frame(r.left, r.top, r.right - r.left, r.bottom - r.top, _config.QuickTerminalSize);
+        SetWindowPos(_hwnd, new IntPtr(-1), f.X, f.Y, f.Width, f.Height, SWP_NOACTIVATE);
+        RegridCover();
+    }
+
+    private void SummonQuick(bool pin, bool global = false)
+    {
+        var host = EnsureQuickHost();
+        if (!pin && !global && !host._quickVisible && host._quickAutoHiddenAt != 0
+            && Environment.TickCount64 - host._quickAutoHiddenAt < 300) return;
+        if (pin) host._quickPinned = true; // an API show also pins an already-visible human summon
+        if (host._quickVisible) return;
+        host._quickAutoHiddenAt = 0;
+        host._quickPreviousForeground = GetForegroundWindow();
+        host.PositionQuick();
+        if (host._quick is { S.HasExited: true }) { host._quick.S.Dispose(); host._quick = null; }
+        host._quick ??= host.CreatePane("quick:" + Guid.NewGuid().ToString("N")[..6],
+            new Workspace { Id = "", Name = "" }, Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), (float)_config.FontSize);
+        host._cover = host._quick; host._coverKind = 2; host.SyncSession(); host.RegridCover();
+        host._quickVisible = true;
+        ShowWindow(host._hwnd, SW_SHOWNOACTIVATE);
+        if (!pin) SetForegroundWindow(host._hwnd); // human summons only; scripts do not seize focus
+        host.RequestRedraw();
+    }
+
+    private void DismissQuick(bool blur = false)
+    {
+        if (!_isQuickWindow) { _quickHost?.DismissQuick(blur); return; }
+        if (!_quickVisible) return;
+        bool restoreFocus = !blur && GetForegroundWindow() == _hwnd;
+        _quickVisible = false; _quickPinned = false;
+        _quickAutoHiddenAt = blur ? Environment.TickCount64 : 0;
+        _selecting = false; _selPane = null; StopSelAutoscroll();
+        if (GetCapture() == _hwnd) ReleaseCapture();
+        ShowWindow(_hwnd, 0 /* SW_HIDE */);
+        if (restoreFocus && _quickPreviousForeground != IntPtr.Zero && IsWindow(_quickPreviousForeground))
+            SetForegroundWindow(_quickPreviousForeground);
+        _quickPreviousForeground = IntPtr.Zero;
+    }
+
+    private static void DestroyQuickHost()
+    {
+        if (_quickHost is not { } host) return;
+        if (_quickHotkeyId != 0) UnregisterHotKey(host._hwnd, _quickHotkeyId);
+        _quickHotkeyId = 0; _registeredQuickChord = default;
+        host._quick?.S.Dispose(); host._quick = null; host._cover = null; host._session = null;
+        DestroyWindow(host._hwnd);
+        host._brush?.Dispose(); host._rt?.Dispose();
+        _quickHost = null;
+    }
+}

--- a/src/Agwinterm.Win32/Program.Render.cs
+++ b/src/Agwinterm.Win32/Program.Render.cs
@@ -626,8 +626,7 @@ internal partial class Program
             brush.Color = new Color4(0f, 0f, 0f, Math.Clamp(_config.UnfocusedDim, 0, 90) / 100f);
             rt.FillRectangle(new Rect(dx, dy, dw, dh), brush);
         }
-        DrawSidebar(rt, brush);
-        DrawTitleBar(rt, brush);
+        if (!_isQuickWindow) { DrawSidebar(rt, brush); DrawTitleBar(rt, brush); }
         DrawSearchBar(rt, brush);
         DrawToast(rt, brush);
         DrawButtonTip(rt, brush);
@@ -643,7 +642,7 @@ internal partial class Program
     {
         // Quick terminal (kind 2) and a sized floating overlay (kind 3) both render as a centered
         // panel over the live main window — a "tool window" look. Scratch (1) / full overlay fill.
-        bool floatingPanel = _cover is not null && ((_coverKind == 3 && _ovlOwner is { Overlay.SizePercent: > 0 }) || _coverKind == 2);
+        bool floatingPanel = !_isQuickWindow && _cover is not null && ((_coverKind == 3 && _ovlOwner is { Overlay.SizePercent: > 0 }) || _coverKind == 2);
         if (_cover is not null && !floatingPanel)
         {
             var (ox, oy, cw0, ch0) = ContentArea();

--- a/src/Agwinterm.Win32/Program.Render.cs
+++ b/src/Agwinterm.Win32/Program.Render.cs
@@ -640,8 +640,8 @@ internal partial class Program
     /// <summary>The normal terminal content: the active session's pane grid, or a cover/quick/overlay panel.</summary>
     private void DrawWindowContent(ID2D1HwndRenderTarget rt, ID2D1SolidColorBrush brush)
     {
-        // Quick terminal (kind 2) and a sized floating overlay (kind 3) both render as a centered
-        // panel over the live main window — a "tool window" look. Scratch (1) / full overlay fill.
+        // Sized program overlays float over normal content. The detached quick host (kind 2)
+        // fills its own tool window, as scratch/full overlays fill their normal content region.
         bool floatingPanel = !_isQuickWindow && _cover is not null && ((_coverKind == 3 && _ovlOwner is { Overlay.SizePercent: > 0 }) || _coverKind == 2);
         if (_cover is not null && !floatingPanel)
         {

--- a/src/Agwinterm.Win32/Program.Services.cs
+++ b/src/Agwinterm.Win32/Program.Services.cs
@@ -922,6 +922,7 @@ internal partial class Program
         "restore-commands", "restore-buffer", "blocked-sound", "notification-sound", "omp-theme", "omp-integration", "prompt-engine", "starship-theme",
         "new-session-dir-mode", "confirm-close-session", "compact-toolbar", "toolbar-mode", "notification-badges", "workspace-add-button",
         "show-scratch-button", "show-split-button", "show-dashboard-button", "show-quick-button",
+        "quick-terminal-size", "quick-terminal-hotkey",
         "attention-button", "status-color-active", "status-color-blocked", "status-color-completed",
         "paste-protection", "clipboard-write", "notification-flash", "claude-update-check", "update-check",
         "session-host", "fresh-env", "emulator-core",
@@ -991,6 +992,8 @@ internal partial class Program
         "show-split-button" => _config.ShowSplitButton ? "true" : "false",
         "show-dashboard-button" => _config.ShowDashboardButton ? "true" : "false",
         "show-quick-button" => _config.ShowQuickButton ? "true" : "false",
+        "quick-terminal-size" => _config.QuickTerminalSize.ToString(),
+        "quick-terminal-hotkey" => _config.QuickTerminalHotkey,
         "notification-flash" => _config.NotificationFlash,
         "claude-update-check" => _config.ClaudeUpdateCheck ? "true" : "false",
         "update-check" => _config.UpdateCheck ? "true" : "false",
@@ -1011,8 +1014,14 @@ internal partial class Program
     {
         key = key.Trim().ToLowerInvariant();
         if (Array.IndexOf(ConfigKeys, key) < 0) return "error: unknown key '" + key + "'";
-        WriteConfigKey(key, value.Trim());
+        if (key == "quick-terminal-size" && (!int.TryParse(value.Trim(), out int qs) || qs is < 40 or > 90))
+            return "error: quick-terminal-size must be an integer from 40 through 90";
+        string oldHotkey = _config.QuickTerminalHotkey;
+        if (key == "quick-terminal-hotkey" && SetQuickHotkey(value.Trim()) is { } error) return error;
+        try { WriteConfigKey(key, value.Trim()); }
+        catch { if (key == "quick-terminal-hotkey") SetQuickHotkey(oldHotkey); throw; }
         _config = TerminalConfig.Load(ConfigPath);       // reparse so clamping/validation is centralized
+        if (key == "quick-terminal-size" && _quickHost?._quickVisible == true) _quickHost.PositionQuick();
         if (key == "theme") _theme = FindTheme(_config.Theme);
         if (key is "theme" or "theme-follow-system" or "theme-dark" or "theme-light") ApplySystemTheme();
         if (key == "session-host")
@@ -1421,6 +1430,7 @@ internal partial class Program
     private bool TrySaveState(out string? why, bool captureCommands = false)
     {
         why = null;
+        if (_isQuickWindow) { why = "quick terminal is not restored"; return false; }
         if (_restoring) { why = "the window is still restoring its saved state"; return false; }
         try
         {

--- a/src/Agwinterm.Win32/Program.Services.cs
+++ b/src/Agwinterm.Win32/Program.Services.cs
@@ -934,7 +934,7 @@ internal partial class Program
         string path = ConfigPath;
         string text = File.Exists(path) ? File.ReadAllText(path) : TerminalConfig.DefaultText;
         var lines = text.Replace("\r\n", "\n").Split('\n').ToList();
-        int idx = lines.FindIndex(l =>
+        int idx = lines.FindLastIndex(l =>
         {
             var t = l.TrimStart();
             int eq = l.IndexOf('=');
@@ -943,7 +943,15 @@ internal partial class Program
         string ln = $"{key} = {value}";
         if (idx >= 0) lines[idx] = ln; else { lines.Add(ln); }
         Directory.CreateDirectory(Path.GetDirectoryName(path)!);
-        File.WriteAllText(path, string.Join(Environment.NewLine, lines));
+        // A failed write must never truncate the user's existing configuration. The sibling
+        // temporary file keeps replacement on the same volume; a failed move leaves path intact.
+        string temp = path + "." + Guid.NewGuid().ToString("N") + ".tmp";
+        try
+        {
+            File.WriteAllText(temp, string.Join(Environment.NewLine, lines));
+            File.Move(temp, path, overwrite: true);
+        }
+        finally { if (File.Exists(temp)) File.Delete(temp); }
     }
 
     /// <summary>Current value of a config key as a string (for config get/list + the Settings window).</summary>
@@ -1016,10 +1024,11 @@ internal partial class Program
         if (Array.IndexOf(ConfigKeys, key) < 0) return "error: unknown key '" + key + "'";
         if (key == "quick-terminal-size" && (!int.TryParse(value.Trim(), out int qs) || qs is < 40 or > 90))
             return "error: quick-terminal-size must be an integer from 40 through 90";
-        string oldHotkey = _config.QuickTerminalHotkey;
-        if (key == "quick-terminal-hotkey" && SetQuickHotkey(value.Trim()) is { } error) return error;
-        try { WriteConfigKey(key, value.Trim()); }
-        catch { if (key == "quick-terminal-hotkey") SetQuickHotkey(oldHotkey); throw; }
+        if (key == "quick-terminal-hotkey")
+        {
+            if (SetQuickHotkey(value.Trim(), () => WriteConfigKey(key, value.Trim())) is { } error) return error;
+        }
+        else WriteConfigKey(key, value.Trim());
         _config = TerminalConfig.Load(ConfigPath);       // reparse so clamping/validation is centralized
         if (key == "quick-terminal-size" && _quickHost?._quickVisible == true) _quickHost.PositionQuick();
         if (key == "theme") _theme = FindTheme(_config.Theme);

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -62,7 +62,7 @@ internal partial class Program
         // — the still-running shell reconnects instead of a fresh one spawning.
         ISession session;
         bool adopted = false;
-        if (handoff is not null) session = InProcessSessionBackend.Instance.Create(paneId, cols, rows);
+        if (handoff is not null || _isQuickWindow) session = InProcessSessionBackend.Instance.Create(paneId, cols, rows);
         else if (ReferenceEquals(_sessionBackend, InProcessSessionBackend.Instance)) session = _sessionBackend.Create(paneId, cols, rows);
         else
             try
@@ -705,6 +705,7 @@ internal partial class Program
     /// active session's panes, which stay partially visible behind floating overlays — so both count.</summary>
     private bool IsSurfaceVisible(Pane p)
     {
+        if (_isQuickWindow && !_quickVisible) return false;
         if (_dashboardOpen) return true;
         if (_cover is { } c && ReferenceEquals(c, p)) return true;
         var act = _active;
@@ -734,6 +735,7 @@ internal partial class Program
 
     private void HideCover()
     {
+        if (_isQuickWindow) { DismissQuick(); return; }
         _cover = null; _coverKind = 0; SyncSession();
         if (_active is not null) RegridSession(_active);
         RequestRedraw();
@@ -753,6 +755,7 @@ internal partial class Program
     private (float x, float y, float w, float h) CoverRect()
     {
         var (x0, y0, w, h) = ContentArea();
+        if (_isQuickWindow) return (x0, y0, w, h);
         if (_coverKind == 3 && _ovlOwner is { Overlay.SizePercent: > 0 and <= 100 } o)
         {
             float fw = w * o.Overlay.SizePercent / 100f, fh = h * o.Overlay.SizePercent / 100f;
@@ -784,9 +787,7 @@ internal partial class Program
 
     private void ShowQuick()
     {
-        _quick ??= CreatePane("quick:" + Guid.NewGuid().ToString("N")[..6], ActiveWorkspace(),
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), (float)_config.FontSize);
-        ShowCover(_quick, 2);
+        SummonQuick(pin: false);
     }
 
     /// <summary>scratch op on|off|toggle for a session's scratch cover.</summary>
@@ -798,12 +799,12 @@ internal partial class Program
         if (showing) HideCover(); else ShowScratch(ses); // toggle
     }
 
-    private void QuickOp(string op)
+    private void QuickOp(string op, bool control = false, bool global = false)
     {
-        bool showing = _coverKind == 2;
-        if (op == "off") { if (showing) HideCover(); return; }
-        if (op == "on") { if (!showing) ShowQuick(); return; }
-        if (showing) HideCover(); else ShowQuick(); // toggle
+        bool showing = _quickHost?._quickVisible == true;
+        if (op == "off") { DismissQuick(); return; }
+        if (op == "on") { SummonQuick(control, global); return; }
+        if (showing) DismissQuick(); else SummonQuick(control, global);
     }
 
     // ---- Overlays (Wave B3): an ephemeral program run over a session ----
@@ -1505,6 +1506,11 @@ internal partial class Program
     /// (promote it into the main pane). Single-pane sessions keep the exited shell visible. (agterm #121.)</summary>
     private void OnPaneProcessExited(Pane p)
     {
+        if (_isQuickWindow && ReferenceEquals(p, _quick))
+        {
+            DismissQuick(); _quick = null; _cover = null; _coverKind = 0; _session = null;
+            p.S.Dispose(); return;
+        }
         Ses? ses;
         lock (_workspaces) ses = _workspaces.SelectMany(w => w.Sessions).FirstOrDefault(s => s.Panes.Contains(p));
         if (ses is null || ses.Panes.Count <= 1) return;   // not a live split pane → leave the shell as-is

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -785,11 +785,6 @@ internal partial class Program
         ShowCover(ses.Scratch, 1);
     }
 
-    private void ShowQuick()
-    {
-        SummonQuick(pin: false);
-    }
-
     /// <summary>scratch op on|off|toggle for a session's scratch cover.</summary>
     private void ScratchOp(Ses ses, string op)
     {
@@ -801,6 +796,11 @@ internal partial class Program
 
     private void QuickOp(string op, bool control = false, bool global = false)
     {
+        if (_quickHost is { } host && !IsWindowEnabled(host._hwnd))
+        {
+            if (control) throw new InvalidOperationException("quick terminal has a modal dialog open");
+            return;
+        }
         bool showing = _quickHost?._quickVisible == true;
         if (op == "off") { DismissQuick(); return; }
         if (op == "on") { SummonQuick(control, global); return; }

--- a/src/Agwinterm.Win32/Program.WndProc.cs
+++ b/src/Agwinterm.Win32/Program.WndProc.cs
@@ -38,6 +38,18 @@ internal partial class Program
 
     private IntPtr WindowProcCore(IntPtr hwnd, uint msg, IntPtr wParam, IntPtr lParam)
     {
+        if (_isQuickWindow)
+        {
+            if (msg == WM_CLOSE) { DismissQuick(); return IntPtr.Zero; }
+            if (msg == WM_NCHITTEST) return (IntPtr)HTCLIENT;
+            if (msg == WM_NCCALCSIZE) return IntPtr.Zero;
+            if (msg == QuickHotkeyMessage)
+            {
+                if ((int)wParam == _quickHotkeyId && _quickHotkeyId != 0) QuickOp("toggle", global: true);
+                return IntPtr.Zero;
+            }
+            if (msg == WM_DESTROY) { _uiGone.Cancel(); return IntPtr.Zero; }
+        }
         switch (msg)
         {
             case 0x003D: // WM_GETOBJECT — expose the terminal to screen readers (UIA, T2-14)
@@ -599,7 +611,8 @@ internal partial class Program
                 if (_windowActive != wasActive && _session is { } fs && fs.Emulator.FocusReporting)
                     fs.Write(_windowActive ? "\x1b[I"u8.ToArray() : "\x1b[O"u8.ToArray());
                 if (_config.UnfocusedDim > 0) RequestRedraw();
-                if (_windowActive && _frontmostId != Id) // this window is frontmost
+                if (_isQuickWindow && !_windowActive && _quickVisible && !_quickPinned) DismissQuick(blur: true);
+                if (!_isQuickWindow && _windowActive && _frontmostId != Id) // this library window is frontmost
                 {
                     Frontmost = this; _frontmostId = Id; SaveIndex();
                 }
@@ -650,7 +663,7 @@ internal partial class Program
                     }
                 }
                 SaveIndex();
-                if (lastWindow) PostQuitMessage(0);
+                if (lastWindow) { DestroyQuickHost(); PostQuitMessage(0); }
                 return IntPtr.Zero;
         }
         return DefWindowProcW(hwnd, msg, wParam, lParam);

--- a/src/Agwinterm.Win32/Program.WndProc.cs
+++ b/src/Agwinterm.Win32/Program.WndProc.cs
@@ -163,6 +163,7 @@ internal partial class Program
                 return IntPtr.Zero;
 
             case WM_KILLFOCUS:
+                if (_isQuickWindow) ReleaseQuickKeys();
                 DropCaret();
                 return IntPtr.Zero;
 
@@ -231,6 +232,12 @@ internal partial class Program
                     _dpi = (ushort)((long)wParam & 0xFFFF);       // wParam packs the new DPI in both words
                     if (_dpi <= 0) _dpi = 96f;
                     if (_rt is not null) _rt.Dpi = new Vortice.Mathematics.Size(_dpi, _dpi);
+                    if (_isQuickWindow)
+                    {
+                        // Quick geometry is a physical monitor percentage, not a logical normal
+                        // window size. Do not scale PositionQuick's already-sized rectangle again.
+                        RegridCover(); RequestRedraw(); return IntPtr.Zero;
+                    }
                     // Take the SUGGESTED rect. It is the contract for this message: it already accounts
                     // for the new scaling, and a window that sizes itself here instead lands wrong.
                     var sug = System.Runtime.InteropServices.Marshal.PtrToStructure<RECT>(lParam);
@@ -611,7 +618,8 @@ internal partial class Program
                 if (_windowActive != wasActive && _session is { } fs && fs.Emulator.FocusReporting)
                     fs.Write(_windowActive ? "\x1b[I"u8.ToArray() : "\x1b[O"u8.ToArray());
                 if (_config.UnfocusedDim > 0) RequestRedraw();
-                if (_isQuickWindow && !_windowActive && _quickVisible && !_quickPinned) DismissQuick(blur: true);
+                if (_isQuickWindow && !_windowActive && _quickVisible && !_quickPinned
+                    && (lParam == IntPtr.Zero || GetAncestor(lParam, 3 /* GA_ROOTOWNER */) != _hwnd)) DismissQuick(blur: true);
                 if (!_isQuickWindow && _windowActive && _frontmostId != Id) // this library window is frontmost
                 {
                     Frontmost = this; _frontmostId = Id; SaveIndex();
@@ -628,7 +636,8 @@ internal partial class Program
                 // App-quit (last window, or an update-quit closing all of them) DETACHES panes —
                 // server-hosted sessions keep running and the next start adopts them (#105 2c).
                 // An explicit window close (others remain) still disposes = kills, like a pane
-                // close. Scratch/overlay/quick are never restored, so they always dispose.
+                // close. Scratch/overlay always dispose; the app-level quick shell survives until
+                // the LAST library window closes, when DestroyQuickHost disposes it too.
                 bool quitting;
                 lock (_windowIndex) quitting = _updateQuitting || _byId.Count <= 1;
                 foreach (var s in AllSessions())

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -1233,7 +1233,7 @@ internal partial class Program : ISessionHost, IWindowHost
     /// <summary>Move the hidden system caret onto the active pane's text cursor (client px).</summary>
     private void UpdateCaretPos()
     {
-        if (!_caretOwned || _active is null) return;
+        if (!_caretOwned || ActiveSurface() is null) return;
         var (ox, oy, cw, ch) = ActivePaneView();
         var p = ActiveSurface();
         if (p is null) return;
@@ -1258,6 +1258,7 @@ internal partial class Program : ISessionHost, IWindowHost
         MeasureCell();
         foreach (var s in AllSessions()) RegridSession(s);
         if (_cover is not null) RegridCover();
+        if (!_isQuickWindow && _quickHost?._cover is not null) _quickHost.RegridCover();
         RequestRedraw();
     }
 

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -152,7 +152,7 @@ internal partial class Program : ISessionHost, IWindowHost
     private static string ToolbarModeResolved =>
         _config?.ToolbarMode is "normal" or "compact" or "hidden" ? _config.ToolbarMode!
         : (_config is { CompactToolbar: true } ? "compact" : "normal");
-    private static float TitleBarH => ToolbarModeResolved switch { "hidden" => 0f, "compact" => 30f, _ => 40f };
+    private float TitleBarH => _isQuickWindow ? 0f : ToolbarModeResolved switch { "hidden" => 0f, "compact" => 30f, _ => 40f };
     private static bool ToolbarHidden => ToolbarModeResolved == "hidden";
     private const float FooterH = 34f;       // toolbar at the bottom of the sidebar
     // The default and the 120..600 range live in Agwinterm.Pty.SidebarWidths, with the chrome
@@ -665,7 +665,10 @@ internal partial class Program : ISessionHost, IWindowHost
         // leaving the window invisible and unreachable — clamp it onto the nearest visible work area first.
         if (_geoValid) ClampGeoToVisibleScreen(ref _geoX, ref _geoY, ref _geoW, ref _geoH);
         _creating = this;                    // so the WindowProc trampoline can resolve us during CreateWindowExW
-        _hwnd = _geoValid
+        _hwnd = _isQuickWindow
+            ? CreateWindowExW(WS_EX_TOOLWINDOW | WS_EX_TOPMOST, ClassName, "agwinterm quick terminal", WS_POPUP,
+                0, 0, 640, 480, IntPtr.Zero, IntPtr.Zero, hInstance, IntPtr.Zero)
+            : _geoValid
             ? CreateWindowExW(0, ClassName, AppName, WS_OVERLAPPEDWINDOW,
                 _geoX, _geoY, _geoW, _geoH, IntPtr.Zero, IntPtr.Zero, hInstance, IntPtr.Zero)
             : CreateWindowExW(0, ClassName, AppName, WS_OVERLAPPEDWINDOW,
@@ -702,7 +705,7 @@ internal partial class Program : ISessionHost, IWindowHost
         DragAcceptFiles(_hwnd, true);   // drop files/folders onto a pane -> quoted paths pasted
 
         CreateRenderTarget();
-        StartSession();
+        if (!_isQuickWindow) StartSession();
 
         ApplySystemTheme();   // if "follow Windows light/dark" is on, pick light/dark before the first paint
 
@@ -713,12 +716,19 @@ internal partial class Program : ISessionHost, IWindowHost
         // runs unconditionally; the cursor render itself stays solid when cursor-blink is disabled.
         SetTimer(_hwnd, (IntPtr)1, (uint)_config.CursorBlinkMs, IntPtr.Zero);
 
+        if (_isQuickWindow) return; // auxiliary window is shown only by a deliberate summon
+
         ShowWindow(_hwnd, _argMaximized || (_geoValid && _geoMax) ? SW_MAXIMIZE : SW_SHOW);
         if (_argFullscreen) { _argFullscreen = false; ToggleFullscreen(); }   // first window only
         _argMaximized = false;
         _wasMaximized = IsZoomed(_hwnd);
         ApplyWindowOpacity();
         UpdateWindow(_hwnd);
+        if (_quickHost is null)
+        {
+            EnsureQuickHost();
+            if (SetQuickHotkey(_config.QuickTerminalHotkey) is { } why) ShowToast(why, 7000);
+        }
     }
 
     private static IDWriteTextFormat CreateTextFormat(TerminalConfig cfg)

--- a/src/Agwinterm.Win32/Settings.cs
+++ b/src/Agwinterm.Win32/Settings.cs
@@ -149,6 +149,7 @@ internal partial class Program
         Sld(1, "window-opacity", "Window opacity", 30, 100);
         Sld(1, "sidebar-tint", "Sidebar tint", -100, 100);
         Sld(1, "sidebar-font-size", "Sidebar font size", 9, 20);
+        Sld(1, "quick-terminal-size", "Quick terminal size (%)", 40, 90);
         Sec(1, "Panes");
         Sld(1, "inactive-pane-dim", "Inactive pane mute", 0, 100);
 

--- a/tests/Agwinterm.Core.Tests/QuickTerminalTests.cs
+++ b/tests/Agwinterm.Core.Tests/QuickTerminalTests.cs
@@ -1,0 +1,42 @@
+using Agwinterm.Core;
+
+namespace Agwinterm.Core.Tests;
+
+public class QuickTerminalTests
+{
+    [Theory]
+    [InlineData("", 0, 0)]
+    [InlineData("Ctrl+Alt+backtick", 3, 192)]
+    [InlineData(" alt + shift + z ", 5, 90)]
+    [InlineData("ctrl+0", 2, 48)]
+    [InlineData("alt+f11", 1, 122)]
+    public void SupportedChords(string text, uint mods, uint key)
+    {
+        Assert.True(QuickHotkey.TryParse(text, out var chord));
+        Assert.Equal(new QuickHotkey(mods, key), chord);
+    }
+
+    [Theory]
+    [InlineData("a")][InlineData("shift+a")][InlineData("win+a")]
+    [InlineData("ctrl+f12")][InlineData("ctrl+ctrl+a")][InlineData("ctrl++a")]
+    [InlineData("ctrl+a|alt+b")][InlineData("ctrl+")][InlineData("ctrl+printscreen")]
+    public void UnsupportedChords(string text) => Assert.False(QuickHotkey.TryParse(text, out _));
+
+    [Theory]
+    [InlineData(40, 800, 400, -1400, 500)]
+    [InlineData(90, 1800, 900, -1900, 250)]
+    [InlineData(1, 800, 400, -1400, 500)]
+    [InlineData(999, 1800, 900, -1900, 250)]
+    public void MonitorGeometry(int percent, int width, int height, int x, int y)
+        => Assert.Equal((x, y, width, height), QuickTerminalGeometry.Frame(-2000, 200, 2000, 1000, percent));
+
+    [Fact] public void ConfigDefaultsAndBounds()
+    {
+        var c = TerminalConfig.Parse("");
+        Assert.Equal(70, c.QuickTerminalSize); Assert.Equal("", c.QuickTerminalHotkey);
+        Assert.Equal(40, TerminalConfig.Parse("quick-terminal-size = -1").QuickTerminalSize);
+        Assert.Equal(90, TerminalConfig.Parse("quick-terminal-size = 999").QuickTerminalSize);
+        Assert.Equal(70, TerminalConfig.Parse("quick-terminal-size = nope").QuickTerminalSize);
+        Assert.Equal("ctrl+alt+q", TerminalConfig.Parse("quick-terminal-hotkey = ctrl+alt+q").QuickTerminalHotkey);
+    }
+}

--- a/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
+++ b/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
@@ -9,6 +9,7 @@ namespace Agwinterm.Pty.Tests;
 /// asserted end-to-end. Peripheral verbs return sensible constants.</summary>
 internal sealed class FakeSessionHost : ISessionHost
 {
+    public bool IsQuickSurface { get; set; }
     internal sealed class Sess
     {
         public string Id = "", Name = "";

--- a/tests/Agwinterm.Pty.Tests/QuickTerminalContractTests.cs
+++ b/tests/Agwinterm.Pty.Tests/QuickTerminalContractTests.cs
@@ -7,7 +7,7 @@ public class QuickTerminalContractTests
 {
     [Theory]
     [InlineData("session.new")][InlineData("workspace.new")][InlineData("session.split")]
-    [InlineData("restore.capture")][InlineData("dashboard")][InlineData("command.run")]
+    [InlineData("restore.capture")][InlineData("dashboard")]
     public void AuxiliaryHostRefusesTreeMutations(string cmd)
     {
         var host = new FakeSessionHost { IsQuickSurface = true };

--- a/tests/Agwinterm.Pty.Tests/QuickTerminalContractTests.cs
+++ b/tests/Agwinterm.Pty.Tests/QuickTerminalContractTests.cs
@@ -1,0 +1,31 @@
+using System.Text.Json;
+using Agwinterm.Pty;
+
+namespace Agwinterm.Pty.Tests;
+
+public class QuickTerminalContractTests
+{
+    [Theory]
+    [InlineData("session.new")][InlineData("workspace.new")][InlineData("session.split")]
+    [InlineData("restore.capture")][InlineData("dashboard")][InlineData("command.run")]
+    public void AuxiliaryHostRefusesTreeMutations(string cmd)
+    {
+        var host = new FakeSessionHost { IsQuickSurface = true };
+        string before = JsonSerializer.Serialize(host.Tree());
+        var server = new ControlServer(host);
+        using var reply = JsonDocument.Parse(server.Dispatch(JsonSerializer.Serialize(new { cmd })));
+        Assert.False(reply.RootElement.GetProperty("ok").GetBoolean());
+        Assert.Contains("no workspace/session tree", reply.RootElement.GetProperty("error").GetString());
+        Assert.Equal(before, JsonSerializer.Serialize(host.Tree()));
+    }
+
+    [Theory]
+    [InlineData("on", true)][InlineData("off", true)][InlineData("toggle", true)]
+    [InlineData("bogus", false)][InlineData("", false)]
+    public void QuickOperationIsValidated(string op, bool ok)
+    {
+        var server = new ControlServer(new FakeSessionHost());
+        using var reply = JsonDocument.Parse(server.Dispatch(JsonSerializer.Serialize(new { cmd = "quick", args = new { op } })));
+        Assert.Equal(ok, reply.RootElement.GetProperty("ok").GetBoolean());
+    }
+}

--- a/tests/integration/hud-ui.ps1
+++ b/tests/integration/hud-ui.ps1
@@ -1,10 +1,11 @@
 # Dedicated P13 fixture: private app-data, no clipboard/registry writes, exact owned job teardown.
 param([string]$Exe="$PSScriptRoot/../../src/Agwinterm.Win32/bin/x64/Release/net10.0-windows/win-x64/Agwinterm.Win32.exe",
-      [string]$TokenOwner=$env:AGWINTERM_TEST_OWNER,[switch]$Strict)
+      [string]$TokenOwner=$env:AGWINTERM_TEST_OWNER,[switch]$Strict,
+      [ValidateSet('Hud','Quick')][string]$Suite='Hud')
 $ErrorActionPreference='Stop'
 $PSNativeCommandUseErrorActionPreference=$false
 $root=[IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
-$run='hud-ui-'+(Get-Date -Format yyyyMMddTHHmmss)+'-'+[guid]::NewGuid().ToString('N').Substring(0,6)
+$run=$Suite.ToLowerInvariant()+'-ui-'+(Get-Date -Format yyyyMMddTHHmmss)+'-'+[guid]::NewGuid().ToString('N').Substring(0,6)
 $artifact=Join-Path $root ".revmux/$run"
 New-Item -ItemType Directory $artifact|Out-Null
 Start-Transcript (Join-Path $artifact 'transcript.log')|Out-Null
@@ -15,7 +16,7 @@ function Check([string]$name,[bool]$ok,[string]$detail='') {
 try {
     if(Test-Path $hub){
         if([string]::IsNullOrWhiteSpace($TokenOwner)){throw 'Local HUD tests require -TokenOwner'}
-        $raw=& python $hub acquire --owner $TokenOwner --run $run --worktree $root --holder-pid $PID --purpose 'P13 private HUD UI acceptance'
+        $raw=& python $hub acquire --owner $TokenOwner --run $run --worktree $root --holder-pid $PID --purpose "$Suite private UI acceptance"
         $state=$raw|ConvertFrom-Json
         if($LASTEXITCODE-ne 0 -or -not $state.ok){throw "Suite token unavailable: $raw"}
         $lease=$state
@@ -116,13 +117,13 @@ public sealed class HudOwnedJob {
     $env:AGWINTERM_APP_ID=$appId+'-fallback'
     $job=[HudOwnedJob]::new()
     $job.Start([IO.Path]::GetFullPath($Exe),"--app-id $appId --pipe $pipe --no-restore",$root)
-    function Rpc([string]$verb,$params=@{},[string]$target='active',[switch]$AllowError){
+    function Rpc([string]$verb,$params=@{},[string]$target='active',[switch]$AllowError,[string]$Window='active'){
         $client=[IO.Pipes.NamedPipeClientStream]::new('.',$pipe,[IO.Pipes.PipeDirection]::InOut)
         try {
             $client.Connect(1500)
             $writer=[IO.StreamWriter]::new($client);$writer.AutoFlush=$true
             $reader=[IO.StreamReader]::new($client)
-            $writer.WriteLine((@{cmd=$verb;args=$params;target=$target}|ConvertTo-Json -Compress -Depth 8))
+            $writer.WriteLine((@{cmd=$verb;args=$params;target=$target;window=$Window}|ConvertTo-Json -Compress -Depth 8))
             $read=$reader.ReadLineAsync();if(-not $read.Wait(15000)){throw 'HUD RPC deadline exceeded'}
             $answer=$read.Result|ConvertFrom-Json
             if($AllowError){return $answer}
@@ -130,7 +131,7 @@ public sealed class HudOwnedJob {
         }finally{$client.Dispose()}
     }
     $ready=$false
-    for($i=0;$i-lt 60;$i++){try{$null=Rpc 'ping';$ready=$true;break}catch{Start-Sleep -Milliseconds 200}}
+    for($i=0;$i-lt 60;$i++){try{if(@((Rpc 'tree').workspaces[0].sessions).Count-gt 0){$ready=$true;break}}catch{};Start-Sleep -Milliseconds 200}
     if(-not $ready){throw 'Private app did not answer'}
     if(Test-Path ($appDir+'-fallback')){throw 'App ignored --app-id'}
     $proc=[Diagnostics.Process]::GetProcessById($job.Pid);$hwnd=[IntPtr]::Zero
@@ -156,6 +157,7 @@ public sealed class HudOwnedJob {
             }finally{$bitmap.UnlockBits($bits)}
         }finally{$graphics.Dispose();$bitmap.Dispose()}
     }
+    if($Suite-eq 'Quick') { . "$PSScriptRoot/quick-ui-cases.ps1" } else {
     $ctl=Join-Path $root 'src/Agwinterm.Ctl/bin/Release/net10.0-windows/agwintermctl.exe'
     $null=& $ctl session hud --spinner 'CLI HUD' --detail 'private acceptance' --size-percent 35 --target $session --pipe $pipe --json
     Check 'CLI default open accepts spinner before message and numeric width' ($LASTEXITCODE-eq 0 -and (Node).hud.message-eq 'CLI HUD' -and (Node).hud.sizePercent-eq 35)
@@ -250,6 +252,7 @@ public sealed class HudOwnedJob {
     $null=Rpc 'session.close' @{} $session
     for($i=0;$i-lt 50 -and $null-ne (Node);$i++){Start-Sleep -Milliseconds 50}
     Check 'session close removes HUD state' ($null-eq (Node))
+    }
 }catch{$failed++;"FAIL fixture: $($_.Exception.Message)"}
 finally {
     if($job){
@@ -265,7 +268,7 @@ finally {
         $raw|Set-Content (Join-Path $artifact 'release.json');$raw
         if($LASTEXITCODE-ne 0){$cleanup=$false}
     }
-    "hud-ui: $checks checks, $failed failed; cleanup complete: $cleanup; artifacts $artifact"
+    "$Suite-ui: $checks checks, $failed failed; cleanup complete: $cleanup; artifacts $artifact"
     Stop-Transcript|Out-Null
 }
-if(-not $cleanup){exit 2};if($failed){exit 1};exit 0
+if(-not $cleanup){exit 2};if($failed -or ($Strict -and $checks-eq 0)){exit 1};exit 0

--- a/tests/integration/hud-ui.ps1
+++ b/tests/integration/hud-ui.ps1
@@ -61,6 +61,10 @@ public sealed class HudOwnedJob {
         uint pid;uint t=GetWindowThreadProcessId(h,out pid);var info=new GUI {size=Marshal.SizeOf<GUI>()};
         if(!GetGUIThreadInfo(t,ref info))throw new Exception("GetGUIThreadInfo");return capture?info.capture:info.focus;
     }
+    public static RECT CaretRect(IntPtr h) {
+        uint pid;uint t=GetWindowThreadProcessId(h,out pid);var info=new GUI {size=Marshal.SizeOf<GUI>()};
+        if(!GetGUIThreadInfo(t,ref info))throw new Exception("GetGUIThreadInfo");return info.rect;
+    }
     IntPtr job,process; bool assigned; public uint Pid { get; private set; }
     public void Start(string exe,string args,string cwd) {
         job=CreateJobObjectW(IntPtr.Zero,null); if(job==IntPtr.Zero)throw new Exception("CreateJobObject");
@@ -109,6 +113,10 @@ public sealed class HudOwnedJob {
     @{default='HUD-test';profiles=@(@{name='HUD-test';command='cmd.exe';args=@('/d');cwd=$artifact})}|ConvertTo-Json -Depth 5|Set-Content (Join-Path $appDir 'profiles.json')
     @('session-host = in-process','claude-update-check = false','update-check = false','fresh-env = false','copy-on-select = false')|Set-Content (Join-Path $appDir 'agwinterm.conf')
     'map f12 = close_pane'|Set-Content (Join-Path $appDir 'keymap.conf')
+    if($Suite-eq 'Quick'){
+        @('map f7 = toggle_search','map f8 = command:QuickProbe',
+          ('command [send] QuickProbe = echo {AGW_PANE}>"'+(Join-Path $artifact 'keymap-send.txt')+'"'))|Add-Content (Join-Path $appDir 'keymap.conf')
+    }
     $savedEnv=@{}
     foreach($name in 'AGWINTERM_APP_ID','AGWINTERM_PIPE','AGWINTERM_SESSION_ID','AGWINTERM_PANE_ID','AGWINTERM_DUMP','AGWINTERM_PERF','AGWINTERM_IMGLOG'){
         $savedEnv[$name]=[Environment]::GetEnvironmentVariable($name)
@@ -259,6 +267,11 @@ finally {
         try{
             if($hwnd){[void][HudOwnedJob]::PostMessageW($hwnd,0x10,[IntPtr]::Zero,[IntPtr]::Zero)}
             $job.Finish();'Cleanup: owned job has zero live processes; no name-based cleanup.'
+            if($verifyQuickShutdown){
+                $probe=[QuickProbe]::RegisterHotKey([IntPtr]::Zero,0x615,0x4007,0x78)
+                try{Check 'last library window shutdown releases quick hotkey' $probe}
+                finally{if($probe -and -not [QuickProbe]::UnregisterHotKey([IntPtr]::Zero,0x615)){throw 'Cannot release shutdown hotkey probe'}}
+            }
         }catch{$cleanup=$false;"CLEANUP INCOMPLETE: $_"}
     }
     if($savedEnv){foreach($name in $savedEnv.Keys){[Environment]::SetEnvironmentVariable($name,$savedEnv[$name])}}

--- a/tests/integration/quick-ui-cases.ps1
+++ b/tests/integration/quick-ui-cases.ps1
@@ -41,6 +41,7 @@ $normalRect=[QuickProbe]::Rect($hwnd)
 $normalMetrics=Rpc 'session.metrics' @{} $session|ConvertTo-Json -Compress
 $library=Rpc 'window.list'|ConvertTo-Json -Compress
 Check 'quick shell is lazy and panel initially hidden' (-not [QuickProbe]::IsWindowVisible($q) -and -not (Rpc 'session.text' -Window quick -AllowError).ok)
+Check 'send command refuses before quick shell exists' (-not (Rpc 'command.run' @{name='echo dropped';mode='send'} -Window quick -AllowError).ok)
 $fg=[HudOwnedJob]::GetForegroundWindow()
 $null=Rpc 'quick' @{op='on'}
 for($i=0;$i-lt 50 -and -not (Rpc 'window.state').quickTerminalVisible;$i++){Start-Sleep -Milliseconds 100}
@@ -91,9 +92,18 @@ $keymapSink=Join-Path $artifact 'keymap-send.txt'
 for($i=0;$i-lt 50 -and -not (Test-Path $keymapSink);$i++){Start-Sleep -Milliseconds 100}
 Check 'surface-local custom keymap command runs in quick' ((Test-Path $keymapSink) -and (Get-Content $keymapSink -Raw).Trim()-eq 'quick')
 $commandSink=Join-Path $artifact 'quick-command.txt'
+$blockedSink=Join-Path $artifact 'quick-command-blocked.txt'
+$null=Rpc 'session.readonly' @{op='on'} -Window quick
+Check 'read-only quick refuses raw send command' (-not (Rpc 'command.run' @{name="echo forbidden>`"$blockedSink`"";mode='send'} -Window quick -AllowError).ok)
+Check 'read-only quick refuses named send command' (-not (Rpc 'command.run' @{name='QuickProbe'} -Window quick -AllowError).ok)
+$null=Rpc 'session.readonly' @{op='off'} -Window quick
 $null=Rpc 'command.run' @{name="echo {AGW_PANE}>`"$commandSink`"";mode='send'} -Window quick
 for($i=0;$i-lt 50 -and -not (Test-Path $commandSink);$i++){Start-Sleep -Milliseconds 100}
 Check 'surface-local send command retains quick context' ((Test-Path $commandSink) -and (Get-Content $commandSink -Raw).Trim()-eq 'quick')
+Check 'refused send wrote nothing before subsequent accepted command' ((Test-Path $commandSink) -and -not (Test-Path $blockedSink))
+$null=Rpc 'session.readonly' @{op='on'} $session
+Check 'library read-only send uses the same refusal guard' (-not (Rpc 'command.run' @{name='echo forbidden';mode='send'} -AllowError).ok)
+$null=Rpc 'session.readonly' @{op='off'} $session
 Check 'quick refuses new-session custom command mode' (-not (Rpc 'command.run' @{name='echo forbidden';mode='new'} -Window quick -AllowError).ok)
 # Posted logical DPI transition: no monitor setting is changed and no foreground is taken.
 $realDpi=[QuickProbe]::GetDpiForWindow($q);$beforeDpi=[QuickProbe]::Rect($q)
@@ -185,6 +195,7 @@ $null=Rpc 'quick' @{op='on'}
 $null=Rpc 'session.type' @{text="exit`r"} -Window quick
 for($i=0;$i-lt 50 -and (Rpc 'window.state').quickTerminalVisible;$i++){Start-Sleep -Milliseconds 100}
 Check 'shell exit dismisses and discards quick surface' (-not (Rpc 'window.state').quickTerminalVisible -and -not (Rpc 'session.text' -Window quick -AllowError).ok)
+Check 'send command refuses after quick shell exit' (-not (Rpc 'command.run' @{name='echo dropped';mode='send'} -Window quick -AllowError).ok)
 $null=Rpc 'quick' @{op='on'}
 for($i=0;$i-lt 50 -and -not (Rpc 'session.text' -Window quick -AllowError).ok;$i++){Start-Sleep -Milliseconds 100}
 Check 'summon after exit creates fresh shell' ((Rpc 'session.text' -Window quick -AllowError).ok)

--- a/tests/integration/quick-ui-cases.ps1
+++ b/tests/integration/quick-ui-cases.ps1
@@ -19,6 +19,7 @@ public static class QuickProbe {
     [DllImport("user32.dll",SetLastError=true)] public static extern bool RegisterHotKey(IntPtr h,int id,uint m,uint k);
     [DllImport("user32.dll",SetLastError=true)] public static extern bool UnregisterHotKey(IntPtr h,int id);
     [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h);
+    [DllImport("user32.dll")] public static extern uint GetDpiForWindow(IntPtr h);
     [DllImport("user32.dll")] static extern void keybd_event(byte k,byte scan,uint flags,UIntPtr extra);
     public static void Hotkey() {
         keybd_event(0x11,0,0,UIntPtr.Zero);keybd_event(0x12,0,0,UIntPtr.Zero);keybd_event(0x10,0,0,UIntPtr.Zero);
@@ -69,6 +70,47 @@ $null=Rpc 'session.type' @{text="echo %P14_KEEP%>`"$sink`"`r"} -Window quick
 for($i=0;$i-lt 50 -and -not (Test-Path $sink);$i++){Start-Sleep -Milliseconds 100}
 Check 'same shell and environment survive hide/show' ((Test-Path $sink) -and (Get-Content $sink -Raw).Trim()-eq 'alive')
 Check 'explicit quick prefix routes readback from library window' ((Rpc 'session.text' @{} 'quick:')-ceq (Rpc 'session.text' -Window quick))
+$beforeFont=Rpc 'session.metrics' -Window quick
+$null=Rpc 'font' @{op='inc'} -Window quick
+$afterFont=Rpc 'session.metrics' -Window quick
+Check 'font inc addresses active quick surface' ($afterFont.cellHeight-gt $beforeFont.cellHeight)
+$null=Rpc 'font' @{op='reset'} -Window quick
+Check 'font reset restores quick cell metrics' ((Rpc 'session.metrics' -Window quick).cellHeight-eq $beforeFont.cellHeight)
+$null=Rpc 'session.type' @{text="echo P14-FIND-MARKER`r"} -Window quick
+for($i=0;$i-lt 50 -and ([string](Rpc 'session.text' -Window quick))-notmatch '(?m)^P14-FIND-MARKER\s*$';$i++){Start-Sleep -Milliseconds 100}
+Check 'quick search reaches its active surface' ((Rpc 'session.search' @{query='P14-FIND-MARKER'} -Window quick)-match 'of [1-9]')
+$null=Rpc 'session.search' @{query='NO-MATCH-OLD-QUERY'} -Window quick
+$null=Rpc 'session.search' @{action='close'} -Window quick
+[void][HudOwnedJob]::SendMessageW($q,0x100,[IntPtr]118,[IntPtr]1) # F7 mapped to toggle_search
+foreach($c in 'P14-FIND-MARKER'.ToCharArray()){[void][HudOwnedJob]::SendMessageW($q,0x102,[IntPtr][int]$c,[IntPtr]1)}
+$keySearch=Rpc 'session.search' @{action='state'} -Window quick
+Check 'surface-local search keymap action accepts its query' ($keySearch-match 'of [1-9]') ([string]$keySearch)
+$null=Rpc 'session.search' @{action='close'} -Window quick
+[void][HudOwnedJob]::SendMessageW($q,0x100,[IntPtr]119,[IntPtr]1) # F8 mapped to custom send
+$keymapSink=Join-Path $artifact 'keymap-send.txt'
+for($i=0;$i-lt 50 -and -not (Test-Path $keymapSink);$i++){Start-Sleep -Milliseconds 100}
+Check 'surface-local custom keymap command runs in quick' ((Test-Path $keymapSink) -and (Get-Content $keymapSink -Raw).Trim()-eq 'quick')
+$commandSink=Join-Path $artifact 'quick-command.txt'
+$null=Rpc 'command.run' @{name="echo {AGW_PANE}>`"$commandSink`"";mode='send'} -Window quick
+for($i=0;$i-lt 50 -and -not (Test-Path $commandSink);$i++){Start-Sleep -Milliseconds 100}
+Check 'surface-local send command retains quick context' ((Test-Path $commandSink) -and (Get-Content $commandSink -Raw).Trim()-eq 'quick')
+Check 'quick refuses new-session custom command mode' (-not (Rpc 'command.run' @{name='echo forbidden';mode='new'} -Window quick -AllowError).ok)
+# Posted logical DPI transition: no monitor setting is changed and no foreground is taken.
+$realDpi=[QuickProbe]::GetDpiForWindow($q);$beforeDpi=[QuickProbe]::Rect($q)
+$suggested=[QuickProbe+RECT]::new();$suggested.left=5;$suggested.top=7;$suggested.right=405;$suggested.bottom=307
+$rectMemory=[Runtime.InteropServices.Marshal]::AllocHGlobal([Runtime.InteropServices.Marshal]::SizeOf($suggested))
+try {
+    [Runtime.InteropServices.Marshal]::StructureToPtr($suggested,$rectMemory,$false)
+    [void][HudOwnedJob]::SendMessageW($q,0x2e0,[IntPtr]((144-shl 16)-bor 144),$rectMemory)
+    Check 'DPI transition cannot override physical percentage frame' ([QuickProbe]::Rect($q)-eq $beforeDpi)
+    [void][HudOwnedJob]::SendMessageW($q,0x2e0,[IntPtr](($realDpi-shl 16)-bor $realDpi),$rectMemory)
+}finally{[Runtime.InteropServices.Marshal]::FreeHGlobal($rectMemory)}
+$null=Rpc 'session.write' @{text=([string][char]27+'[6;9H')} -Window quick
+[void][HudOwnedJob]::SendMessageW($q,7,[IntPtr]::Zero,[IntPtr]::Zero) # logical focus: owns only this process's caret
+[void][HudOwnedJob]::SendMessageW($q,0xf,[IntPtr]::Zero,[IntPtr]::Zero)
+$caret=[HudOwnedJob]::CaretRect($q)
+Check 'quick system caret follows nonzero terminal cursor' ($caret.left-gt 20 -and $caret.top-gt 40)
+[void][HudOwnedJob]::SendMessageW($q,8,[IntPtr]::Zero,[IntPtr]::Zero)
 Check 'quick does not enter library list' ((Rpc 'window.list'|ConvertTo-Json -Compress)-eq $library)
 foreach($verb in 'session.new','workspace.new','session.split','restore.capture','dashboard'){
     Check "$verb cannot create hidden tree in quick host" (-not (Rpc $verb -Window quick -AllowError).ok)
@@ -86,8 +128,22 @@ try {
     $r=Rpc 'config.set' @{key='quick-terminal-hotkey';value='ctrl+alt+shift+f10'} -AllowError
     Check 'hotkey conflict refuses and keeps old config' (-not $r.ok -and (Rpc 'config.get' @{key='quick-terminal-hotkey'})-eq 'ctrl+alt+shift+f9')
     $probe=[QuickProbe]::RegisterHotKey([IntPtr]::Zero,0x615,0x4007,0x78)
-    if($probe){[void][QuickProbe]::UnregisterHotKey([IntPtr]::Zero,0x615)}
+    if($probe -and -not [QuickProbe]::UnregisterHotKey([IntPtr]::Zero,0x615)){$cleanup=$false;throw 'Cannot release unexpected old-chord probe'}
     Check 'old hotkey remains registered after replacement conflict' (-not $probe)
+    $configFile=Join-Path $appDir 'agwinterm.conf'
+    $beforeConfig=[IO.File]::ReadAllText($configFile)
+    $locked=[IO.File]::Open($configFile,[IO.FileMode]::Open,[IO.FileAccess]::Read,[IO.FileShare]::Read)
+    try {
+        $r=Rpc 'config.set' @{key='quick-terminal-hotkey';value='ctrl+alt+shift+f8'} -AllowError
+        Check 'failed save is an error and preserves complete config bytes' (-not $r.ok -and [IO.File]::ReadAllText($configFile)-ceq $beforeConfig)
+        $probe=[QuickProbe]::RegisterHotKey([IntPtr]::Zero,0x615,0x4007,0x77)
+        try { Check 'failed save releases provisional new chord' $probe }
+        finally {if($probe -and -not [QuickProbe]::UnregisterHotKey([IntPtr]::Zero,0x615)){$cleanup=$false;throw 'Cannot release provisional-chord probe'}}
+        $probe=[QuickProbe]::RegisterHotKey([IntPtr]::Zero,0x615,0x4007,0x78)
+        if($probe -and -not [QuickProbe]::UnregisterHotKey([IntPtr]::Zero,0x615)){$cleanup=$false;throw 'Cannot release retained-chord probe'}
+        Check 'failed save never releases old chord' (-not $probe)
+        Check 'size write failure is not a successful empty reply' (-not (Rpc 'config.set' @{key='quick-terminal-size';value='50'} -AllowError).ok)
+    }finally{$locked.Dispose()}
     if($env:CI-eq 'true' -and -not (Test-Path $hub)){
         $null=Rpc 'quick' @{op='off'}
         [void][QuickProbe]::SetForegroundWindow($hwnd)
@@ -97,12 +153,32 @@ try {
         [void][QuickProbe]::SetForegroundWindow($hwnd)
         for($i=0;$i-lt 50 -and (Rpc 'window.state').quickTerminalVisible;$i++){Start-Sleep -Milliseconds 100}
         Check 'human panel dismisses on real focus loss' (-not (Rpc 'window.state').quickTerminalVisible)
+        $second=[string](Rpc 'window.new' @{name='P14-second'})
+        for($i=0;$i-lt 50 -and @((Rpc 'window.list').windows|Where-Object {$_.id-eq $second -and $_.open}).Count-eq 0;$i++){Start-Sleep -Milliseconds 100}
+        $null=Rpc 'quick' @{op='on'} -Window $second
+        Check 'second library window shares singleton quick host and visibility' ([QuickProbe]::Find($job.Pid)-eq $q -and (Rpc 'window.state' -Window $second).quickTerminalVisible)
+        $null=Rpc 'window.close' @{} $second
+        for($i=0;$i-lt 50 -and @((Rpc 'window.list').windows|Where-Object {$_.id-eq $second -and $_.open}).Count-gt 0;$i++){Start-Sleep -Milliseconds 100}
+        Check 'closing one of two library windows preserves quick shell' ((Rpc 'window.state').quickTerminalVisible -and (Rpc 'session.text' -Window quick -AllowError).ok)
     }else{'CI-only: real global-key injection / foreground check not run on shared desktop.'}
     $null=Rpc 'config.set' @{key='quick-terminal-hotkey';value=''}
     $probe=[QuickProbe]::RegisterHotKey([IntPtr]::Zero,0x615,0x4007,0x78)
     try { Check 'disabling hotkey releases OS reservation' $probe }
     finally { if($probe -and -not [QuickProbe]::UnregisterHotKey([IntPtr]::Zero,0x615)){$cleanup=$false;throw 'Cannot release probe hotkey'} }
 } finally { if(-not [QuickProbe]::UnregisterHotKey([IntPtr]::Zero,0x614)){$cleanup=$false;throw 'Cannot release conflict-test hotkey'} }
+# Simulate an invalid desired startup chord with no actual reservation, then fail its replacement.
+$beforeConfig=[IO.File]::ReadAllText($configFile)
+try {
+    [IO.File]::AppendAllText($configFile,"`nquick-terminal-hotkey = invalid`n")
+    $null=Rpc 'config.set' @{key='quick-terminal-size';value='90'} # reload desired config, not OS binding
+    $locked=[IO.File]::Open($configFile,[IO.FileMode]::Open,[IO.FileAccess]::Read,[IO.FileShare]::Read)
+    try {
+        $r=Rpc 'config.set' @{key='quick-terminal-hotkey';value='ctrl+alt+shift+f8'} -AllowError
+        $probe=[QuickProbe]::RegisterHotKey([IntPtr]::Zero,0x615,0x4007,0x77)
+        try { Check 'invalid old configured chord cannot strand replacement on save failure' (-not $r.ok -and $probe) }
+        finally {if($probe -and -not [QuickProbe]::UnregisterHotKey([IntPtr]::Zero,0x615)){$cleanup=$false;throw 'Cannot release invalid-config probe'}}
+    }finally{$locked.Dispose()}
+}finally{[IO.File]::WriteAllText($configFile,$beforeConfig);$null=Rpc 'config.set' @{key='quick-terminal-size';value='90'}}
 [void][HudOwnedJob]::SendMessageW($q,0x10,[IntPtr]::Zero,[IntPtr]::Zero)
 Check 'quick window close hides instead of destroying shell' (-not [QuickProbe]::IsWindowVisible($q) -and (Rpc 'session.text' -Window quick -AllowError).ok)
 $null=Rpc 'quick' @{op='on'}
@@ -112,3 +188,5 @@ Check 'shell exit dismisses and discards quick surface' (-not (Rpc 'window.state
 $null=Rpc 'quick' @{op='on'}
 for($i=0;$i-lt 50 -and -not (Rpc 'session.text' -Window quick -AllowError).ok;$i++){Start-Sleep -Milliseconds 100}
 Check 'summon after exit creates fresh shell' ((Rpc 'session.text' -Window quick -AllowError).ok)
+$null=Rpc 'config.set' @{key='quick-terminal-hotkey';value='ctrl+alt+shift+f9'}
+$verifyQuickShutdown=$true # parent verifies release only AFTER owned-job teardown, before token release

--- a/tests/integration/quick-ui-cases.ps1
+++ b/tests/integration/quick-ui-cases.ps1
@@ -1,0 +1,114 @@
+# Dot-sourced only by hud-ui.ps1 -Suite Quick, after its token and owned-job setup.
+Add-Type -TypeDefinition @'
+using System;
+using System.Text;
+using System.Runtime.InteropServices;
+public static class QuickProbe {
+    delegate bool Visitor(IntPtr h,IntPtr p);
+    [StructLayout(LayoutKind.Sequential)] public struct POINT { public int x,y; }
+    [StructLayout(LayoutKind.Sequential)] public struct RECT { public int left,top,right,bottom; }
+    [StructLayout(LayoutKind.Sequential)] struct MON { public int size; public RECT monitor,work; public uint flags; }
+    [DllImport("user32.dll")] static extern bool EnumWindows(Visitor f,IntPtr p);
+    [DllImport("user32.dll",CharSet=CharSet.Unicode)] static extern int GetWindowTextW(IntPtr h,StringBuilder b,int n);
+    [DllImport("user32.dll")] static extern uint GetWindowThreadProcessId(IntPtr h,out uint p);
+    [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr h,out RECT r);
+    [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr h);
+    [DllImport("user32.dll")] static extern bool GetCursorPos(out POINT p);
+    [DllImport("user32.dll")] static extern IntPtr MonitorFromPoint(POINT p,uint f);
+    [DllImport("user32.dll")] static extern bool GetMonitorInfoW(IntPtr h,ref MON m);
+    [DllImport("user32.dll",SetLastError=true)] public static extern bool RegisterHotKey(IntPtr h,int id,uint m,uint k);
+    [DllImport("user32.dll",SetLastError=true)] public static extern bool UnregisterHotKey(IntPtr h,int id);
+    [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h);
+    [DllImport("user32.dll")] static extern void keybd_event(byte k,byte scan,uint flags,UIntPtr extra);
+    public static void Hotkey() {
+        keybd_event(0x11,0,0,UIntPtr.Zero);keybd_event(0x12,0,0,UIntPtr.Zero);keybd_event(0x10,0,0,UIntPtr.Zero);
+        keybd_event(0x78,0,0,UIntPtr.Zero);keybd_event(0x78,0,2,UIntPtr.Zero);
+        keybd_event(0x10,0,2,UIntPtr.Zero);keybd_event(0x12,0,2,UIntPtr.Zero);keybd_event(0x11,0,2,UIntPtr.Zero);
+    }
+    public static IntPtr Find(uint pid) {
+        IntPtr result=IntPtr.Zero;
+        EnumWindows((h,p)=>{uint n;GetWindowThreadProcessId(h,out n);if(n==pid){var s=new StringBuilder(256);GetWindowTextW(h,s,256);if(s.ToString()=="agwinterm quick terminal"){result=h;return false;}}return true;},IntPtr.Zero);
+        return result;
+    }
+    public static RECT WorkArea() { POINT p;GetCursorPos(out p);var m=new MON {size=Marshal.SizeOf<MON>()};if(!GetMonitorInfoW(MonitorFromPoint(p,2),ref m))throw new Exception("Monitor query");return m.work; }
+    public static string Rect(IntPtr h) { RECT r;if(!GetWindowRect(h,out r))throw new Exception("Window rect");return $"{r.left},{r.top},{r.right},{r.bottom}"; }
+}
+'@
+$q=[QuickProbe]::Find($job.Pid)
+if($q-eq [IntPtr]::Zero){throw 'No owned quick host'}
+$normalRect=[QuickProbe]::Rect($hwnd)
+$normalMetrics=Rpc 'session.metrics' @{} $session|ConvertTo-Json -Compress
+$library=Rpc 'window.list'|ConvertTo-Json -Compress
+Check 'quick shell is lazy and panel initially hidden' (-not [QuickProbe]::IsWindowVisible($q) -and -not (Rpc 'session.text' -Window quick -AllowError).ok)
+$fg=[HudOwnedJob]::GetForegroundWindow()
+$null=Rpc 'quick' @{op='on'}
+for($i=0;$i-lt 50 -and -not (Rpc 'window.state').quickTerminalVisible;$i++){Start-Sleep -Milliseconds 100}
+Check 'control show makes detached quick visible without activating' ([QuickProbe]::IsWindowVisible($q) -and [HudOwnedJob]::GetForegroundWindow()-eq $fg)
+for($i=0;$i-lt 50 -and ([string](Rpc 'session.text' -Window quick))-notmatch '>';$i++){Start-Sleep -Milliseconds 100}
+$null=Rpc 'session.type' @{text="set P14_KEEP=alive`r"} -Window quick
+foreach($percent in 40,70,90){
+    $null=Rpc 'config.set' @{key='quick-terminal-size';value=[string]$percent}
+    $wa=[QuickProbe]::WorkArea();$qr=[QuickProbe+RECT]::new();[void][QuickProbe]::GetWindowRect($q,[ref]$qr)
+    $wantW=[int][Math]::Floor(($wa.right-$wa.left)*$percent/100)
+    $wantH=[int][Math]::Floor(($wa.bottom-$wa.top)*$percent/100)
+    Check "quick uses $percent percent of monitor work area" (($qr.right-$qr.left)-eq $wantW -and ($qr.bottom-$qr.top)-eq $wantH)
+    Check "normal geometry/grid untouched at $percent" ([QuickProbe]::Rect($hwnd)-eq $normalRect -and (Rpc 'session.metrics' @{} $session|ConvertTo-Json -Compress)-eq $normalMetrics)
+}
+foreach($bad in '39','91','NaN'){
+    $r=Rpc 'config.set' @{key='quick-terminal-size';value=$bad} -AllowError
+    Check "invalid size $bad refused with prior value retained" (-not $r.ok -and (Rpc 'config.get' @{key='quick-terminal-size'})-eq '90')
+}
+[void][HudOwnedJob]::SendMessageW($q,6,[IntPtr]::Zero,[IntPtr]::Zero) # logical blur, no foreground change
+Check 'control show remains pinned across logical blur' ([QuickProbe]::IsWindowVisible($q))
+$null=Rpc 'quick' @{op='off'}
+for($i=0;$i-lt 50 -and (Rpc 'window.state').quickTerminalVisible;$i++){Start-Sleep -Milliseconds 50}
+Check 'hide keeps quick host but removes it from screen' (-not [QuickProbe]::IsWindowVisible($q) -and [QuickProbe]::Find($job.Pid)-eq $q)
+$null=Rpc 'quick' @{op='on'}
+$sink=Join-Path $artifact 'quick-survived.txt'
+$null=Rpc 'session.type' @{text="echo %P14_KEEP%>`"$sink`"`r"} -Window quick
+for($i=0;$i-lt 50 -and -not (Test-Path $sink);$i++){Start-Sleep -Milliseconds 100}
+Check 'same shell and environment survive hide/show' ((Test-Path $sink) -and (Get-Content $sink -Raw).Trim()-eq 'alive')
+Check 'explicit quick prefix routes readback from library window' ((Rpc 'session.text' @{} 'quick:')-ceq (Rpc 'session.text' -Window quick))
+Check 'quick does not enter library list' ((Rpc 'window.list'|ConvertTo-Json -Compress)-eq $library)
+foreach($verb in 'session.new','workspace.new','session.split','restore.capture','dashboard'){
+    Check "$verb cannot create hidden tree in quick host" (-not (Rpc $verb -Window quick -AllowError).ok)
+}
+Check 'unknown quick operation refuses' (-not (Rpc 'quick' @{op='bogus'} -AllowError).ok)
+foreach($bad in 'win+a','ctrl+f12','shift+x','q'){
+    Check "unsafe hotkey $bad refuses" (-not (Rpc 'config.set' @{key='quick-terminal-hotkey';value=$bad} -AllowError).ok)
+}
+# Reserve a private, uncommon chord on this runner's thread; a conflicting app registration
+# must fail. The runner never sends its keystroke. Always release the exact registration.
+$reserved=[QuickProbe]::RegisterHotKey([IntPtr]::Zero,0x614,0x4007,0x79) # Ctrl+Alt+Shift+F10
+if(-not $reserved){throw 'Cannot reserve private conflict-test hotkey'}
+try {
+    $null=Rpc 'config.set' @{key='quick-terminal-hotkey';value='ctrl+alt+shift+f9'}
+    $r=Rpc 'config.set' @{key='quick-terminal-hotkey';value='ctrl+alt+shift+f10'} -AllowError
+    Check 'hotkey conflict refuses and keeps old config' (-not $r.ok -and (Rpc 'config.get' @{key='quick-terminal-hotkey'})-eq 'ctrl+alt+shift+f9')
+    $probe=[QuickProbe]::RegisterHotKey([IntPtr]::Zero,0x615,0x4007,0x78)
+    if($probe){[void][QuickProbe]::UnregisterHotKey([IntPtr]::Zero,0x615)}
+    Check 'old hotkey remains registered after replacement conflict' (-not $probe)
+    if($env:CI-eq 'true' -and -not (Test-Path $hub)){
+        $null=Rpc 'quick' @{op='off'}
+        [void][QuickProbe]::SetForegroundWindow($hwnd)
+        [QuickProbe]::Hotkey()
+        for($i=0;$i-lt 50 -and -not (Rpc 'window.state').quickTerminalVisible;$i++){Start-Sleep -Milliseconds 100}
+        Check 'disposable CI real global chord summons and focuses panel' ((Rpc 'window.state').quickTerminalVisible -and [HudOwnedJob]::GetForegroundWindow()-eq $q)
+        [void][QuickProbe]::SetForegroundWindow($hwnd)
+        for($i=0;$i-lt 50 -and (Rpc 'window.state').quickTerminalVisible;$i++){Start-Sleep -Milliseconds 100}
+        Check 'human panel dismisses on real focus loss' (-not (Rpc 'window.state').quickTerminalVisible)
+    }else{'CI-only: real global-key injection / foreground check not run on shared desktop.'}
+    $null=Rpc 'config.set' @{key='quick-terminal-hotkey';value=''}
+    $probe=[QuickProbe]::RegisterHotKey([IntPtr]::Zero,0x615,0x4007,0x78)
+    try { Check 'disabling hotkey releases OS reservation' $probe }
+    finally { if($probe -and -not [QuickProbe]::UnregisterHotKey([IntPtr]::Zero,0x615)){$cleanup=$false;throw 'Cannot release probe hotkey'} }
+} finally { if(-not [QuickProbe]::UnregisterHotKey([IntPtr]::Zero,0x614)){$cleanup=$false;throw 'Cannot release conflict-test hotkey'} }
+[void][HudOwnedJob]::SendMessageW($q,0x10,[IntPtr]::Zero,[IntPtr]::Zero)
+Check 'quick window close hides instead of destroying shell' (-not [QuickProbe]::IsWindowVisible($q) -and (Rpc 'session.text' -Window quick -AllowError).ok)
+$null=Rpc 'quick' @{op='on'}
+$null=Rpc 'session.type' @{text="exit`r"} -Window quick
+for($i=0;$i-lt 50 -and (Rpc 'window.state').quickTerminalVisible;$i++){Start-Sleep -Milliseconds 100}
+Check 'shell exit dismisses and discards quick surface' (-not (Rpc 'window.state').quickTerminalVisible -and -not (Rpc 'session.text' -Window quick -AllowError).ok)
+$null=Rpc 'quick' @{op='on'}
+for($i=0;$i-lt 50 -and -not (Rpc 'session.text' -Window quick -AllowError).ok;$i++){Start-Sleep -Milliseconds 100}
+Check 'summon after exit creates fresh shell' ((Rpc 'session.text' -Window quick -AllowError).ok)

--- a/tests/integration/win32-control.ps1
+++ b/tests/integration/win32-control.ps1
@@ -579,7 +579,7 @@ try {
         Start-Sleep -Seconds 2
         $captureLiteral = $captureFile.Replace("'", "''")
         $captureCommand = "Set-Content -LiteralPath '$captureLiteral' -Value `$env:AGWINTERM_SESSION_ID -Encoding utf8`r"
-        Invoke-Ctl @('session', 'type', $captureCommand, '--target', 'active') | Out-Null
+        Invoke-Ctl @('session', 'type', $captureCommand, '--target', 'active', '--window', 'quick') | Out-Null
         for ($i = 0; $i -lt 40 -and -not (Test-Path -LiteralPath $captureFile); $i++) {
             Start-Sleep -Milliseconds 250
         }
@@ -596,11 +596,13 @@ try {
                 "quick=$($quickReadonly.result); background=$($backgroundReadonly.result)"
 
             $coverMetrics = Invoke-Ctl @('session', 'metrics', '--target', $quickId)
+            $directQuickMetrics = Invoke-Ctl @('session', 'metrics', '--target', 'active', '--window', 'quick')
             $coverIsDistinct = $coverMetrics.ok -and $sessionMetrics.ok -and
                 $coverMetrics.result.widthPx -gt 0 -and $coverMetrics.result.heightPx -gt 0 -and
-                $coverMetrics.result.widthPx -lt $sessionMetrics.result.widthPx -and
-                $coverMetrics.result.heightPx -lt $sessionMetrics.result.heightPx
-            Check 'session.metrics measures the quick cover rectangle' $coverIsDistinct
+                $directQuickMetrics.ok -and
+                $coverMetrics.result.widthPx -eq $directQuickMetrics.result.widthPx -and
+                $coverMetrics.result.heightPx -eq $directQuickMetrics.result.heightPx
+            Check 'session.metrics resolves the detached quick rectangle through either selector' $coverIsDistinct
 
             $quickMarker = 'quick-cover-' + [guid]::NewGuid().ToString('N')
             Invoke-Ctl @('session', 'type', "Write-Output '$quickMarker'`r", '--target', $quickId) | Out-Null


### PR DESCRIPTION
## P14: detached quick terminal

- One app-level tool window and retained quick shell, 40–90% monitor sizing, no normal-window/PTY resize.
- Optional global hotkey (disabled by default); transactional native registration and atomic config persistence.
- API show pins without taking focus; human summons dismiss on blur; surface-local keymaps, font, search, selection and custom commands remain available.
- Owned acceptance fixture plus CI-only real hotkey/focus and multi-window checks. No clipboard/registry writes in the new fixture.

Validation: Core 265 / Pty 760 passed, initial HUD regression 51/51, expanded quick fixture 47/47. Suite tokens released after owned-job and hotkey cleanup. Broad Codex-only revmux 4/4 complete; functional findings batched in d87314f. Narrow Codex-only confirmation and exact-head CI are pending merge gates.

Plan and dispositions: docs/plans/2026-09-09-p14-quick-terminal.md, qa/p14-quick-terminal.md. P15 follows only after this merges; lite mirrors P13–P16 in P17. No release/install in this PR.
