### PR TITLE
P15: workspace navigation and small UI controls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,11 @@ jobs:
         timeout-minutes: 5
         run: ./tests/integration/hud-ui.ps1 -Suite Quick -Strict
 
+      - name: Workspace navigation and sidebar integration
+        shell: pwsh
+        timeout-minutes: 5
+        run: ./tests/integration/hud-ui.ps1 -Suite Navigation -Strict
+
       - name: Test (Core + Pty)
         # One retry for the known .NET 10 test-host #118 pathology under named-pipe churn, which
         # manifests two ways: a native CRASH ("Test Run Aborted") OR a DEADLOCK that hangs the run

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A Windows homage to [umputun's **agterm**](https://github.com/umputun/agterm).
 
 agwinterm exists because of **[umputun](https://github.com/umputun)** and his terminal
 **[agterm](https://github.com/umputun/agterm)**. agterm's design — a terminal that treats AI coding
-agents as first-class citizens, with per-session status, a sidebar of workspaces, a [detached quick terminal](docs/quick-terminal.md),
+agents as first-class citizens, with per-session status, [workspace navigation](docs/navigation.md), a [detached quick terminal](docs/quick-terminal.md),
 and a language-agnostic control socket — is the blueprint this project follows on Windows.
 
 This is an **independent, from-scratch implementation** written in C# on a native Win32/Direct2D

--- a/docs/agterm-parity.md
+++ b/docs/agterm-parity.md
@@ -134,19 +134,19 @@ HUD with detail, spinners, colors and bounded width; it leaves terminal input an
 unchanged. See [session-hud.md](session-hud.md) for targeting, replacement and validation.
 The agliteterm mirror remains owed in P17; the shared conformance floor is unchanged.
 
-### 3. Quick terminal: screen percentage, and a global hotkey
-**agterm 0.24.0 / 0.25.0.** Sizes as 40–90% of the screen, and a system-wide hotkey summons it over
-any app. Ours is a fixed size with no global hotkey. Size: medium (the hotkey is a `RegisterHotKey`
-and a policy decision about stealing a chord system-wide).
+### 3. Quick terminal — shipped in P14 (#266)
+Detached app-wide shell, monitor work-area percentage and opt-in global hotkey.
+See [quick-terminal.md](quick-terminal.md) for focus, lifetime and refusal policy;
+UIA per-window provider parity remains #267. Lite mirror is P17.
 
-### 4. Workspace navigation and keymap alternatives
-**agterm 0.23.0 / 0.24.0.** `workspace.go next|prev`, `toggle_workspace_collapse`, and keymap entries
-that accept several chords for one action separated by `|` (a native chord *and* a tmux-style
-leader). We have `session go`; workspaces are keyboard-unreachable without a chord. Size: small.
+### 4. Workspace navigation and keymap alternatives — P15
+Implemented in the P15 candidate: wrapped `workspace.go`, collapse action, alternative
+normal/leader map chords. See [navigation.md](navigation.md); QA records delivery gates.
 
 ### 5. Smaller things from 0.26
-Cursor shape and blink settings; sidebar tooltips revealing truncated names; the tree naming the
-shell holding each pane's foreground process. (The other two that were here — `session.restore`
+P15 covers existing cursor shape/blink controls with live acceptance, adds truncated-name
+tooltips and conservative Windows foreground-shell hints (not prompt safety).
+(The other two that were here — `session.restore`
 reporting the pane, and `--size-percent` validated rather than clamped — closed in P2.)
 
 ---

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -1,0 +1,57 @@
+# Workspace navigation and small UI controls
+
+`agwintermctl workspace go next|prev` (or `--to next|prev`, alias `previous`)
+returns the destination workspace ID. It wraps in visible sidebar order, including
+collapsed workspaces. Flagged mode and fewer than two visible workspaces refuse.
+`--window ID|active` selects the library window; quick windows and `--target` refuse.
+
+A destination with sessions selects its first session. An empty destination becomes
+the current workspace without creating or closing a shell; the previously selected
+terminal remains visible. `tree` and `window state` report that current workspace.
+Subsequent `session new` uses it only when neither an explicit workspace nor a valid
+caller pane supplies a workspace (the CLI sends its `AGWINTERM_SESSION_ID`). Selecting
+a session clears this transient empty-workspace target. It is not restore state.
+
+## Keymaps and sidebar
+
+These actions appear in the action palette and can be bound without new default chords:
+`next_workspace`, `previous_workspace`, `toggle_workspace_collapse`.
+Collapse changes only current workspace expansion, even while the sidebar is hidden.
+Quick terminals refuse these library actions.
+
+```text
+map f5 | f7 = next_workspace
+map f8 = previous_workspace
+map f9 = toggle_workspace_collapse
+leader = f10
+map leader a | b = next_workspace
+```
+
+Alternatives also work for `command:Label` targets. Defaults remain; later bindings win.
+An invalid or empty alternative rejects the entire map line with a diagnostic.
+`leader =` still takes one chord; pipes in command text remain shell syntax.
+Fixed gestures such as F6 sidebar focus still precede keymap dispatch.
+
+Dwell over a truncated workspace or session name to reveal a passive, wrapped tooltip
+within the client area (maximum 600 DIP width, bounded by available height). It never
+takes focus. Leaving, clicking, editing or invalidating that row dismisses it.
+
+## Foreground shell hints
+
+Tree sessions add `foregroundShells`, in pane order, with null for unknown entries.
+Known primary/split entries also supply `foregroundShell` / `splitForegroundShell`.
+Windows reports only a recognized, live root shell with no observed child process:
+cmd, powershell, pwsh, bash, sh, zsh, fish or nu. Failed queries and exited shells are
+unknown. This conservative snapshot is not Unix foreground-process-group detection:
+a builtin or loop can be busy with no child. **Never treat it as proof of an idle
+prompt or permission to send input.** No command arguments are exposed by these fields.
+
+## Cursor settings
+
+Existing Settings/config controls apply live: `cursor-style` accepts bar/beam/line,
+block/box or underline/underscore; `cursor-blink` accepts true/false, on/off, yes/no,
+1/0; `cursor-blink-ms` takes a positive 32-bit integer. Invalid API writes refuse
+without changing the prior value. File parsing remains compatible. Terminal DECSCUSR
+cursor overrides still take precedence. Shape changes do not resize terminal cells.
+
+P17 mirrors this contract to lite. Shared conformance is unchanged until then.

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -11,6 +11,9 @@ terminal remains visible. `tree` and `window state` report that current workspac
 Subsequent `session new` uses it only when neither an explicit workspace nor a valid
 caller pane supplies a workspace (the CLI sends its `AGWINTERM_SESSION_ID`). Selecting
 a session clears this transient empty-workspace target. It is not restore state.
+Delete-current actions use the current workspace, not the still-selected terminal's
+workspace. Terminal input (including broadcast) continues to follow that visible
+selected terminal; empty navigation does not silently retarget it.
 
 ## Keymaps and sidebar
 

--- a/docs/plans/2026-09-03-parity-batches.md
+++ b/docs/plans/2026-09-03-parity-batches.md
@@ -43,7 +43,7 @@ Three contract questions gate their batches. They are cheap to answer and expens
 | --- | --- | --- |
 | 1 | ~~`session.new` with an unknown workspace: **refuse** (lite does) or **fall back to active** (agwinterm does)?~~ **Answered: refuse** (2026-09-04, in P2 #226). lite already refused, every other workspace-taking verb here already refused, and the contract file states the principle in prose for `workspace.select`. A bare `session new` with *no* workspace named now lands in the **caller's** workspace, not the active one (P2 task 5a, from a live agliteterm report). | P2 |
 | 2 | ~~On the alt screen, do selections scroll into main-screen history (lite) or pin to row 0 (agwinterm)? Both are self-consistent; they cannot both stay.~~ **Answered: pin to row 0** (Boris, 2026-09-07) — agwinterm's way and most terminals'. lite stops scrolling into main-screen history while the alt screen is up, and `selection all` on the alt screen is the app's screen only, in both products. Lands in P6-lite (the verb's range) and P7-lite (the wheel and the drag). | P6, P7 |
-| 3 | Is `control.pick` (P16) worth its size, or does the picker stay out of scope? It is the biggest single capability gap and also the biggest plan. | P16 |
+| 3 | Resolved: Boris explicitly requested P14–P17 on 2026-09-09; implement the P16 native picker. | P16 |
 
 ---
 
@@ -286,21 +286,23 @@ remains P17 work; this batch does not expand shared conformance or publish a rel
 ### P14 · agwinterm · quick terminal
 Size as 40–90% of the screen · a system-wide hotkey that summons it over any app
 
-The hotkey is a `RegisterHotKey` plus a policy decision about stealing a chord machine-wide, which
-the plan should state rather than assume.
+Shipped in #266, merge `0a784b4`. [Contract](../quick-terminal.md),
+[QA](../../qa/p14-quick-terminal.md). Registration is opt-in, with no default global chord.
 
 ### P15 · agwinterm · navigation and the small sweep
 `workspace.go next|prev` · `toggle_workspace_collapse` · keymap entries accepting several chords for
 one action separated by `|` · sidebar tooltips revealing truncated names · the tree naming the shell
 holding each pane's foreground process · cursor shape and blink settings
 
-Workspaces are currently keyboard-unreachable without a chord.
+Implemented by [the P15 plan](2026-09-09-p15-navigation.md); see
+[contract](../navigation.md) and [QA](../../qa/p15-navigation.md) for delivery gates.
 
 ### P16 · agwinterm · `control.pick`
 The native picker driven over the API. Half the agterm cookbook is built on it — project launcher,
 workspace picker, conversation picker, backlog picker, SQLite browser — and nothing here can do that
 without shipping a picker binary of its own. **The biggest single capability gap and the biggest
-plan; expect more than two revmux rounds.** *Needs decision 3.*
+plan.** Boris authorized it on 2026-09-09 (decision 3). Use the standing one broad review,
+batched fixes and narrow confirmation rule; extra rounds require a substantive blocker.
 
 ### P17 · lite · mirror Wave 3
 Whatever of P13–P16 survives contact, mirrored. Sized once P13–P16 are real rather than guessed at.

--- a/docs/plans/2026-09-09-p15-navigation.md
+++ b/docs/plans/2026-09-09-p15-navigation.md
@@ -1,0 +1,64 @@
+# P15 — navigation and small UI sweep
+
+Authority: Boris requested P14–P17 sequentially, 2026-09-09. Codex owns delivery
+during Claude's outage. Base: P14 merge 0a784b452ae8b544552f1bf32dd92612bc7b5278. No release/install.
+
+## Contract
+
+- `workspace go next|prev` (also `--to next|prev`, `previous` alias) wraps through
+  this window's visible workspace order. Collapsed workspaces still count. Refuse
+  flagged mode or fewer than two visible workspaces. Ignore no destinations silently;
+  invalid/missing direction and an explicit target refuse. Return destination id.
+- Match upstream v0.26.0 AppStore navigation: first session selected when present;
+  an empty destination becomes the current workspace for subsequent new sessions,
+  without closing the prior session or creating a shell. P2's explicit workspace or
+  valid caller-pane workspace still takes precedence over this current-workspace fallback.
+  Current workspace and selected
+  session are deliberately separate while the destination is empty. Tree/window state
+  must report the destination. Selecting a session ends the empty-workspace override.
+- Add `next_workspace`, `previous_workspace`, `toggle_workspace_collapse` actions to
+  keymap and action palette/menu. No new default chords that steal existing bindings.
+  Fold toggling changes only current workspace expansion, including a hidden sidebar.
+  Quick surface refuses these tree actions.
+- `map chord | chord = action` and `map leader chord | chord = action` expand to
+  independent bindings, for builtins and custom commands. Preserve existing defaults,
+  single-chord grammar and last-write-wins collision behavior. An invalid/empty alternative
+  rejects that entire map line with a diagnostic, never half-applies it. `leader =`
+  remains one chord; pipes in command text remain literal shell syntax.
+- Sidebar dwell tooltip reveals the full truncated workspace/session name, including
+  flagged mode. Never displays a stale row after rename/reorder/resize/leave; no input
+  interception or popup focus. Reuse native renderer's tooltip layering and DPI units.
+- Tree adds per-pane foreground shell names with explicit unknown entries and primary/
+  split aliases matching upstream. A Windows snapshot can conservatively report a
+  recognized live shell with no descendants; any child/query failure/exited process is
+  unknown, NOT an idle prompt or permission to type. No CIM child process per tree poll.
+  Verify process identity and avoid OS enumeration under the workspace lock.
+- Cursor style/blink already exist in config, Settings and DECSCUSR rendering. Cover
+  their live behavior and add strict API validation for these existing fields rather
+  than a second settings implementation; preserve compatible file parsing aliases.
+
+## Evidence and bounds
+
+Carry P14's final QA/roadmap receipts forward after merge. Correct its send-guard
+comment to say local write failures propagate, not that every process-exit race throws;
+transport acceptance is not child consumption/execution (#268). Directly verify that
+wording clarification; it does not warrant another P14 review round.
+
+Pinned primary sources: agterm v0.26.0 AppStore.swift (navigateWorkspace/currentWorkspaceID),
+ControlServer+WorkspaceCommands.swift, agtermctlKit/WorkspaceCommands.swift, Keymap.swift
+and ControlProjection.swift. Windows foreground inference differs from Unix process groups;
+document it. No full command-line foreground capture, workspace focus-set expansion,
+UIA provider rewrite (#267) or shared conformance expansion before P17.
+
+## Acceptance / delivery
+
+Pure navigation and keymap alternative tests; dispatcher invalid/valid/quick-host cases;
+owned GUI suite for wrap/collapse/empty workspace/new placement/filter refusal, multiple
+chords and leader dispatch, sidebar tooltip pixels/state, tree split/exit/child behavior,
+cursor setting rejection/read-back and rendered shape/blink. Retained-job fixture with
+canonical suite token; no clipboard/registry/foreground changes locally. Full legacy
+integration remains disposable Windows CI only.
+
+One full Codex-only revmux, batched fixes, narrow confirmation if needed. Update QA and
+parity docs, exact-head green CI, merge normally, then start P16. Cosmetic residue does
+not require additional rounds.

--- a/qa/p14-quick-terminal.md
+++ b/qa/p14-quick-terminal.md
@@ -63,6 +63,19 @@ not cosmetic residue.
 conformance and Win32 integration, HUD 51, quick 51, Core 265 and Pty 760.
 The send-guard candidate built cleanly and passed 53/53 local quick checks; token 108
 was released after zero owned processes and exact hotkey cleanup. Evidence:
-`.revmux/quick-ui-20260909T165817-a9963b`. Narrow review and exact-head CI remain gates.
+`.revmux/quick-ui-20260909T165817-a9963b`.
 The pre-existing process-wide UIA provider limitation is tracked in
 [#267](https://github.com/yeroo/agwinterm/issues/267); full quick UIA parity is not claimed.
+
+## Final delivery receipt (carried forward in P15)
+
+Round `03-send-confirmation`: 2/2 healthy Codex sources; one verified finding about
+hosted input acceptance racing child exit. Owner disposition: pre-existing protocol
+limitation, accepted as [#268](https://github.com/yeroo/agwinterm/issues/268), not a
+zero-finding review. The hosted backend files are unchanged from the P14 base; quick
+uses the in-process backend. Transport acceptance does not prove child execution.
+
+Exact candidate `4dc24c4` passed [CI 34360590996](https://github.com/yeroo/agwinterm/actions/runs/34360590996):
+conformance, clipboard/paste, Win32 integration, HUD 51, quick 57, Core 265/Pty 760.
+Merged [#266](https://github.com/yeroo/agwinterm/pull/266) as `0a784b4` on 2026-09-09.
+No release, tag or installation performed.

--- a/qa/p15-navigation.md
+++ b/qa/p15-navigation.md
@@ -24,3 +24,32 @@ Final pre-review private navigation fixture: **44/44**, artifact
 processes. Includes empty explicit selection, caller placement precedence, deletion
 fallback, flagged-session tooltip and rename invalidation. Earlier corrected fixture
 passed 38/38 (token 111). The retained tooltip screenshot was visually inspected.
+
+## Broad review and one fix batch
+
+Round `01-initial`, candidate `4389171`: 4 expected/4 reported Codex sources, no
+degradation. Runner, reviewers, synthesis and verification all Codex. Final report:
+two Critical entries for the same wrong-workspace deletion mechanism (keymap/palette,
+independently found by bugs+impl and adversarial), one Major stale-focus navigation
+failure, four Minors (parser globals, DECSCUSR test, reserved F6 test, tooltip comments).
+One pre-existing Major and two Immaterials; no open questions.
+
+- Both delete-current actions now share a CurrentWorkspace-based helper. Named-row
+  context deletion still uses its named workspace; terminal broadcast intentionally
+  follows the visible selected terminal. Swept all `_active.Ws` and deletion call sites.
+- Workspace deletion clears matching focus and empty-placement state. The existing
+  last-workspace false-success defect is fixed in the same deletion path: queued UI
+  execution returns the actual membership/count refusal before mutation.
+- Parser rule sets are private/frozen and exposed defaults are read-only.
+- Added live F6 conflict/ownership, both delete action paths, focused deletion,
+  last-workspace refusal, and nonzero DECSCUSR shape/blink precedence acceptance.
+- Broadened the two tooltip comments while editing the same file.
+- Immaterials left unchanged: duplicate-but-equal cursor grammar and redundant target
+  check. Neither changes execution; no extra polish round is warranted.
+
+Initial candidate passed [CI 34365129644](https://github.com/yeroo/agwinterm/actions/runs/34365129644):
+conformance, clipboard/paste, Win32, HUD 51, quick 57, navigation 44, Core 296/Pty 774.
+Fix batch: Release build passed; Core 297/Pty 774 passed; private navigation **51/51**.
+Artifact `.revmux/navigation-ui-20260909T180805-03bb23`, token 113 released after zero
+owned processes. Clipboard/registry untouched, no queued launches. Narrow Codex
+confirmation and exact-head CI remain the final gates.

--- a/qa/p15-navigation.md
+++ b/qa/p15-navigation.md
@@ -1,0 +1,26 @@
+# P15 acceptance and review record
+
+Base: P14 merge `0a784b4`. Owner: Codex. [Plan](../docs/plans/2026-09-09-p15-navigation.md),
+[contract](../docs/navigation.md). Candidate implementation; review/CI/merge remain gates.
+
+- Release solution build succeeds. Native Rust release built before final headless run.
+- Core 296 / Pty 774 passed, no failures or skips (including parser/navigation/selector tests).
+- Initial private GUI runs exposed fixture ordering and an F6 binding conflict with the
+  existing accessibility focus-zone gesture. Wait for new-session materialization and
+  use unreserved F5/F7; do not remove the production accessibility gesture.
+- Cursor bar/block/underline and blinking pixels, tooltip dwell/leave, shell split,
+  live-child unknown and exited-shell unknown checks passed in those initial runs.
+- Token generations 109/110 released after retained-job zero-process proof; clipboard
+  and registry untouched. Logical messages target only the private fixture HWND.
+- A lost headless runner stalled with a locked test DLL. Its exact PID, creation time,
+  executable and ancestry were verified before terminating only that owned test host;
+  clean build and a fresh bounded headless run passed afterward.
+
+Full legacy GUI integration runs only in disposable Windows CI. Codex-only revmux and
+exact-head CI receipts will be recorded before merge. Lite mirror remains P17.
+
+Final pre-review private navigation fixture: **44/44**, artifact
+`.revmux/navigation-ui-20260909T173834-b25abb`, token 112 released after zero owned
+processes. Includes empty explicit selection, caller placement precedence, deletion
+fallback, flagged-session tooltip and rename invalidation. Earlier corrected fixture
+passed 38/38 (token 111). The retained tooltip screenshot was visually inspected.

--- a/src/Agwinterm.Core/Keymap.cs
+++ b/src/Agwinterm.Core/Keymap.cs
@@ -1,11 +1,10 @@
-using static Agwinterm.Win32.Win32;
-
-namespace Agwinterm.Win32;
+namespace Agwinterm.Core;
 
 /// <summary>
 /// Parses %LOCALAPPDATA%\agwinterm\keymap.conf into chord→action bindings and custom
 /// commands. Our own simple format (inspired by agterm, not copied):
 ///   map &lt;chord&gt; = &lt;action&gt;          rebind a built-in action
+///   map &lt;chord&gt; | &lt;chord&gt; = &lt;action&gt;  bind alternatives (also after map leader)
 ///   map &lt;chord&gt; = command:&lt;Label&gt;  bind a chord to a custom command
 ///   command &lt;Label&gt; = &lt;text&gt;       run &lt;text&gt; (default: type it into the active session)
 ///   command [new|overlay|detached|send] &lt;Label&gt; = &lt;text&gt;   choose the run mode
@@ -19,7 +18,7 @@ namespace Agwinterm.Win32;
 /// The command &lt;text&gt; may contain {AGW_*} tokens (expanded from the active session) and the
 /// launched process receives $AGW_* environment variables — see the agent skill for the list.
 /// </summary>
-internal static class Keymap
+public static class Keymap
 {
     /// <summary>Built-in action ids and their default chords (overridable by keymap.conf).</summary>
     public static readonly (string Chord, string Action)[] DefaultBindings =
@@ -61,6 +60,7 @@ internal static class Keymap
         // chords: ctrl+alt+up / ctrl+alt+down are previous_attention / next_attention, and a
         // second chord for a walk the first already makes would be a binding nobody asked for.
         "focus_top_pane", "focus_bottom_pane",
+        "next_workspace", "previous_workspace", "toggle_workspace_collapse",
         "toggle_sidebar", "rename_session", "delete_workspace", "session_palette", "action_palette",
         "attention_list", "custom_palette", "next_attention", "previous_attention", "reload_keymap",
         "toggle_search", "toggle_scratch", "quick_terminal", "close_cover", "toggle_fullscreen", "toggle_broadcast", "mark_mode", "toggle_read_only",
@@ -75,6 +75,7 @@ internal static class Keymap
         # agwinterm keymap (our own simple format)
         #
         #   map <chord> = <action>          rebind a built-in action
+        #   map <chord> | <chord> = <action> bind alternatives (also map leader ...)
         #   map <chord> = command:<Label>   bind a chord to a custom command below
         #   command <Label> = <text>        run <text> (default: type it into the active session)
         #   command [new|overlay|detached] <Label> = <text>   choose the run mode
@@ -162,14 +163,17 @@ internal static class Keymap
                 bool isLeader = chordRaw.StartsWith("leader ", StringComparison.OrdinalIgnoreCase);
                 if (isLeader) chordRaw = chordRaw["leader ".Length..].Trim();
 
-                string? chord = Canonicalize(chordRaw);
-                if (chord is null) { p.Diagnostics.Add($"line {lineNo}: bad chord '{chordRaw}'"); continue; }
+                var chords = chordRaw.Split('|').Select(Canonicalize).ToArray();
+                if (chords.Any(chord => chord is null))
+                { p.Diagnostics.Add($"line {lineNo}: bad chord alternatives '{chordRaw}'"); continue; }
                 var into = isLeader ? p.LeaderBindings : p.Bindings;
+                string action;
                 if (target.StartsWith("command:", StringComparison.OrdinalIgnoreCase))
-                    into[chord] = "command:" + target["command:".Length..].Trim();
+                    action = "command:" + target["command:".Length..].Trim();
                 else if (ValidActions.Contains(target))
-                    into[chord] = target.ToLowerInvariant();
-                else { p.Diagnostics.Add($"line {lineNo}: unknown action '{target}'"); }
+                    action = target.ToLowerInvariant();
+                else { p.Diagnostics.Add($"line {lineNo}: unknown action '{target}'"); continue; }
+                foreach (string? chord in chords) into[chord!] = action;
             }
             else if (line.StartsWith("command ", StringComparison.OrdinalIgnoreCase))
             {
@@ -246,14 +250,14 @@ internal static class Keymap
         if (vk >= 0x70 && vk <= 0x7B) return "f" + (vk - 0x70 + 1);
         return vk switch
         {
-            VK_TAB => "tab",
-            VK_RETURN => "enter",
-            VK_ESCAPE => "escape",
-            VK_SPACE => "space",
-            VK_UP => "up",
-            VK_DOWN => "down",
-            VK_LEFT => "left",
-            VK_RIGHT => "right",
+            0x09 => "tab",
+            0x0D => "enter",
+            0x1B => "escape",
+            0x20 => "space",
+            0x26 => "up",
+            0x28 => "down",
+            0x25 => "left",
+            0x27 => "right",
             // OEM punctuation VKs (US layout names)
             0xBA => "semicolon",
             0xBB => "equals",

--- a/src/Agwinterm.Core/Keymap.cs
+++ b/src/Agwinterm.Core/Keymap.cs
@@ -1,3 +1,5 @@
+using System.Collections.Frozen;
+
 namespace Agwinterm.Core;
 
 /// <summary>
@@ -21,8 +23,8 @@ namespace Agwinterm.Core;
 public static class Keymap
 {
     /// <summary>Built-in action ids and their default chords (overridable by keymap.conf).</summary>
-    public static readonly (string Chord, string Action)[] DefaultBindings =
-    {
+    public static IReadOnlyList<(string Chord, string Action)> DefaultBindings { get; } =
+        Array.AsReadOnly<(string Chord, string Action)>(new (string, string)[] {
         ("ctrl+shift+t", "new_session"),
         ("ctrl+shift+n", "new_workspace"),
         ("ctrl+shift+w", "close_pane"),
@@ -48,10 +50,9 @@ public static class Keymap
         ("ctrl+shift+down", "next_prompt"),
         ("ctrl+shift+m", "mark_mode"),
         ("ctrl+shift+r", "reopen_session"),
-    };
+    });
 
-    public static readonly HashSet<string> ValidActions = new(StringComparer.OrdinalIgnoreCase)
-    {
+    private static readonly FrozenSet<string> ValidActions = new[] {
         "new_session", "duplicate_session", "new_workspace", "close_session", "close_pane", "split_pane",
         "focus_left_pane", "focus_right_pane", "next_session", "previous_session",
         // P4: aliases of focus_left_pane / focus_right_pane for a horizontal split (top/bottom panes).
@@ -68,7 +69,7 @@ public static class Keymap
         "toggle_flag", "toggle_flagged_view", "focus_workspace",
         "select_all", "copy_selection", "paste",
         "new_window", "close_window", "switch_window",
-    };
+    }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 
     public const string StarterText =
         """
@@ -115,8 +116,8 @@ public static class Keymap
     /// <param name="Mode">send | new | overlay | detached.</param>
     public sealed record CmdDef(string Label, string Text, string Mode);
 
-    public static readonly HashSet<string> ValidModes = new(StringComparer.OrdinalIgnoreCase)
-    { "send", "new", "overlay", "detached" };
+    private static readonly FrozenSet<string> ValidModes = new[]
+    { "send", "new", "overlay", "detached" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 
     public sealed class Parsed
     {

--- a/src/Agwinterm.Core/WorkspaceNavigation.cs
+++ b/src/Agwinterm.Core/WorkspaceNavigation.cs
@@ -1,0 +1,31 @@
+namespace Agwinterm.Core;
+
+/// <summary>Relative navigation in the visible workspace order; expansion does not affect order.</summary>
+public static class WorkspaceNavigation
+{
+    public static bool TryDirection(string? direction, out int step)
+    {
+        step = direction switch { "next" => 1, "prev" or "previous" => -1, _ => 0 };
+        return step != 0;
+    }
+
+    public static int Destination(int count, int current, int step)
+    {
+        if (count < 2 || step is not (-1 or 1)) return -1;
+        if (current < 0 || current >= count) return step > 0 ? 0 : count - 1;
+        return (current + step + count) % count;
+    }
+}
+
+/// <summary>A conservative Windows shell-name hint, never proof of an interactive prompt.</summary>
+public static class ForegroundShellNames
+{
+    public static string? Recognize(string? executable, bool hasChildren, bool isLive)
+    {
+        if (!isLive || hasChildren || string.IsNullOrEmpty(executable)) return null;
+        string name = executable.ToLowerInvariant();
+        if (name.EndsWith(".exe", StringComparison.Ordinal)) name = name[..^4];
+        return name is "cmd" or "powershell" or "pwsh" or "bash" or "sh" or "zsh" or "fish" or "nu"
+            ? name : null;
+    }
+}

--- a/src/Agwinterm.Ctl/Program.cs
+++ b/src/Agwinterm.Ctl/Program.cs
@@ -187,6 +187,14 @@ switch (area)
                 break;
             case "delete": cmd = "workspace.delete"; break;
             case "select": cmd = "workspace.select"; break;
+            case "go":
+                if (options.ContainsKey("target") || rest.Count > 1 || (rest.Count > 0 && options.ContainsKey("to")))
+                { Console.Error.WriteLine("workspace go accepts one direction and no target"); return 2; }
+                string? direction = Opt("to") ?? rest.FirstOrDefault();
+                if (!Agwinterm.Core.WorkspaceNavigation.TryDirection(direction, out _))
+                { Console.Error.WriteLine("workspace go requires next or prev"); return 2; }
+                cmd = "workspace.go"; target = null; cargs["to"] = direction;
+                break;
             case "collapse": cmd = "workspace.collapse"; if (rest.Count > 0) target = rest[0]; break;
             case "expand": cmd = "workspace.expand"; if (rest.Count > 0) target = rest[0]; break;
             case "focus":

--- a/src/Agwinterm.Pty/AgentSkill.cs
+++ b/src/Agwinterm.Pty/AgentSkill.cs
@@ -125,6 +125,9 @@ public static class AgentSkill
         - `agwintermctl session move --to up|down|top|bottom`     — reorder within its workspace
         - `agwintermctl session move <workspace-id>`             — relocate to another workspace
         - `agwintermctl workspace new [name]` / `workspace rename <name> [--target WS]` / `workspace select [--target WS]` / `workspace move --to <dir> [--target WS]` / `workspace delete [--target WS]`
+        - `agwintermctl workspace go next|prev [--window ID]` (also `--to`, alias `previous`) wraps visible workspaces, including collapsed ones; refuses flagged mode, no other destination, quick windows and explicit `--target`.
+          An empty destination becomes current without closing the selected terminal. New-session explicit workspace/caller placement still wins over this fallback.
+          Tree `foregroundShells` (pane-order, null unknown) and primary/split aliases are conservative Windows shell hints, never idle-prompt or input-safety proof.
         - `agwintermctl workspace collapse [WS] [--target WS]` / `workspace expand [WS]` — collapse/expand a single workspace's session list (default: active)
 
         ## Read a session's output
@@ -340,6 +343,8 @@ public static class AgentSkill
 
         ## Custom commands (keymap.conf) & the launcher
         Define commands in keymap.conf, then run them by chord (Ctrl+Shift+O palette) or the control API:
+        Map heads accept alternatives: `map f5 | f7 = next_workspace`, also `map leader a | b = next_workspace`.
+        An invalid alternative rejects the entire map line. Fixed gestures such as F6 keep precedence; pipes in command bodies are unchanged.
         - `command <Label> = <text>`                    — default "send" mode: types the text into the active session
         - `command [new] <Label> = <text>`              — run in a fresh session's shell (stays interactive after)
         - `command [overlay] <Label> = <text>`          — run in an ephemeral overlay pane over the session

--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -169,6 +169,14 @@ public sealed class ControlServer : IDisposable
             JsonElement args = root.TryGetProperty("args", out var a) ? a : default;
             // --window <id|prefix|active>: content verbs act on the resolved window (default = frontmost).
             string? windowSel = root.TryGetProperty("window", out var wv) && wv.ValueKind == JsonValueKind.String ? wv.GetString() : null;
+            if (cmd == "workspace.go")
+            {
+                if (root.TryGetProperty("target", out var gt) && gt.ValueKind != JsonValueKind.Null)
+                    return Err("workspace go does not accept a target");
+                if ((root.TryGetProperty("window", out var gw) && gw.ValueKind is not (JsonValueKind.String or JsonValueKind.Null)) || windowSel == "")
+                    return Err("workspace go requires a nonempty window selector");
+                if (windowSel is not null && _windows is null) return Err("workspace go: window routing is unavailable in this host");
+            }
             if (cmd.StartsWith("session.hud.", StringComparison.Ordinal))
             {
                 if ((root.TryGetProperty("target", out var ht) && ht.ValueKind is not (JsonValueKind.String or JsonValueKind.Null)) ||
@@ -274,6 +282,11 @@ public sealed class ControlServer : IDisposable
                 case "workspace.rename": return host.WorkspaceRename(target, GetString(args, "name") ?? "") ? Ok("renamed") : Err("workspace not found");
                 case "workspace.delete": return host.WorkspaceDelete(target) ? Ok("deleted") : Err("workspace not found");
                 case "workspace.select": return host.WorkspaceSelect(target) ? Ok("selected") : Err("workspace not found");
+                case "workspace.go":
+                    if (target is not null) return Err("workspace go does not accept a target");
+                    string? direction = GetString(args, "to");
+                    if (!WorkspaceNavigation.TryDirection(direction, out _)) return Err("workspace go requires next or prev");
+                    return HostReply(host.WorkspaceGo(direction!));
                 case "workspace.move": return host.WorkspaceReorder(target, GetString(args, "dir") ?? "down") ? Ok("moved") : Err("workspace not found");
                 case "workspace.collapse": return host.WorkspaceCollapse(target, expand: false) ? Ok("collapsed") : Err("workspace not found");
                 case "workspace.expand": return host.WorkspaceCollapse(target, expand: true) ? Ok("expanded") : Err("workspace not found");
@@ -455,6 +468,7 @@ public sealed class ControlServer : IDisposable
             sb.Append("{\"id\":").Append(JsonSerializer.Serialize(ws.Id))
               .Append(",\"name\":").Append(JsonSerializer.Serialize(ws.Name))
               .Append(",\"active\":").Append(ws.Active ? "true" : "false")
+              .Append(",\"collapsed\":").Append(ws.Collapsed ? "true" : "false")
               .Append(",\"sessions\":[");
             for (int i = 0; i < ws.Sessions.Count; i++)
             {
@@ -470,6 +484,14 @@ public sealed class ControlServer : IDisposable
                   .Append(",\"statusChangedAt\":").Append(n.StatusChangedAt.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 if (n.Overlay) sb.Append(",\"overlay\":true");
                 if (n.Hud is { } hud) sb.Append(",\"hud\":").Append(JsonSerializer.Serialize(hud, SessionHuds.JsonOptions));
+                if (n.ForegroundShells is { } shells)
+                {
+                    sb.Append(",\"foregroundShells\":").Append(JsonSerializer.Serialize(shells));
+                    if (shells.Count > 0 && shells[0] is { } primary)
+                        sb.Append(",\"foregroundShell\":").Append(JsonSerializer.Serialize(primary));
+                    if (n.PaneCount > 1 && shells.Count > 1 && shells[1] is { } split)
+                        sb.Append(",\"splitForegroundShell\":").Append(JsonSerializer.Serialize(split));
+                }
                 if (n.Flagged) sb.Append(",\"flagged\":true");
                 if (n.Background) sb.Append(",\"background\":true");
                 if (n.Notifications > 0) sb.Append(",\"notifications\":").Append(n.Notifications);

--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -280,7 +280,7 @@ public sealed class ControlServer : IDisposable
                 case "session.readonly": return Ok(host.ReadOnlyOp(target, GetString(args, "op") ?? "toggle"));
                 case "session.output": return Ok(host.SessionOutput(target)); // last completed command's output (FTCS)
                 case "workspace.rename": return host.WorkspaceRename(target, GetString(args, "name") ?? "") ? Ok("renamed") : Err("workspace not found");
-                case "workspace.delete": return host.WorkspaceDelete(target) ? Ok("deleted") : Err("workspace not found");
+                case "workspace.delete": return host.WorkspaceDelete(target) ? Ok("deleted") : Err("workspace not found / cannot delete last workspace");
                 case "workspace.select": return host.WorkspaceSelect(target) ? Ok("selected") : Err("workspace not found");
                 case "workspace.go":
                     if (target is not null) return Err("workspace go does not accept a target");

--- a/src/Agwinterm.Pty/ISessionHost.cs
+++ b/src/Agwinterm.Pty/ISessionHost.cs
@@ -21,10 +21,11 @@ public sealed record SessionSnapshot(string Id, string Name, bool Active, AgentS
     IReadOnlyList<double>? SplitRatios = null, IReadOnlyList<string>? PaneIds = null,
     IReadOnlyList<string>? RestoreCommands = null, long StatusChangedAt = 0,
     string? Context = null, IReadOnlyList<string>? CapturedCommands = null,
-    string? Axis = null, IReadOnlyList<string>? PaneOverlays = null, HudSpec? Hud = null);
+    string? Axis = null, IReadOnlyList<string>? PaneOverlays = null, HudSpec? Hud = null,
+    IReadOnlyList<string?>? ForegroundShells = null);
 
 /// <summary>A workspace (with its sessions) for the control-API tree.</summary>
-public sealed record WorkspaceSnapshot(string Id, string Name, bool Active, IReadOnlyList<SessionSnapshot> Sessions);
+public sealed record WorkspaceSnapshot(string Id, string Name, bool Active, IReadOnlyList<SessionSnapshot> Sessions, bool Collapsed = false);
 
 /// <summary>Where a <c>session.restore</c> call landed: the pane the target resolved to and the session
 /// that owns it, so the reply can name both — a split has several panes and the caller cannot otherwise
@@ -231,6 +232,8 @@ public interface ISessionHost
     /// <summary>Collapse (expand=false) or expand (true) a single workspace by id; null target = active.</summary>
     bool WorkspaceCollapse(string? target, bool expand);
     bool WorkspaceSelect(string? target);
+    /// <summary>Relative visible-workspace navigation; returns destination id or RefusePrefix.</summary>
+    string WorkspaceGo(string direction) => RefusePrefix + "workspace navigation unavailable";
     /// <summary>Reorder a workspace among its siblings: dir = up|down|top|bottom.</summary>
     bool WorkspaceReorder(string? target, string dir);
 

--- a/src/Agwinterm.Win32/Program.Chrome.cs
+++ b/src/Agwinterm.Win32/Program.Chrome.cs
@@ -592,9 +592,9 @@ internal partial class Program
         }
     }
 
-    private void DeleteWorkspace(Workspace ws)
+    private bool DeleteWorkspace(Workspace ws)
     {
-        lock (_workspaces) if (_workspaces.Count <= 1) return; // agterm: can't delete the last workspace
+        lock (_workspaces) if (_workspaces.Count <= 1 || !_workspaces.Contains(ws)) return false;
         List<Ses> sessions;
         bool hadActive = _active is not null && ReferenceEquals(_active.Ws, ws);
         lock (_workspaces)
@@ -603,6 +603,8 @@ internal partial class Program
             CaptureClosedWorkspace(ws, sessions);   // remember it so Reopen Closed can bring the whole workspace back
             ws.Sessions.Clear();
             _workspaces.Remove(ws);
+            if (_focusedWorkspaceId == ws.Id) _focusedWorkspaceId = null;
+            if (ReferenceEquals(_workspaceTarget, ws)) _workspaceTarget = null;
             if (_workspaces.Count == 0) _workspaces.Add(new Workspace { Id = Guid.NewGuid().ToString(), Name = "workspace 1" });
         }
         RefreshHudTimer(); // a removed workspace may have owned the last animated HUD
@@ -616,6 +618,7 @@ internal partial class Program
         RequestRedraw();
         SaveState();
         EmitEvent("tree");   // control-API event log (#273)
+        return true;
     }
 
     /// <summary>Modal folder picker (native shell). Returns the chosen path or null.</summary>
@@ -825,7 +828,7 @@ internal partial class Program
                     bool stacked = _active is { Axis: SplitAxes.Horizontal };
                     A(stacked ? "Focus Top Pane" : "Focus Left Pane", "Ctrl+Alt+Left", () => FocusPane(-1));
                     A(stacked ? "Focus Bottom Pane" : "Focus Right Pane", "Ctrl+Alt+Right", () => FocusPane(1));
-                    A("Delete Active Workspace", "", () => { if (_active is not null) DeleteWorkspace(_active.Ws); });
+                    A("Delete Active Workspace", "", DeleteCurrentWorkspace);
                     A("Flag / Unflag Session", "Ctrl+Shift+F", () => { if (_active is not null) FlagOp(_active, "toggle"); });
                     A("Show Flagged / All Sessions", "", ToggleFlaggedView);
                     A("Focus Workspace", "", () => WorkspaceFocusOp("toggle"));
@@ -1431,7 +1434,7 @@ internal partial class Program
         RequestRedraw();
     }
 
-    /// <summary>TipTimer fired: show the tooltip for the still-hovered button.</summary>
+    /// <summary>TipTimer fired: show the still-hovered chrome button or truncated row name.</summary>
     private void TipTick()
     {
         KillTimer(_hwnd, (IntPtr)TipTimer);
@@ -1439,7 +1442,7 @@ internal partial class Program
         RequestRedraw();
     }
 
-    /// <summary>Draw the hover tooltip near its button (below title-bar buttons, above footer ones).</summary>
+    /// <summary>Draw a passive tooltip near its chrome button or truncated sidebar row.</summary>
     private void DrawButtonTip(ID2D1HwndRenderTarget rt, ID2D1SolidColorBrush brush)
     {
         if (_tipText is null) return;

--- a/src/Agwinterm.Win32/Program.Chrome.cs
+++ b/src/Agwinterm.Win32/Program.Chrome.cs
@@ -50,6 +50,7 @@ internal partial class Program
     private void DrawSidebar(ID2D1HwndRenderTarget rt, ID2D1SolidColorBrush brush)
     {
         _sidebarRows.Clear();
+        _sidebarNames.Clear();
         _footerButtons.Clear();
         if (_sidebarW <= 0) return;
 
@@ -99,8 +100,11 @@ internal partial class Program
             brush.Color = SbHeaderText;
             rt.DrawText(expanded ? "▾" : "▸", _format, TextRect(6f, y, 18f, rowH), brush); // chevron (mono, top-aligned)
             if (!ReferenceEquals(_editing, ws)) // the rename box covers the name while editing
+            {
                 // Clip + ellipsis so a long workspace name (or enlarged font) stops before the session count.
                 rt.DrawText(ws.Name, _sidebarFont, new Rect(24f, y, _sidebarW - 56f, rowH), brush, DrawTextOptions.Clip);
+                RecordSidebarName(ws, ws.Name, 24f, y, _sidebarW - 56f, rowH);
+            }
             rt.DrawText(sessions.Count.ToString(), _sidebarSmall, new Rect(_sidebarW - 28f, y, 22f, rowH), brush);
             if (_config.WorkspaceAddButton)   // "+" to add a session in this workspace (#233/#252)
                 rt.DrawText("+", _sidebarFont, new Rect(_sidebarW - 46f, y, 16f, rowH), brush);
@@ -187,6 +191,7 @@ internal partial class Program
             float nameAvail = _sidebarW - nameX - 22f;
             // Clip + ellipsis-trim so a long name (or an enlarged sidebar font) never spills over the dot.
             rt.DrawText(s.Name, _sidebarFont, new Rect(nameX, y, nameAvail, rowH), brush, DrawTextOptions.Clip);
+            RecordSidebarName(s, s.Name, nameX, y, nameAvail, rowH);
             // session.context (P3): a dimmer, smaller suffix after the name in the SAME row, clipped to
             // the name rect. The name keeps its full width and the context takes what is left; it is
             // never a second line and never changes rowH — DrawSidebar computes ONE rowH per paint and
@@ -824,6 +829,9 @@ internal partial class Program
                     A("Flag / Unflag Session", "Ctrl+Shift+F", () => { if (_active is not null) FlagOp(_active, "toggle"); });
                     A("Show Flagged / All Sessions", "", ToggleFlaggedView);
                     A("Focus Workspace", "", () => WorkspaceFocusOp("toggle"));
+                    A("Next Workspace", "", () => NavigateWorkspace("next"));
+                    A("Previous Workspace", "", () => NavigateWorkspace("prev"));
+                    A("Toggle Workspace Collapse", "", ToggleWorkspaceCollapse);
                     A("Toggle Sidebar", "", ToggleSidebar);
                     A("Select All", "Ctrl+Shift+A", () => { if (ActiveSurface() is { } p) SelectAll(p); });
                     A("Copy Selection", "Ctrl+C", () => { if (ActiveSurface() is { } p && HasLiveSel(p)) CopySelection(p); });
@@ -1384,41 +1392,81 @@ internal partial class Program
         string? hit = null;
         if (my < (int)TitleBarH) hit = ChromeHit(_titleButtons, mx);
         else if (mx < (int)_sidebarW && my >= ClientH() - (int)FooterH) hit = ChromeHit(_footerButtons, mx);
-        if (hit == _hotBtn) return;
+        SidebarNameHit? name = hit is null ? _sidebarNames.FirstOrDefault(n => mx >= n.X && mx < n.X + n.Width && my >= n.Y && my < n.Y + n.Height) : null;
+        if (hit == _hotBtn && Equals(name, _sidebarTip)) return;
         _hotBtn = hit;
+        _sidebarTip = name;
+        _tipText = null;
         if (hit is not null)
         {
             _hotPaint = hit; _hotAlpha = 1f;   // light instantly on hover-in
             if (Uia.ClientsListening) Uia.Announce(ChromeButtonLabel(hit) + " button");   // speak the hovered button
-            _tipText = null;
-            SetTimer(_hwnd, (IntPtr)TipTimer, 550, IntPtr.Zero);    // tooltip after a short hover dwell
         }
         else
         {
-            KillTimer(_hwnd, (IntPtr)TipTimer);
-            _tipText = null;
             SetTimer(_hwnd, (IntPtr)HoverTimer, 15, IntPtr.Zero);   // fade out when leaving
         }
+        if (hit is not null || name is not null) SetTimer(_hwnd, (IntPtr)TipTimer, 550, IntPtr.Zero);
+        else KillTimer(_hwnd, (IntPtr)TipTimer);
         RequestRedraw();
     }
 
     // ---- Hover tooltips for chrome buttons ----
     private const int TipTimer = 12;      // WM_TIMER id: show the tip after a hover dwell
     private string? _tipText;             // visible tooltip text (null = none)
+    private sealed record SidebarNameHit(object Owner, string Text, float X, float Y, float Width, float Height);
+    private readonly List<SidebarNameHit> _sidebarNames = new();
+    private SidebarNameHit? _sidebarTip;
+
+    private void RecordSidebarName(object owner, string text, float x, float y, float width, float height)
+    {
+        if (width > 0 && MeasureText(text, _sidebarFont) > width)
+            _sidebarNames.Add(new(owner, text, x, y, width, height));
+    }
+
+    private void DismissHoverTip()
+    {
+        _tipText = null; _sidebarTip = null;
+        KillTimer(_hwnd, (IntPtr)TipTimer);
+        RequestRedraw();
+    }
 
     /// <summary>TipTimer fired: show the tooltip for the still-hovered button.</summary>
     private void TipTick()
     {
         KillTimer(_hwnd, (IntPtr)TipTimer);
-        if (_hotBtn is null) return;
-        _tipText = ChromeButtonLabel(_hotBtn);
+        _tipText = _hotBtn is not null ? ChromeButtonLabel(_hotBtn) : _sidebarTip?.Text;
         RequestRedraw();
     }
 
     /// <summary>Draw the hover tooltip near its button (below title-bar buttons, above footer ones).</summary>
     private void DrawButtonTip(ID2D1HwndRenderTarget rt, ID2D1SolidColorBrush brush)
     {
-        if (_tipText is null || _hotBtn is null) return;
+        if (_tipText is null) return;
+        if (_sidebarTip is { } name)
+        {
+            // Hit data is rebuilt each frame: moving, renaming, collapsing or resizing a row
+            // invalidates its old tooltip without waiting for another mouse message.
+            if (_editing is not null || _dragging || !_sidebarNames.Contains(name))
+            { _tipText = null; _sidebarTip = null; return; }
+            float width = Math.Max(1f, Math.Min(600f, ClientW() - 24f));
+            float height = Math.Max(1f, ClientH() - 32f);
+            using var layout = _dwrite.CreateTextLayout(name.Text, _uiSmall, Math.Max(1, width - 16), height);
+            layout.WordWrapping = WordWrapping.EmergencyBreak;
+            layout.TextAlignment = TextAlignment.Leading;
+            layout.ParagraphAlignment = ParagraphAlignment.Near;
+            height = Math.Min(height + 16, layout.Metrics.Height + 16);
+            float x = Math.Clamp(name.X, 8, Math.Max(8, ClientW() - width - 8));
+            float y = Math.Clamp(name.Y + name.Height + 4, 8, Math.Max(8, ClientH() - height - 8));
+            brush.Color = Mix(PalBg, ChromeText, 0.10f);
+            rt.FillRoundedRectangle(new RoundedRectangle { Rect = new Rect(x, y, width, height), RadiusX = 5, RadiusY = 5 }, brush);
+            brush.Color = PalBorder;
+            rt.DrawRoundedRectangle(new RoundedRectangle { Rect = new Rect(x, y, width, height), RadiusX = 5, RadiusY = 5 }, brush, 1);
+            brush.Color = ChromeText;
+            rt.DrawTextLayout(new System.Numerics.Vector2(x + 8, y + 8), layout, brush, DrawTextOptions.Clip);
+            return;
+        }
+        if (_hotBtn is null) return;
         float bx0 = -1, bx1 = -1; bool footer = false;
         foreach (var b in _titleButtons) if (b.action == _hotBtn) { bx0 = b.x0; bx1 = b.x1; }
         if (bx0 < 0) foreach (var b in _footerButtons) if (b.action == _hotBtn) { bx0 = b.x0; bx1 = b.x1; footer = true; }

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -190,9 +190,12 @@ internal partial class Program
 
     public IReadOnlyList<WorkspaceSnapshot> Tree()
     {
+        Pane[] panes;
+        lock (_workspaces) panes = _workspaces.SelectMany(w => w.Sessions).SelectMany(s => s.Panes).ToArray();
+        var shells = ReadForegroundShells(panes);
         lock (_workspaces)
             return _workspaces.Select(w => new WorkspaceSnapshot(
-                w.Id, w.Name, _active is not null && ReferenceEquals(_active.Ws, w),
+                w.Id, w.Name, ReferenceEquals(CurrentWorkspace(), w),
                 w.Sessions.Select(s =>
                 {
                     var (status, statusChangedAt) = AggStatusAndAt(s);
@@ -211,9 +214,10 @@ internal partial class Program
                         // panes and the slots ride on them, so `["right"]` becomes `["left"]` by
                         // construction. Empty = the server omits the key.
                         PaneOverlays: s.Panes.Select((p, i) => (p, i)).Where(t => t.p.Overlay.Term is not null)
-                                             .Select(t => OverlayPanes.Word(t.i)).ToList(), Hud: s.Hud);
+                                             .Select(t => OverlayPanes.Word(t.i)).ToList(), Hud: s.Hud,
+                        ForegroundShells: s.Panes.Select(p => p.S.HasExited ? null : shells.GetValueOrDefault(p)).ToList());
                 }).ToList()
-            )).ToList();
+            , Collapsed: !w.Expanded)).ToList();
     }
 
     // Read-back snapshot: plain field reads + a Win32 query, safe from the pipe thread (worst case slightly stale).
@@ -224,7 +228,7 @@ internal partial class Program
             SidebarVisible: _sidebarW > 0, Fullscreen: _fullscreen, Maximized: IsZoomed(_hwnd),
             QuickTerminalVisible: _quickHost?._quickVisible == true,
             // ActiveSession is the NAME; session.context is not a name and is not folded in — it is read from the tree (P3).
-            ActiveWorkspace: a?.Ws.Name, ActiveSession: a is null ? null : (a.CustomName ?? a.Name));
+            ActiveWorkspace: CurrentWorkspace()?.Name, ActiveSession: a is null ? null : (a.CustomName ?? a.Name));
     }
 
     /// <summary>
@@ -510,13 +514,7 @@ internal partial class Program
         return true;
     }
 
-    public bool WorkspaceSelect(string? target)
-    {
-        var ws = FindWs(target);
-        if (ws is null) return false;
-        PostVerb(() => { var s = ws.Sessions.FirstOrDefault(); if (s is not null) SetActive(s); });
-        return true;
-    }
+    public bool WorkspaceSelect(string? target) => InvokeOnUiQueued(() => SelectWorkspaceCore(FindWs(target)));
 
     public bool WorkspaceReorder(string? target, string dir)
     {

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -507,12 +507,7 @@ internal partial class Program
     }
 
     public bool WorkspaceDelete(string? target)
-    {
-        var ws = FindWs(target);
-        if (ws is null) return false;
-        PostVerb(() => DeleteWorkspace(ws));
-        return true;
-    }
+        => InvokeOnUiQueued(() => FindWs(target) is { } ws && DeleteWorkspace(ws));
 
     public bool WorkspaceSelect(string? target) => InvokeOnUiQueued(() => SelectWorkspaceCore(FindWs(target)));
 

--- a/src/Agwinterm.Win32/Program.Input.cs
+++ b/src/Agwinterm.Win32/Program.Input.cs
@@ -170,6 +170,9 @@ internal partial class Program
             case "toggle_flag": if (_active is not null) FlagOp(_active, "toggle"); break;
             case "toggle_flagged_view": ToggleFlaggedView(); break;
             case "focus_workspace": WorkspaceFocusOp("toggle"); break;
+            case "next_workspace": NavigateWorkspace("next"); break;
+            case "previous_workspace": NavigateWorkspace("prev"); break;
+            case "toggle_workspace_collapse": ToggleWorkspaceCollapse(); break;
             case "close_cover": CloseCover(); break;
             case "toggle_fullscreen": ToggleFullscreen(); break;
             case "toggle_broadcast": ToggleBroadcast(); break;
@@ -234,8 +237,8 @@ internal partial class Program
             default: // send — type it into the active session, as if the user typed it + Enter
                 // Send's human-key path may quietly reject input. A command acknowledgement must
                 // instead report that refusal, for library and quick surfaces alike. These checks
-                // and Send run together on the UI thread; an exit/write race throws through the
-                // queued CommandRun bridge and becomes an API error, not a successful empty write.
+                // and Send run together on the UI thread; local write failures propagate through
+                // queued CommandRun. Accepted transport input is not proof of child execution (#268).
                 var surface = ActiveSurface();
                 if (surface is null || _session is null || surface.S.HasExited)
                     return ISessionHost.RefusePrefix + "no live pane for send command";

--- a/src/Agwinterm.Win32/Program.Input.cs
+++ b/src/Agwinterm.Win32/Program.Input.cs
@@ -18,7 +18,8 @@ namespace Agwinterm.Win32;
 internal partial class Program
 {
     // ---- Broadcast input (WT's toggleBroadcastInput analog): keyboard input mirrors to every
-    // pane of every session in the ACTIVE WORKSPACE. Paste stays targeted (safety). ----
+    // pane of every session in the SELECTED TERMINAL'S WORKSPACE. Empty-workspace
+    // navigation leaves that terminal visible and does not retarget its input. Paste stays targeted. ----
     private bool _broadcast;
 
     private void ToggleBroadcast()
@@ -151,7 +152,7 @@ internal partial class Program
             case "previous_session": CycleSession(-1); break;
             case "toggle_sidebar": ToggleSidebar(); break;
             case "rename_session": if (_active is not null) StartRename(_active); break;
-            case "delete_workspace": if (_active is not null) DeleteWorkspace(_active.Ws); break;
+            case "delete_workspace": DeleteCurrentWorkspace(); break;
             case "session_palette": TogglePalette(PaletteKind.Sessions); break;
             case "action_palette": TogglePalette(PaletteKind.Actions); break;
             case "attention_list": TogglePalette(PaletteKind.Attention); break;

--- a/src/Agwinterm.Win32/Program.Navigation.cs
+++ b/src/Agwinterm.Win32/Program.Navigation.cs
@@ -1,0 +1,103 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Agwinterm.Core;
+using Agwinterm.Pty;
+using static Agwinterm.Win32.Win32;
+
+namespace Agwinterm.Win32;
+
+internal partial class Program
+{
+    // Empty workspaces have no session to select. Keep their placement target separately
+    // from the terminal still visible; the next explicit session selection clears it.
+    private Workspace? _workspaceTarget;
+
+    private Workspace? CurrentWorkspace()
+    {
+        lock (_workspaces)
+            return _workspaceTarget is { } target && _workspaces.Contains(target) ? target
+                : _active is { } active && _workspaces.Contains(active.Ws) ? active.Ws
+                : _workspaces.FirstOrDefault();
+    }
+
+    private bool SelectWorkspaceCore(Workspace? ws)
+    {
+        if (ws is null) return false;
+        lock (_workspaces) if (!_workspaces.Contains(ws)) return false;
+        MruCommit();
+        if (_focusedWorkspaceId is not null && _focusedWorkspaceId != ws.Id)
+            _focusedWorkspaceId = null; // explicit selection must reveal its destination
+        if (ws.Sessions.FirstOrDefault() is { } first) SetActive(first);
+        else { _workspaceTarget = ws; RequestRedraw(); SaveState(); }
+        EmitEvent("tree");
+        return true;
+    }
+
+    public string WorkspaceGo(string direction) => InvokeOnUiQueued(() => WorkspaceGoCore(direction));
+
+    private string WorkspaceGoCore(string direction)
+    {
+        if (!WorkspaceNavigation.TryDirection(direction, out int step))
+            return ISessionHost.RefusePrefix + "workspace go requires next or prev";
+        List<Workspace> visible;
+        lock (_workspaces) visible = _sidebarMode == SidebarMode.Flagged ? new()
+            : _workspaces.Where(w => _focusedWorkspaceId is null || w.Id == _focusedWorkspaceId).ToList();
+        int index = WorkspaceNavigation.Destination(visible.Count, visible.IndexOf(CurrentWorkspace()!), step);
+        if (index < 0) return ISessionHost.RefusePrefix + "no other visible workspace to navigate to";
+        var destination = visible[index];
+        return SelectWorkspaceCore(destination) ? destination.Id : ISessionHost.RefusePrefix + "workspace not found";
+    }
+
+    private void NavigateWorkspace(string direction)
+    {
+        string result = WorkspaceGoCore(direction);
+        if (result.StartsWith(ISessionHost.RefusePrefix, StringComparison.Ordinal))
+            ShowToast(result[ISessionHost.RefusePrefix.Length..]);
+        else if (CurrentWorkspace() is { Sessions.Count: 0 } empty)
+            ShowToast(empty.Name + " — no sessions");
+    }
+
+    private void ToggleWorkspaceCollapse()
+    {
+        lock (_workspaces) if (CurrentWorkspace() is { } ws) ws.Expanded = !ws.Expanded;
+        RequestRedraw(); SaveState(); EmitEvent("tree");
+    }
+
+    // One Toolhelp pass per tree read, no subprocess/CIM and never under _workspaces.
+    // Windows has no Unix foreground process group: report only a recognized, live root
+    // shell with no child processes. A builtin/loop may still be busy; this is not a prompt gate.
+    private static Dictionary<Pane, string?> ReadForegroundShells(Pane[] panes)
+    {
+        var result = new Dictionary<Pane, string?>();
+        IntPtr snapshot = CreateToolhelp32Snapshot(0x2, 0);
+        if (snapshot == IntPtr.Zero || snapshot == new IntPtr(-1)) return result;
+        try
+        {
+            var entry = new PROCESSENTRY32W { dwSize = (uint)Marshal.SizeOf<PROCESSENTRY32W>() };
+            if (!Process32FirstW(snapshot, ref entry)) return result;
+            var names = new Dictionary<int, string>();
+            var parents = new HashSet<int>();
+            do
+            {
+                names[(int)entry.th32ProcessID] = entry.szExeFile;
+                parents.Add((int)entry.th32ParentProcessID);
+            } while (Process32NextW(snapshot, ref entry));
+            if (Marshal.GetLastWin32Error() != 18 /* ERROR_NO_MORE_FILES */) return result;
+            foreach (var pane in panes)
+            {
+                if (pane.S.HasExited || pane.S.ChildProcessId is not int pid || !names.TryGetValue(pid, out string? name)) continue;
+                string? shell = ForegroundShellNames.Recognize(name, parents.Contains(pid), true);
+                if (shell is null) continue;
+                try
+                {
+                    using var process = Process.GetProcessById(pid);
+                    if (!process.HasExited && !pane.S.HasExited && pane.S.ChildProcessId == pid &&
+                        string.Equals(process.ProcessName, shell, StringComparison.OrdinalIgnoreCase)) result[pane] = shell;
+                }
+                catch (Exception ex) when (ex is ArgumentException or InvalidOperationException or System.ComponentModel.Win32Exception) { }
+            }
+        }
+        finally { CloseHandle(snapshot); }
+        return result;
+    }
+}

--- a/src/Agwinterm.Win32/Program.Navigation.cs
+++ b/src/Agwinterm.Win32/Program.Navigation.cs
@@ -63,6 +63,12 @@ internal partial class Program
         RequestRedraw(); SaveState(); EmitEvent("tree");
     }
 
+    private void DeleteCurrentWorkspace()
+    {
+        if (CurrentWorkspace() is not { } ws || !DeleteWorkspace(ws))
+            ShowToast("cannot delete the last workspace");
+    }
+
     // One Toolhelp pass per tree read, no subprocess/CIM and never under _workspaces.
     // Windows has no Unix foreground process group: report only a recognized, live root
     // shell with no child processes. A builtin/loop may still be busy; this is not a prompt gate.

--- a/src/Agwinterm.Win32/Program.Services.cs
+++ b/src/Agwinterm.Win32/Program.Services.cs
@@ -1022,6 +1022,12 @@ internal partial class Program
     {
         key = key.Trim().ToLowerInvariant();
         if (Array.IndexOf(ConfigKeys, key) < 0) return "error: unknown key '" + key + "'";
+        if (key == "cursor-style" && value.Trim().ToLowerInvariant() is not ("bar" or "beam" or "line" or "block" or "box" or "underline" or "underscore"))
+            return "error: cursor-style must be bar, block or underline";
+        if (key == "cursor-blink" && value.Trim().ToLowerInvariant() is not ("true" or "false" or "on" or "off" or "yes" or "no" or "1" or "0"))
+            return "error: cursor-blink must be a boolean";
+        if (key == "cursor-blink-ms" && (!int.TryParse(value.Trim(), out int blinkMs) || blinkMs <= 0))
+            return "error: cursor-blink-ms must be a positive integer";
         if (key == "quick-terminal-size" && (!int.TryParse(value.Trim(), out int qs) || qs is < 40 or > 90))
             return "error: quick-terminal-size must be an integer from 40 through 90";
         if (key == "quick-terminal-hotkey")
@@ -1053,7 +1059,9 @@ internal partial class Program
             ShowToast(_emulatorCoreNote ?? "emulator-core = managed — new sessions use the C# emulator", 6000);
             _emulatorCoreNote = null;   // startup path only announces once
         }
-        if (key == "cursor-blink-ms" && _hwnd != IntPtr.Zero) SetTimer(_hwnd, (IntPtr)1, (uint)_config.CursorBlinkMs, IntPtr.Zero);
+        if (key == "cursor-blink-ms")
+            foreach (var window in _registry.Values.ToArray())
+                if (window._hwnd != IntPtr.Zero) SetTimer(window._hwnd, (IntPtr)1, (uint)_config.CursorBlinkMs, IntPtr.Zero);
         RecomputeChrome();
         ApplyWindowOpacity();
         if (key is "compact-toolbar" or "toolbar-mode")   // title-bar height changed → reflow the terminal grid

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -28,7 +28,7 @@ internal partial class Program
     {
         lock (_workspaces)
         {
-            if (_active is not null) return _active.Ws;
+            if (CurrentWorkspace() is { } current) return current;
             if (_workspaces.Count == 0) _workspaces.Add(new Workspace { Id = Guid.NewGuid().ToString(), Name = "workspace 1" });
             return _workspaces[0];
         }
@@ -337,8 +337,8 @@ internal partial class Program
     }
 
     [DllImport("kernel32.dll", SetLastError = true)] private static extern IntPtr CreateToolhelp32Snapshot(uint flags, uint pid);
-    [DllImport("kernel32.dll", CharSet = CharSet.Unicode)] private static extern bool Process32FirstW(IntPtr snapshot, ref PROCESSENTRY32W entry);
-    [DllImport("kernel32.dll", CharSet = CharSet.Unicode)] private static extern bool Process32NextW(IntPtr snapshot, ref PROCESSENTRY32W entry);
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)] private static extern bool Process32FirstW(IntPtr snapshot, ref PROCESSENTRY32W entry);
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)] private static extern bool Process32NextW(IntPtr snapshot, ref PROCESSENTRY32W entry);
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     private struct PROCESSENTRY32W
     {
@@ -556,6 +556,7 @@ internal partial class Program
 
     private void SetActive(Ses ses)
     {
+        _workspaceTarget = null;
         // Navigating to a session outside the multi-selection drops the selection (single-select again).
         if (!_selectedIds.Contains(ses.Id)) _selectedIds.Clear();
         _active = ses;
@@ -1786,7 +1787,7 @@ internal partial class Program
     {
         lock (_workspaces)
         {
-            if (string.IsNullOrEmpty(target) || target == "active") return _active?.Ws ?? _workspaces.FirstOrDefault();
+            if (string.IsNullOrEmpty(target) || target == "active") return CurrentWorkspace();
             return _workspaces.FirstOrDefault(w => w.Id == target) ?? _workspaces.FirstOrDefault(w => w.Id.StartsWith(target));
         }
     }
@@ -1967,6 +1968,8 @@ internal partial class Program
             "off" => null,
             _ => _focusedWorkspaceId is not null ? null : wsId, // toggle
         };
+        if (_workspaceTarget is { } target && _focusedWorkspaceId is not null && _focusedWorkspaceId != target.Id)
+            _workspaceTarget = null;
         RequestRedraw(); SaveState();
     }
 

--- a/src/Agwinterm.Win32/Program.WndProc.cs
+++ b/src/Agwinterm.Win32/Program.WndProc.cs
@@ -68,6 +68,7 @@ internal partial class Program
 
             case WM_MOUSELEAVE:
                 _mouseTracking = false;
+                DismissHoverTip();
                 if (_hotBtn is not null) { _hotBtn = null; SetTimer(hwnd, (IntPtr)HoverTimer, 15, IntPtr.Zero); RequestRedraw(); }
                 return IntPtr.Zero;
 
@@ -359,6 +360,7 @@ internal partial class Program
                 }
 
             case WM_LBUTTONDOWN:
+                DismissHoverTip();
                 {
                     int mx = DipX(lParam), my = DipY(lParam);   // device px -> DIP layout
                     if (_chromeFocus) ExitChromeFocus(announce: false);   // a click leaves the F6 sidebar zone

--- a/tests/Agwinterm.Core.Tests/NavigationTests.cs
+++ b/tests/Agwinterm.Core.Tests/NavigationTests.cs
@@ -4,6 +4,14 @@ namespace Agwinterm.Core.Tests;
 
 public class NavigationTests
 {
+    [Fact] public void DefaultBindingsCannotBeMutatedByConsumers()
+    {
+        var collection = Assert.IsAssignableFrom<IList<(string Chord, string Action)>>(Keymap.DefaultBindings);
+        Assert.True(collection.IsReadOnly);
+        Assert.Throws<NotSupportedException>(() => collection[0] = ("f1", "delete_workspace"));
+        Assert.Equal("new_session", Keymap.Parse("").Bindings["ctrl+shift+t"]);
+    }
+
     [Theory]
     [InlineData("next", 1)][InlineData("prev", -1)][InlineData("previous", -1)]
     [InlineData(null, 0)][InlineData("", 0)][InlineData("up", 0)][InlineData("Next", 0)]

--- a/tests/Agwinterm.Core.Tests/NavigationTests.cs
+++ b/tests/Agwinterm.Core.Tests/NavigationTests.cs
@@ -1,0 +1,59 @@
+using Agwinterm.Core;
+
+namespace Agwinterm.Core.Tests;
+
+public class NavigationTests
+{
+    [Theory]
+    [InlineData("next", 1)][InlineData("prev", -1)][InlineData("previous", -1)]
+    [InlineData(null, 0)][InlineData("", 0)][InlineData("up", 0)][InlineData("Next", 0)]
+    public void DirectionIsExplicit(string? word, int step)
+    { Assert.Equal(step != 0, WorkspaceNavigation.TryDirection(word, out int actual)); Assert.Equal(step, actual); }
+
+    [Theory]
+    [InlineData(0, -1, 1, -1)][InlineData(1, 0, 1, -1)]
+    [InlineData(3, 0, -1, 2)][InlineData(3, 2, 1, 0)]
+    [InlineData(3, 1, 1, 2)][InlineData(3, 1, -1, 0)]
+    [InlineData(3, -1, 1, 0)][InlineData(3, -1, -1, 2)]
+    [InlineData(3, 1, 0, -1)]
+    public void NavigationWrapsVisibleOrder(int count, int current, int step, int expected)
+        => Assert.Equal(expected, WorkspaceNavigation.Destination(count, current, step));
+
+    [Fact] public void AlternativesExpandWithoutRemovingDefaults()
+    {
+        var result = Keymap.Parse("map ctrl+g | alt+g = next_workspace\nmap leader a | b = previous_workspace\nleader=f10");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("next_workspace", result.Bindings["ctrl+g"]);
+        Assert.Equal("next_workspace", result.Bindings["alt+g"]);
+        Assert.Equal("previous_workspace", result.LeaderBindings["a"]);
+        Assert.Equal("previous_workspace", result.LeaderBindings["b"]);
+        Assert.Equal("new_session", result.Bindings["ctrl+shift+t"]);
+        Assert.Equal("f10", result.Leader);
+    }
+
+    [Theory][InlineData("ctrl+g | bogus")][InlineData("| ctrl+g")][InlineData("ctrl+g |")][InlineData("ctrl+g || alt+g")]
+    public void BadAlternativeRejectsWholeLine(string keys)
+    {
+        var result = Keymap.Parse($"map {keys} = next_workspace");
+        Assert.Single(result.Diagnostics); Assert.False(result.Bindings.ContainsKey("ctrl+g"));
+    }
+
+    [Fact] public void CommandsKeepPipesAndLastMappingWins()
+    {
+        var result = Keymap.Parse("command Pipe = echo a | more\nmap f6 | f7 = command:Pipe\nmap f6=toggle_workspace_collapse");
+        Assert.Empty(result.Diagnostics); Assert.Equal("echo a | more", Assert.Single(result.Commands).Text);
+        Assert.Equal("command:Pipe", result.Bindings["f7"]);
+        Assert.Equal("toggle_workspace_collapse", result.Bindings["f6"]);
+    }
+
+    [Fact] public void LeaderIsStillExactlyOneChord()
+    { var result = Keymap.Parse("leader=f6|f7"); Assert.Null(result.Leader); Assert.Single(result.Diagnostics); }
+
+    [Theory]
+    [InlineData("CMD.EXE", false, true, "cmd")][InlineData("pwsh.exe", false, true, "pwsh")]
+    [InlineData("powershell.exe", false, true, "powershell")][InlineData("bash", false, true, "bash")]
+    [InlineData("cmd.exe", true, true, null)][InlineData("cmd.exe", false, false, null)]
+    [InlineData("python.exe", false, true, null)][InlineData(null, false, true, null)]
+    public void ShellHintsAreConservative(string? name, bool children, bool live, string? expected)
+        => Assert.Equal(expected, ForegroundShellNames.Recognize(name, children, live));
+}

--- a/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
+++ b/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
@@ -25,6 +25,7 @@ internal sealed class FakeSessionHost : ISessionHost
         /// so a test asserts a set the way a caller does and a refusal the way it must: unchanged.</summary>
         public string? Context;
         public HudSpec? Hud;
+        public List<string?>? ForegroundShells;
         public int Notifications, PaneCount = 1, FocusedPane, OverlaySize;
         public List<double> Ratios = new() { 1.0 };
         /// <summary>The split's orientation — what the app keeps in Ses.Axis: one of <see cref="SplitAxes"/>'
@@ -166,7 +167,7 @@ internal sealed class FakeSessionHost : ISessionHost
         public string LastResult = OverlayPanes.NoResult;
         public bool Open => Term is not null;
     }
-    internal sealed class Ws { public string Id = "", Name = ""; public List<Sess> Sessions = new(); }
+    internal sealed class Ws { public string Id = "", Name = ""; public bool Collapsed; public List<Sess> Sessions = new(); }
 
     internal readonly List<Ws> Workspaces = new();
     internal Ws ActiveWs;
@@ -321,8 +322,8 @@ internal sealed class FakeSessionHost : ISessionHost
                 Context: s.Context,
                 CapturedCommands: s.PaneIds.Select(id => s.Captured.TryGetValue(id, out var c) ? c : "").ToList(),   // the slot, "" = none, parallel to PaneIds
                 Axis: s.Axis,
-                PaneOverlays: s.PaneOverlayWords(), Hud: s.Hud);
-        }).ToList())).ToList();
+                PaneOverlays: s.PaneOverlayWords(), Hud: s.Hud, ForegroundShells: s.ForegroundShells);
+        }).ToList(), Collapsed: w.Collapsed)).ToList();
 
     public WindowStateSnapshot WindowState() =>
         new(SidebarVisible, Fullscreen: false, Maximized: false, QuickVisible, ActiveWs.Name, ActiveSess?.Name);
@@ -505,6 +506,15 @@ internal sealed class FakeSessionHost : ISessionHost
     public bool WorkspaceRename(string? target, string name) { var w = FindWs(target); if (w is null || string.IsNullOrWhiteSpace(name)) return false; w.Name = name; return true; }
     public bool WorkspaceDelete(string? target) { var w = FindWs(target); if (w is null || Workspaces.Count <= 1) return false; Workspaces.Remove(w); if (ReferenceEquals(ActiveWs, w)) { ActiveWs = Workspaces[0]; ActiveSess = ActiveWs.Sessions.FirstOrDefault(); } return true; }
     public bool WorkspaceSelect(string? target) { var w = FindWs(target); if (w is null) return false; ActiveWs = w; ActiveSess = w.Sessions.FirstOrDefault(); return true; }
+    public string WorkspaceGo(string direction)
+    {
+        if (!WorkspaceNavigation.TryDirection(direction, out int step)) return ISessionHost.RefusePrefix + "bad direction";
+        int index = WorkspaceNavigation.Destination(Workspaces.Count, Workspaces.IndexOf(ActiveWs), step);
+        if (index < 0) return ISessionHost.RefusePrefix + "no other visible workspace to navigate to";
+        ActiveWs = Workspaces[index];
+        if (ActiveWs.Sessions.FirstOrDefault() is { } first) ActiveSess = first;
+        return ActiveWs.Id;
+    }
     public bool WorkspaceReorder(string? target, string dir) => FindWs(target) is not null;
     public string Split(string? target, string op, string? axis)
     {

--- a/tests/Agwinterm.Pty.Tests/WorkspaceNavigationTests.cs
+++ b/tests/Agwinterm.Pty.Tests/WorkspaceNavigationTests.cs
@@ -1,0 +1,63 @@
+using System.Text.Json;
+
+namespace Agwinterm.Pty.Tests;
+
+public class WorkspaceNavigationTests
+{
+    private static JsonElement Call(ControlServer server, string raw)
+    { using var doc = JsonDocument.Parse(server.Dispatch(raw)); return doc.RootElement.Clone(); }
+
+    [Theory]
+    [InlineData("{}")][InlineData("{\"to\":\"up\"}")][InlineData("{\"to\":null}")]
+    [InlineData("{\"to\":2}")][InlineData("{\"to\":\"\"}")]
+    public void BadDirectionsRefuseWithoutMutation(string args)
+    {
+        var host = new FakeSessionHost(); host.NewWorkspace("second");
+        string before = JsonSerializer.Serialize(host.Tree());
+        var result = Call(new(host), "{\"cmd\":\"workspace.go\",\"args\":" + args + "}");
+        Assert.False(result.GetProperty("ok").GetBoolean()); Assert.Equal(before, JsonSerializer.Serialize(host.Tree()));
+    }
+
+    [Theory]
+    [InlineData("\"target\":2")][InlineData("\"target\":\"\"")]
+    [InlineData("\"target\":false")][InlineData("\"window\":2")]
+    [InlineData("\"window\":\"\"")][InlineData("\"window\":\"active\"")]
+    public void MalformedOrUnroutableSelectorsRefuse(string selector)
+    {
+        var host = new FakeSessionHost(); host.NewWorkspace("second");
+        string before = JsonSerializer.Serialize(host.Tree());
+        Assert.False(Call(new(host), "{\"cmd\":\"workspace.go\",\"args\":{\"to\":\"next\"}," + selector + "}").GetProperty("ok").GetBoolean());
+        Assert.Equal(before, JsonSerializer.Serialize(host.Tree()));
+    }
+
+    [Fact] public void ExplicitTargetAndQuickHostRefuse()
+    {
+        var host = new FakeSessionHost(); host.NewWorkspace("second");
+        var server = new ControlServer(host);
+        Assert.False(Call(server, "{\"cmd\":\"workspace.go\",\"target\":\"active\",\"args\":{\"to\":\"next\"}}").GetProperty("ok").GetBoolean());
+        host.IsQuickSurface = true;
+        Assert.False(Call(server, "{\"cmd\":\"workspace.go\",\"args\":{\"to\":\"next\"}}").GetProperty("ok").GetBoolean());
+    }
+
+    [Fact] public void EmptyDestinationIsCurrentWithoutErasingSelectedSession()
+    {
+        var host = new FakeSessionHost(); var old = host.ActiveSess; string next = host.NewWorkspace("empty");
+        var server = new ControlServer(host);
+        var response = Call(server, "{\"cmd\":\"workspace.go\",\"args\":{\"to\":\"next\"}}");
+        Assert.True(response.GetProperty("ok").GetBoolean()); Assert.Equal(next, response.GetProperty("result").GetString());
+        Assert.Equal(next, host.ActiveWs.Id); Assert.Same(old, host.ActiveSess);
+        Assert.Equal("w1", Call(server, "{\"cmd\":\"workspace.go\",\"args\":{\"to\":\"previous\"}}").GetProperty("result").GetString());
+    }
+
+    [Fact] public void TreeCarriesCollapsedAndPerPaneShellHints()
+    {
+        var host = new FakeSessionHost(); host.ActiveWs.Collapsed = true;
+        host.ActiveSess!.PaneCount = 2; host.ActiveSess.ForegroundShells = new() { null, "pwsh" };
+        var tree = Call(new(host), "{\"cmd\":\"tree\"}").GetProperty("result").GetProperty("workspaces")[0];
+        Assert.True(tree.GetProperty("collapsed").GetBoolean());
+        var session = tree.GetProperty("sessions")[0];
+        Assert.Equal(JsonValueKind.Null, session.GetProperty("foregroundShells")[0].ValueKind);
+        Assert.False(session.TryGetProperty("foregroundShell", out _));
+        Assert.Equal("pwsh", session.GetProperty("splitForegroundShell").GetString());
+    }
+}

--- a/tests/integration/hud-ui.ps1
+++ b/tests/integration/hud-ui.ps1
@@ -1,7 +1,7 @@
 # Dedicated P13 fixture: private app-data, no clipboard/registry writes, exact owned job teardown.
 param([string]$Exe="$PSScriptRoot/../../src/Agwinterm.Win32/bin/x64/Release/net10.0-windows/win-x64/Agwinterm.Win32.exe",
       [string]$TokenOwner=$env:AGWINTERM_TEST_OWNER,[switch]$Strict,
-      [ValidateSet('Hud','Quick')][string]$Suite='Hud')
+      [ValidateSet('Hud','Quick','Navigation')][string]$Suite='Hud')
 $ErrorActionPreference='Stop'
 $PSNativeCommandUseErrorActionPreference=$false
 $root=[IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
@@ -117,6 +117,10 @@ public sealed class HudOwnedJob {
         @('map f7 = toggle_search','map f8 = command:QuickProbe',
           ('command [send] QuickProbe = echo {AGW_PANE}>"'+(Join-Path $artifact 'keymap-send.txt')+'"'))|Add-Content (Join-Path $appDir 'keymap.conf')
     }
+    if($Suite-eq 'Navigation'){
+        @('map f5 | f7 = next_workspace','map f8 = previous_workspace','map f9 = toggle_workspace_collapse',
+          'leader = f10','map leader a | b = next_workspace')|Add-Content (Join-Path $appDir 'keymap.conf')
+    }
     $savedEnv=@{}
     foreach($name in 'AGWINTERM_APP_ID','AGWINTERM_PIPE','AGWINTERM_SESSION_ID','AGWINTERM_PANE_ID','AGWINTERM_DUMP','AGWINTERM_PERF','AGWINTERM_IMGLOG'){
         $savedEnv[$name]=[Environment]::GetEnvironmentVariable($name)
@@ -125,13 +129,15 @@ public sealed class HudOwnedJob {
     $env:AGWINTERM_APP_ID=$appId+'-fallback'
     $job=[HudOwnedJob]::new()
     $job.Start([IO.Path]::GetFullPath($Exe),"--app-id $appId --pipe $pipe --no-restore",$root)
-    function Rpc([string]$verb,$params=@{},[string]$target='active',[switch]$AllowError,[string]$Window='active'){
+    function Rpc([string]$verb,$params=@{},[string]$target='active',[switch]$AllowError,[string]$Window='active',[switch]$NoTarget){
         $client=[IO.Pipes.NamedPipeClientStream]::new('.',$pipe,[IO.Pipes.PipeDirection]::InOut)
         try {
             $client.Connect(1500)
             $writer=[IO.StreamWriter]::new($client);$writer.AutoFlush=$true
             $reader=[IO.StreamReader]::new($client)
-            $writer.WriteLine((@{cmd=$verb;args=$params;target=$target;window=$Window}|ConvertTo-Json -Compress -Depth 8))
+            $request=@{cmd=$verb;args=$params;target=$target;window=$Window}
+            if($NoTarget){$request.Remove('target')}
+            $writer.WriteLine(($request|ConvertTo-Json -Compress -Depth 8))
             $read=$reader.ReadLineAsync();if(-not $read.Wait(15000)){throw 'HUD RPC deadline exceeded'}
             $answer=$read.Result|ConvertFrom-Json
             if($AllowError){return $answer}
@@ -165,7 +171,8 @@ public sealed class HudOwnedJob {
             }finally{$bitmap.UnlockBits($bits)}
         }finally{$graphics.Dispose();$bitmap.Dispose()}
     }
-    if($Suite-eq 'Quick') { . "$PSScriptRoot/quick-ui-cases.ps1" } else {
+    if($Suite-eq 'Navigation') { . "$PSScriptRoot/navigation-ui-cases.ps1" }
+    elseif($Suite-eq 'Quick') { . "$PSScriptRoot/quick-ui-cases.ps1" } else {
     $ctl=Join-Path $root 'src/Agwinterm.Ctl/bin/Release/net10.0-windows/agwintermctl.exe'
     $null=& $ctl session hud --spinner 'CLI HUD' --detail 'private acceptance' --size-percent 35 --target $session --pipe $pipe --json
     Check 'CLI default open accepts spinner before message and numeric width' ($LASTEXITCODE-eq 0 -and (Node).hud.message-eq 'CLI HUD' -and (Node).hud.sizePercent-eq 35)

--- a/tests/integration/hud-ui.ps1
+++ b/tests/integration/hud-ui.ps1
@@ -118,7 +118,8 @@ public sealed class HudOwnedJob {
           ('command [send] QuickProbe = echo {AGW_PANE}>"'+(Join-Path $artifact 'keymap-send.txt')+'"'))|Add-Content (Join-Path $appDir 'keymap.conf')
     }
     if($Suite-eq 'Navigation'){
-        @('map f5 | f7 = next_workspace','map f8 = previous_workspace','map f9 = toggle_workspace_collapse',
+        @('map f5 | f7 = next_workspace','map f6 = next_workspace',
+          'map f3 = delete_workspace','map f4 = action_palette','map f8 = previous_workspace','map f9 = toggle_workspace_collapse',
           'leader = f10','map leader a | b = next_workspace')|Add-Content (Join-Path $appDir 'keymap.conf')
     }
     $savedEnv=@{}

--- a/tests/integration/navigation-ui-cases.ps1
+++ b/tests/integration/navigation-ui-cases.ps1
@@ -1,0 +1,148 @@
+# Dot-sourced by hud-ui.ps1 inside its private app/profile and canonical token/owned-job lifetime.
+function NavTree { (Rpc 'tree').workspaces }
+function CurrentWs { @((NavTree)|Where-Object active)[0].id }
+function NavWait([scriptblock]$condition){for($i=0;$i-lt 60;$i++){if(& $condition){return $true};Start-Sleep -Milliseconds 100};return $false}
+function NavKey([int]$key){[void][HudOwnedJob]::SendMessageW($hwnd,0x100,[IntPtr]$key,[IntPtr]1)}
+function NavPixels([string]$name){
+    Start-Sleep -Milliseconds 180
+    $rc=[HudOwnedJob+RECT]::new();[void][HudOwnedJob]::GetClientRect($hwnd,[ref]$rc)
+    $bitmap=[Drawing.Bitmap]::new($rc.right,$rc.bottom);$g=[Drawing.Graphics]::FromImage($bitmap)
+    try{
+        $dc=$g.GetHdc();try{if(-not [HudOwnedJob]::PrintWindow($hwnd,$dc,3)){throw 'Navigation PrintWindow failed'}}finally{$g.ReleaseHdc($dc)}
+        $bitmap.Save((Join-Path $artifact "$name.png"))
+        $bits=$bitmap.LockBits([Drawing.Rectangle]::new(0,0,$bitmap.Width,$bitmap.Height),[Drawing.Imaging.ImageLockMode]::ReadOnly,[Drawing.Imaging.PixelFormat]::Format32bppArgb)
+        try{$pixels=[int[]]::new($bitmap.Width*$bitmap.Height);[Runtime.InteropServices.Marshal]::Copy($bits.Scan0,$pixels,0,$pixels.Length);return @{pixels=$pixels;width=$bitmap.Width;height=$bitmap.Height}}
+        finally{$bitmap.UnlockBits($bits)}
+    }finally{$g.Dispose();$bitmap.Dispose()}
+}
+function PixelDifference($a,$b,[int]$x=0,[int]$y=0,[int]$w=0,[int]$h=0){
+    if($a.width-ne $b.width -or $a.height-ne $b.height){throw 'Unexpected image resize'}
+    if($w-le 0){$w=$a.width};if($h-le 0){$h=$a.height};$different=0
+    for($row=$y;$row-lt [Math]::Min($a.height,$y+$h);$row++){for($col=$x;$col-lt [Math]::Min($a.width,$x+$w);$col++){
+        $index=$row*$a.width+$col;if($a.pixels[$index]-ne $b.pixels[$index]){$different++}
+    }};return $different
+}
+$first=[string](CurrentWs);$beforeText=Rpc 'session.text' @{} $session
+Check 'one workspace navigation refuses' (-not (Rpc 'workspace.go' @{to='next'} -NoTarget -AllowError).ok)
+$second=[string](Rpc 'workspace.new' @{name='P15-empty'})
+Check 'empty workspace created' (NavWait {@(NavTree|Where-Object id -eq $second).Count-eq 1})
+Check 'go reaches empty workspace and reports id' ((Rpc 'workspace.go' @{to='next'} -NoTarget)-eq $second -and (CurrentWs)-eq $second)
+Check 'empty destination leaves selected terminal intact' ((Rpc 'window.state').activeWorkspace-eq 'P15-empty' -and (Node $session).active)
+$placed=[string](Rpc 'session.new' @{name='P15-placed';wait=$true})
+Check 'new session without caller lands in current empty workspace' (NavWait {@((NavTree|Where-Object id -eq $second).sessions|Where-Object id -eq $placed).Count-eq 1 -and (Node $placed).active})
+$null=Rpc 'workspace.collapse' @{} $second
+Check 'collapsed workspace readback' (NavWait {(NavTree|Where-Object id -eq $second).collapsed})
+Check 'previous wraps without skipping collapsed destinations' ((Rpc 'workspace.go' @{to='prev'} -NoTarget)-eq $first -and (Rpc 'workspace.go' @{to='next'} -NoTarget)-eq $second)
+$null=Rpc 'workspace.select' @{} $first
+NavKey 116 # F5 (F6 remains the reserved accessibility focus-zone gesture)
+Check 'first alternative chord navigates' ((CurrentWs)-eq $second)
+NavKey 118 # F7
+Check 'second alternative chord navigates and wraps' ((CurrentWs)-eq $first)
+NavKey 119 # F8
+Check 'previous workspace keymap navigates' ((CurrentWs)-eq $second)
+NavKey 120 # F9
+Check 'collapse action expands current workspace' (-not (NavTree|Where-Object id -eq $second).collapsed)
+$null=Rpc 'sidebar' @{op='hide'}
+NavKey 120
+Check 'collapse action works while sidebar hidden' ((NavTree|Where-Object id -eq $second).collapsed)
+$null=Rpc 'sidebar' @{op='show'}
+NavKey 121;NavKey 65 # leader F10, A
+Check 'first leader alternative navigates' ((CurrentWs)-eq $first)
+NavKey 121;NavKey 66 # leader F10, B
+Check 'second leader alternative navigates' ((CurrentWs)-eq $second)
+$null=Rpc 'workspace.focus' @{op='on'}
+Check 'single focused workspace refuses navigation' (-not (Rpc 'workspace.go' @{to='next'} -NoTarget -AllowError).ok)
+$null=Rpc 'workspace.focus' @{op='off'}
+$null=Rpc 'sidebar' @{op='mode:flagged'}
+Check 'flagged mode refuses workspace navigation' (-not (Rpc 'workspace.go' @{to='prev'} -NoTarget -AllowError).ok)
+$null=Rpc 'sidebar' @{op='mode:tree'}
+Check 'explicit target refuses without moving' (-not (Rpc 'workspace.go' @{to='next'} $first -AllowError).ok -and (CurrentWs)-eq $second)
+Check 'quick window refuses library navigation' (-not (Rpc 'workspace.go' @{to='next'} -NoTarget -Window quick -AllowError).ok)
+$ctl=Join-Path $root 'src/Agwinterm.Ctl/bin/Release/net10.0-windows/agwintermctl.exe'
+$cli=& $ctl workspace go --to next --pipe $pipe --window active
+Check 'CLI --to routes to workspace go' ($LASTEXITCODE-eq 0 -and ([string]$cli).Trim()-eq $first)
+$cli=& $ctl workspace go prev --pipe $pipe --window active
+Check 'CLI positional direction works' ($LASTEXITCODE-eq 0 -and ([string]$cli).Trim()-eq $second)
+$null=& $ctl workspace go bogus --pipe $pipe --window active 2>$null
+Check 'CLI invalid direction refuses before send' ($LASTEXITCODE-eq 2 -and (CurrentWs)-eq $second)
+$empty=[string](Rpc 'workspace.new' @{name='P15-explicit-empty'})
+Check 'third empty workspace materializes' (NavWait {@(NavTree|Where-Object id -eq $empty).Count-eq 1})
+$null=Rpc 'workspace.select' @{} $empty
+Check 'explicit empty selection reports current workspace' ((CurrentWs)-eq $empty)
+$callerPlaced=[string](Rpc 'session.new' @{name='P15-caller';caller=$session;'no-select'=$true})
+Check 'valid caller wins over empty placement without selecting' (NavWait {@((NavTree|Where-Object id -eq $first).sessions|Where-Object id -eq $callerPlaced).Count-eq 1 -and (CurrentWs)-eq $empty})
+$null=Rpc 'workspace.delete' @{} $empty
+Check 'deleting empty current workspace restores selected-session workspace' (NavWait {@(NavTree|Where-Object id -eq $empty).Count-eq 0 -and (CurrentWs)-eq $second})
+$null=Rpc 'workspace.select' @{} $first
+Check 'live shell name appears per pane and primary alias' (NavWait {(Node $session).foregroundShell-eq 'cmd' -and (Node $session).foregroundShells[0]-eq 'cmd'})
+$split=[string](Rpc 'session.split' @{op='on'} $session)
+Check 'split shell names follow pane order' (NavWait {(Node $session).splitForegroundShell-eq 'cmd' -and (Node $session).foregroundShells.Count-eq 2})
+$null=Rpc 'session.split' @{op='off'} $session
+$childDone=Join-Path $artifact 'child-done.txt'
+$null=Rpc 'session.type' @{text="powershell.exe -NoProfile -Command Start-Sleep 2 & echo done>`"$childDone`"`r"} $session
+Check 'child command makes foreground shell unknown' (NavWait {$null-eq (Node $session).foregroundShell})
+Check 'shell hint returns after child completes' (NavWait {(Test-Path $childDone) -and (Node $session).foregroundShell-eq 'cmd'})
+foreach($pair in @(@('cursor-style','nonsense'),@('cursor-blink','perhaps'),@('cursor-blink-ms','0'),@('cursor-blink-ms','x'))){
+    $old=Rpc 'config.get' @{key=$pair[0]}
+    Check "invalid $($pair[0]) refuses and preserves value" (-not (Rpc 'config.set' @{key=$pair[0];value=$pair[1]} -AllowError).ok -and (Rpc 'config.get' @{key=$pair[0]})-eq $old)
+}
+$null=Rpc 'config.set' @{key='cursor-blink';value='off'}
+$null=Rpc 'config.set' @{key='cursor-blink-ms';value='60000'} # manual timer messages below, no clock-dependent samples
+$null=Rpc 'session.type' @{text="echo P15-READY`r"} $session
+Check 'shell output settled before cursor paint checks' (NavWait {([string](Rpc 'session.text' @{} $session))-match '(?m)^P15-READY\s*$'})
+$null=Rpc 'session.write' @{text=([string][char]27+'[10;10H'+[char]27+'[0 q')} $session
+[void][HudOwnedJob]::SendMessageW($hwnd,7,[IntPtr]::Zero,[IntPtr]::Zero)
+$caret=[HudOwnedJob]::CaretRect($hwnd);$metrics=Rpc 'session.metrics' @{} $session
+$null=Rpc 'config.set' @{key='cursor-style';value='bar'};$bar=NavPixels 'cursor-bar'
+$null=Rpc 'config.set' @{key='cursor-style';value='block'};$block=NavPixels 'cursor-block'
+Check 'cursor style changes rendered cell without resizing' ((PixelDifference $bar $block $caret.left $caret.top ($metrics.cellWidth+2) ($metrics.cellHeight+2))-gt 5 -and (Rpc 'session.metrics' @{} $session).cols-eq $metrics.cols)
+$null=Rpc 'config.set' @{key='cursor-style';value='underline'};$under=NavPixels 'cursor-underline'
+Check 'underline differs from block cursor' ((PixelDifference $block $under $caret.left $caret.top ($metrics.cellWidth+2) ($metrics.cellHeight+2))-gt 5)
+[void][HudOwnedJob]::SendMessageW($hwnd,0x113,[IntPtr]1,[IntPtr]::Zero);$steady=NavPixels 'cursor-steady'
+Check 'disabled blinking keeps cursor stable' ((PixelDifference $under $steady $caret.left $caret.top ($metrics.cellWidth+2) ($metrics.cellHeight+2))-eq 0)
+$null=Rpc 'config.set' @{key='cursor-blink';value='true'}
+$a=NavPixels 'cursor-blink-a';[void][HudOwnedJob]::SendMessageW($hwnd,0x113,[IntPtr]1,[IntPtr]::Zero);$b=NavPixels 'cursor-blink-b'
+Check 'enabled blinking changes rendered cursor' ((PixelDifference $a $b $caret.left $caret.top ($metrics.cellWidth+2) ($metrics.cellHeight+2))-gt 0)
+$null=Rpc 'config.set' @{key='cursor-blink';value='false'}
+[void][HudOwnedJob]::SendMessageW($hwnd,8,[IntPtr]::Zero,[IntPtr]::Zero)
+# Sidebar tooltip checks use only owned-window posted hover and screenshots, no desktop mouse movement.
+$long='P15 workspace full truncated name — alpha beta gamma delta epsilon zeta eta theta'
+$null=Rpc 'workspace.rename' @{name=$long} $first
+$null=Rpc 'sidebar' @{op='width';width=160}
+Start-Sleep -Milliseconds 100
+$baseline=NavPixels 'tooltip-before'
+Add-Type -TypeDefinition 'using System; using System.Runtime.InteropServices; public static class NavDpi { [DllImport("user32.dll")] public static extern uint GetDpiForWindow(IntPtr h); }'
+$dpiScale=[NavDpi]::GetDpiForWindow($hwnd)/96.0
+$x=[int](40*$dpiScale);$y=[int](50*$dpiScale)
+[void][HudOwnedJob]::SendMessageW($hwnd,0x200,[IntPtr]::Zero,[IntPtr](($y-shl 16)-bor $x))
+Start-Sleep -Milliseconds 650
+$tip=NavPixels 'tooltip-long-workspace'
+Check 'truncated workspace name paints a tooltip' ((PixelDifference $baseline $tip)-gt 150)
+[void][HudOwnedJob]::SendMessageW($hwnd,0x2a3,[IntPtr]::Zero,[IntPtr]::Zero)
+$gone=NavPixels 'tooltip-left'
+Check 'mouse leave clears tooltip' ((PixelDifference $tip $gone)-gt 150)
+$null=Rpc 'workspace.rename' @{name='short'} $first
+$short=NavPixels 'tooltip-short-before'
+[void][HudOwnedJob]::SendMessageW($hwnd,0x200,[IntPtr]::Zero,[IntPtr](($y-shl 16)-bor $x))
+Start-Sleep -Milliseconds 650
+$shortAfter=NavPixels 'tooltip-short-after'
+Check 'untruncated name does not paint a tooltip' ((PixelDifference $short $shortAfter)-eq 0)
+[void][HudOwnedJob]::SendMessageW($hwnd,0x2a3,[IntPtr]::Zero,[IntPtr]::Zero)
+$null=Rpc 'session.rename' @{name='P15 session full truncated name alpha beta gamma delta epsilon'} $session
+$null=Rpc 'session.flag' @{op='on'} $session
+$null=Rpc 'sidebar' @{op='mode:flagged'}
+$sessionBefore=NavPixels 'tooltip-session-before'
+$rowDip=[Math]::Max($metrics.cellHeight/$dpiScale+8,24)
+$sy=[int]((50+$rowDip)*$dpiScale)
+[void][HudOwnedJob]::SendMessageW($hwnd,0x200,[IntPtr]::Zero,[IntPtr](($sy-shl 16)-bor $x))
+Start-Sleep -Milliseconds 650
+$sessionTip=NavPixels 'tooltip-session-flagged'
+Check 'flagged session truncated name paints tooltip' ((PixelDifference $sessionBefore $sessionTip)-gt 150)
+$null=Rpc 'session.rename' @{name='short session'} $session
+$renamed=NavPixels 'tooltip-session-renamed'
+[void][HudOwnedJob]::SendMessageW($hwnd,0x2a3,[IntPtr]::Zero,[IntPtr]::Zero)
+$renamedLeft=NavPixels 'tooltip-session-renamed-left'
+Check 'renaming hovered row invalidates tooltip without a move' ((PixelDifference $renamed $renamedLeft)-eq 0)
+$null=Rpc 'sidebar' @{op='mode:tree'}
+$null=Rpc 'session.type' @{text="exit`r"} $session
+Check 'exited shell does not retain shell-name hint' (NavWait {$null-eq (Node $session).foregroundShell})

--- a/tests/integration/navigation-ui-cases.ps1
+++ b/tests/integration/navigation-ui-cases.ps1
@@ -24,6 +24,7 @@ function PixelDifference($a,$b,[int]$x=0,[int]$y=0,[int]$w=0,[int]$h=0){
 }
 $first=[string](CurrentWs);$beforeText=Rpc 'session.text' @{} $session
 Check 'one workspace navigation refuses' (-not (Rpc 'workspace.go' @{to='next'} -NoTarget -AllowError).ok)
+Check 'last workspace deletion refuses without removing its terminal' (-not (Rpc 'workspace.delete' @{} $first -AllowError).ok -and @(NavTree).Count-eq 1 -and $null-ne (Node $session))
 $second=[string](Rpc 'workspace.new' @{name='P15-empty'})
 Check 'empty workspace created' (NavWait {@(NavTree|Where-Object id -eq $second).Count-eq 1})
 Check 'go reaches empty workspace and reports id' ((Rpc 'workspace.go' @{to='next'} -NoTarget)-eq $second -and (CurrentWs)-eq $second)
@@ -50,6 +51,11 @@ NavKey 121;NavKey 65 # leader F10, A
 Check 'first leader alternative navigates' ((CurrentWs)-eq $first)
 NavKey 121;NavKey 66 # leader F10, B
 Check 'second leader alternative navigates' ((CurrentWs)-eq $second)
+NavKey 117 # reserved F6 enters sidebar, despite its conflicting map
+NavKey 116 # F5 would navigate if the sidebar did not own input
+Check 'reserved F6 owns sidebar keys ahead of conflicting mappings' ((CurrentWs)-eq $second)
+NavKey 117 # back to terminal; must not execute next_workspace
+Check 'reserved F6 returns without executing its map' ((CurrentWs)-eq $second)
 $null=Rpc 'workspace.focus' @{op='on'}
 Check 'single focused workspace refuses navigation' (-not (Rpc 'workspace.go' @{to='next'} -NoTarget -AllowError).ok)
 $null=Rpc 'workspace.focus' @{op='off'}
@@ -71,8 +77,21 @@ $null=Rpc 'workspace.select' @{} $empty
 Check 'explicit empty selection reports current workspace' ((CurrentWs)-eq $empty)
 $callerPlaced=[string](Rpc 'session.new' @{name='P15-caller';caller=$session;'no-select'=$true})
 Check 'valid caller wins over empty placement without selecting' (NavWait {@((NavTree|Where-Object id -eq $first).sessions|Where-Object id -eq $callerPlaced).Count-eq 1 -and (CurrentWs)-eq $empty})
+NavKey 114 # F3 = delete_workspace: current empty workspace, not selected terminal's workspace
+Check 'delete action removes current empty workspace and preserves selected terminal' (NavWait {@(NavTree|Where-Object id -eq $empty).Count-eq 0 -and (CurrentWs)-eq $second -and $null-ne (Node $placed) -and $null-ne (Node $session)})
+$empty=[string](Rpc 'workspace.new' @{name='P15-palette-delete'})
+$null=NavWait {@(NavTree|Where-Object id -eq $empty).Count-eq 1}
+$null=Rpc 'workspace.select' @{} $empty
+NavKey 115 # F4 = action palette
+foreach($letter in 'Delete Active Workspace'.ToCharArray()){[void][HudOwnedJob]::SendMessageW($hwnd,0x102,[IntPtr][int]$letter,[IntPtr]1)}
+NavKey 13
+Check 'palette delete uses current workspace and preserves both live workspaces' (NavWait {@(NavTree|Where-Object id -eq $empty).Count-eq 0 -and @(NavTree).Count-eq 2 -and $null-ne (Node $placed) -and $null-ne (Node $session)})
+$empty=[string](Rpc 'workspace.new' @{name='P15-focused-delete'})
+$null=NavWait {@(NavTree|Where-Object id -eq $empty).Count-eq 1}
+$null=Rpc 'workspace.select' @{} $empty
+$null=Rpc 'workspace.focus' @{op='on'}
 $null=Rpc 'workspace.delete' @{} $empty
-Check 'deleting empty current workspace restores selected-session workspace' (NavWait {@(NavTree|Where-Object id -eq $empty).Count-eq 0 -and (CurrentWs)-eq $second})
+Check 'deleting focused workspace clears navigation filter' ((Rpc 'workspace.go' @{to='next'} -NoTarget)-eq $first)
 $null=Rpc 'workspace.select' @{} $first
 Check 'live shell name appears per pane and primary alias' (NavWait {(Node $session).foregroundShell-eq 'cmd' -and (Node $session).foregroundShells[0]-eq 'cmd'})
 $split=[string](Rpc 'session.split' @{op='on'} $session)
@@ -103,6 +122,14 @@ Check 'disabled blinking keeps cursor stable' ((PixelDifference $under $steady $
 $null=Rpc 'config.set' @{key='cursor-blink';value='true'}
 $a=NavPixels 'cursor-blink-a';[void][HudOwnedJob]::SendMessageW($hwnd,0x113,[IntPtr]1,[IntPtr]::Zero);$b=NavPixels 'cursor-blink-b'
 Check 'enabled blinking changes rendered cursor' ((PixelDifference $a $b $caret.left $caret.top ($metrics.cellWidth+2) ($metrics.cellHeight+2))-gt 0)
+$null=Rpc 'session.write' @{text=([string][char]27+'[2 q')} $session # steady block overrides both config fields
+$null=Rpc 'config.set' @{key='cursor-style';value='bar'}
+$override=NavPixels 'cursor-decscusr-block'
+Check 'DECSCUSR block overrides configured bar' ((PixelDifference $block $override $caret.left $caret.top ($metrics.cellWidth+2) ($metrics.cellHeight+2))-eq 0)
+[void][HudOwnedJob]::SendMessageW($hwnd,0x113,[IntPtr]1,[IntPtr]::Zero)
+$overrideTick=NavPixels 'cursor-decscusr-steady'
+Check 'DECSCUSR steady overrides enabled configured blinking' ((PixelDifference $override $overrideTick $caret.left $caret.top ($metrics.cellWidth+2) ($metrics.cellHeight+2))-eq 0)
+$null=Rpc 'session.write' @{text=([string][char]27+'[0 q')} $session
 $null=Rpc 'config.set' @{key='cursor-blink';value='false'}
 [void][HudOwnedJob]::SendMessageW($hwnd,8,[IntPtr]::Zero,[IntPtr]::Zero)
 # Sidebar tooltip checks use only owned-window posted hover and screenshots, no desktop mouse movement.


### PR DESCRIPTION
## P15 — navigation and small UI controls

- Wrapped workspace navigation, empty-workspace placement target, collapse actions.
- Alternative normal/leader keymap chords with atomic invalid-line rejection.
- Passive truncated-name tooltips and conservative per-pane Windows shell hints.
- Strict live cursor-setting validation; retained DECSCUSR behavior.
- P14 final merge/review receipts carried forward; picker and lite mirror follow sequentially.

Validation: Release/native builds; Core 296 / Pty 774 passed; private GUI 44/44 with
canonical suite token 112 released on owned-job zero-process proof. No shared clipboard,
registry or foreground mutation. Full integration runs in disposable CI.

Codex-only revmux review in progress; findings and exact-head CI gate merge.
See docs/navigation.md and qa/p15-navigation.md. No release/install.
