### PR TITLE
P16: native API picker and exact-id CLI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,11 @@ jobs:
         timeout-minutes: 5
         run: ./tests/integration/hud-ui.ps1 -Suite Navigation -Strict
 
+      - name: Native picker integration
+        shell: pwsh
+        timeout-minutes: 5
+        run: ./tests/integration/hud-ui.ps1 -Suite Picker -Strict
+
       - name: Test (Core + Pty)
         # One retry for the known .NET 10 test-host #118 pathology under named-pipe churn, which
         # manifests two ways: a native CRASH ("Test Run Aborted") OR a DEADLOCK that hangs the run

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A Windows homage to [umputun's **agterm**](https://github.com/umputun/agterm).
 agwinterm exists because of **[umputun](https://github.com/umputun)** and his terminal
 **[agterm](https://github.com/umputun/agterm)**. agterm's design — a terminal that treats AI coding
 agents as first-class citizens, with per-session status, [workspace navigation](docs/navigation.md), a [detached quick terminal](docs/quick-terminal.md),
-and a language-agnostic control socket — is the blueprint this project follows on Windows.
+a [native API picker](docs/native-picker.md), and a language-agnostic control socket — is the blueprint this project follows on Windows.
 
 This is an **independent, from-scratch implementation** written in C# on a native Win32/Direct2D
 stack (agterm is Swift on libghostty); no agterm code is used. It is a **tribute and a port of the

--- a/docs/agterm-parity.md
+++ b/docs/agterm-parity.md
@@ -121,11 +121,10 @@ agterm's `--cwd`, `--follow` and `--background-color` on `open`, deliberately le
 
 ## Open — UI
 
-### 1. `control.pick` — the native picker, driven over the API
-**agterm 2026-07-28.** Half the agterm cookbook is built on it: project launcher, workspace picker,
-conversation picker, backlog picker, SQLite browser. Nothing here can do that without shipping a
-picker binary of its own.
-**The biggest single capability gap.** Size: large.
+### 1. Native picker — P16
+`pick.open/result/cancel` and `agwintermctl pick` provide bounded native controls,
+label filtering, custom results, exact-ID waiting and window-owned lifetime.
+See [native-picker.md](native-picker.md). Lite mirror/conformance remain P17.
 
 ### 2. `session.hud` and `--position` — implemented in P13
 **agterm 0.22.0 / 0.24.0.** A transient overlay for status an agent wants seen without printing into
@@ -140,7 +139,7 @@ See [quick-terminal.md](quick-terminal.md) for focus, lifetime and refusal polic
 UIA per-window provider parity remains #267. Lite mirror is P17.
 
 ### 4. Workspace navigation and keymap alternatives — P15
-Implemented in the P15 candidate: wrapped `workspace.go`, collapse action, alternative
+Merged in #269: wrapped `workspace.go`, collapse action, alternative
 normal/leader map chords. See [navigation.md](navigation.md); QA records delivery gates.
 
 ### 5. Smaller things from 0.26

--- a/docs/native-picker.md
+++ b/docs/native-picker.md
@@ -1,0 +1,83 @@
+# Native picker
+
+P16 adds a native, window-owned picker to agwinterm. Item data is never executed.
+The agliteterm mirror and shared conformance expansion are P17 work.
+
+```powershell
+'Alpha','Beta' | agwintermctl pick --prompt 'Choose a project'
+'[{"id":"repo-a","label":"Alpha","subtitle":"Read-only checkout"}]' |
+    agwintermctl pick --query al --no-block
+agwintermctl pick result PICKER-ID
+agwintermctl pick cancel PICKER-ID
+```
+
+`pick [open]` reads UTF-8 JSON items or plain lines from stdin until EOF. Empty/whitespace
+lines are omitted; other line spelling is preserved as both label and ID. Duplicate IDs
+refuse, including duplicate plain lines. JSON IDs are exact/case-sensitive; empty IDs and
+duplicate labels are legal. Each item needs string `id` and nonempty `label`; `subtitle`
+is optional. `--prompt`, `--query`, `--allow-custom`, `--window`, `--follow`, `--no-block`
+are open options. `--pipe`/`--socket` choose transport. There is no session target or
+implicit `$AGWINTERM_SESSION_ID` selection for a picker.
+
+Open displays without stealing another application's foreground. `--follow` requests
+normal OS activation (not guaranteed by Windows). Arrows clamp, typing resets selection,
+Enter/Select/double-click choose, Escape/Cancel/window close cancel, Tab moves between
+native controls. Keyboard input remains in the picker, including when the owner receives
+a key message. Explicit API writes to a terminal remain independent.
+
+Filtering searches labels only, **never consequence subtitles**. Case-insensitive whitespace
+terms use prefix, substring, then subsequence ranking. Ties use ordinal case-insensitive
+label order; blank queries preserve caller order. This native filter operates on UTF-16
+with invariant case folding. `--allow-custom` offers a custom row only for a nonblank query
+with no matching items; its result contains the trimmed query.
+
+## Wire and results
+
+Requests use the existing root `window` selector (not `args.window`).
+
+```json
+{"cmd":"pick.open","window":"active","args":{"items":[{"id":"a","label":"Alpha"}],"allowCustom":false,"follow":false}}
+{"cmd":"pick.result","target":"EXACT-PICKER-ID"}
+{"cmd":"pick.cancel","target":"EXACT-PICKER-ID"}
+```
+
+Wire replies have the normal `{ok,result}` / `{ok:false,error}` envelope. Open's result
+is `{id}`; result's is `{pick:OUTCOME}`; cancel's is the string `cancelled`.
+
+| Outcome | Fields | CLI exit |
+|---|---|---|
+| pending | `result: "pending"` | 1 for one-shot result |
+| picked | `result: "picked", id, label, index` | 0 |
+| custom | `result: "custom", query` | 0 |
+| cancelled | `result: "cancelled"` | 2 |
+
+Picked ID belongs to the item; `index` is its original zero-based input position.
+The CLI deliberately prints payload JSON: `{id}` for no-block, the outcome for result
+or a completed blocking open, even with `--json`. Cancel prints `cancelled`, or the
+normal envelope under `--json`. Refusal/transport/protocol failures exit 1; invalid CLI
+arguments/input exit 2, with diagnostics on stderr rather than a success payload.
+
+A blocking open waits without an overall answer deadline: ten 100ms waits, then 500ms.
+Each transport operation is bounded. Polls and best-effort failure/Ctrl+C cancellation
+use the exact ID **without retaining the moving window selector**. `--no-block` transfers
+pending ownership to the caller, who must later read/cancel it. One-shot result/cancel
+may supply `--window` to restrict ownership; omitted window searches exact IDs globally.
+
+## Bounds and lifetime
+
+One pending picker per open library window; a second open refuses rather than replacing.
+Conflicting settings, rename, context-menu, dashboard or drag operations refuse opening;
+an ordinary command palette closes. Quick terminal is not a picker owner. Readonly
+terminal state does not prohibit this separate native UI.
+
+At most 1000 items, 4096 UTF-16 units per field, 1 MiB UTF-8 serialized open args and
+1 MiB stdin. Labels/subtitles/prompt/query reject C0 and DEL display controls. IDs are
+opaque data. Empty items require `allowCustom`. Results are in-memory, never restored:
+eight completed answers per live window, 32 across closed windows, evicted by answer
+order rather than window-close order. Owner closure cancels pending before retention.
+Global exact-ID reads work after owner closure/deletion until eviction. An explicit
+selector must still resolve the owning library metadata; deleted metadata no longer does.
+Cancel is idempotent for retained completed results and cannot overwrite a choice.
+
+Standard native controls supply their own accessibility; this does not repair the
+terminal's process-wide UIA provider limitation (#267) or workspace teardown issue #270.

--- a/docs/native-picker.md
+++ b/docs/native-picker.md
@@ -11,7 +11,10 @@ agwintermctl pick result PICKER-ID
 agwintermctl pick cancel PICKER-ID
 ```
 
-`pick [open]` reads UTF-8 JSON items or plain lines from stdin until EOF. Empty/whitespace
+`pick [open]` reads UTF-8 JSON items or plain lines from stdin until EOF. Auto format
+selects JSON when the first non-whitespace character is `[`. Use `--input-format lines`
+for a bracket-prefixed plain label such as `[Draft]`, or `--input-format json` to require
+JSON. Empty/whitespace
 lines are omitted; other line spelling is preserved as both label and ID. Duplicate IDs
 refuse, including duplicate plain lines. JSON IDs are exact/case-sensitive; empty IDs and
 duplicate labels are legal. Each item needs string `id` and nonempty `label`; `subtitle`
@@ -58,8 +61,13 @@ normal envelope under `--json`. Refusal/transport/protocol failures exit 1; inva
 arguments/input exit 2, with diagnostics on stderr rather than a success payload.
 
 A blocking open waits without an overall answer deadline: ten 100ms waits, then 500ms.
+The initial UI creation wait is 10 seconds; timeout withdraws queued work and rolls back
+in-flight construction, so the UI queue cannot later publish an abandoned picker.
 Each transport operation is bounded. Polls and best-effort failure/Ctrl+C cancellation
-use the exact ID **without retaining the moving window selector**. `--no-block` transfers
+use the exact ID **without retaining the moving window selector** once the ID is received.
+If the successful open reply itself is lost, the client cannot know that ID: the user
+must dismiss the visible picker with Escape/Cancel. Transport loss does not provide
+exactly-once delivery; no successful cancellation is claimed in that case. `--no-block` transfers
 pending ownership to the caller, who must later read/cancel it. One-shot result/cancel
 may supply `--window` to restrict ownership; omitted window searches exact IDs globally.
 
@@ -71,13 +79,21 @@ an ordinary command palette closes. Quick terminal is not a picker owner. Readon
 terminal state does not prohibit this separate native UI.
 
 At most 1000 items, 4096 UTF-16 units per field, 1 MiB UTF-8 serialized open args and
-1 MiB stdin. Labels/subtitles/prompt/query reject C0 and DEL display controls. IDs are
+1 MiB stdin. Filtering additionally caps total label UTF-16 units multiplied by distinct
+query terms at 64 Mi units. Repeated terms are evaluated once, retaining their ranking
+weight. An over-complex initial query refuses; an over-complex edited query shows an
+error and disables selection until corrected, without closing the picker.
+Labels/subtitles/prompt/query reject C0 and DEL display controls. IDs are
 opaque data. Empty items require `allowCustom`. Results are in-memory, never restored:
 eight completed answers per live window, 32 across closed windows, evicted by answer
 order rather than window-close order. Owner closure cancels pending before retention.
 Global exact-ID reads work after owner closure/deletion until eviction. An explicit
 selector must still resolve the owning library metadata; deleted metadata no longer does.
 Cancel is idempotent for retained completed results and cannot overwrite a choice.
+Opening while this UI thread holds mouse capture refuses before creating state. File
+drops on the exposed owner are discarded (and their native drop handle released), not
+pasted into a terminal. Failed native construction is aborted without consuming an
+answer slot. Picker selectors require an exact or unique-prefix window match.
 
 Standard native controls supply their own accessibility; this does not repair the
 terminal's process-wide UIA provider limitation (#267) or workspace teardown issue #270.

--- a/docs/plans/2026-09-03-parity-batches.md
+++ b/docs/plans/2026-09-03-parity-batches.md
@@ -298,6 +298,8 @@ Implemented by [the P15 plan](2026-09-09-p15-navigation.md); see
 [contract](../navigation.md) and [QA](../../qa/p15-navigation.md) for delivery gates.
 
 ### P16 · agwinterm · `control.pick`
+Implemented by [the P16 plan](2026-09-09-p16-native-picker.md); see
+[contract](../native-picker.md) and [QA](../../qa/p16-native-picker.md).
 The native picker driven over the API. Half the agterm cookbook is built on it — project launcher,
 workspace picker, conversation picker, backlog picker, SQLite browser — and nothing here can do that
 without shipping a picker binary of its own. **The biggest single capability gap and the biggest

--- a/docs/plans/2026-09-03-parity-batches.md
+++ b/docs/plans/2026-09-03-parity-batches.md
@@ -300,10 +300,9 @@ Implemented by [the P15 plan](2026-09-09-p15-navigation.md); see
 ### P16 · agwinterm · `control.pick`
 Implemented by [the P16 plan](2026-09-09-p16-native-picker.md); see
 [contract](../native-picker.md) and [QA](../../qa/p16-native-picker.md).
-The native picker driven over the API. Half the agterm cookbook is built on it — project launcher,
-workspace picker, conversation picker, backlog picker, SQLite browser — and nothing here can do that
-without shipping a picker binary of its own. **The biggest single capability gap and the biggest
-plan.** Boris authorized it on 2026-09-09 (decision 3). Use the standing one broad review,
+The native picker supports project/workspace/conversation/backlog selection and similar
+API-driven menus without an external picker binary. Boris authorized it on 2026-09-09
+(decision 3). Use the standing one broad review,
 batched fixes and narrow confirmation rule; extra rounds require a substantive blocker.
 
 ### P17 · lite · mirror Wave 3

--- a/docs/plans/2026-09-09-p16-native-picker.md
+++ b/docs/plans/2026-09-09-p16-native-picker.md
@@ -1,0 +1,62 @@
+# P16 — native API picker
+
+Authority: Boris requested P14–P17 sequentially. Base: P15 merge `482612b`.
+Codex owns this worktree/implementation, Codex-only review, integration and normal
+PR merge. No release/install. P17 mirrors the resulting contract afterward.
+
+## Contract and design
+
+- Wire verbs `pick.open`, `pick.result`, `pick.cancel` (roadmap `control.pick` is the
+  feature name). Open args: items `{id,label,subtitle?}`, prompt/query strings,
+  allowCustom/follow booleans. Root `window` uses the existing Windows dialect.
+  No session target on open; result/cancel target is an exact picker ID.
+- At most 1000 items; exact unique item IDs (empty allowed), nonempty labels, no
+  C0/DEL in displayed text. Native safety bounds: 4096 UTF-16 units per field and
+  1 MiB UTF-8 open payload/stdin. Refuse malformed/oversize input before UI mutation.
+  Empty items require allowCustom. Prompt/query also reject display controls.
+- Open returns `{id}`; result returns `{pick:{result:pending|picked|custom|cancelled,
+  id?,label?,index?,query?}}`. Picked ID identifies the item, index its original
+  zero-based position. Cancel is idempotent for retained terminal outcomes.
+- One pending picker per library window; busy refuses, never replaces. Retain eight
+  answers per live window and 32 after window closure, evicting by answer order.
+  Close cancels pending first. Unscoped result/cancel find exact IDs across focus and
+  window closure/deletion; explicit window selectors restrict ownership. Quick refuses.
+- Pure bounded Core state/filter policy; standard owned modeless Win32 edit/list/button
+  controls, no dependency on the terminal's process-wide UIA provider. Keyboard arrows,
+  Enter, Escape, Tab and mouse selection operate on the picker, never enter the PTY.
+  Conflicting settings/rename/context surfaces refuse; close ordinary palette on open.
+- Show without activating another app/window. Explicit follow requests normal OS focus;
+  user activation selects the owning library context. Background cancellation never
+  grabs focus. Owner close settles state and destroys native resources.
+- Match pinned upstream v0.26.0 picker filtering: labels ONLY, not subtitles (which can
+  contain consequence warnings). Case-insensitive whitespace terms, prefix/substring/
+  subsequence ranking, label tie-break and stable input order for blank query. Filtering
+  resets selection; arrows clamp. Custom row only when allowed, query nonblank and no
+  item matches; custom result uses trimmed query. Item data is never executed.
+- CLI `pick [open]` reads UTF-8 JSON array or plain lines from stdin (blank lines omitted,
+  other line spelling retained; label=id). `--no-block` prints `{id}`. Otherwise poll
+  exact ID without carrying the moving window selector: ten 100ms waits, then 500ms.
+  No implicit answer deadline. Best-effort cancel on Ctrl+C/protocol/transport failure.
+  Picked/custom exit0, cancelled2, one-shot pending1, transport/refusal1. Successful
+  open/result output is JSON payload even under --json; cancel uses normal ack envelope.
+
+## Grounding and acceptance
+
+Pinned primary upstream files read: ControlPick.swift, Pick.swift, ControlDispatcher+Pick.swift,
+ControlServer+Pick.swift, MiscCommands.swift Pick section, SocketClient picker helpers,
+Fuzzy.swift, Palette.swift picker filtering, PaletteSearchKeys.swift, PickTests.swift,
+PickCustomRowTests.swift, PickFocusGuardTests.swift, native-dir-picker cookbook.
+Windows [IsDialogMessage](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-isdialogmessagew)
+supports modeless controls; handled messages must not be dispatched twice.
+[ShowWindow](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-showwindow)
+provides nonactivating presentation. These inform the native message/focus design.
+
+Pure validation/filter/retention tests; dispatcher malformed/ownership cases; injectable
+CLI transport/wait/output tests. Retained-job private GUI fixture under canonical suite
+token: controls, filtering, original index, custom, cancel, busy, readonly/input isolation,
+geometry, window lifecycle. Actual foreground/multi-window activation CI-only. Full legacy
+integration disposable CI-only. One broad Codex review, batched fixes and narrow confirmation;
+exact-head green CI and merge before P17. No shared conformance expansion until P17.
+
+Carry P15 final receipts into QA here. Its pre-existing full-workspace split/auxiliary
+teardown gap remains #270; do not claim the picker repairs that separate deletion path.

--- a/docs/plans/2026-09-09-p16-native-picker.md
+++ b/docs/plans/2026-09-09-p16-native-picker.md
@@ -14,6 +14,8 @@ PR merge. No release/install. P17 mirrors the resulting contract afterward.
   C0/DEL in displayed text. Native safety bounds: 4096 UTF-16 units per field and
   1 MiB UTF-8 open payload/stdin. Refuse malformed/oversize input before UI mutation.
   Empty items require allowCustom. Prompt/query also reject display controls.
+  Review refinement: aggregate label-unit × distinct-query-term work is capped at 64 Mi;
+  repeated terms share matching work while retaining ranking weight.
 - Open returns `{id}`; result returns `{pick:{result:pending|picked|custom|cancelled,
   id?,label?,index?,query?}}`. Picked ID identifies the item, index its original
   zero-based position. Cancel is idempotent for retained terminal outcomes.
@@ -37,6 +39,10 @@ PR merge. No release/install. P17 mirrors the resulting contract afterward.
   other line spelling retained; label=id). `--no-block` prints `{id}`. Otherwise poll
   exact ID without carrying the moving window selector: ten 100ms waits, then 500ms.
   No implicit answer deadline. Best-effort cancel on Ctrl+C/protocol/transport failure.
+  The initial UI open has a withdrawable 10s wait. Once its reply exposes the ID,
+  failures can cancel exactly; a lost open reply before ID receipt still needs user
+  Escape/Cancel (no exactly-once transport guarantee). `--input-format lines|json`
+  disambiguates bracket-prefixed plain lines; default auto recognizes leading `[`.
   Picked/custom exit0, cancelled2, one-shot pending1, transport/refusal1. Successful
   open/result output is JSON payload even under --json; cancel uses normal ack envelope.
 

--- a/qa/p16-native-picker.md
+++ b/qa/p16-native-picker.md
@@ -1,0 +1,33 @@
+# P16 native picker acceptance
+
+- Base: P15 merge `482612bcb07813db33db1a0c57b49ff08cb2965c`.
+- Release/install: none. Lite mirror/conformance remain P17.
+- Build: Release solution and release Rust workspace pass.
+- New focused tests: Core 23, Pty/CLI/dispatch 19, all pass.
+- Private owned GUI fixture: 22/22 checks, screenshot visually inspected; artifact
+  `.revmux/picker-ui-20260909T184600-8b51af`. Canonical token generation 115 released
+  after retained-job zero-process proof. Clipboard/registry untouched, no queued launches.
+- Earlier fixture run generation 114: four failed assertions; corrected cross-process
+  EDIT probe to WM_SETTEXT, and moved foreground-changing Tab to disposable CI.
+  Its cleanup also proved zero processes before release.
+- Real foreground/Tab and multi-window close/ownership cases run only on disposable CI.
+- Final pre-review private GUI: 25/25, generation 116 released after zero owned
+  processes; `.revmux/picker-ui-20260909T184913-dd2b67`. Added readonly/quick refusal
+  and immediate background-cancellation foreground check.
+- Full headless Core 320 passes. Two local Pty runs hit the documented .NET #118
+  completion-poller native pathology (753/773 assertions passed before host abort).
+  Focused new Pty/CLI/dispatch tests pass 19/19. Full clean CI remains a merge gate.
+- Review/CI exact-head receipts are recorded on the PR before merge.
+
+## P15 final receipt carried forward
+
+- PR #269 merged at `482612b`; candidate `309222ca0055b3c238d5ef17e542ab860e733a34`.
+- Exact-head CI 34368364930 passed: conformance, clipboard/paste, Win32, HUD 51,
+  Quick 57, Navigation 51, Core 297 and Pty 774.
+- Broad Codex review: four healthy sources. Batched current-workspace deletion,
+  stale focus, last-workspace refusal and parser/test fixes in `309222c`.
+- Narrow final review: two healthy sources, no introduced findings/open questions.
+  Confirmed pre-existing split/auxiliary workspace teardown is tracked separately as #270.
+- Local Navigation 51/51, generation 113 released after owned-job cleanup; no shared
+  clipboard/registry mutation. Artifact `.revmux/navigation-ui-20260909T180805-03bb23`
+  in the P15 worktree. No further review rounds for cosmetic findings.

--- a/qa/p16-native-picker.md
+++ b/qa/p16-native-picker.md
@@ -19,6 +19,38 @@
   Focused new Pty/CLI/dispatch tests pass 19/19. Full clean CI remains a merge gate.
 - Review/CI exact-head receipts are recorded on the PR before merge.
 
+## Broad review fix batch
+
+- Four of four Codex sources reported; no degraded sources or open questions.
+- Duplicate complexity findings: tokenize/deduplicate once, retain repeated-term
+  ranking weights, stop completed subsequences, cap aggregate label/term work.
+  Initial over-budget queries refuse; edited queries disable choice and recover.
+- Timed-out opens withdraw queued work; in-flight construction rolls back unless
+  publication won the deadline race. Failed construction aborts without retaining
+  an unexposed answer or evicting old results. Native callback failures log diagnostics.
+- Owner keyboard, mouse motion and file-drop routes cannot enter the PTY while a
+  picker is pending. File drops explicitly release HDROP. Opening during any held
+  capture refuses without creating state. The capture regression failed against
+  the old binary, then passed with the guard.
+- Cancellation accepts an exact retained terminal outcome after owner shutdown.
+  Picker window selection requires exact IDs or unique prefixes; the pre-existing
+  general window resolver ambiguity remains outside this picker change.
+- CLI adds explicit auto/lines/json input format (bracket-prefixed labels can use
+  lines), validates plain items incrementally and refuses excess/duplicate input.
+- Accepted residual: a transport failure after successful open but before the ID
+  reaches the client cannot cancel that unknown ID; Escape/Cancel remains available.
+  This is documented, not advertised as exactly-once delivery.
+- Local fix validation: full headless Core 326 and Pty 794 pass; focused new Core
+  29 and Pty 20 pass. Private GUI generation 118: 32/32, zero owned processes,
+  clipboard/registry untouched, no queued launches; token released. Artifact
+  `.revmux/picker-ui-20260909T193146-a04086`.
+- Final input-route rebuild: private GUI 32/32 again, generation 119 released on
+  the same zero-process proof; `.revmux/picker-ui-20260909T193752-a9b607`.
+- Initial CI 34372905725 passed other integrations but failed a picker foreground
+  assertion that incorrectly required a foreground picker not to restore its owner.
+  The corrected assertion distinguishes that case from background cancellation.
+  The final exact-head CI remains required; no unchanged-head rerun is substituted.
+
 ## P15 final receipt carried forward
 
 - PR #269 merged at `482612b`; candidate `309222ca0055b3c238d5ef17e542ab860e733a34`.

--- a/src/Agwinterm.Core/NativePick.cs
+++ b/src/Agwinterm.Core/NativePick.cs
@@ -36,6 +36,7 @@ public sealed record PickSpec(IReadOnlyList<PickItem> Items, string? Prompt, str
         string? prompt = Text(args, "prompt"), query = Text(args, "query");
         if ((prompt is not null && !DisplayText(prompt)) || (query is not null && !DisplayText(query)))
             throw new ArgumentException("pick prompt/query must not contain controls");
+        PickSelection.ValidateWork(query ?? "", items);
         return new(items.AsReadOnly(), prompt, query, custom);
     }
 
@@ -78,6 +79,15 @@ public sealed record PickOutcome(string Result, string? Id = null, string? Label
 /// <summary>UI-thread query/selection state. Filtering never searches consequence subtitles.</summary>
 public sealed class PickSelection
 {
+    public const long MaxMatchWork = 64 * 1024 * 1024;
+    private static KeyValuePair<string, int>[] Terms(string query) => query.ToLowerInvariant()
+        .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries).GroupBy(t => t, StringComparer.Ordinal)
+        .Select(g => new KeyValuePair<string,int>(g.Key,g.Count())).ToArray();
+    public static void ValidateWork(string query, IReadOnlyList<PickItem> items)
+    {
+        if (items.Sum(i => (long)i.Label.Length) * Terms(query).Length > MaxMatchWork)
+            throw new ArgumentException("picker query is too complex (64 Mi UTF-16 label-unit/unique-term work limit)");
+    }
     public PickSpec Spec { get; }
     public string Query { get; private set; } = "";
     public IReadOnlyList<int> Matches { get; private set; } = Array.Empty<int>();
@@ -89,10 +99,12 @@ public sealed class PickSelection
     public void SetQuery(string query)
     {
         if (!PickSpec.DisplayText(query)) throw new ArgumentException("invalid picker query");
+        ValidateWork(query, Spec.Items);
         Query = query; Selected = 0;
         string trimmed = query.Trim();
+        var terms = Terms(trimmed);
         var indices = Enumerable.Range(0, Spec.Items.Count);
-        Matches = (trimmed.Length == 0 ? indices : indices.Select(i => (Index: i, Score: Score(trimmed, Spec.Items[i].Label)))
+        Matches = (trimmed.Length == 0 ? indices : indices.Select(i => (Index: i, Score: ScoreTerms(terms, Spec.Items[i].Label)))
             .Where(x => x.Score.HasValue).OrderBy(x => x.Score).ThenBy(x => Spec.Items[x.Index].Label, StringComparer.OrdinalIgnoreCase)
             .ThenBy(x => x.Index).Select(x => x.Index)).ToArray();
     }
@@ -107,18 +119,20 @@ public sealed class PickSelection
         return new("picked", item.Id, item.Label, index);
     }
 
-    public static int? Score(string query, string label)
+    public static int? Score(string query, string label) => ScoreTerms(Terms(query), label);
+    private static int? ScoreTerms(KeyValuePair<string,int>[] terms, string label)
     {
         string text = label.ToLowerInvariant(); int total = 0;
-        foreach (string term in query.ToLowerInvariant().Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries))
+        foreach (var entry in terms)
         {
+            string term = entry.Key;
             if (text.StartsWith(term, StringComparison.Ordinal)) continue;
             int offset = text.IndexOf(term, StringComparison.Ordinal);
-            if (offset >= 0) { total += 5 + Math.Min(offset, 34); continue; }
+            if (offset >= 0) { total += (5 + Math.Min(offset, 34)) * entry.Value; continue; }
             int cursor = 0;
-            foreach (char c in text) if (cursor < term.Length && c == term[cursor]) cursor++;
+            foreach (char c in text) if (c == term[cursor] && ++cursor == term.Length) break;
             if (cursor != term.Length) return null;
-            total += 40 + text.Length - term.Length;
+            total += (40 + text.Length - term.Length) * entry.Value;
         }
         return total;
     }
@@ -174,6 +188,13 @@ public sealed class PickRegistry
         }
     }
 
+    public void Abort(string id)
+    {
+        lock (_gate)
+            foreach (var state in _windows.Values)
+                if (state.Pending?.Id == id) { state.Pending = null; return; }
+    }
+
     public void CloseWindow(string window)
     {
         lock (_gate)
@@ -185,4 +206,45 @@ public sealed class PickRegistry
             if (_closed.Count > 32) _closed.RemoveRange(0, _closed.Count - 32);
         }
     }
+}
+
+/// <summary>A queued open can be withdrawn; an in-flight open rolls back on the UI thread.</summary>
+public sealed class PickOpenCall<T>
+{
+    private readonly TaskCompletionSource<T> _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    public Task<T> Task => _completion.Task;
+    public bool Pending => !Task.IsCompleted;
+    public bool Withdraw() => _completion.TrySetCanceled();
+    public void Run(Func<T> create, Action<T> rollback)
+    {
+        if (!Pending) return;
+        try { var value = create(); if (!_completion.TrySetResult(value)) rollback(value); }
+        catch (Exception ex) { if (!_completion.TrySetException(ex)) throw; }
+    }
+}
+
+public static class PickWindowSelector
+{
+    public static string? Resolve(string? selector, IEnumerable<string> ids, string active)
+    {
+        string wanted = selector is null or "active" ? active : selector;
+        var candidates = ids.ToArray();
+        if (candidates.Contains(wanted, StringComparer.Ordinal)) return wanted;
+        if (wanted.Length == 0) return null;
+        var matches = candidates.Where(id => id.StartsWith(wanted, StringComparison.Ordinal)).Take(2).ToArray();
+        return matches.Length == 1 ? matches[0] : null;
+    }
+}
+
+public enum PickInputRoute { None, Keyboard, Focus, Drop, Ignore }
+public static class PickInputPolicy
+{
+    public static PickInputRoute Route(uint message) => message switch
+    {
+        0x100 or 0x101 or 0x102 or 0x104 or 0x105 or 0x106 => PickInputRoute.Keyboard,
+        0x7 or 0x201 or 0x202 or 0x203 or 0x204 or 0x205 or 0x207 or 0x208 or 0x20a or 0x7b => PickInputRoute.Focus,
+        0x233 => PickInputRoute.Drop, // WM_DROPFILES requires DragFinish, never terminal paste
+        0x200 => PickInputRoute.Ignore, // passive motion must neither reach the PTY nor activate the picker
+        _ => PickInputRoute.None
+    };
 }

--- a/src/Agwinterm.Core/NativePick.cs
+++ b/src/Agwinterm.Core/NativePick.cs
@@ -1,0 +1,188 @@
+using System.Text;
+using System.Text.Json;
+
+namespace Agwinterm.Core;
+
+public sealed record PickItem(string Id, string Label, string? Subtitle = null);
+
+/// <summary>Validated caller data only; none of these strings is a command.</summary>
+public sealed record PickSpec(IReadOnlyList<PickItem> Items, string? Prompt, string? Query, bool AllowCustom)
+{
+    public const int MaxItems = 1000, MaxFieldLength = 4096, MaxBytes = 1024 * 1024;
+
+    public static bool DisplayText(string value) => value.Length <= MaxFieldLength &&
+        !value.Any(c => c < 32 || c == 127);
+
+    public static PickSpec Parse(JsonElement args)
+    {
+        if (args.ValueKind != JsonValueKind.Object || Encoding.UTF8.GetByteCount(args.GetRawText()) > MaxBytes)
+            throw new ArgumentException("pick.open requires an object of at most 1 MiB");
+        if (!args.TryGetProperty("items", out var input) || input.ValueKind != JsonValueKind.Array)
+            throw new ArgumentException("pick.open requires an items array");
+        if (input.GetArrayLength() > MaxItems) throw new ArgumentException("too many items (max 1000)");
+        bool custom = Boolean(args, "allowCustom");
+        var items = new List<PickItem>(); var ids = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var item in input.EnumerateArray())
+        {
+            string id = Text(item, "id", required: true)!;
+            string label = Text(item, "label", required: true)!;
+            string? subtitle = Text(item, "subtitle");
+            if (!ids.Add(id)) throw new ArgumentException("pick item ids must be unique");
+            if (label.Length == 0 || !DisplayText(label) || (subtitle is not null && !DisplayText(subtitle)))
+                throw new ArgumentException("pick labels must be nonempty; display text must not contain controls");
+            items.Add(new(id, label, subtitle));
+        }
+        if (items.Count == 0 && !custom) throw new ArgumentException("pick.open requires items or allowCustom");
+        string? prompt = Text(args, "prompt"), query = Text(args, "query");
+        if ((prompt is not null && !DisplayText(prompt)) || (query is not null && !DisplayText(query)))
+            throw new ArgumentException("pick prompt/query must not contain controls");
+        return new(items.AsReadOnly(), prompt, query, custom);
+    }
+
+    public static bool Boolean(JsonElement args, string name)
+    {
+        if (!args.TryGetProperty(name, out var value) || value.ValueKind == JsonValueKind.Null) return false;
+        if (value.ValueKind is not (JsonValueKind.True or JsonValueKind.False))
+            throw new ArgumentException("pick " + name + " must be a boolean");
+        return value.GetBoolean();
+    }
+
+    private static string? Text(JsonElement item, string name, bool required = false)
+    {
+        if (item.ValueKind != JsonValueKind.Object) throw new ArgumentException("pick item must be an object");
+        if (!item.TryGetProperty(name, out var v) || v.ValueKind == JsonValueKind.Null)
+        {
+            if (required) throw new ArgumentException("pick item requires " + name);
+            return null;
+        }
+        if (v.ValueKind != JsonValueKind.String) throw new ArgumentException("pick " + name + " must be a string");
+        string text = v.GetString()!;
+        if (text.Length > MaxFieldLength) throw new ArgumentException("pick field exceeds 4096 UTF-16 units");
+        return text;
+    }
+}
+
+public sealed record PickOutcome(string Result, string? Id = null, string? Label = null, int? Index = null, string? Query = null)
+{
+    public Dictionary<string, object> Wire()
+    {
+        var data = new Dictionary<string, object> { ["result"] = Result };
+        if (Id is not null) data["id"] = Id;
+        if (Label is not null) data["label"] = Label;
+        if (Index is not null) data["index"] = Index.Value;
+        if (Query is not null) data["query"] = Query;
+        return data;
+    }
+}
+
+/// <summary>UI-thread query/selection state. Filtering never searches consequence subtitles.</summary>
+public sealed class PickSelection
+{
+    public PickSpec Spec { get; }
+    public string Query { get; private set; } = "";
+    public IReadOnlyList<int> Matches { get; private set; } = Array.Empty<int>();
+    public int Selected { get; private set; }
+    public bool Custom => Spec.AllowCustom && Query.Trim().Length > 0 && Matches.Count == 0;
+    public int Count => Matches.Count + (Custom ? 1 : 0);
+    public PickSelection(PickSpec spec) { Spec = spec; SetQuery(spec.Query ?? ""); }
+
+    public void SetQuery(string query)
+    {
+        if (!PickSpec.DisplayText(query)) throw new ArgumentException("invalid picker query");
+        Query = query; Selected = 0;
+        string trimmed = query.Trim();
+        var indices = Enumerable.Range(0, Spec.Items.Count);
+        Matches = (trimmed.Length == 0 ? indices : indices.Select(i => (Index: i, Score: Score(trimmed, Spec.Items[i].Label)))
+            .Where(x => x.Score.HasValue).OrderBy(x => x.Score).ThenBy(x => Spec.Items[x.Index].Label, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(x => x.Index).Select(x => x.Index)).ToArray();
+    }
+
+    public void Select(int index) => Selected = Math.Clamp(index, 0, Math.Max(0, Count - 1));
+    public void Move(int delta) => Select(Selected + delta);
+    public PickOutcome? Choose()
+    {
+        if (Custom) return new("custom", Query: Query.Trim());
+        if (Matches.Count == 0) return null;
+        int index = Matches[Selected]; var item = Spec.Items[index];
+        return new("picked", item.Id, item.Label, index);
+    }
+
+    public static int? Score(string query, string label)
+    {
+        string text = label.ToLowerInvariant(); int total = 0;
+        foreach (string term in query.ToLowerInvariant().Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (text.StartsWith(term, StringComparison.Ordinal)) continue;
+            int offset = text.IndexOf(term, StringComparison.Ordinal);
+            if (offset >= 0) { total += 5 + Math.Min(offset, 34); continue; }
+            int cursor = 0;
+            foreach (char c in text) if (cursor < term.Length && c == term[cursor]) cursor++;
+            if (cursor != term.Length) return null;
+            total += 40 + text.Length - term.Length;
+        }
+        return total;
+    }
+}
+
+public sealed record PendingPick(string Id, string Window, PickSpec Spec);
+public sealed record LocatedPick(string Window, PickOutcome Outcome);
+
+/// <summary>Thread-safe bounded results; callers perform all native UI work outside this lock.</summary>
+public sealed class PickRegistry
+{
+    private sealed record Answer(string Id, string Window, PickOutcome Outcome, long Sequence);
+    private sealed class WindowState { public PendingPick? Pending; public List<Answer> Answers = new(); }
+    private readonly object _gate = new();
+    private readonly Dictionary<string, WindowState> _windows = new(StringComparer.Ordinal);
+    private readonly List<Answer> _closed = new();
+    private long _sequence;
+
+    public PendingPick? Open(string window, PickSpec spec)
+    {
+        lock (_gate)
+        {
+            if (!_windows.TryGetValue(window, out var state)) _windows[window] = state = new();
+            if (state.Pending is not null) return null;
+            return state.Pending = new(Guid.NewGuid().ToString(), window, spec);
+        }
+    }
+
+    public LocatedPick? Find(string id)
+    {
+        lock (_gate)
+        {
+            foreach (var state in _windows.Values)
+            {
+                if (state.Pending is { } pending && pending.Id == id) return new(pending.Window, new("pending"));
+                if (state.Answers.FirstOrDefault(a => a.Id == id) is { } answer) return new(answer.Window, answer.Outcome);
+            }
+            return _closed.FirstOrDefault(a => a.Id == id) is { } old ? new(old.Window, old.Outcome) : null;
+        }
+    }
+
+    public bool Resolve(string id, PickOutcome outcome)
+    {
+        if (outcome.Result is not ("picked" or "custom" or "cancelled")) throw new ArgumentException("terminal outcome required");
+        lock (_gate)
+        {
+            var state = _windows.Values.FirstOrDefault(s => s.Pending?.Id == id);
+            if (state?.Pending is not { } pending) return false;
+            state.Answers.Add(new(id, pending.Window, outcome, ++_sequence));
+            if (state.Answers.Count > 8) state.Answers.RemoveAt(0);
+            state.Pending = null;
+            return true;
+        }
+    }
+
+    public void CloseWindow(string window)
+    {
+        lock (_gate)
+        {
+            if (!_windows.TryGetValue(window, out var state)) return;
+            if (state.Pending is { } pending) Resolve(pending.Id, new("cancelled"));
+            _closed.AddRange(state.Answers); _windows.Remove(window);
+            _closed.Sort((a, b) => a.Sequence.CompareTo(b.Sequence));
+            if (_closed.Count > 32) _closed.RemoveRange(0, _closed.Count - 32);
+        }
+    }
+}

--- a/src/Agwinterm.Ctl/PickCli.cs
+++ b/src/Agwinterm.Ctl/PickCli.cs
@@ -1,0 +1,179 @@
+using System.IO.Pipes;
+using System.Text;
+using System.Text.Json;
+using Agwinterm.Core;
+
+namespace Agwinterm.Ctl;
+
+/// <summary>Picker-specific payload output and exact-id waiting; no shell execution.</summary>
+public static class PickCli
+{
+    private sealed record Options(string Verb, string? Id, Dictionary<string, string> Values, HashSet<string> Flags);
+    private static readonly UTF8Encoding Utf8 = new(false, true);
+
+    private static Options Parse(string[] argv)
+    {
+        var values = new Dictionary<string, string>(); var flags = new HashSet<string>();
+        var positionals = new List<string>();
+        for (int i = 1; i < argv.Length; i++)
+        {
+            string word = argv[i];
+            if (!word.StartsWith("--", StringComparison.Ordinal)) { positionals.Add(word); continue; }
+            string key = word[2..];
+            if (key is "allow-custom" or "follow" or "no-block" or "json")
+            { if (!flags.Add(key)) throw new ArgumentException("duplicate picker option: " + word); continue; }
+            if (key is not ("prompt" or "query" or "window" or "pipe" or "socket")) throw new ArgumentException("unknown picker option: " + word);
+            if (++i >= argv.Length || argv[i].StartsWith("--", StringComparison.Ordinal) || !values.TryAdd(key, argv[i]))
+                throw new ArgumentException("missing or duplicate picker option: " + word);
+        }
+        string verb = positionals.FirstOrDefault() ?? "open";
+        if (verb is not ("open" or "result" or "cancel")) throw new ArgumentException("pick accepts open, result or cancel");
+        if ((verb == "open" && positionals.Count > 1) || (verb != "open" && positionals.Count != 2))
+            throw new ArgumentException("pick result/cancel require one exact id; open reads items from stdin");
+        if (values.TryGetValue("window", out var window) && window.Length == 0) throw new ArgumentException("empty window selector");
+        if (verb != "open" && (flags.Any(f => f != "json") || values.ContainsKey("prompt") || values.ContainsKey("query")))
+            throw new ArgumentException("open-only picker option on result/cancel");
+        if (values.ContainsKey("pipe") && values.ContainsKey("socket")) throw new ArgumentException("choose --pipe or --socket");
+        return new(verb, verb == "open" ? null : positionals[1], values, flags);
+    }
+
+    public static PickItem[] ParseItems(byte[] input)
+    {
+        if (input.Length > PickSpec.MaxBytes) throw new ArgumentException("picker stdin exceeds 1 MiB");
+        string text = Utf8.GetString(input);
+        if (text.TrimStart(' ', '\t', '\r', '\n').StartsWith('['))
+        {
+            using var items = JsonDocument.Parse(text);
+            using var args = JsonDocument.Parse("{\"allowCustom\":true,\"items\":" + items.RootElement.GetRawText() + "}");
+            return PickSpec.Parse(args.RootElement).Items.ToArray();
+        }
+        return text.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n')
+            .Where(line => !string.IsNullOrWhiteSpace(line)).Select(line => new PickItem(line, line)).ToArray();
+    }
+
+    private static string Request(string verb, string? id = null, string? window = null, object? args = null)
+    {
+        var data = new Dictionary<string, object> { ["cmd"] = "pick." + verb };
+        if (id is not null) data["target"] = id;
+        if (window is not null) data["window"] = window;
+        if (args is not null) data["args"] = args;
+        return JsonSerializer.Serialize(data);
+    }
+
+    public static int Execute(string[] argv, byte[] input, Func<string, JsonElement> send, Action<int> wait,
+        Action<string> output, Action<string> error, CancellationToken cancellation = default)
+    {
+        string? pending = null; bool terminal = false;
+        Options options;
+        try { options = Parse(argv); }
+        catch (Exception ex) { error(ex.Message); return 2; }
+        try
+        {
+            cancellation.ThrowIfCancellationRequested();
+            string? window = options.Values.GetValueOrDefault("window");
+            if (options.Verb != "open")
+            {
+                var answer = send(Request(options.Verb, options.Id, window));
+                var result = Success(answer);
+                if (options.Verb == "cancel") { output(options.Flags.Contains("json") ? answer.GetRawText() : "cancelled"); return 0; }
+                var outcome = Outcome(result); output(outcome.GetRawText()); return ExitCode(outcome);
+            }
+            object[] items;
+            try { items = ParseItems(input).Select(i => (object)new { id = i.Id, label = i.Label, subtitle = i.Subtitle }).ToArray(); }
+            catch (Exception ex) { error(ex.Message); return 2; }
+            var arguments = new { items, prompt = options.Values.GetValueOrDefault("prompt"), query = options.Values.GetValueOrDefault("query"),
+                allowCustom = options.Flags.Contains("allow-custom"), follow = options.Flags.Contains("follow") };
+            // Same validation as the server before connecting, including line-input duplicate IDs.
+            using (var check = JsonDocument.Parse(JsonSerializer.Serialize(arguments)))
+            {
+                try { PickSpec.Parse(check.RootElement); }
+                catch (Exception ex) { error(ex.Message); return 2; }
+            }
+            var opened = Success(send(Request("open", window: window, args: arguments)));
+            if (!opened.TryGetProperty("id", out var id) || id.ValueKind != JsonValueKind.String || string.IsNullOrEmpty(id.GetString()))
+                throw new InvalidOperationException("pick.open result missing id");
+            pending = id.GetString();
+            if (options.Flags.Contains("no-block")) { output(JsonSerializer.Serialize(new { id = pending })); terminal = true; return 0; }
+            int polls = 0;
+            while (true)
+            {
+                cancellation.ThrowIfCancellationRequested();
+                var outcome = Outcome(Success(send(Request("result", pending)))); // intentionally no window selector
+                if (outcome.GetProperty("result").GetString() != "pending")
+                { terminal = true; output(outcome.GetRawText()); return ExitCode(outcome); }
+                wait(++polls <= 10 ? 100 : 500);
+            }
+        }
+        catch (Exception ex) { error(ex is OperationCanceledException ? "picker wait cancelled" : ex.Message); return 1; }
+        finally
+        {
+            if (pending is not null && !terminal)
+                try { send(Request("cancel", pending)); } catch { /* best effort, preserve original failure */ }
+        }
+    }
+
+    private static JsonElement Success(JsonElement response)
+    {
+        if (!response.TryGetProperty("ok", out var ok) || ok.ValueKind != JsonValueKind.True)
+            throw new InvalidOperationException(response.TryGetProperty("error", out var error) && error.ValueKind == JsonValueKind.String ? error.GetString() : "invalid picker reply");
+        if (!response.TryGetProperty("result", out var result)) throw new InvalidOperationException("picker reply missing result");
+        return result;
+    }
+
+    private static JsonElement Outcome(JsonElement result)
+    {
+        if (!result.TryGetProperty("pick", out var pick) || !pick.TryGetProperty("result", out var state) || state.ValueKind != JsonValueKind.String ||
+            state.GetString() is not ("pending" or "picked" or "custom" or "cancelled")) throw new InvalidOperationException("invalid pick.result outcome");
+        if (state.GetString() == "picked" &&
+            (!pick.TryGetProperty("id", out var id) || id.ValueKind != JsonValueKind.String ||
+             !pick.TryGetProperty("label", out var label) || label.ValueKind != JsonValueKind.String || string.IsNullOrEmpty(label.GetString()) ||
+             !pick.TryGetProperty("index", out var index) || !index.TryGetInt32(out int n) || n < 0))
+            throw new InvalidOperationException("invalid picked item");
+        if (state.GetString() == "custom" && (!pick.TryGetProperty("query", out var query) || query.ValueKind != JsonValueKind.String || string.IsNullOrWhiteSpace(query.GetString())))
+            throw new InvalidOperationException("invalid custom query");
+        return pick;
+    }
+    private static int ExitCode(JsonElement outcome) => outcome.GetProperty("result").GetString() switch
+    { "picked" or "custom" => 0, "cancelled" => 2, _ => 1 };
+
+    public static int Run(string[] argv)
+    {
+        using var stop = new CancellationTokenSource();
+        ConsoleCancelEventHandler handler = (_, e) => { e.Cancel = true; stop.Cancel(); };
+        Console.CancelKeyPress += handler;
+        try
+        {
+            Options options;
+            try { options = Parse(argv); } catch (Exception ex) { Console.Error.WriteLine(ex.Message); return 2; }
+            string pipe = options.Values.GetValueOrDefault("pipe") ?? options.Values.GetValueOrDefault("socket") ?? Environment.GetEnvironmentVariable("AGWINTERM_PIPE") ?? "agwinterm";
+            byte[] input = Array.Empty<byte>();
+            if (options.Verb == "open")
+            {
+                using var data = new MemoryStream(); var chunk = new byte[8192]; using var stdin = Console.OpenStandardInput();
+                int count;
+                while ((count = stdin.ReadAsync(chunk.AsMemory(), stop.Token).AsTask().WaitAsync(stop.Token).GetAwaiter().GetResult()) > 0)
+                { stop.Token.ThrowIfCancellationRequested(); if (data.Length + count > PickSpec.MaxBytes) throw new ArgumentException("picker stdin exceeds 1 MiB"); data.Write(chunk, 0, count); }
+                input = data.ToArray();
+            }
+            return Execute(argv, input, request => Send(pipe, request), ms =>
+            { if (stop.Token.WaitHandle.WaitOne(ms)) stop.Token.ThrowIfCancellationRequested(); }, Console.WriteLine, Console.Error.WriteLine, stop.Token);
+        }
+        catch (Exception ex) { Console.Error.WriteLine(ex.Message); return ex is ArgumentException ? 2 : 1; }
+        finally { Console.CancelKeyPress -= handler; }
+    }
+
+    private static JsonElement Send(string pipeName, string request)
+    {
+        using var deadline = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        using var pipe = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+        pipe.ConnectAsync(3000, deadline.Token).GetAwaiter().GetResult();
+        using var writer = new StreamWriter(pipe, new UTF8Encoding(false), leaveOpen: true) { AutoFlush = true };
+        using var reader = new StreamReader(pipe, Utf8, false, leaveOpen: true);
+        // Bound the operation without using cancellation on NamedPipe's write path (#118).
+        // Disposal closes the owned handle if the deadline interrupts this wait.
+        writer.WriteLineAsync(request.AsMemory(), CancellationToken.None).WaitAsync(deadline.Token).GetAwaiter().GetResult();
+        string? line = reader.ReadLineAsync(deadline.Token).AsTask().GetAwaiter().GetResult();
+        if (line is null) throw new IOException("picker connection closed without a reply");
+        using var document = JsonDocument.Parse(line); return document.RootElement.Clone();
+    }
+}

--- a/src/Agwinterm.Ctl/PickCli.cs
+++ b/src/Agwinterm.Ctl/PickCli.cs
@@ -22,7 +22,7 @@ public static class PickCli
             string key = word[2..];
             if (key is "allow-custom" or "follow" or "no-block" or "json")
             { if (!flags.Add(key)) throw new ArgumentException("duplicate picker option: " + word); continue; }
-            if (key is not ("prompt" or "query" or "window" or "pipe" or "socket")) throw new ArgumentException("unknown picker option: " + word);
+            if (key is not ("prompt" or "query" or "window" or "pipe" or "socket" or "input-format")) throw new ArgumentException("unknown picker option: " + word);
             if (++i >= argv.Length || argv[i].StartsWith("--", StringComparison.Ordinal) || !values.TryAdd(key, argv[i]))
                 throw new ArgumentException("missing or duplicate picker option: " + word);
         }
@@ -31,24 +31,33 @@ public static class PickCli
         if ((verb == "open" && positionals.Count > 1) || (verb != "open" && positionals.Count != 2))
             throw new ArgumentException("pick result/cancel require one exact id; open reads items from stdin");
         if (values.TryGetValue("window", out var window) && window.Length == 0) throw new ArgumentException("empty window selector");
-        if (verb != "open" && (flags.Any(f => f != "json") || values.ContainsKey("prompt") || values.ContainsKey("query")))
+        if (verb != "open" && (flags.Any(f => f != "json") || values.ContainsKey("prompt") || values.ContainsKey("query") || values.ContainsKey("input-format")))
             throw new ArgumentException("open-only picker option on result/cancel");
         if (values.ContainsKey("pipe") && values.ContainsKey("socket")) throw new ArgumentException("choose --pipe or --socket");
+        if (values.GetValueOrDefault("input-format", "auto") is not ("auto" or "lines" or "json")) throw new ArgumentException("input-format must be auto, lines or json");
         return new(verb, verb == "open" ? null : positionals[1], values, flags);
     }
 
-    public static PickItem[] ParseItems(byte[] input)
+    public static PickItem[] ParseItems(byte[] input, string format = "auto")
     {
         if (input.Length > PickSpec.MaxBytes) throw new ArgumentException("picker stdin exceeds 1 MiB");
         string text = Utf8.GetString(input);
-        if (text.TrimStart(' ', '\t', '\r', '\n').StartsWith('['))
+        if (format == "json" || (format == "auto" && text.TrimStart(' ', '\t', '\r', '\n').StartsWith('[')))
         {
             using var items = JsonDocument.Parse(text);
             using var args = JsonDocument.Parse("{\"allowCustom\":true,\"items\":" + items.RootElement.GetRawText() + "}");
             return PickSpec.Parse(args.RootElement).Items.ToArray();
         }
-        return text.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n')
-            .Where(line => !string.IsNullOrWhiteSpace(line)).Select(line => new PickItem(line, line)).ToArray();
+        var result = new List<PickItem>(); var ids = new HashSet<string>(StringComparer.Ordinal);
+        using var lines = new StringReader(text);
+        while (lines.ReadLine() is { } line)
+        {
+            if (string.IsNullOrWhiteSpace(line)) continue;
+            if (result.Count == PickSpec.MaxItems) throw new ArgumentException("too many items (max 1000)");
+            if (!PickSpec.DisplayText(line) || !ids.Add(line)) throw new ArgumentException("invalid or duplicate plain-line item");
+            result.Add(new(line, line));
+        }
+        return result.ToArray();
     }
 
     private static string Request(string verb, string? id = null, string? window = null, object? args = null)
@@ -79,7 +88,7 @@ public static class PickCli
                 var outcome = Outcome(result); output(outcome.GetRawText()); return ExitCode(outcome);
             }
             object[] items;
-            try { items = ParseItems(input).Select(i => (object)new { id = i.Id, label = i.Label, subtitle = i.Subtitle }).ToArray(); }
+            try { items = ParseItems(input, options.Values.GetValueOrDefault("input-format", "auto")).Select(i => (object)new { id = i.Id, label = i.Label, subtitle = i.Subtitle }).ToArray(); }
             catch (Exception ex) { error(ex.Message); return 2; }
             var arguments = new { items, prompt = options.Values.GetValueOrDefault("prompt"), query = options.Values.GetValueOrDefault("query"),
                 allowCustom = options.Flags.Contains("allow-custom"), follow = options.Flags.Contains("follow") };

--- a/src/Agwinterm.Ctl/Program.cs
+++ b/src/Agwinterm.Ctl/Program.cs
@@ -99,6 +99,9 @@ using System.Text.Json;
 //   agwintermctl install hooks
 // Target defaults to $AGWINTERM_SESSION_ID (the current session) when not given.
 
+if (args.Length > 0 && args[0].Equals("pick", StringComparison.OrdinalIgnoreCase))
+    return Agwinterm.Ctl.PickCli.Run(args);
+
 if (args.Length == 0)
 {
     Console.Error.WriteLine("usage: agwintermctl <ping|version|tree|session|surface|image|install> ... (see README.md, \"Control it from anything\")");

--- a/src/Agwinterm.Pty/AgentSkill.cs
+++ b/src/Agwinterm.Pty/AgentSkill.cs
@@ -130,6 +130,15 @@ public static class AgentSkill
           Tree `foregroundShells` (pane-order, null unknown) and primary/split aliases are conservative Windows shell hints, never idle-prompt or input-safety proof.
         - `agwintermctl workspace collapse [WS] [--target WS]` / `workspace expand [WS]` — collapse/expand a single workspace's session list (default: active)
 
+        ## Native picker (P16, full app; lite mirror pending)
+        - Pipe UTF-8 lines or JSON `[{"id":"a","label":"Alpha","subtitle":"optional consequence"}]` to `agwintermctl pick [open]`.
+        - `--prompt TEXT --query TEXT --allow-custom --window ID --follow --no-block`; no session target. Default display does not steal foreground; follow requests OS activation.
+        - `--no-block` returns JSON `{id}`. Otherwise waits by exact id without a window selector; picked/custom exit 0, cancelled 2. Ctrl+C/failure best-effort cancels the owned pending picker.
+        - `pick result ID` prints the JSON outcome (`result: pending|picked|custom|cancelled`); pending exits 1. Picked adds item id/label/original index; custom adds trimmed query.
+        - `pick cancel ID` is idempotent for retained answers. Result/cancel optionally restrict `--window`; omit it for global exact-ID lookup across focus/owner closure.
+        - One pending/window, eight completed/window, 32 closed-window answers. Quick refuses. Items never execute; matching searches labels only, custom appears only when no item matches.
+        - Max 1000 items, 4096 UTF-16 units/field, 1 MiB UTF-8 stdin/open args; duplicate IDs and display controls refuse. Open/result JSON is payload even with --json; cancel uses the normal envelope under --json.
+
         ## Read a session's output
         - `agwintermctl session text [--all|--lines N] [--target <id>]` — dump the pane as plain text. Without a flag that is
           the visible screen; `--lines N` returns the last N lines ending at the bottom of the screen, reaching back into

--- a/src/Agwinterm.Pty/AgentSkill.cs
+++ b/src/Agwinterm.Pty/AgentSkill.cs
@@ -132,12 +132,14 @@ public static class AgentSkill
 
         ## Native picker (P16, full app; lite mirror pending)
         - Pipe UTF-8 lines or JSON `[{"id":"a","label":"Alpha","subtitle":"optional consequence"}]` to `agwintermctl pick [open]`.
-        - `--prompt TEXT --query TEXT --allow-custom --window ID --follow --no-block`; no session target. Default display does not steal foreground; follow requests OS activation.
+        - `--prompt TEXT --query TEXT --allow-custom --window ID --follow --no-block`; no session target. Default display does not steal foreground; follow requests OS activation. Auto input treats leading `[` as JSON; use `--input-format lines` for `[Draft]`-style line labels, or `json` to require JSON.
         - `--no-block` returns JSON `{id}`. Otherwise waits by exact id without a window selector; picked/custom exit 0, cancelled 2. Ctrl+C/failure best-effort cancels the owned pending picker.
         - `pick result ID` prints the JSON outcome (`result: pending|picked|custom|cancelled`); pending exits 1. Picked adds item id/label/original index; custom adds trimmed query.
         - `pick cancel ID` is idempotent for retained answers. Result/cancel optionally restrict `--window`; omit it for global exact-ID lookup across focus/owner closure.
         - One pending/window, eight completed/window, 32 closed-window answers. Quick refuses. Items never execute; matching searches labels only, custom appears only when no item matches.
         - Max 1000 items, 4096 UTF-16 units/field, 1 MiB UTF-8 stdin/open args; duplicate IDs and display controls refuse. Open/result JSON is payload even with --json; cancel uses the normal envelope under --json.
+        - Filtering work caps total label UTF-16 units times distinct query terms at 64 Mi. Over-complex edited queries disable choice until corrected. Mouse capture blocks opening; file drops on the owner are discarded.
+        - Initial UI open waits 10s and withdraws/rolls back on timeout. Best-effort cancel needs the received picker ID; a lost successful open reply can require user Escape/Cancel. No exactly-once transport guarantee.
 
         ## Read a session's output
         - `agwintermctl session text [--all|--lines N] [--target <id>]` — dump the pane as plain text. Without a flag that is

--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -169,6 +169,23 @@ public sealed class ControlServer : IDisposable
             JsonElement args = root.TryGetProperty("args", out var a) ? a : default;
             // --window <id|prefix|active>: content verbs act on the resolved window (default = frontmost).
             string? windowSel = root.TryGetProperty("window", out var wv) && wv.ValueKind == JsonValueKind.String ? wv.GetString() : null;
+            if (cmd is "pick.open" or "pick.result" or "pick.cancel")
+            {
+                if ((root.TryGetProperty("window", out var pw) && pw.ValueKind is not (JsonValueKind.String or JsonValueKind.Null)) || windowSel == "")
+                    return Err("pick requires a nonempty window selector");
+                if ((_windows as IPickHost ?? _host as IPickHost) is not { } picks) return Err("native picker unavailable");
+                if (cmd == "pick.open")
+                {
+                    if (root.TryGetProperty("target", out var pt) && pt.ValueKind != JsonValueKind.Null)
+                        return Err("pick.open does not accept a session target");
+                    var spec = PickSpec.Parse(args);
+                    return OkRaw(JsonSerializer.Serialize(new { id = picks.OpenPick(spec, windowSel, PickSpec.Boolean(args, "follow")) }));
+                }
+                if (target is null) return Err("pick.result/cancel require an exact picker id");
+                if (cmd == "pick.result") return OkRaw(JsonSerializer.Serialize(new { pick = picks.ReadPick(target, windowSel).Wire() }));
+                picks.CancelPick(target, windowSel);
+                return Ok("cancelled");
+            }
             if (cmd == "workspace.go")
             {
                 if (root.TryGetProperty("target", out var gt) && gt.ValueKind != JsonValueKind.Null)

--- a/src/Agwinterm.Pty/IPickHost.cs
+++ b/src/Agwinterm.Pty/IPickHost.cs
@@ -1,0 +1,11 @@
+using Agwinterm.Core;
+
+namespace Agwinterm.Pty;
+
+/// <summary>App-level picker routing, independent of session selectors and window liveness.</summary>
+public interface IPickHost
+{
+    string OpenPick(PickSpec spec, string? window, bool follow);
+    PickOutcome ReadPick(string id, string? window);
+    void CancelPick(string id, string? window);
+}

--- a/src/Agwinterm.Win32/NativePicker.cs
+++ b/src/Agwinterm.Win32/NativePicker.cs
@@ -1,0 +1,247 @@
+using System.Runtime.InteropServices;
+using System.Text;
+using Agwinterm.Core;
+using static Agwinterm.Win32.Win32;
+
+namespace Agwinterm.Win32;
+
+/// <summary>Owned modeless native controls. Only its owner UI thread calls this object.</summary>
+internal sealed class NativePicker : IDisposable
+{
+    private const string ClassName = "Agwinterm.NativePicker";
+    private const uint NcDestroy = 0x82, GetDlgCode = 0x87;
+    private const uint LbAdd = 0x180, LbReset = 0x184, LbGetSel = 0x188, LbSetSel = 0x186;
+    private static readonly WndProc RootProc = WindowProc;
+    private static readonly Dictionary<IntPtr, NativePicker> Roots = new();
+    private static readonly Dictionary<IntPtr, NativePicker> Children = new();
+    private static NativePicker? _creating;
+    private static bool _registered;
+    private readonly WndProc _childProc;
+    private readonly Dictionary<IntPtr, IntPtr> _original = new();
+    private readonly IntPtr _owner;
+    private readonly Action<PickOutcome> _finish;
+    private readonly Action _activated;
+    private readonly PickSelection _selection;
+    private IntPtr _hwnd, _edit, _list, _accept, _cancel, _label, _font;
+    private bool _ended, _disposing;
+    private int _dpi = 96;
+    public PendingPick Request { get; }
+
+    [DllImport("user32.dll")] private static extern IntPtr GetNextDlgTabItem(IntPtr dialog, IntPtr control, bool previous);
+    [DllImport("user32.dll")] private static extern bool EnableWindow(IntPtr hwnd, bool enabled);
+    [DllImport("user32.dll")] private static extern uint GetDpiForWindow(IntPtr hwnd);
+    [DllImport("user32.dll")] private static extern IntPtr GetForegroundWindow();
+    [DllImport("user32.dll")] private static extern bool IsWindow(IntPtr hwnd);
+    [DllImport("gdi32.dll", CharSet = CharSet.Unicode)] private static extern IntPtr CreateFontW(int height, int width, int escapement, int orientation, int weight,
+        uint italic, uint underline, uint strikeout, uint charset, uint outPrecision, uint clipPrecision, uint quality, uint pitch, string family);
+
+    public NativePicker(IntPtr owner, PendingPick request, Action<PickOutcome> finish, Action activated)
+    {
+        _owner = owner; Request = request; _finish = finish; _activated = activated;
+        _selection = new(request.Spec); _childProc = ChildProc;
+    }
+
+    public void Show(bool follow)
+    {
+        if (!_registered)
+        {
+            var cls = new WNDCLASSEXW { cbSize = (uint)Marshal.SizeOf<WNDCLASSEXW>(), lpfnWndProc = RootProc,
+                hInstance = GetModuleHandleW(null), hCursor = LoadCursorW(IntPtr.Zero, IDC_ARROW),
+                hbrBackground = (IntPtr)6 /* COLOR_WINDOW + 1 */, lpszClassName = ClassName };
+            if (RegisterClassExW(ref cls) == 0) throw new InvalidOperationException("picker class registration failed");
+            _registered = true;
+        }
+        _dpi = (int)GetDpiForWindow(_owner); if (_dpi <= 0) _dpi = 96;
+        GetWindowRect(_owner, out var ownerRect);
+        var monitor = MonitorFromRect(ref ownerRect, MONITOR_DEFAULTTONEAREST);
+        var info = new MONITORINFO { cbSize = Marshal.SizeOf<MONITORINFO>() };
+        if (!GetMonitorInfoW(monitor, ref info)) throw new InvalidOperationException("picker monitor unavailable");
+        var area = info.rcWork;
+        int width = Math.Min(Scale(640), area.right - area.left), height = Math.Min(Scale(420), area.bottom - area.top);
+        int x = Math.Clamp(ownerRect.left + (ownerRect.right - ownerRect.left - width) / 2, area.left, area.right - width);
+        int y = Math.Clamp(ownerRect.top + Scale(60), area.top, area.bottom - height);
+        _creating = this;
+        try
+        {
+            _hwnd = CreateWindowExW(0x10000 /* WS_EX_CONTROLPARENT */, ClassName, "agwinterm picker", WS_CAPTION | WS_SYSMENU | WS_POPUP,
+                x, y, width, height, _owner, IntPtr.Zero, GetModuleHandleW(null), IntPtr.Zero);
+        }
+        finally { _creating = null; }
+        if (_hwnd == IntPtr.Zero) throw new InvalidOperationException("picker window creation failed");
+        _label = Child("STATIC", Request.Spec.Prompt ?? "Select…", 0x80 /* SS_NOPREFIX */, 100);
+        _edit = Child("EDIT", "", WS_TABSTOP | ES_AUTOHSCROLL | 0x800000 /* WS_BORDER */, 101);
+        _list = Child("LISTBOX", "", WS_TABSTOP | WS_VSCROLL | 1 /* LBS_NOTIFY */ | 0x100 /* LBS_NOINTEGRALHEIGHT */ | 0x800000, 102);
+        _accept = Child("BUTTON", "Select", WS_TABSTOP | 1 /* default push button */, 1);
+        _cancel = Child("BUTTON", "Cancel", WS_TABSTOP, 2);
+        foreach (var child in new[] { _edit, _list, _accept, _cancel })
+        {
+            Children[child] = this;
+            _original[child] = SetWindowLongPtrW(child, GWLP_WNDPROC, Marshal.GetFunctionPointerForDelegate(_childProc));
+            if (_original[child] == IntPtr.Zero) throw new InvalidOperationException("picker control subclass failed");
+        }
+        SendMessageW(_edit, 0xc5 /* EM_SETLIMITTEXT */, (IntPtr)PickSpec.MaxFieldLength, IntPtr.Zero);
+        UpdateFont(); Layout();
+        SetWindowTextW(_edit, Request.Spec.Query ?? "");
+        Refilter();
+        if (_ended || _hwnd == IntPtr.Zero) throw new InvalidOperationException("picker closed during creation");
+        ShowWindow(_hwnd, 4 /* SW_SHOWNOACTIVATE */);
+        if (follow) SetForegroundWindow(_hwnd);
+        FocusIfForeground();
+    }
+
+    private IntPtr Child(string cls, string text, uint style, int id)
+    {
+        var child = CreateWindowExW(0, cls, text, WS_CHILD | WS_VISIBLE | style, 0, 0, 1, 1, _hwnd, (IntPtr)id, GetModuleHandleW(null), IntPtr.Zero);
+        if (child == IntPtr.Zero) throw new InvalidOperationException("picker control creation failed");
+        return child;
+    }
+
+    private int Scale(int n) => Math.Max(1, (int)Math.Round(n * _dpi / 96.0));
+    private void UpdateFont()
+    {
+        var font = CreateFontW(-Scale(14), 0, 0, 0, 400, 0, 0, 0, 1, 0, 0, 5, 0, "Segoe UI");
+        if (font == IntPtr.Zero) throw new InvalidOperationException("picker font creation failed");
+        foreach (var h in new[] { _label, _edit, _list, _accept, _cancel }) if (h != IntPtr.Zero) SendMessageW(h, WM_SETFONT, font, (IntPtr)1);
+        if (_font != IntPtr.Zero) DeleteObject(_font);
+        _font = font;
+    }
+
+    private void Layout()
+    {
+        if (_cancel == IntPtr.Zero) return;
+        GetClientRect(_hwnd, out var r);
+        int pad = Scale(12), full = Math.Max(1, r.right - 2 * pad), bottom = Math.Max(pad, r.bottom - pad - Scale(30));
+        Place(_label, pad, pad, full, Scale(24));
+        Place(_edit, pad, pad + Scale(26), full, Scale(28));
+        Place(_list, pad, pad + Scale(62), full, Math.Max(1, bottom - pad - Scale(70)));
+        Place(_accept, Math.Max(pad, r.right - pad - Scale(204)), bottom, Scale(96), Scale(30));
+        Place(_cancel, Math.Max(pad, r.right - pad - Scale(96)), bottom, Scale(96), Scale(30));
+    }
+
+    private static void Place(IntPtr h, int x, int y, int w, int height)
+        => SetWindowPos(h, IntPtr.Zero, x, y, w, height, SWP_NOZORDER | SWP_NOACTIVATE);
+
+    private void Refilter()
+    {
+        if (_list == IntPtr.Zero) return;
+        var query = new StringBuilder(PickSpec.MaxFieldLength + 1);
+        GetWindowTextW(_edit, query, query.Capacity);
+        _selection.SetQuery(query.ToString());
+        SendMessageW(_list, LbReset, IntPtr.Zero, IntPtr.Zero);
+        foreach (int index in _selection.Matches)
+        {
+            var item = Request.Spec.Items[index];
+            string text = item.Label + (string.IsNullOrEmpty(item.Subtitle) ? "" : " — " + item.Subtitle);
+            if (SendMessageW(_list, LbAdd, IntPtr.Zero, text).ToInt64() < 0) throw new InvalidOperationException("picker list allocation failed");
+        }
+        if (_selection.Custom && SendMessageW(_list, LbAdd, IntPtr.Zero, "Use \"" + _selection.Query.Trim() + "\"").ToInt64() < 0)
+            throw new InvalidOperationException("picker list allocation failed");
+        SendMessageW(_list, LbSetSel, (IntPtr)(_selection.Count == 0 ? -1 : 0), IntPtr.Zero);
+        EnableWindow(_accept, _selection.Count > 0);
+    }
+
+    private void Choose()
+    {
+        _selection.Select((int)SendMessageW(_list, LbGetSel, IntPtr.Zero, IntPtr.Zero));
+        if (_selection.Choose() is { } outcome) End(outcome);
+    }
+
+    public void FocusIfForeground()
+    {
+        if (_ended || _edit == IntPtr.Zero) return;
+        IntPtr front = GetForegroundWindow();
+        if (front == _owner || front == _hwnd) SetFocus(_edit);
+    }
+
+    public void Forward(uint msg, IntPtr key, IntPtr detail)
+    {
+        if (!_ended && _edit != IntPtr.Zero) SendMessageW(_edit, msg, key, detail);
+    }
+
+    private void End(PickOutcome outcome)
+    {
+        if (_ended) return;
+        _ended = true;
+        try { _finish(outcome); } finally { Dispose(); }
+    }
+
+    private static IntPtr WindowProc(IntPtr hwnd, uint msg, IntPtr w, IntPtr l)
+    {
+        if (!Roots.TryGetValue(hwnd, out var picker))
+        {
+            picker = _creating;
+            if (picker is null) return DefWindowProcW(hwnd, msg, w, l);
+            picker._hwnd = hwnd; Roots[hwnd] = picker;
+        }
+        try
+        {
+            switch (msg)
+            {
+                case WM_CLOSE: picker.End(new("cancelled")); return IntPtr.Zero;
+                case WM_COMMAND:
+                    int id = (int)((long)w & 0xffff), code = (int)(((long)w >> 16) & 0xffff);
+                    if (id == 101 && code == 0x300) picker.Refilter();
+                    else if ((id == 1 && code == 0) || (id == 102 && code == 2)) picker.Choose();
+                    else if (id == 2 && code == 0) picker.End(new("cancelled"));
+                    return IntPtr.Zero;
+                case WM_SIZE: picker.Layout(); break;
+                case WM_ACTIVATE:
+                    if (((long)w & 0xffff) != 0) { picker._activated(); picker.FocusIfForeground(); }
+                    break;
+                case WM_SETFOCUS: picker.FocusIfForeground(); return IntPtr.Zero;
+                case WM_DPICHANGED:
+                    picker._dpi = (int)((long)w & 0xffff);
+                    var rect = Marshal.PtrToStructure<RECT>(l);
+                    SetWindowPos(hwnd, IntPtr.Zero, rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top, SWP_NOZORDER | SWP_NOACTIVATE);
+                    picker.UpdateFont(); picker.Layout(); break;
+                case NcDestroy:
+                    Roots.Remove(hwnd); picker._hwnd = IntPtr.Zero;
+                    if (picker._font != IntPtr.Zero) { DeleteObject(picker._font); picker._font = IntPtr.Zero; }
+                    picker.End(new("cancelled")); break;
+            }
+            return DefWindowProcW(hwnd, msg, w, l);
+        }
+        catch { picker.End(new("cancelled")); return IntPtr.Zero; }
+    }
+
+    private IntPtr ChildProc(IntPtr hwnd, uint msg, IntPtr w, IntPtr l)
+    {
+        if (!_original.TryGetValue(hwnd, out var original)) return DefWindowProcW(hwnd, msg, w, l);
+        try
+        {
+            if (msg == GetDlgCode) return CallWindowProcW(original, hwnd, msg, w, l) | (IntPtr)4; // own Tab/Enter/Escape, including direct messages
+            if (msg == WM_KEYDOWN)
+            {
+                int key = (int)w;
+                if (key == VK_ESCAPE) { End(new("cancelled")); return IntPtr.Zero; }
+                if (key == VK_RETURN) { if (hwnd == _cancel) End(new("cancelled")); else Choose(); return IntPtr.Zero; }
+                if (key == VK_TAB) { SetFocus(GetNextDlgTabItem(_hwnd, hwnd, (GetKeyState(VK_SHIFT) & 0x8000) != 0)); return IntPtr.Zero; }
+                if (hwnd == _edit && key == 65 && (GetKeyState(VK_CONTROL) & 0x8000) != 0)
+                { SendMessageW(_edit, EM_SETSEL, IntPtr.Zero, (IntPtr)(-1)); return IntPtr.Zero; }
+                if ((hwnd == _edit || hwnd == _list) && key is VK_UP or VK_DOWN)
+                {
+                    _selection.Select((int)SendMessageW(_list, LbGetSel, IntPtr.Zero, IntPtr.Zero));
+                    _selection.Move(key == VK_UP ? -1 : 1);
+                    SendMessageW(_list, LbSetSel, (IntPtr)_selection.Selected, IntPtr.Zero); return IntPtr.Zero;
+                }
+            }
+            if (msg == WM_CHAR && (int)w is VK_RETURN or VK_ESCAPE or VK_TAB) return IntPtr.Zero;
+            if (msg == NcDestroy) { Children.Remove(hwnd); _original.Remove(hwnd); }
+            return CallWindowProcW(original, hwnd, msg, w, l);
+        }
+        catch { End(new("cancelled")); return IntPtr.Zero; }
+    }
+
+    public void Dispose()
+    {
+        if (_disposing) return;
+        _disposing = true;
+        bool restore = _hwnd != IntPtr.Zero && GetForegroundWindow() == _hwnd;
+        if (_hwnd != IntPtr.Zero) DestroyWindow(_hwnd);
+        foreach (var child in _original.Keys) Children.Remove(child);
+        _original.Clear();
+        if (_font != IntPtr.Zero) { DeleteObject(_font); _font = IntPtr.Zero; }
+        if (restore && IsWindow(_owner) && GetForegroundWindow() == _owner) SetFocus(_owner);
+        GC.KeepAlive(_childProc);
+    }
+}

--- a/src/Agwinterm.Win32/NativePicker.cs
+++ b/src/Agwinterm.Win32/NativePicker.cs
@@ -21,9 +21,10 @@ internal sealed class NativePicker : IDisposable
     private readonly IntPtr _owner;
     private readonly Action<PickOutcome> _finish;
     private readonly Action _activated;
+    private readonly Action<string> _diagnostic;
     private readonly PickSelection _selection;
     private IntPtr _hwnd, _edit, _list, _accept, _cancel, _label, _font;
-    private bool _ended, _disposing;
+    private bool _ended, _disposing, _queryError;
     private int _dpi = 96;
     public PendingPick Request { get; }
 
@@ -35,9 +36,9 @@ internal sealed class NativePicker : IDisposable
     [DllImport("gdi32.dll", CharSet = CharSet.Unicode)] private static extern IntPtr CreateFontW(int height, int width, int escapement, int orientation, int weight,
         uint italic, uint underline, uint strikeout, uint charset, uint outPrecision, uint clipPrecision, uint quality, uint pitch, string family);
 
-    public NativePicker(IntPtr owner, PendingPick request, Action<PickOutcome> finish, Action activated)
+    public NativePicker(IntPtr owner, PendingPick request, Action<PickOutcome> finish, Action activated, Action<string> diagnostic)
     {
-        _owner = owner; Request = request; _finish = finish; _activated = activated;
+        _owner = owner; Request = request; _finish = finish; _activated = activated; _diagnostic = diagnostic;
         _selection = new(request.Spec); _childProc = ChildProc;
     }
 
@@ -126,7 +127,13 @@ internal sealed class NativePicker : IDisposable
         if (_list == IntPtr.Zero) return;
         var query = new StringBuilder(PickSpec.MaxFieldLength + 1);
         GetWindowTextW(_edit, query, query.Capacity);
-        _selection.SetQuery(query.ToString());
+        try { _selection.SetQuery(query.ToString()); _queryError = false; }
+        catch (ArgumentException ex)
+        {
+            _queryError = true; SendMessageW(_list, LbReset, IntPtr.Zero, IntPtr.Zero);
+            EnableWindow(_accept, false); SetWindowTextW(_label, ex.Message); return;
+        }
+        SetWindowTextW(_label, Request.Spec.Prompt ?? "Select…");
         SendMessageW(_list, LbReset, IntPtr.Zero, IntPtr.Zero);
         foreach (int index in _selection.Matches)
         {
@@ -142,6 +149,7 @@ internal sealed class NativePicker : IDisposable
 
     private void Choose()
     {
+        if (_queryError) return;
         _selection.Select((int)SendMessageW(_list, LbGetSel, IntPtr.Zero, IntPtr.Zero));
         if (_selection.Choose() is { } outcome) End(outcome);
     }
@@ -201,7 +209,7 @@ internal sealed class NativePicker : IDisposable
             }
             return DefWindowProcW(hwnd, msg, w, l);
         }
-        catch { picker.End(new("cancelled")); return IntPtr.Zero; }
+        catch (Exception ex) { picker.Fail(msg, ex); return IntPtr.Zero; }
     }
 
     private IntPtr ChildProc(IntPtr hwnd, uint msg, IntPtr w, IntPtr l)
@@ -229,7 +237,14 @@ internal sealed class NativePicker : IDisposable
             if (msg == NcDestroy) { Children.Remove(hwnd); _original.Remove(hwnd); }
             return CallWindowProcW(original, hwnd, msg, w, l);
         }
-        catch { End(new("cancelled")); return IntPtr.Zero; }
+        catch (Exception ex) { Fail(msg, ex); return IntPtr.Zero; }
+    }
+
+    private void Fail(uint message, Exception ex)
+    {
+        _diagnostic($"picker wndproc ex msg=0x{message:X}: {ex.GetType().Name} {ex.Message}");
+        try { End(new("cancelled")); }
+        catch (Exception cleanup) { _diagnostic($"picker cleanup ex: {cleanup.GetType().Name} {cleanup.Message}"); }
     }
 
     public void Dispose()

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -669,7 +669,11 @@ internal partial class Program
     public string ConfigSet(string key, string value) => InvokeOnUiQueued(() => ConfigSetInternal(key, value));
     public string ConfigGet(string key) => InvokeOnUi(() => ConfigValue(key.Trim().ToLowerInvariant()));
     public string ConfigList() => InvokeOnUi(() => string.Join("\n", ConfigKeys.Select(k => $"{k} = {ConfigValue(k)}")));
-    public string SettingsOpen() { PostVerb(OpenSettingsWindow); return "settings opened"; }
+    public string SettingsOpen() => InvokeOnUiQueued(() =>
+    {
+        if (_nativePick is not null) throw new InvalidOperationException("a picker owns this window");
+        OpenSettingsWindow(); return "settings opened";
+    });
 
     public string ProfilesList() => InvokeOnUi(() => string.Join("\n", _profileCfg.Profiles.Select(p =>
         $"{(p.Name.Equals(_profileCfg.Default, StringComparison.OrdinalIgnoreCase) ? "*" : " ")} {p.Name}\t{p.Command}{(p.Args is { Length: > 0 } a ? " " + string.Join(" ", a) : "")}")));

--- a/src/Agwinterm.Win32/Program.Pick.cs
+++ b/src/Agwinterm.Win32/Program.Pick.cs
@@ -1,0 +1,90 @@
+using Agwinterm.Core;
+using Agwinterm.Pty;
+using static Agwinterm.Win32.Win32;
+
+namespace Agwinterm.Win32;
+
+internal partial class Program : IPickHost
+{
+    private static readonly PickRegistry Picks = new();
+    private NativePicker? _nativePick;
+
+    public string OpenPick(PickSpec spec, string? window, bool follow)
+    {
+        if (window == "quick") throw new InvalidOperationException("quick terminal has no picker");
+        var owner = ResolveOpen(window) ?? throw new InvalidOperationException("picker window not found");
+        return owner.InvokeOnUiQueued(() => owner.OpenPickCore(spec, follow));
+    }
+
+    private string OpenPickCore(PickSpec spec, bool follow)
+    {
+        if (_nativePick is not null) throw new InvalidOperationException("pick already pending");
+        if (_setOpen || _editing is not null || _menuHwnd != IntPtr.Zero || _dashboardOpen || _dragging)
+            throw new InvalidOperationException("another modal UI operation owns this window");
+        var request = Picks.Open(Id, spec) ?? throw new InvalidOperationException("pick already pending");
+        try
+        {
+            ClosePalette(); CancelLeader(); ExitChromeFocus(announce: false); DismissHoverTip();
+            _nativePick = new NativePicker(_hwnd, request, outcome =>
+            {
+                Picks.Resolve(request.Id, outcome);
+                var ui = _nativePick;
+                if (ui?.Request.Id == request.Id) { _nativePick = null; ui.Dispose(); }
+                RequestRedraw();
+            }, () => { Frontmost = this; _frontmostId = Id; });
+            _nativePick.Show(follow);
+            RequestRedraw();
+            return request.Id;
+        }
+        catch
+        {
+            Picks.Resolve(request.Id, new("cancelled"));
+            var ui = _nativePick; _nativePick = null; ui?.Dispose();
+            throw;
+        }
+    }
+
+    private static LocatedPick LocatePick(string id, string? window)
+    {
+        var found = Picks.Find(id) ?? throw new InvalidOperationException("unknown pick: " + id);
+        if (window is not null)
+        {
+            if (window == "quick" || ResolveMeta(window) is not { } target || target.Id != found.Window)
+                throw new InvalidOperationException("pick does not belong to the selected window");
+        }
+        return found;
+    }
+
+    public PickOutcome ReadPick(string id, string? window) => LocatePick(id, window).Outcome;
+
+    public void CancelPick(string id, string? window)
+    {
+        var found = LocatePick(id, window);
+        if (found.Outcome.Result != "pending") return;
+        var owner = ResolveOpen(found.Window);
+        if (owner is null) return; // WM_DESTROY settled and retained it after the lookup
+        owner.InvokeOnUiQueued(() =>
+        {
+            if (Picks.Resolve(id, new("cancelled")) && owner._nativePick?.Request.Id == id)
+            { var ui = owner._nativePick; owner._nativePick = null; ui.Dispose(); owner.RequestRedraw(); }
+            return true;
+        });
+    }
+
+    private void CloseWindowPicker()
+    {
+        Picks.CloseWindow(Id);
+        var ui = _nativePick; _nativePick = null; ui?.Dispose();
+    }
+
+    private bool PickerMessage(uint msg, IntPtr w, IntPtr l)
+    {
+        if (_nativePick is not { } picker) return false;
+        if (msg is WM_KEYDOWN or WM_SYSKEYDOWN or WM_KEYUP or WM_SYSKEYUP or WM_CHAR or WM_SYSCHAR)
+        { picker.Forward(msg, w, l); return true; }
+        if (msg is WM_SETFOCUS or WM_LBUTTONDOWN or WM_LBUTTONUP or WM_LBUTTONDBLCLK or WM_RBUTTONDOWN or WM_RBUTTONUP
+            or WM_MBUTTONDOWN or WM_MBUTTONUP or WM_MOUSEWHEEL or WM_CONTEXTMENU)
+        { picker.FocusIfForeground(); return true; }
+        return false;
+    }
+}

--- a/src/Agwinterm.Win32/Program.Pick.cs
+++ b/src/Agwinterm.Win32/Program.Pick.cs
@@ -12,34 +12,58 @@ internal partial class Program : IPickHost
     public string OpenPick(PickSpec spec, string? window, bool follow)
     {
         if (window == "quick") throw new InvalidOperationException("quick terminal has no picker");
-        var owner = ResolveOpen(window) ?? throw new InvalidOperationException("picker window not found");
-        return owner.InvokeOnUiQueued(() => owner.OpenPickCore(spec, follow));
+        var owner = ResolveOpen(PickOwnerId(window, true) ?? throw new InvalidOperationException("picker window not found or ambiguous"))
+            ?? throw new InvalidOperationException("picker window not found");
+        var call = new PickOpenCall<string>();
+        if (!owner.Post(() => call.Run(() => owner.OpenPickCore(spec, follow, () => call.Pending), owner.AbortPick)))
+            throw new InvalidOperationException(owner.NothingApplied());
+        try { return call.Task.WaitAsync(TimeSpan.FromSeconds(10), owner._uiGone.Token).GetAwaiter().GetResult(); }
+        catch (Exception ex) when (ex is TimeoutException or OperationCanceledException)
+        {
+            if (!call.Withdraw()) return call.Task.GetAwaiter().GetResult(); // publication won the deadline race
+            throw new InvalidOperationException("picker open withdrawn; any in-flight native construction will be discarded", ex);
+        }
     }
 
-    private string OpenPickCore(PickSpec spec, bool follow)
+    private static string? PickOwnerId(string? selector, bool openOnly)
     {
+        lock (_windowIndex)
+            return PickWindowSelector.Resolve(selector, _windowIndex.Where(m => !openOnly || m.IsOpen).Select(m => m.Id), _frontmostId ?? "");
+    }
+
+    private void AbortPick(string id)
+    {
+        Picks.Abort(id);
+        if (_nativePick?.Request.Id == id) { var ui = _nativePick; _nativePick = null; ui.Dispose(); RequestRedraw(); }
+    }
+
+    private string OpenPickCore(PickSpec spec, bool follow, Func<bool> wanted)
+    {
+        if (!wanted()) throw new InvalidOperationException("picker open was withdrawn");
         if (_nativePick is not null) throw new InvalidOperationException("pick already pending");
-        if (_setOpen || _editing is not null || _menuHwnd != IntPtr.Zero || _dashboardOpen || _dragging)
+        if (_setOpen || _editing is not null || _menuHwnd != IntPtr.Zero || _dashboardOpen || _dragging || GetCapture() != IntPtr.Zero)
             throw new InvalidOperationException("another modal UI operation owns this window");
         var request = Picks.Open(Id, spec) ?? throw new InvalidOperationException("pick already pending");
+        bool initialized = false;
         try
         {
             ClosePalette(); CancelLeader(); ExitChromeFocus(announce: false); DismissHoverTip();
             _nativePick = new NativePicker(_hwnd, request, outcome =>
             {
-                Picks.Resolve(request.Id, outcome);
+                if (initialized) Picks.Resolve(request.Id, outcome); else Picks.Abort(request.Id);
                 var ui = _nativePick;
                 if (ui?.Request.Id == request.Id) { _nativePick = null; ui.Dispose(); }
                 RequestRedraw();
-            }, () => { Frontmost = this; _frontmostId = Id; });
+            }, () => { Frontmost = this; _frontmostId = Id; }, Perf);
+            if (!wanted()) throw new InvalidOperationException("picker open was withdrawn");
             _nativePick.Show(follow);
+            initialized = true;
             RequestRedraw();
             return request.Id;
         }
         catch
         {
-            Picks.Resolve(request.Id, new("cancelled"));
-            var ui = _nativePick; _nativePick = null; ui?.Dispose();
+            AbortPick(request.Id);
             throw;
         }
     }
@@ -49,7 +73,7 @@ internal partial class Program : IPickHost
         var found = Picks.Find(id) ?? throw new InvalidOperationException("unknown pick: " + id);
         if (window is not null)
         {
-            if (window == "quick" || ResolveMeta(window) is not { } target || target.Id != found.Window)
+            if (window == "quick" || PickOwnerId(window, false) != found.Window)
                 throw new InvalidOperationException("pick does not belong to the selected window");
         }
         return found;
@@ -63,12 +87,14 @@ internal partial class Program : IPickHost
         if (found.Outcome.Result != "pending") return;
         var owner = ResolveOpen(found.Window);
         if (owner is null) return; // WM_DESTROY settled and retained it after the lookup
-        owner.InvokeOnUiQueued(() =>
+        try { owner.InvokeOnUiQueued(() =>
         {
             if (Picks.Resolve(id, new("cancelled")) && owner._nativePick?.Request.Id == id)
             { var ui = owner._nativePick; owner._nativePick = null; ui.Dispose(); owner.RequestRedraw(); }
             return true;
-        });
+        }); }
+        catch when (owner._uiGone.IsCancellationRequested && Picks.Find(id)?.Outcome.Result is "picked" or "custom" or "cancelled")
+        { /* Owner shutdown already settled this exact retained picker. */ }
     }
 
     private void CloseWindowPicker()
@@ -80,11 +106,13 @@ internal partial class Program : IPickHost
     private bool PickerMessage(uint msg, IntPtr w, IntPtr l)
     {
         if (_nativePick is not { } picker) return false;
-        if (msg is WM_KEYDOWN or WM_SYSKEYDOWN or WM_KEYUP or WM_SYSKEYUP or WM_CHAR or WM_SYSCHAR)
-        { picker.Forward(msg, w, l); return true; }
-        if (msg is WM_SETFOCUS or WM_LBUTTONDOWN or WM_LBUTTONUP or WM_LBUTTONDBLCLK or WM_RBUTTONDOWN or WM_RBUTTONUP
-            or WM_MBUTTONDOWN or WM_MBUTTONUP or WM_MOUSEWHEEL or WM_CONTEXTMENU)
-        { picker.FocusIfForeground(); return true; }
-        return false;
+        switch (PickInputPolicy.Route(msg))
+        {
+            case PickInputRoute.Ignore: return true;
+            case PickInputRoute.Drop: DragFinish(w); return true;
+            case PickInputRoute.Keyboard: picker.Forward(msg, w, l); return true;
+            case PickInputRoute.Focus: picker.FocusIfForeground(); return true;
+            default: return false;
+        }
     }
 }

--- a/src/Agwinterm.Win32/Program.WndProc.cs
+++ b/src/Agwinterm.Win32/Program.WndProc.cs
@@ -38,6 +38,7 @@ internal partial class Program
 
     private IntPtr WindowProcCore(IntPtr hwnd, uint msg, IntPtr wParam, IntPtr lParam)
     {
+        if (PickerMessage(msg, wParam, lParam)) return IntPtr.Zero;
         if (_isQuickWindow)
         {
             if (msg == WM_CLOSE) { DismissQuick(); return IntPtr.Zero; }
@@ -632,6 +633,7 @@ internal partial class Program
                 return DefWindowProcW(hwnd, msg, wParam, lParam);
 
             case WM_DESTROY:
+                CloseWindowPicker();
                 _uiGone.Cancel();                 // release any pipe thread waiting in InvokeOnUiQueued
                 RemoveTrayIcon();                 // drop the shell tray balloon icon
                 SaveState(captureCommands: true); // persist this window's tree before tearing down its sessions

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -972,7 +972,7 @@ internal partial class Program : ISessionHost, IWindowHost
             Kind = Uia.NodeKind.Terminal,
             Name = "terminal",
             Parent = 0,
-            Focused = !_chromeFocus && !_setOpen,
+            Focused = !_chromeFocus && !_setOpen && _nativePick is null,
             Rect = ScreenRect(_sidebarW, TitleBarH, ClientW() - _sidebarW, contentBottom - TitleBarH),
         });
 
@@ -1052,6 +1052,7 @@ internal partial class Program : ISessionHost, IWindowHost
     /// <summary>UIA Invoke on a button/control — run the same action a click/keypress would.</summary>
     private void HandleUiaInvoke(Uia.NodeKind kind, int index)
     {
+        if (_nativePick is not null) return;
         if (kind == Uia.NodeKind.ChromeButton)
         {
             var b = ChromeButtonsForUia();
@@ -1074,6 +1075,7 @@ internal partial class Program : ISessionHost, IWindowHost
     /// <summary>A UIA client (or Narrator) called SetFocus on a tree element — move our internal focus.</summary>
     private void HandleUiaSetFocus(Uia.NodeKind kind, int index)
     {
+        if (_nativePick is not null) { _nativePick.FocusIfForeground(); return; }
         switch (kind)
         {
             case Uia.NodeKind.Terminal: ExitChromeFocus(announce: false); break;

--- a/tests/Agwinterm.Core.Tests/NativePickTests.cs
+++ b/tests/Agwinterm.Core.Tests/NativePickTests.cs
@@ -73,6 +73,66 @@ public class NativePickTests
         Assert.Equal("b",registry.Find(b.Id)!.Window); Assert.Null(registry.Find("active"));
     }
 
+    [Fact] public void RepeatedTermsKeepRankingButDoNotMultiplyMatchingWork()
+    {
+        var items=Enumerable.Range(0,240).Select(i=>new PickItem(i.ToString(),"ab"+new string('x',4092)+"a")).ToArray();
+        string query=string.Join(' ',Enumerable.Repeat("aa",1365));
+        var watch=System.Diagnostics.Stopwatch.StartNew();
+        var model=new PickSelection(new(items,null,query,false));
+        Assert.Equal(240,model.Count);Assert.True(watch.Elapsed<TimeSpan.FromSeconds(3));
+        Assert.Equal(PickSelection.Score("aa",items[0].Label)*1365,PickSelection.Score(query,items[0].Label));
+    }
+
+    [Fact] public void AggregateWorkRejectsBeforeChangingSelection()
+    {
+        var items=Enumerable.Range(0,240).Select(i=>new PickItem(i.ToString(),new string('a',4096))).ToArray();
+        var model=new PickSelection(new(items,null,"a",false));
+        string query=string.Join(' ',Enumerable.Range(0,70).Select(i=>"term"+i));
+        Assert.Throws<ArgumentException>(()=>model.SetQuery(query));Assert.Equal("a",model.Query);Assert.Equal(240,model.Count);
+    }
+
+    [Fact] public void AbortedConstructionDoesNotEvictAnswers()
+    {
+        var registry=new PickRegistry();var ids=new List<string>();
+        for(int i=0;i<8;i++){var p=registry.Open("w",Spec())!;ids.Add(p.Id);registry.Resolve(p.Id,new("cancelled"));}
+        var aborted=registry.Open("w",Spec())!;registry.Abort(aborted.Id);
+        Assert.False(registry.Resolve(aborted.Id,new("cancelled")));Assert.Null(registry.Find(aborted.Id));
+        Assert.All(ids,id=>Assert.NotNull(registry.Find(id)));
+    }
+
+    [Fact] public async Task WithdrawnQueuedOpenNeverRunsAndInFlightOpenRollsBack()
+    {
+        var before=new PickOpenCall<string>();Assert.True(before.Withdraw());
+        before.Run(()=>throw new Exception("must not run"),_=>Assert.Fail("nothing to roll back"));
+        Assert.True(before.Task.IsCanceled);
+        var during=new PickOpenCall<string>();var rolledBack=new List<string>();
+        during.Run(()=>{Assert.True(during.Withdraw());return "created";},rolledBack.Add);
+        Assert.True(during.Task.IsCanceled);Assert.Equal("created",Assert.Single(rolledBack));
+        var completed=new PickOpenCall<string>();completed.Run(()=>"published",_=>Assert.Fail("published result retained"));
+        Assert.False(completed.Withdraw());Assert.Equal("published",await completed.Task);
+    }
+
+    [Fact] public void PickerWindowsRequireExactOrUniquePrefix()
+    {
+        string[] ids=["abc-one","abc-two","z-last"];
+        Assert.Null(PickWindowSelector.Resolve("abc",ids,"abc-one"));
+        Assert.Equal("abc-two",PickWindowSelector.Resolve("abc-two",ids,"abc-one"));
+        Assert.Equal("z-last",PickWindowSelector.Resolve("z",ids,"abc-one"));
+        Assert.Equal("abc-one",PickWindowSelector.Resolve(null,ids,"abc-one"));
+        Assert.Null(PickWindowSelector.Resolve("",ids,"abc-one"));
+    }
+
+    [Fact] public void InputPolicySeparatesDropCleanupFromKeyboardAndFocus()
+    {
+        Assert.Equal(PickInputRoute.Drop,PickInputPolicy.Route(0x233));
+        Assert.Equal(PickInputRoute.Ignore,PickInputPolicy.Route(0x200));
+        foreach(uint message in new uint[]{0x100,0x101,0x102,0x104,0x105,0x106})
+            Assert.Equal(PickInputRoute.Keyboard,PickInputPolicy.Route(message));
+        foreach(uint message in new uint[]{7,0x201,0x202,0x203,0x204,0x205,0x207,0x208,0x20a,0x7b})
+            Assert.Equal(PickInputRoute.Focus,PickInputPolicy.Route(message));
+        foreach(uint message in new uint[]{0xf,0x10,0x82}) Assert.Equal(PickInputRoute.None,PickInputPolicy.Route(message));
+    }
+
     [Fact] public void LiveResultsRetainEightAndClosedResultsRetainNewestThirtyTwoByAnswerTime()
     {
         var registry=new PickRegistry(); var ids=new List<string>();

--- a/tests/Agwinterm.Core.Tests/NativePickTests.cs
+++ b/tests/Agwinterm.Core.Tests/NativePickTests.cs
@@ -1,0 +1,88 @@
+using System.Text.Json;
+using Agwinterm.Core;
+
+namespace Agwinterm.Core.Tests;
+
+public class NativePickTests
+{
+    private static PickSpec Parse(string json) { using var doc = JsonDocument.Parse(json); return PickSpec.Parse(doc.RootElement); }
+    private static PickSpec Spec(params PickItem[] items) => new(items, null, null, true);
+
+    [Theory]
+    [InlineData("{}")] [InlineData("[]")] [InlineData("{\"items\":[]}")]
+    [InlineData("{\"items\":[{}]}")] [InlineData("{\"items\":[null]}")]
+    [InlineData("{\"items\":[{\"id\":1,\"label\":\"x\"}]}")]
+    [InlineData("{\"items\":[{\"id\":\"a\",\"label\":\"\"}]}")]
+    [InlineData("{\"items\":[{\"id\":\"a\",\"label\":\"x\\ny\"}]}")]
+    [InlineData("{\"items\":[{\"id\":\"a\",\"label\":\"x\",\"subtitle\":\"\\u007f\"}]}")]
+    [InlineData("{\"items\":[],\"allowCustom\":\"true\"}")]
+    [InlineData("{\"items\":[],\"allowCustom\":true,\"query\":\"\\t\"}")]
+    [InlineData("{\"items\":[],\"allowCustom\":true,\"prompt\":false}")]
+    public void InvalidInputRefuses(string json) => Assert.Throws<ArgumentException>(() => Parse(json));
+
+    [Fact] public void EmptyIdsUnicodeAndDuplicateLabelsAreLegalButDuplicateIdsAreNot()
+    {
+        var spec = Parse("{\"items\":[{\"id\":\"\",\"label\":\"中文 🦊\"},{\"id\":\"A\",\"label\":\"中文 🦊\"},{\"id\":\"a\",\"label\":\"same\"}]}");
+        Assert.Equal(3, spec.Items.Count); Assert.Equal("", spec.Items[0].Id);
+        Assert.Throws<ArgumentException>(() => Parse("{\"items\":[{\"id\":\"a\",\"label\":\"x\"},{\"id\":\"a\",\"label\":\"y\"}]}"));
+    }
+
+    [Fact] public void InputCapsApplyBeforeOpening()
+    {
+        string Wire(int count, int length) => JsonSerializer.Serialize(new { items = Enumerable.Range(0,count).Select(i => new { id=i.ToString(), label=new string('x',length) }) });
+        Assert.Equal(1000, Parse(Wire(1000,1)).Items.Count);
+        Assert.Throws<ArgumentException>(() => Parse(Wire(1001,1)));
+        Assert.Equal(4096, Parse(Wire(1,4096)).Items[0].Label.Length);
+        Assert.Throws<ArgumentException>(() => Parse(Wire(1,4097)));
+        Assert.Throws<ArgumentException>(() => Parse(Wire(300,4096)));
+    }
+
+    [Fact] public void FilteringUsesLabelsOnlyAndPreservesOriginalIndex()
+    {
+        var model = new PickSelection(Spec(new("z","Zulu","danger"),new("a","Alpha"),new("b","Alpine")));
+        Assert.Equal(new[]{0,1,2},model.Matches);
+        model.SetQuery(" AL "); Assert.Equal(new[]{1,2},model.Matches);
+        model.Move(500); Assert.Equal(new PickOutcome("picked","b","Alpine",2), model.Choose());
+        model.Move(-500); Assert.Equal(0,model.Selected);
+        model.SetQuery("danger"); Assert.Empty(model.Matches); Assert.True(model.Custom);
+        Assert.Equal(new PickOutcome("custom",Query:"danger"),model.Choose());
+        model.SetQuery("   "); Assert.False(model.Custom); Assert.Equal(new[]{0,1,2},model.Matches);
+    }
+
+    [Fact] public void CustomRequiresNonblankNoMatchesAndOptIn()
+    {
+        var spec = Spec(new PickItem("a","alpha")); var model = new PickSelection(spec);
+        model.SetQuery("  custom  "); Assert.Equal("custom",model.Choose()!.Query);
+        model.SetQuery("alpha"); Assert.False(model.Custom);
+        model = new PickSelection(spec with {AllowCustom=false}); model.SetQuery("xyz");
+        Assert.Equal(0,model.Count); Assert.Null(model.Choose());
+    }
+
+    [Theory][InlineData("al","Alpha",0)][InlineData("ph","Alpha",7)][InlineData("aa","Alpha",43)]
+    [InlineData("zz","Alpha",null)][InlineData("AL PH","Alpha",7)]
+    public void FuzzyTermsHaveStableScores(string query,string label,int? score) => Assert.Equal(score,PickSelection.Score(query,label));
+
+    [Fact] public void PendingIsPerWindowAndTerminalResultsAreImmutable()
+    {
+        var registry = new PickRegistry(); var spec = Spec();
+        var a = registry.Open("a",spec)!; var b=registry.Open("b",spec)!;
+        Assert.Null(registry.Open("a",spec)); Assert.Equal("pending",registry.Find(a.Id)!.Outcome.Result);
+        Assert.True(registry.Resolve(a.Id,new("custom",Query:"one")));
+        Assert.False(registry.Resolve(a.Id,new("cancelled"))); Assert.Equal("custom",registry.Find(a.Id)!.Outcome.Result);
+        registry.CloseWindow("b"); Assert.Equal("cancelled",registry.Find(b.Id)!.Outcome.Result);
+        Assert.Equal("b",registry.Find(b.Id)!.Window); Assert.Null(registry.Find("active"));
+    }
+
+    [Fact] public void LiveResultsRetainEightAndClosedResultsRetainNewestThirtyTwoByAnswerTime()
+    {
+        var registry=new PickRegistry(); var ids=new List<string>();
+        for(int n=0;n<40;n++) { var p=registry.Open("w"+(n/8),Spec())!; ids.Add(p.Id); registry.Resolve(p.Id,new("cancelled")); }
+        // Reverse closure order must not replace the newer answers with older ones.
+        for(int n=4;n>=0;n--) registry.CloseWindow("w"+n);
+        Assert.All(ids.Take(8),id=>Assert.Null(registry.Find(id)));
+        Assert.All(ids.Skip(8),id=>Assert.NotNull(registry.Find(id)));
+        var live=new List<string>();
+        for(int n=0;n<9;n++) { var p=registry.Open("live",Spec())!; live.Add(p.Id); registry.Resolve(p.Id,new("cancelled")); }
+        Assert.Null(registry.Find(live[0])); Assert.All(live.Skip(1),id=>Assert.NotNull(registry.Find(id)));
+    }
+}

--- a/tests/Agwinterm.Pty.Tests/PickCliTests.cs
+++ b/tests/Agwinterm.Pty.Tests/PickCliTests.cs
@@ -73,4 +73,16 @@ public class PickCliTests
         foreach(string input in new[]{"A\nA", "A\tB", ""})
             Assert.Equal(2,PickCli.Execute(["pick"],Encoding.UTF8.GetBytes(input),_=>throw new Exception("must not connect"),_=>{},_=>{},_=>{}));
     }
+
+    [Fact] public void ExplicitLineFormatSupportsBracketLabelsAndInputCapsAreEarly()
+    {
+        Assert.Equal("[Draft]",Assert.Single(PickCli.ParseItems(Encoding.UTF8.GetBytes("[Draft]"),"lines")).Label);
+        Assert.ThrowsAny<JsonException>(()=>PickCli.ParseItems(Encoding.UTF8.GetBytes("[Draft]")));
+        Assert.Throws<ArgumentException>(()=>PickCli.ParseItems(Encoding.UTF8.GetBytes(string.Join('\n',Enumerable.Range(0,1001)))));
+        Assert.Throws<ArgumentException>(()=>PickCli.ParseItems(Encoding.UTF8.GetBytes(string.Concat(Enumerable.Repeat("A\n",500000)))));
+        int sends=0;
+        Assert.Equal(0,PickCli.Execute(["pick","--input-format","lines","--no-block"],Encoding.UTF8.GetBytes("[Draft]"),_=>{sends++;return Opened;},_=>{},_=>{},Assert.Fail));
+        Assert.Equal(1,sends);
+        Assert.Equal(2,PickCli.Execute(["pick","--input-format","bad"],[],_=>throw new Exception("no send"),_=>{},_=>{},_=>{}));
+    }
 }

--- a/tests/Agwinterm.Pty.Tests/PickCliTests.cs
+++ b/tests/Agwinterm.Pty.Tests/PickCliTests.cs
@@ -1,0 +1,76 @@
+using System.Text;
+using System.Text.Json;
+using Agwinterm.Ctl;
+
+namespace Agwinterm.Pty.Tests;
+
+public class PickCliTests
+{
+    private static JsonElement Json(string raw) { using var doc=JsonDocument.Parse(raw); return doc.RootElement.Clone(); }
+    private static JsonElement Reply(string state) => Json("{\"ok\":true,\"result\":{\"pick\":"+state+"}}");
+    private static readonly JsonElement Opened=Json("{\"ok\":true,\"result\":{\"id\":\"picker-1\"}}");
+
+    [Theory][InlineData("pending",1)][InlineData("cancelled",2)]
+    public void OneShotResultIsPayloadAndHasHonestExit(string state,int code)
+    {
+        var output=new List<string>();
+        Assert.Equal(code,PickCli.Execute(["pick","result","picker-1","--json"],[],_=>Reply("{\"result\":\""+state+"\"}"),_=>Assert.Fail("no wait"),output.Add,Assert.Fail));
+        Assert.Equal(state,Json(Assert.Single(output)).GetProperty("result").GetString());
+    }
+
+    [Fact] public void BlockingWaitPinsOnlyIdAndUsesTwoPhaseBackoff()
+    {
+        var requests=new List<JsonElement>(); var delays=new List<int>(); var output=new List<string>();
+        int SendCount=0;
+        JsonElement Send(string raw) {
+            var request=Json(raw);requests.Add(request);
+            return SendCount++ switch { 0=>Opened, <=12=>Reply("{\"result\":\"pending\"}"), _=>Reply("{\"result\":\"picked\",\"id\":\"\",\"label\":\"A\",\"index\":0}") };
+        }
+        Assert.Equal(0,PickCli.Execute(["pick","--window","active","--follow"],Encoding.UTF8.GetBytes("A\n"),Send,delays.Add,output.Add,Assert.Fail));
+        Assert.Equal("active",requests[0].GetProperty("window").GetString());
+        Assert.True(requests[0].GetProperty("args").GetProperty("follow").GetBoolean());
+        Assert.All(requests.Skip(1),r=>{Assert.False(r.TryGetProperty("window",out _));Assert.Equal("picker-1",r.GetProperty("target").GetString());});
+        Assert.Equal(Enumerable.Repeat(100,10).Concat(new[]{500,500}),delays);
+        Assert.Equal("",Json(Assert.Single(output)).GetProperty("id").GetString());
+    }
+
+    [Fact] public void NoBlockTransfersPendingOwnershipWithoutPollingOrCancelling()
+    {
+        int count=0; var output=new List<string>();
+        Assert.Equal(0,PickCli.Execute(["pick","open","--no-block"],Encoding.UTF8.GetBytes("A"),_=>{count++;return Opened;},_=>Assert.Fail("wait"),output.Add,Assert.Fail));
+        Assert.Equal(1,count);Assert.Equal("picker-1",Json(Assert.Single(output)).GetProperty("id").GetString());
+    }
+
+    [Theory][InlineData("{\"result\":\"picked\"}")][InlineData("{\"result\":\"custom\",\"query\":\" \"}")]
+    [InlineData("{\"result\":\"unknown\"}")]
+    public void MalformedTerminalReplyFailsAndBestEffortCancels(string result)
+    {
+        var requests=new List<JsonElement>();var errors=new List<string>();
+        int code=PickCli.Execute(["pick"],Encoding.UTF8.GetBytes("A"),raw=>{
+            requests.Add(Json(raw)); return requests.Count==1?Opened:Reply(result);
+        },_=>{},_=>Assert.Fail("no successful output"),errors.Add);
+        Assert.Equal(1,code); Assert.Single(errors);
+        Assert.Equal("pick.cancel",requests[^1].GetProperty("cmd").GetString());
+        Assert.False(requests[^1].TryGetProperty("window",out _));
+    }
+
+    [Fact] public void CancellationCleansUpOwnedPendingRequest()
+    {
+        using var stop=new CancellationTokenSource();var commands=new List<string>();
+        int code=PickCli.Execute(["pick"],Encoding.UTF8.GetBytes("A"),raw=>{
+            commands.Add(Json(raw).GetProperty("cmd").GetString()!);return commands.Count==1?Opened:Reply("{\"result\":\"pending\"}");
+        },_=>stop.Cancel(),_=>{},_=>{},stop.Token);
+        Assert.Equal(1,code);Assert.Equal(new[]{"pick.open","pick.result","pick.cancel"},commands);
+    }
+
+    [Theory][InlineData("--target")][InlineData("--unknown")][InlineData("--follow=true")]
+    public void UnknownFlagsFailBeforeConnecting(string flag) => Assert.Equal(2,PickCli.Execute(["pick",flag],[],_=>throw new Exception("must not connect"),_=>{},_=>{},_=>{}));
+
+    [Fact] public void Utf8LinesPreserveTextAndRejectDuplicatesAndControlsBeforeConnecting()
+    {
+        Assert.Equal(new[]{" A ","中文 🦊"},PickCli.ParseItems(Encoding.UTF8.GetBytes(" A \r\n \n中文 🦊\n")).Select(i=>i.Label));
+        Assert.Throws<DecoderFallbackException>(()=>PickCli.ParseItems([0xff]));
+        foreach(string input in new[]{"A\nA", "A\tB", ""})
+            Assert.Equal(2,PickCli.Execute(["pick"],Encoding.UTF8.GetBytes(input),_=>throw new Exception("must not connect"),_=>{},_=>{},_=>{}));
+    }
+}

--- a/tests/Agwinterm.Pty.Tests/PickDispatchTests.cs
+++ b/tests/Agwinterm.Pty.Tests/PickDispatchTests.cs
@@ -1,0 +1,42 @@
+using System.Text.Json;
+using Agwinterm.Core;
+
+namespace Agwinterm.Pty.Tests;
+
+public class PickDispatchTests
+{
+    private sealed class Host : IWindowHost, IPickHost
+    {
+        public int Calls; public string? Window; public bool Follow; public PickSpec? Spec;
+        public string OpenPick(PickSpec spec,string? window,bool follow) {Calls++;Spec=spec;Window=window;Follow=follow;return "pick-id";}
+        public PickOutcome ReadPick(string id,string? window) {Calls++;Window=window;return new("pending");}
+        public void CancelPick(string id,string? window) {Calls++;Window=window;}
+        public ISessionHost? ResolveWindow(string? selector) => throw new Exception("picker must not resolve a session host");
+        public IReadOnlyList<WindowSnapshot> Windows()=>[];
+        public string WindowNew(string? n)=>throw new NotSupportedException();
+        public bool WindowSelect(string? s)=>false; public bool WindowClose(string? s)=>false;
+        public bool WindowDelete(string? s)=>false; public bool WindowRename(string? s,string n)=>false;
+        public bool WindowResize(string? s,int w,int h)=>false; public bool WindowMove(string? s,int x,int y)=>false; public bool WindowZoom(string? s)=>false;
+    }
+    private static JsonElement Call(Host host,string raw)
+    { using var server=new ControlServer(new FakeSessionHost(),host);using var doc=JsonDocument.Parse(server.Dispatch(raw));return doc.RootElement.Clone(); }
+
+    [Fact] public void PickerRoutesBeforeSessionResolutionAndPreservesTypedOptions()
+    {
+        var host=new Host();var result=Call(host,"{\"cmd\":\"pick.open\",\"window\":\"w1\",\"args\":{\"items\":[{\"id\":\"\",\"label\":\"A\"}],\"follow\":true}}");
+        Assert.True(result.GetProperty("ok").GetBoolean());Assert.Equal("pick-id",result.GetProperty("result").GetProperty("id").GetString());
+        Assert.Equal("w1",host.Window);Assert.True(host.Follow);Assert.Single(host.Spec!.Items);
+        result=Call(host,"{\"cmd\":\"pick.result\",\"target\":\"pick-id\"}");
+        Assert.Equal("pending",result.GetProperty("result").GetProperty("pick").GetProperty("result").GetString());Assert.Null(host.Window);
+        Assert.True(Call(host,"{\"cmd\":\"pick.cancel\",\"target\":\"pick-id\"}").GetProperty("ok").GetBoolean());
+    }
+
+    [Theory]
+    [InlineData("{\"cmd\":\"pick.result\"}")][InlineData("{\"cmd\":\"pick.cancel\",\"target\":3}")]
+    [InlineData("{\"cmd\":\"pick.result\",\"target\":\"id\",\"window\":\"\"}")]
+    [InlineData("{\"cmd\":\"pick.open\",\"target\":\"active\",\"args\":{\"items\":[],\"allowCustom\":true}}")]
+    [InlineData("{\"cmd\":\"pick.open\",\"window\":false,\"args\":{\"items\":[],\"allowCustom\":true}}")]
+    [InlineData("{\"cmd\":\"pick.open\",\"args\":{\"items\":[],\"allowCustom\":true,\"follow\":\"true\"}}")]
+    public void InvalidRequestNeverCallsHost(string raw)
+    {var host=new Host();Assert.False(Call(host,raw).GetProperty("ok").GetBoolean());Assert.Equal(0,host.Calls);}
+}

--- a/tests/integration/hud-ui.ps1
+++ b/tests/integration/hud-ui.ps1
@@ -1,7 +1,7 @@
 # Dedicated P13 fixture: private app-data, no clipboard/registry writes, exact owned job teardown.
 param([string]$Exe="$PSScriptRoot/../../src/Agwinterm.Win32/bin/x64/Release/net10.0-windows/win-x64/Agwinterm.Win32.exe",
       [string]$TokenOwner=$env:AGWINTERM_TEST_OWNER,[switch]$Strict,
-      [ValidateSet('Hud','Quick','Navigation')][string]$Suite='Hud')
+      [ValidateSet('Hud','Quick','Navigation','Picker')][string]$Suite='Hud')
 $ErrorActionPreference='Stop'
 $PSNativeCommandUseErrorActionPreference=$false
 $root=[IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
@@ -138,6 +138,7 @@ public sealed class HudOwnedJob {
             $reader=[IO.StreamReader]::new($client)
             $request=@{cmd=$verb;args=$params;target=$target;window=$Window}
             if($NoTarget){$request.Remove('target')}
+            if($Window-eq ''){$request.Remove('window')}
             $writer.WriteLine(($request|ConvertTo-Json -Compress -Depth 8))
             $read=$reader.ReadLineAsync();if(-not $read.Wait(15000)){throw 'HUD RPC deadline exceeded'}
             $answer=$read.Result|ConvertFrom-Json
@@ -172,7 +173,8 @@ public sealed class HudOwnedJob {
             }finally{$bitmap.UnlockBits($bits)}
         }finally{$graphics.Dispose();$bitmap.Dispose()}
     }
-    if($Suite-eq 'Navigation') { . "$PSScriptRoot/navigation-ui-cases.ps1" }
+    if($Suite-eq 'Picker') { . "$PSScriptRoot/picker-ui-cases.ps1" }
+    elseif($Suite-eq 'Navigation') { . "$PSScriptRoot/navigation-ui-cases.ps1" }
     elseif($Suite-eq 'Quick') { . "$PSScriptRoot/quick-ui-cases.ps1" } else {
     $ctl=Join-Path $root 'src/Agwinterm.Ctl/bin/Release/net10.0-windows/agwintermctl.exe'
     $null=& $ctl session hud --spinner 'CLI HUD' --detail 'private acceptance' --size-percent 35 --target $session --pipe $pipe --json

--- a/tests/integration/picker-ui-cases.ps1
+++ b/tests/integration/picker-ui-cases.ps1
@@ -10,6 +10,8 @@ public static class PickerProbe {
     [DllImport("user32.dll")] public static extern IntPtr GetDlgItem(IntPtr h,int id);
     [DllImport("user32.dll",CharSet=CharSet.Unicode,SetLastError=true)] public static extern bool SetWindowTextW(IntPtr h,string t);
     [DllImport("user32.dll",CharSet=CharSet.Unicode)] public static extern IntPtr SendMessageW(IntPtr h,uint m,IntPtr w,string t);
+    [DllImport("user32.dll",CharSet=CharSet.Unicode)] static extern IntPtr SendMessageW(IntPtr h,uint m,IntPtr w,System.Text.StringBuilder t);
+    public static string Text(IntPtr h) { var text=new System.Text.StringBuilder(4097);SendMessageW(h,13,(IntPtr)text.Capacity,text);return text.ToString(); }
     public static IntPtr Find(IntPtr owner) {
         IntPtr found=IntPtr.Zero;EnumWindows((h,p)=>{var b=new System.Text.StringBuilder(100);GetClassNameW(h,b,100);
             if(GetWindow(h,4)==owner && b.ToString()=="Agwinterm.NativePicker"){found=h;return false;}return true;},IntPtr.Zero);return found;
@@ -35,6 +37,16 @@ for($i=0;$i-lt 50 -and ([string](Rpc 'session.text' @{} $session))-notmatch '>';
 $text=Rpc 'session.text' @{all=$true} $session
 $metrics=Rpc 'session.metrics' @{} $session|ConvertTo-Json -Compress
 $front=[HudOwnedJob]::GetForegroundWindow()
+$bounds=[HudOwnedJob+RECT]::new();[void][HudOwnedJob]::GetClientRect($hwnd,[ref]$bounds)
+$point=([int]($bounds.bottom/2)-shl 16)-bor [int]($bounds.right*0.75)
+[void][HudOwnedJob]::SendMessageW($hwnd,0x201,[IntPtr]1,[IntPtr]$point)
+try {
+    Check 'terminal press owns capture before picker request' ([HudOwnedJob]::InputWindow($hwnd,$true)-eq $hwnd)
+    $duringDrag=Rpc 'pick.open' @{items=@();allowCustom=$true} -NoTarget -AllowError
+    Check 'picker refuses every held capture before creating state' (-not $duringDrag.ok -and [HudOwnedJob]::InputWindow($hwnd,$true)-eq $hwnd)
+    if($duringDrag.ok){$null=Rpc 'pick.cancel' @{} $duringDrag.result.id -Window ''}
+}finally{[void][HudOwnedJob]::SendMessageW($hwnd,0x202,[IntPtr]::Zero,[IntPtr]$point)}
+$front=[HudOwnedJob]::GetForegroundWindow()
 $null=Open-Pick
 Check 'open is pending and has native controls' ((Pick-Result).result-eq 'pending' -and $edit-ne [IntPtr]::Zero -and (Pick-Count)-eq 3)
 Check 'default open never steals foreground' ([HudOwnedJob]::GetForegroundWindow()-eq $front)
@@ -44,6 +56,9 @@ $settings=Rpc 'settings.open' @{} -AllowError
 Check 'settings refuses while picker owns input' (-not $settings.ok)
 Pick-Query 'dangerous';Check 'subtitle consequences do not match' ((Pick-Count)-eq 0)
 Pick-Query 'al';Check 'query filters labels' ((Pick-Count)-eq 2)
+Pick-Query ''
+foreach($letter in 'al'.ToCharArray()){[void][HudOwnedJob]::SendMessageW($hwnd,0x102,[IntPtr][int]$letter,[IntPtr]1)}
+Check 'owner keyboard forwarding updates picker edit' ([PickerProbe]::Text($edit)-ceq 'al' -and (Pick-Count)-eq 2)
 Pick-Key 0x28;Pick-Key 0x28
 Check 'down clamps to last filtered item' ([int][HudOwnedJob]::SendMessageW($list,0x188,[IntPtr]::Zero,[IntPtr]::Zero)-eq 1)
 # Capture the actual native controls while the picker is open.
@@ -70,7 +85,9 @@ $null=Open-Pick
 $cancelFront=[HudOwnedJob]::GetForegroundWindow()
 $null=Rpc 'pick.cancel' @{} $pickId -Window ''
 Check 'API cancel resolves exact id' ((Pick-Result).result-eq 'cancelled')
-Check 'background API cancellation leaves foreground unchanged' ([HudOwnedJob]::GetForegroundWindow()-eq $cancelFront)
+$expectedFront=if($cancelFront-eq $picker){$hwnd}else{$cancelFront}
+for($i=0;$i-lt 20 -and [HudOwnedJob]::GetForegroundWindow()-ne $expectedFront;$i++){Start-Sleep -Milliseconds 25}
+Check 'cancellation restores its foreground owner or leaves other foreground unchanged' ([HudOwnedJob]::GetForegroundWindow()-eq $expectedFront) "before=$cancelFront picker=$picker owner=$hwnd after=$([HudOwnedJob]::GetForegroundWindow())"
 $bad=Rpc 'pick.result' @{} 'active' -AllowError -Window ''
 Check 'active is not a picker-id alias' (-not $bad.ok)
 Check 'picker input never enters terminal text' ((Rpc 'session.text' @{all=$true} $session)-ceq $text)
@@ -80,6 +97,15 @@ try{$null=Open-Pick;Pick-Key 0x0d;Check 'readonly terminal does not block indepe
 finally{$null=Rpc 'session.readonly' @{op='off'} $session}
 $quick=Rpc 'pick.open' @{items=@();allowCustom=$true} -NoTarget -Window 'quick' -AllowError
 Check 'quick is not a picker owner' (-not $quick.ok)
+$largeItems=@(0..99|ForEach-Object{@{id="$_";label=('a'*4096)}})
+$complexQuery=(0..169|ForEach-Object{"term$_"})-join ' '
+$tooComplex=Rpc 'pick.open' @{items=$largeItems;query=$complexQuery} -NoTarget -AllowError
+Check 'over-complex initial query refuses before native creation' (-not $tooComplex.ok -and [PickerProbe]::Find($hwnd)-eq [IntPtr]::Zero)
+$null=Open-Pick @{items=$largeItems}
+Pick-Query $complexQuery;Pick-Key 0x0d
+Check 'over-complex edited query disables choice but stays pending' ((Pick-Count)-eq 0 -and (Pick-Result).result-eq 'pending')
+Pick-Query 'a';Check 'valid query recovers the pending picker' ((Pick-Count)-eq 100)
+Pick-Key 0x0d;Check 'recovered query can choose original item' ((Pick-Result).result-eq 'picked' -and (Pick-Result).index-eq 0)
 $ctl=Join-Path $root 'src/Agwinterm.Ctl/bin/Release/net10.0-windows/agwintermctl.exe'
 $opened='Alpha'|& $ctl pick --no-block --pipe $pipe|ConvertFrom-Json
 Check 'real CLI stdin no-block returns id payload' ($LASTEXITCODE-eq 0 -and $opened.id)

--- a/tests/integration/picker-ui-cases.ps1
+++ b/tests/integration/picker-ui-cases.ps1
@@ -1,0 +1,105 @@
+# Dot-sourced by the canonical-token, private-data, owned-job fixture. No clipboard or registry writes.
+Add-Type @'
+using System;
+using System.Runtime.InteropServices;
+public static class PickerProbe {
+    delegate bool EnumProc(IntPtr h,IntPtr p);
+    [DllImport("user32.dll")] static extern bool EnumWindows(EnumProc p,IntPtr l);
+    [DllImport("user32.dll")] static extern IntPtr GetWindow(IntPtr h,uint c);
+    [DllImport("user32.dll",CharSet=CharSet.Unicode)] static extern int GetClassNameW(IntPtr h,System.Text.StringBuilder b,int n);
+    [DllImport("user32.dll")] public static extern IntPtr GetDlgItem(IntPtr h,int id);
+    [DllImport("user32.dll",CharSet=CharSet.Unicode,SetLastError=true)] public static extern bool SetWindowTextW(IntPtr h,string t);
+    [DllImport("user32.dll",CharSet=CharSet.Unicode)] public static extern IntPtr SendMessageW(IntPtr h,uint m,IntPtr w,string t);
+    public static IntPtr Find(IntPtr owner) {
+        IntPtr found=IntPtr.Zero;EnumWindows((h,p)=>{var b=new System.Text.StringBuilder(100);GetClassNameW(h,b,100);
+            if(GetWindow(h,4)==owner && b.ToString()=="Agwinterm.NativePicker"){found=h;return false;}return true;},IntPtr.Zero);return found;
+    }
+}
+'@
+function Open-Pick($params=@{items=@(@{id='z';label='Zulu';subtitle='dangerous consequence'},@{id='a';label='Alpha'},@{id='b';label='Alpine'})}){
+    $script:pickId=[string](Rpc 'pick.open' $params -NoTarget).id
+    $script:picker=[PickerProbe]::Find($hwnd)
+    [uint32]$pidCheck=0;[void][HudOwnedJob]::GetWindowThreadProcessId($picker,[ref]$pidCheck)
+    if($picker-eq [IntPtr]::Zero -or $pidCheck-ne $job.Pid){throw 'No owned picker HWND'}
+    $script:edit=[PickerProbe]::GetDlgItem($picker,101);$script:list=[PickerProbe]::GetDlgItem($picker,102)
+    return $pickId
+}
+function Pick-Result([string]$id=$pickId){(Rpc 'pick.result' @{} $id -Window '').pick}
+function Pick-Key([int]$key,[IntPtr]$control=$edit){[void][HudOwnedJob]::SendMessageW($control,0x100,[IntPtr]$key,[IntPtr]::Zero)}
+function Pick-Query([string]$query){
+    $set=[PickerProbe]::SendMessageW($edit,0x0c,[IntPtr]::Zero,$query)
+    if($set-eq [IntPtr]::Zero){throw "Cannot set picker query (HWND $edit, error $([Runtime.InteropServices.Marshal]::GetLastWin32Error()))"}
+}
+function Pick-Count(){[int][HudOwnedJob]::SendMessageW($list,0x18b,[IntPtr]::Zero,[IntPtr]::Zero)}
+for($i=0;$i-lt 50 -and ([string](Rpc 'session.text' @{} $session))-notmatch '>'; $i++){Start-Sleep -Milliseconds 100}
+$text=Rpc 'session.text' @{all=$true} $session
+$metrics=Rpc 'session.metrics' @{} $session|ConvertTo-Json -Compress
+$front=[HudOwnedJob]::GetForegroundWindow()
+$null=Open-Pick
+Check 'open is pending and has native controls' ((Pick-Result).result-eq 'pending' -and $edit-ne [IntPtr]::Zero -and (Pick-Count)-eq 3)
+Check 'default open never steals foreground' ([HudOwnedJob]::GetForegroundWindow()-eq $front)
+$busy=Rpc 'pick.open' @{items=@();allowCustom=$true} -NoTarget -AllowError
+Check 'second pending picker refuses without replacing first' (-not $busy.ok -and (Pick-Result).result-eq 'pending')
+$settings=Rpc 'settings.open' @{} -AllowError
+Check 'settings refuses while picker owns input' (-not $settings.ok)
+Pick-Query 'dangerous';Check 'subtitle consequences do not match' ((Pick-Count)-eq 0)
+Pick-Query 'al';Check 'query filters labels' ((Pick-Count)-eq 2)
+Pick-Key 0x28;Pick-Key 0x28
+Check 'down clamps to last filtered item' ([int][HudOwnedJob]::SendMessageW($list,0x188,[IntPtr]::Zero,[IntPtr]::Zero)-eq 1)
+# Capture the actual native controls while the picker is open.
+$originalHwnd=$hwnd;try{$hwnd=$picker;$null=Shot 'native-picker'}finally{$hwnd=$originalHwnd}
+Pick-Key 0x0d
+$picked=Pick-Result
+Check 'Enter returns original item id label and index' ($picked.result-eq 'picked' -and $picked.id-eq 'b' -and $picked.label-eq 'Alpine' -and $picked.index-eq 2)
+$null=Rpc 'pick.cancel' @{} $pickId -Window ''
+Check 'cancel after choose preserves immutable answer' ((Pick-Result).result-eq 'picked')
+Check 'native window destroyed after answer' ([PickerProbe]::Find($hwnd)-eq [IntPtr]::Zero)
+$null=Open-Pick @{items=@(@{id='';label='中文 🦊'});allowCustom=$true;query='  custom value  ';prompt='Select — Ctrl+C stays in the edit'}
+Check 'unmatched custom query creates one row' ((Pick-Count)-eq 1)
+[void][HudOwnedJob]::SendMessageW([PickerProbe]::GetDlgItem($picker,1),0xf5,[IntPtr]::Zero,[IntPtr]::Zero)
+Check 'button selects trimmed custom query' ((Pick-Result).result-eq 'custom' -and (Pick-Result).query-ceq 'custom value')
+$null=Open-Pick @{items=@(@{id='';label='中文 🦊'})}
+Pick-Key 0x0d
+Check 'Unicode and empty item id round trip' ((Pick-Result).id-ceq '' -and (Pick-Result).label-ceq '中文 🦊')
+$null=Open-Pick;Pick-Key 0x1b
+Check 'Escape cancels' ((Pick-Result).result-eq 'cancelled')
+$null=Open-Pick
+[void][HudOwnedJob]::SendMessageW([PickerProbe]::GetDlgItem($picker,2),0xf5,[IntPtr]::Zero,[IntPtr]::Zero)
+Check 'Cancel button cancels' ((Pick-Result).result-eq 'cancelled')
+$null=Open-Pick
+$cancelFront=[HudOwnedJob]::GetForegroundWindow()
+$null=Rpc 'pick.cancel' @{} $pickId -Window ''
+Check 'API cancel resolves exact id' ((Pick-Result).result-eq 'cancelled')
+Check 'background API cancellation leaves foreground unchanged' ([HudOwnedJob]::GetForegroundWindow()-eq $cancelFront)
+$bad=Rpc 'pick.result' @{} 'active' -AllowError -Window ''
+Check 'active is not a picker-id alias' (-not $bad.ok)
+Check 'picker input never enters terminal text' ((Rpc 'session.text' @{all=$true} $session)-ceq $text)
+Check 'picker never resizes terminal' ((Rpc 'session.metrics' @{} $session|ConvertTo-Json -Compress)-ceq $metrics)
+$null=Rpc 'session.readonly' @{op='on'} $session
+try{$null=Open-Pick;Pick-Key 0x0d;Check 'readonly terminal does not block independent picker' ((Pick-Result).result-eq 'picked')}
+finally{$null=Rpc 'session.readonly' @{op='off'} $session}
+$quick=Rpc 'pick.open' @{items=@();allowCustom=$true} -NoTarget -Window 'quick' -AllowError
+Check 'quick is not a picker owner' (-not $quick.ok)
+$ctl=Join-Path $root 'src/Agwinterm.Ctl/bin/Release/net10.0-windows/agwintermctl.exe'
+$opened='Alpha'|& $ctl pick --no-block --pipe $pipe|ConvertFrom-Json
+Check 'real CLI stdin no-block returns id payload' ($LASTEXITCODE-eq 0 -and $opened.id)
+$reply=& $ctl pick result $opened.id --pipe $pipe|ConvertFrom-Json
+Check 'real CLI pending exits one with payload' ($LASTEXITCODE-eq 1 -and $reply.result-eq 'pending')
+$null=& $ctl pick cancel $opened.id --pipe $pipe
+$reply=& $ctl pick result $opened.id --pipe $pipe|ConvertFrom-Json
+Check 'real CLI cancelled exits two with payload' ($LASTEXITCODE-eq 2 -and $reply.result-eq 'cancelled')
+if($env:CI-eq 'true' -and -not (Test-Path $hub)){
+    $null=Open-Pick;Pick-Key 0x09
+    Check 'Tab stays in native control family' ([HudOwnedJob]::InputWindow($hwnd,$false)-ne $hwnd)
+    $null=Rpc 'pick.cancel' @{} $pickId -Window ''
+    $ownerId=[string]((Rpc 'window.list').windows|Where-Object active|Select-Object -First 1).id
+    $null=Open-Pick;$closingPick=$pickId
+    $other=Rpc 'window.new' @{name='Picker second owner'} -NoTarget
+    for($i=0;$i-lt 50 -and @((Rpc 'window.list').windows|Where-Object {$_.id-eq $other -and $_.active}).Count-eq 0;$i++){Start-Sleep -Milliseconds 100}
+    Check 'global result survives frontmost change' ((Pick-Result $closingPick).result-eq 'pending')
+    $wrong=Rpc 'pick.result' @{} $closingPick -AllowError -Window 'active'
+    Check 'explicit wrong owner refuses' (-not $wrong.ok)
+    $null=Rpc 'window.close' @{} $ownerId -Window ''
+    for($i=0;$i-lt 50 -and (Pick-Result $closingPick).result-eq 'pending';$i++){Start-Sleep -Milliseconds 100}
+    Check 'closing owner cancels and retains global result' ((Pick-Result $closingPick).result-eq 'cancelled')
+}


### PR DESCRIPTION
Implements P16 after P15 merge 482612b. Native owned EDIT/LISTBOX/BUTTON picker, strict bounded input, label-only fuzzy matching, per-window pending state and bounded global completed results, exact-id CLI waiting and best-effort cancel. See docs/native-picker.md and qa/p16-native-picker.md. New Core23/Pty19 focused tests pass; private GUI25/25 with token116 released after owned-job cleanup. Full local Pty hit known #118 runtime crashes; exact-head CI must pass. Codex-only revmux broad review pending; no Claude involvement. No release/install. P17 lite mirror follows after this merge.