### PR TITLE
Fix control refusals, command casing and large text counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,8 +320,8 @@ Thirteen of those answer a question a script would otherwise have to guess at:
   target, an empty one (`--target ''` — only an OMITTED target means every pane), a
   scratch/overlay/quick pane, or a query that fails is refused and nothing is written. One refusal
   leaves something behind and says so — "captured into memory but the state file could not be
-  written": the slots are filled (`tree` shows them) but the checkpoint is not on disk and will not
-  survive a restart; fix the state directory and capture again.
+  written": the slots are filled (`tree` shows them), but this save did not put the new checkpoint
+  on disk. An earlier checkpoint may remain; fix the state directory and capture again.
   `tree --json` reads the slots back as `capturedCommands`, keyed by pane id like `restoreCommands`.
 - `session context "<text>"` sets one line of **what a session is for**, shown dimmed after the name
   in the title bar and the sidebar row and on the session palette's second line, where a name has to

--- a/docs/plans/2026-09-10-post-p17-stabilization.md
+++ b/docs/plans/2026-09-10-post-p17-stabilization.md
@@ -1,0 +1,32 @@
+# Post-P17 stabilization
+
+Boris authorized fixing the unfinished P17 review and the open backlog on 2026-09-10.
+Codex owns `agwinterm-stabilize` and `agliteterm-stabilize`; parked trees are untouched.
+Product boundaries (Lite images/no zoom, process-local windows) remain deliberate.
+No release, tag or installation is included.
+
+## Gates
+
+- Complete independent P17 final confirmation; recovered finder reports alone are not completion.
+- Reproduce or source-verify each issue; close only with linked evidence, not merely a stale label.
+- Batch related fixes with regression tests, Codex-only revmux and author verification.
+- One broad review and, where needed, narrow confirmation; further rounds require substantive blockers.
+- Exact-head required CI and integration tests before merge. Canonical contract before Lite mirror.
+- Shared-desktop suites require the canonical token through proven cleanup; unsafe fixtures stay CI-only.
+
+## Inventory at start
+
+All items below are pending assessment, not claimed fixed.
+
+| Batch | agwinterm | agliteterm |
+| --- | --- | --- |
+| Control truthfulness and persistence | #254, #257, #259 | #36, #42, #53, #55, #63, #64 |
+| UI input, rendering, lifecycle, accessibility | #189, #196, #198, #208, #209, #251, #267, #270 | #39 |
+| Concurrency and host transport | #258, #268 | #21, #27, #43 |
+| Shell integration and configuration | — | #41, #58, #60, #61 |
+| Shared-desktop test safety | — | #51, #56 |
+
+P17 final confirmation: existing task `feat-p17-lite-wave3`, round `04-final-confirmation`,
+scope `baaac5b..ac4896a`; completed successfully, exit 0, 2/2 healthy Codex reviewers,
+zero findings/open questions/pre-existing/immaterial entries. Synthesis completed;
+verification had no findings to process. Receipt posted on Lite PR #65.

--- a/src/Agwinterm.Ctl/Program.cs
+++ b/src/Agwinterm.Ctl/Program.cs
@@ -359,7 +359,7 @@ switch (area)
                 // An unparseable --lines is refused, not dropped: `--lines 5O` used to read the screen and report success.
                 if (Opt("lines") is { } textLinesRaw)
                 {
-                    if (!int.TryParse(textLinesRaw, out var textLines) || textLines < 0) { Console.Error.WriteLine(Agwinterm.Pty.OverlayPanes.LinesRefusal(textLinesRaw)); return 2; }
+                    if (!Agwinterm.Pty.OverlayPanes.TryLines(textLinesRaw, out var textLines)) { Console.Error.WriteLine(Agwinterm.Pty.OverlayPanes.LinesRefusal(textLinesRaw)); return 2; }
                     cargs["lines"] = textLines;
                 }
                 break;
@@ -459,7 +459,7 @@ switch (area)
                     if (options.ContainsKey("all")) cargs["all"] = true;
                     if (Opt("lines") is { } ovLinesRaw)   // refused, not dropped, as on session text
                     {
-                        if (!int.TryParse(ovLinesRaw, out var ovLines) || ovLines < 0) { Console.Error.WriteLine(Agwinterm.Pty.OverlayPanes.LinesRefusal(ovLinesRaw)); return 2; }
+                        if (!Agwinterm.Pty.OverlayPanes.TryLines(ovLinesRaw, out var ovLines)) { Console.Error.WriteLine(Agwinterm.Pty.OverlayPanes.LinesRefusal(ovLinesRaw)); return 2; }
                         cargs["lines"] = ovLines;
                     }
                 }

--- a/src/Agwinterm.Pty/AgentSkill.cs
+++ b/src/Agwinterm.Pty/AgentSkill.cs
@@ -447,7 +447,7 @@ public static class AgentSkill
           or a scratch/overlay/quick pane (never restored, so no slot), is refused and nothing is captured or saved; a
           process query that fails or times out is a refusal too, never an empty answer for every pane. ONE refusal
           leaves something behind and says so: "captured into memory but the state file could not be written" — the
-          slots are filled (`tree` shows them) but the checkpoint is not on disk and will not survive a restart; fix
+          slots are filled (`tree` shows them) but this save did not put the checkpoint on disk; fix
           the state directory and capture again. `session context` / `session rename` replies describe the value in
           memory the same way — their save is best-effort and silent.
         - `agwintermctl install hooks|skill|shell`               — install agent-status hooks / this skill / shell-integration (live cwd)

--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -294,7 +294,7 @@ public sealed class ControlServer : IDisposable
                     }
                 case "session.seen": return host.SessionSeen(target) ? Ok("seen") : Err("session not found");
                 case "broadcast": return Ok(host.BroadcastOp(GetString(args, "op") ?? "toggle"));
-                case "session.readonly": return Ok(host.ReadOnlyOp(target, GetString(args, "op") ?? "toggle"));
+                case "session.readonly": return HostReply(host.ReadOnlyOp(target, GetString(args, "op") ?? "toggle"));
                 case "session.output": return Ok(host.SessionOutput(target)); // last completed command's output (FTCS)
                 case "workspace.rename": return host.WorkspaceRename(target, GetString(args, "name") ?? "") ? Ok("renamed") : Err("workspace not found");
                 case "workspace.delete": return host.WorkspaceDelete(target) ? Ok("deleted") : Err("workspace not found / cannot delete last workspace");
@@ -369,7 +369,7 @@ public sealed class ControlServer : IDisposable
                 case "selection.clear": return HostReply(host.SelectionClear(target));
                 case "selection.finalize": return HostReply(host.SelectionFinalize(target)); // copy-on-select path (testing)
                 case "session.paste": return HostReply(host.SessionPaste(target, GetString(args, "text")));
-                case "session.search": return Ok(host.SessionSearch(target, GetString(args, "query"), GetString(args, "action")));
+                case "session.search": return HostReply(host.SessionSearch(target, GetString(args, "query"), GetString(args, "action")));
                 case "session.scratch": return host.SessionScratch(target, GetString(args, "op") ?? "toggle") ? Ok("scratch") : Err("session not found");
                 case "quick":
                     {
@@ -403,7 +403,7 @@ public sealed class ControlServer : IDisposable
                 case "session.background":
                     return Ok(host.SessionBackground(target, GetString(args, "action") ?? "set",
                         GetString(args, "path"), GetInt(args, "opacity", -1), GetString(args, "mode")));
-                case "session.switch": return Ok(host.SessionSwitch(GetString(args, "op") ?? "advance"));
+                case "session.switch": return HostReply(host.SessionSwitch(GetString(args, "op") ?? "advance"));
                 case "command.run":
                     {
                         string? nameOrCmd = GetString(args, "name") ?? GetString(args, "command");
@@ -689,7 +689,7 @@ public sealed class ControlServer : IDisposable
         bool hasLines = args.TryGetProperty("lines", out var lv);
         if (all && hasLines) { error = OverlayPanes.AllWithLines; return false; }
         int lines = 0;
-        if (hasLines && (lv.ValueKind != JsonValueKind.Number || !lv.TryGetInt32(out lines) || lines < 0))
+        if (hasLines && (lv.ValueKind != JsonValueKind.Number || !OverlayPanes.TryLines(lv.GetRawText(), out lines)))
         {
             error = OverlayPanes.LinesRefusal(lv.ValueKind == JsonValueKind.String ? lv.GetString()! : lv.GetRawText(),
                 quoted: lv.ValueKind == JsonValueKind.String);

--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -165,6 +165,10 @@ public sealed class ControlServer : IDisposable
             using var doc = JsonDocument.Parse(requestJson);
             var root = doc.RootElement;
             string cmd = root.TryGetProperty("cmd", out var c) ? c.GetString() ?? "" : "";
+            if (root.TryGetProperty("target", out var selector) && selector.ValueKind is not (JsonValueKind.String or JsonValueKind.Null))
+                return Err("target must be a string or null");
+            if (root.TryGetProperty("window", out var windowValue) && windowValue.ValueKind is not (JsonValueKind.String or JsonValueKind.Null))
+                return Err("window must be a string or null");
             string? target = root.TryGetProperty("target", out var t) && t.ValueKind == JsonValueKind.String ? t.GetString() : null;
             JsonElement args = root.TryGetProperty("args", out var a) ? a : default;
             // --window <id|prefix|active>: content verbs act on the resolved window (default = frontmost).
@@ -294,7 +298,10 @@ public sealed class ControlServer : IDisposable
                     }
                 case "session.seen": return host.SessionSeen(target) ? Ok("seen") : Err("session not found");
                 case "broadcast": return Ok(host.BroadcastOp(GetString(args, "op") ?? "toggle"));
-                case "session.readonly": return HostReply(host.ReadOnlyOp(target, GetString(args, "op") ?? "toggle"));
+                case "session.readonly":
+                    if (!TryOperation(args, "toggle", SessionOperations.IsReadOnlyOp, out var protectionOp))
+                        return Err("readonly requires on, off, toggle, state or get; nothing changed");
+                    return HostReply(host.ReadOnlyOp(target, protectionOp));
                 case "session.output": return Ok(host.SessionOutput(target)); // last completed command's output (FTCS)
                 case "workspace.rename": return host.WorkspaceRename(target, GetString(args, "name") ?? "") ? Ok("renamed") : Err("workspace not found");
                 case "workspace.delete": return host.WorkspaceDelete(target) ? Ok("deleted") : Err("workspace not found / cannot delete last workspace");
@@ -403,7 +410,11 @@ public sealed class ControlServer : IDisposable
                 case "session.background":
                     return Ok(host.SessionBackground(target, GetString(args, "action") ?? "set",
                         GetString(args, "path"), GetInt(args, "opacity", -1), GetString(args, "mode")));
-                case "session.switch": return HostReply(host.SessionSwitch(GetString(args, "op") ?? "advance"));
+                case "session.switch":
+                    if (!TryOperation(args, "advance", SessionOperations.IsSwitchOp, out var switchOp))
+                        return Err("unknown or malformed switch op; nothing changed");
+                    var switched = host.SessionSwitch(switchOp);
+                    return switched.Ok ? Ok(switched.Text) : Err(switched.Text);
                 case "command.run":
                     {
                         string? nameOrCmd = GetString(args, "name") ?? GetString(args, "command");
@@ -1403,6 +1414,17 @@ public sealed class ControlServer : IDisposable
             return fi.LastWriteTimeUtc.Ticks ^ ((long)fi.Length << 1) ^ (uint)StringComparer.OrdinalIgnoreCase.GetHashCode(path);
         }
         catch { return 0; }
+    }
+
+    private static bool TryOperation(JsonElement args, string fallback, Func<string, bool> valid, out string op)
+    {
+        op = fallback;
+        if (args.ValueKind == JsonValueKind.Undefined) return true;
+        if (args.ValueKind != JsonValueKind.Object) return false;
+        if (!args.TryGetProperty("op", out var value)) return true;
+        if (value.ValueKind != JsonValueKind.String) return false;
+        op = value.GetString()!;
+        return valid(op);
     }
 
     private static string? GetString(JsonElement args, string key)

--- a/src/Agwinterm.Pty/ISessionHost.cs
+++ b/src/Agwinterm.Pty/ISessionHost.cs
@@ -212,7 +212,8 @@ public interface ISessionHost
     /// <summary>Broadcast-input toggle for the frontmost window: op = on|off|toggle|state. Returns "on"/"off".</summary>
     string BroadcastOp(string op);
 
-    /// <summary>Read-only toggle for a target pane: op = on|off|toggle|state. Returns "on"/"off".
+    /// <summary>Read-only toggle for a target pane: op = on|off|toggle|state|get. Returns "on"/"off",
+    /// or <see cref="RefusePrefix"/> plus a reason for an unknown operation or missing target, without mutation.
     /// What "on" blocks: keys typed at the pane and pastes into it — the interactive paste and
     /// <see cref="SessionPaste"/>, which refuses. <c>session type</c> is NOT blocked (ControlServer
     /// writes it to the child's input directly): a script that must not reach a read-only pane
@@ -385,7 +386,8 @@ public interface ISessionHost
     /// first.</summary>
     string SessionPaste(string? target, string? text);
 
-    /// <summary>Open/drive the find bar over the active session; returns "N of M" / "no matches" / "closed".</summary>
+    /// <summary>Open/drive the find bar over the active session; returns "N of M" / "no matches" / "closed".
+    /// A missing target or active surface returns <see cref="RefusePrefix"/> plus a reason without changing search.</summary>
     string SessionSearch(string? target, string? query, string? action);
 
     /// <summary>Toggle/show/hide a session's scratch terminal: op = on|off|toggle. Returns false if the target isn't found.</summary>
@@ -577,9 +579,11 @@ public interface ISessionHost
     string SessionBackground(string? target, string action, string? path, int opacity, string? mode);
 
     /// <summary>Drive the MRU (Ctrl+Tab) session switcher state machine directly:
-    /// op = begin|advance|advance-back|commit|cancel. Returns the resulting active session name.
+    /// op = begin|advance (next)|advance-back (back/prev/previous)|commit|cancel.
+    /// Returns the resulting active session name with Ok=true, or Ok=false and a reason without
+    /// mutation for an unknown operation. Status is never encoded inside the session name.
     /// Lets the control API / tests exercise the walk without synthetic global key input.</summary>
-    string SessionSwitch(string op);
+    SessionSwitchReply SessionSwitch(string op);
 
     /// <summary>Run a custom command (by keymap label) or a raw command string, expanding {AGW_*} tokens and
     /// injecting $AGW_* env from the active session. <paramref name="mode"/> (send|new|overlay|detached)
@@ -688,7 +692,7 @@ public sealed class SingleSessionHost : ISessionHost
     public string UpdateApp() => "unsupported";
     public void WorkspaceFocus(string op) { }
     public string SessionBackground(string? target, string action, string? path, int opacity, string? mode) => "unsupported";
-    public string SessionSwitch(string op) => "unsupported";
+    public SessionSwitchReply SessionSwitch(string op) => new(false, "unsupported");
     public string CommandRun(string nameOrCommand, string? mode) => "unsupported";
     public string CommandList() => "";
     public string CommandLeader(string op) => "idle";

--- a/src/Agwinterm.Pty/OverlayPanes.cs
+++ b/src/Agwinterm.Pty/OverlayPanes.cs
@@ -22,6 +22,23 @@ namespace Agwinterm.Pty;
 /// </summary>
 public static class OverlayPanes
 {
+    /// <summary>Parse a nonnegative decimal count, saturating at the maximum buffer index.</summary>
+    public static bool TryLines(string raw, out int lines)
+    {
+        if (int.TryParse(raw, System.Globalization.NumberStyles.Integer,
+            System.Globalization.CultureInfo.InvariantCulture, out lines)) return lines >= 0;
+        var digits = raw.AsSpan().Trim();
+        if (digits.Length > 0 && digits[0] == '+') digits = digits[1..];
+        lines = 0;
+        if (digits.IsEmpty) return false;
+        foreach (char c in digits)
+        {
+            if (c < '0' || c > '9') return false;
+            lines = lines > (int.MaxValue - (c - '0')) / 10 ? int.MaxValue : lines * 10 + c - '0';
+        }
+        return true;
+    }
+
     /// <summary>Pane 0 — whatever the axis (on a horizontal split, the TOP pane).</summary>
     public const string Left = "left";
     /// <summary>Pane 1 — whatever the axis (on a horizontal split, the BOTTOM pane).</summary>

--- a/src/Agwinterm.Pty/RestoreCaptureReply.cs
+++ b/src/Agwinterm.Pty/RestoreCaptureReply.cs
@@ -89,5 +89,5 @@ public static class RestoreCaptureReply
     /// are left as captured — <c>tree</c> shows them — because rolling them back would make the tree
     /// disagree with a query that read the processes correctly (#246; the wording is lite's).</summary>
     public static string NotSaved(int panes, string? why) =>
-        $"restore capture: {panes} pane(s) were captured into memory but the state file could not be written ({why ?? "unknown reason"}) — the checkpoint is not on disk and will not survive a restart. tree still shows what was captured.";
+        $"restore capture: {panes} pane(s) were captured into memory but the state file could not be written ({why ?? "unknown reason"}) — this save did not put the checkpoint on disk. tree still shows what was captured.";
 }

--- a/src/Agwinterm.Pty/SessionOperations.cs
+++ b/src/Agwinterm.Pty/SessionOperations.cs
@@ -1,0 +1,12 @@
+namespace Agwinterm.Pty;
+
+/// <summary>Shared validation for protection, MRU operations and durable agent commands.</summary>
+public static class SessionOperations
+{
+    public static bool IsReadOnlyOp(string op) => op is "on" or "off" or "toggle" or "state" or "get";
+    public static bool IsSwitchOp(string op) => op is "begin" or "advance" or "next"
+        or "advance-back" or "back" or "prev" or "previous" or "commit" or "cancel";
+    public static string UnknownOp(string op) => ISessionHost.RefusePrefix + $"unknown op '{op}'; nothing changed";
+    public static string? Binding(string agent) => string.IsNullOrWhiteSpace(agent)
+        || agent.Equals("none", StringComparison.OrdinalIgnoreCase) ? null : agent;
+}

--- a/src/Agwinterm.Pty/SessionOperations.cs
+++ b/src/Agwinterm.Pty/SessionOperations.cs
@@ -1,5 +1,8 @@
 namespace Agwinterm.Pty;
 
+/// <summary>Out-of-band status: a session name may contain any refusal-looking prefix.</summary>
+public readonly record struct SessionSwitchReply(bool Ok, string Text);
+
 /// <summary>Shared validation for protection, MRU operations and durable agent commands.</summary>
 public static class SessionOperations
 {

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -725,7 +725,8 @@ internal partial class Program
 
     public string ReadOnlyOp(string? target, string op) => InvokeOnUi(() =>
     {
-        var p = PaneForTarget(target); if (p is null) return "no session";
+        if (!SessionOperations.IsReadOnlyOp(op)) return SessionOperations.UnknownOp(op);
+        var p = PaneForTarget(target); if (p is null) return ISessionHost.RefusePrefix + SessionContexts.NoSession;
         bool want = op switch { "on" => true, "off" => false, "state" or "get" => p.ReadOnly, _ => !p.ReadOnly };
         if (op is not ("state" or "get")) { p.ReadOnly = want; RequestRedraw(); }
         return p.ReadOnly ? "on" : "off";
@@ -828,7 +829,8 @@ internal partial class Program
     // searches the active session.)
     public string SessionSearch(string? target, string? query, string? action) => InvokeOnUi(() =>
     {
-        if (ActiveSurface() is null) return "no session";
+        if (PaneForTarget(target) is null || ActiveSurface() is null)
+            return ISessionHost.RefusePrefix + SessionContexts.NoSession;
         if (action == "close") { CloseSearch(); return "closed"; }
         if (!_searchActive) _searchActive = true;
         if (!string.IsNullOrEmpty(query)) { _searchQuery = query!; RecomputeSearch(); _searchCur = 0; ScrollToMatch(); }
@@ -1209,7 +1211,7 @@ internal partial class Program
         if (string.IsNullOrEmpty(target)) return false;
         var hit = FindPaneById(target!);
         if (hit is null) return false;
-        string? val = string.IsNullOrWhiteSpace(agent) || agent.Equals("none", StringComparison.OrdinalIgnoreCase) ? null : agent.ToLowerInvariant();
+        string? val = SessionOperations.Binding(agent);
         PostVerb(() => { hit.Value.pane.AgentResume = val; SaveState(); });
         return true;
     }

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -1394,7 +1394,7 @@ internal partial class Program
 
     public void WorkspaceFocus(string op) => PostVerb(() => WorkspaceFocusOp(op));
 
-    public string SessionSwitch(string op) => InvokeOnUi(() => SwitchOp(op));
+    public SessionSwitchReply SessionSwitch(string op) => InvokeOnUiQueued(() => SwitchOp(op));
 
     public string CommandRun(string nameOrCommand, string? mode) => InvokeOnUiQueued(() =>
     {

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -661,7 +661,7 @@ internal partial class Program
             case "advance-back": case "back": case "prev": case "previous": MruWalk(-1); break;
             case "commit": MruCommit(); break;
             case "cancel": MruCancel(); break;
-            default: return $"unknown op '{op}'";
+            default: return SessionOperations.UnknownOp(op);
         }
         return _active?.Name ?? "(none)";
     }

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -652,7 +652,7 @@ internal partial class Program
     /// <summary>Drive the MRU walk state machine directly (same methods the Ctrl+Tab keys call).
     /// Exists so the control API / tests can exercise begin→advance→commit deterministically with
     /// zero global key injection. Returns the current active session name (or a short status).</summary>
-    private string SwitchOp(string op)
+    private SessionSwitchReply SwitchOp(string op)
     {
         switch (op)
         {
@@ -661,9 +661,9 @@ internal partial class Program
             case "advance-back": case "back": case "prev": case "previous": MruWalk(-1); break;
             case "commit": MruCommit(); break;
             case "cancel": MruCancel(); break;
-            default: return SessionOperations.UnknownOp(op);
+            default: return new(false, $"unknown op '{op}'; nothing changed");
         }
-        return _active?.Name ?? "(none)";
+        return new(true, _active?.Name ?? "(none)");
     }
 
     // ---- Cover terminals (scratch / quick) ----

--- a/tests/Agwinterm.Pty.Tests/ControlApiTests.cs
+++ b/tests/Agwinterm.Pty.Tests/ControlApiTests.cs
@@ -162,6 +162,87 @@ public class ControlApiTests
         Assert.False(Ok(r));
     }
 
+    [Theory]
+    [InlineData("session.readonly")]
+    [InlineData("session.search")]
+    public void ProtectionAndSearch_MissingTarget_Refuse(string command)
+    {
+        var (server, _) = New();
+        var reply = Dispatch(server, command, new { op = "on", query = "needle" }, target: "missing-pane");
+        Assert.False(Ok(reply));
+        Assert.Equal(SessionContexts.NoSession, reply.GetProperty("error").GetString());
+    }
+
+    [Theory]
+    [InlineData("typo")]
+    [InlineData("")]
+    [InlineData("ON")]
+    public void ReadOnly_UnknownOp_RefusesWithoutChangingProtection(string op)
+    {
+        var (server, host) = New();
+        foreach (bool initial in new[] { false, true })
+        {
+            host.ActiveSess!.ReadOnly = initial;
+            Assert.False(Ok(Dispatch(server, "session.readonly", new { op })));
+            Assert.Equal(initial, host.ActiveSess.ReadOnly);
+        }
+    }
+
+    [Theory]
+    [InlineData("on", false, true)]
+    [InlineData("off", true, false)]
+    [InlineData("toggle", false, true)]
+    [InlineData("toggle", true, false)]
+    [InlineData("state", true, true)]
+    [InlineData("state", false, false)]
+    [InlineData("get", true, true)]
+    [InlineData("get", false, false)]
+    public void ReadOnly_KnownOp_ReturnsEffectiveState(string op, bool initial, bool expected)
+    {
+        var (server, host) = New();
+        host.ActiveSess!.ReadOnly = initial;
+        Assert.Equal(expected ? "on" : "off", Result(Dispatch(server, "session.readonly", new { op })));
+        Assert.Equal(expected, host.ActiveSess.ReadOnly);
+    }
+
+    [Theory]
+    [InlineData("begin")]
+    [InlineData("advance")]
+    [InlineData("next")]
+    [InlineData("advance-back")]
+    [InlineData("back")]
+    [InlineData("prev")]
+    [InlineData("previous")]
+    [InlineData("commit")]
+    [InlineData("cancel")]
+    public void Switch_KnownOperations_AreAccepted(string op)
+    {
+        var (server, _) = New();
+        Assert.True(Ok(Dispatch(server, "session.switch", new { op })));
+    }
+
+    [Fact]
+    public void Switch_UnknownOp_RefusesWithoutChangingFocus()
+    {
+        var (server, host) = New();
+        var initial = host.ActiveSess;
+        Assert.False(Ok(Dispatch(server, "session.switch", new { op = "typo" })));
+        Assert.Same(initial, host.ActiveSess);
+    }
+
+    [Theory]
+    [InlineData("Tool --Path C:/CaseSensitive/Project --Key AbC", "Tool --Path C:/CaseSensitive/Project --Key AbC")]
+    [InlineData("NoNe", null)]
+    [InlineData(" ", null)]
+    public void Binding_PreservesCommandCase_OnlyClearingIsCaseInsensitive(string input, string? expected)
+    {
+        var (server, host) = New();
+        Assert.True(Ok(Dispatch(server, "session.bind", new { agent = input }, target: "s1")));
+        Assert.Equal(expected, host.ActiveSess!.AgentResume);
+        var stored = JsonSerializer.Serialize(new PaneState { AgentResume = host.ActiveSess.AgentResume }, RestoreState.Json);
+        Assert.Equal(expected, JsonSerializer.Deserialize<PaneState>(stored, RestoreState.Json)!.AgentResume);
+    }
+
     [Fact]
     public void ClaudeAdopt_BindsSessions()
     {

--- a/tests/Agwinterm.Pty.Tests/ControlApiTests.cs
+++ b/tests/Agwinterm.Pty.Tests/ControlApiTests.cs
@@ -189,6 +189,63 @@ public class ControlApiTests
     }
 
     [Theory]
+    [InlineData("false")]
+    [InlineData("true")]
+    [InlineData("42")]
+    [InlineData("null")]
+    [InlineData("[]")]
+    [InlineData("{}")]
+    public void MalformedOperationsAndSelectors_RefuseBeforeDispatch(string value)
+    {
+        var (server, host) = New();
+        var initial = host.ActiveSess!;
+        initial.ReadOnly = true;
+        foreach (string command in new[] { "session.readonly", "session.switch" })
+            foreach (string args in new[] { "{\"op\":" + value + "}", value })
+            {
+                // An object without op intentionally selects the default, unlike an op object.
+                if (args == "{}") continue;
+                using var reply = JsonDocument.Parse(server.Dispatch("{\"cmd\":\"" + command + "\",\"args\":" + args + "}"));
+                Assert.False(Ok(reply.RootElement));
+                Assert.True(initial.ReadOnly);
+                Assert.Same(initial, host.ActiveSess);
+            }
+        if (value == "null") return; // null selectors retain the documented omitted-selector meaning
+        foreach (string selector in new[] { "target", "window" })
+            foreach (string command in new[] { "session.readonly", "session.search", "session.switch" })
+            {
+                using var reply = JsonDocument.Parse(server.Dispatch("{\"cmd\":\"" + command + "\",\"" + selector + "\":" + value + ",\"args\":{\"op\":\"off\",\"query\":\"wrong\"}}"));
+                Assert.False(Ok(reply.RootElement));
+                Assert.True(initial.ReadOnly);
+            }
+    }
+
+    [Fact]
+    public void OmittedOperation_Defaults_WithOmittedOrNullSelectors()
+    {
+        var (server, host) = New();
+        foreach (string fields in new[] { "", ",\"args\":{}", ",\"args\":{},\"target\":null,\"window\":null" })
+        {
+            bool before = host.ActiveSess!.ReadOnly;
+            using var reply = JsonDocument.Parse(server.Dispatch("{\"cmd\":\"session.readonly\"" + fields + "}"));
+            Assert.True(Ok(reply.RootElement));
+            Assert.Equal(!before, host.ActiveSess.ReadOnly);
+        }
+    }
+
+    [Fact]
+    public void Switch_NameThatLooksLikeRefusal_IsStillSuccessfulData()
+    {
+        var (server, host) = New();
+        host.ActiveSess!.Name = ISessionHost.RefusePrefix + "my session";
+        var reply = Dispatch(server, "session.switch", new { op = "begin" });
+        Assert.True(Ok(reply));
+        Assert.Equal(host.ActiveSess.Name, Result(reply));
+        Assert.True(host.SessionSwitch("begin").Ok);
+        Assert.False(host.SessionSwitch("typo").Ok);
+    }
+
+    [Theory]
     [InlineData("on", false, true)]
     [InlineData("off", true, false)]
     [InlineData("toggle", false, true)]

--- a/tests/Agwinterm.Pty.Tests/ControlServerTypeTextTests.cs
+++ b/tests/Agwinterm.Pty.Tests/ControlServerTypeTextTests.cs
@@ -177,4 +177,31 @@ public class ControlServerTypeTextTests
         // 0 and a plain integer still read.
         Assert.Contains("\"ok\":true", server.Dispatch("{\"cmd\":\"session.text\",\"args\":{\"lines\":0}}"));
     }
+
+    [Theory]
+    [InlineData("0", 0)]
+    [InlineData("123", 123)]
+    [InlineData("2147483647", int.MaxValue)]
+    [InlineData("2147483648", int.MaxValue)]
+    [InlineData("999999999999999999999999999999999999", int.MaxValue)]
+    public void Text_LargeWholeCountsSaturate(string raw, int expected)
+    {
+        Assert.True(OverlayPanes.TryLines(raw, out int lines));
+        Assert.Equal(expected, lines);
+        var (server, session) = New(rows: 4);
+        session.Emulator.Feed(System.Text.Encoding.UTF8.GetBytes("one\r\ntwo\r\nthree\r\nfour\r\nfive\r\n"));
+        var reply = server.Dispatch("{\"cmd\":\"session.text\",\"args\":{\"lines\":" + raw + "}}");
+        Assert.Contains("\"ok\":true", reply);
+        if (expected == int.MaxValue)
+            Assert.Equal(server.Dispatch("{\"cmd\":\"session.text\",\"args\":{\"all\":true}}"), reply);
+    }
+
+    [Theory]
+    [InlineData("999999999999999x")]
+    [InlineData("-99999999999999")]
+    [InlineData("1e30")]
+    [InlineData("99999999999.5")]
+    [InlineData("")]
+    public void Text_SaturationStillValidatesEveryDigit(string raw)
+        => Assert.False(OverlayPanes.TryLines(raw, out _));
 }

--- a/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
+++ b/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
@@ -923,7 +923,8 @@ internal sealed class FakeSessionHost : ISessionHost
     public string UpdateApp() => "updating agwinterm…";
     public void WorkspaceFocus(string op) { }
     public string SessionBackground(string? target, string action, string? path, int opacity, string? mode) => FindSes(target) is not null ? "ok" : "no session";
-    public string SessionSwitch(string op) => SessionOperations.IsSwitchOp(op) ? ActiveSess?.Name ?? "" : SessionOperations.UnknownOp(op);
+    public SessionSwitchReply SessionSwitch(string op) => SessionOperations.IsSwitchOp(op)
+        ? new(true, ActiveSess?.Name ?? "") : new(false, $"unknown op '{op}'; nothing changed");
     public string CommandRun(string nameOrCommand, string? mode) => $"{mode ?? "new"}: {nameOrCommand}";
     public string CommandList() => "";
     public string CommandLeader(string op) => "idle";

--- a/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
+++ b/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
@@ -501,7 +501,7 @@ internal sealed class FakeSessionHost : ISessionHost
         return new SidebarWidthSnapshot(SidebarW, SidebarVisible);
     }
     public string BroadcastOp(string op) { Broadcast = op switch { "on" => true, "off" => false, "toggle" => !Broadcast, _ => Broadcast }; return Broadcast ? "on" : "off"; }
-    public string ReadOnlyOp(string? target, string op) { var s = FindSes(target); if (s is null) return "off"; s.ReadOnly = op switch { "on" => true, "off" => false, "toggle" => !s.ReadOnly, _ => s.ReadOnly }; return s.ReadOnly ? "on" : "off"; }
+    public string ReadOnlyOp(string? target, string op) { if (!SessionOperations.IsReadOnlyOp(op)) return SessionOperations.UnknownOp(op); var s = FindSes(target); if (s is null) return ISessionHost.RefusePrefix + SessionContexts.NoSession; s.ReadOnly = op switch { "on" => true, "off" => false, "toggle" => !s.ReadOnly, _ => s.ReadOnly }; return s.ReadOnly ? "on" : "off"; }
     public string SessionOutput(string? target) => "";
     public bool WorkspaceRename(string? target, string name) { var w = FindWs(target); if (w is null || string.IsNullOrWhiteSpace(name)) return false; w.Name = name; return true; }
     public bool WorkspaceDelete(string? target) { var w = FindWs(target); if (w is null || Workspaces.Count <= 1) return false; Workspaces.Remove(w); if (ReferenceEquals(ActiveWs, w)) { ActiveWs = Workspaces[0]; ActiveSess = ActiveWs.Sessions.FirstOrDefault(); } return true; }
@@ -761,7 +761,7 @@ internal sealed class FakeSessionHost : ISessionHost
     /// match every cover), and a real pane's id resolves before a cover's, as in FindPaneBy.</summary>
     private (Sess s, string id, ISession pane)? CoverTarget(string? target)
         => string.IsNullOrEmpty(target) || target == "active" || FindPane(target) is not null ? null : FindCover(target);
-    public string SessionSearch(string? target, string? query, string? action) => "no matches";
+    public string SessionSearch(string? target, string? query, string? action) => FindSes(target) is null ? ISessionHost.RefusePrefix + SessionContexts.NoSession : "no matches";
     public bool SessionScratch(string? target, string op) => FindSes(target) is not null;
     public void Quick(string op) { QuickVisible = op switch { "on" => true, "off" => false, "toggle" => !QuickVisible, _ => QuickVisible }; }
     // Mirrors the app: no clamp, because ControlServer.TryOverlaySize refuses out-of-range before the
@@ -916,14 +916,14 @@ internal sealed class FakeSessionHost : ISessionHost
     }
     public bool Notify(string? target, string? title, string body) { var s = FindSes(target); if (s is null) return false; s.Notifications++; return true; }
     public bool SessionFlag(string? target, string op) { if (op == "clear") { foreach (var s in Workspaces.SelectMany(w => w.Sessions)) s.Flagged = false; return true; } var x = FindSes(target); if (x is null) return false; x.Flagged = op switch { "on" => true, "off" => false, "toggle" => !x.Flagged, _ => x.Flagged }; return true; }
-    public bool SessionBind(string? target, string agent) { var s = FindSes(target); /* the app: FindPaneById, a pane, so pane-capable */ if (s is null) return false; s.AgentResume = string.IsNullOrWhiteSpace(agent) || agent == "none" ? null : agent; return true; }
+    public bool SessionBind(string? target, string agent) { var s = FindSes(target); /* the app: FindPaneById, a pane, so pane-capable */ if (s is null) return false; s.AgentResume = SessionOperations.Binding(agent); return true; }
     public string AdoptClaude() { int n = 0; foreach (var s in Workspaces.SelectMany(w => w.Sessions)) { s.AgentResume = "claude --resume x"; n++; } return $"adopted {n}"; }
     public string RestartClaudeYolo(string? target) { var s = FindSes(target); if (s is null) return "no pane"; s.AgentResume = "claude --resume x --dangerously-skip-permissions"; return "restarting Claude in YOLO mode (resumed)"; }
     public string UpdateClaude() => "updating Claude Code…";
     public string UpdateApp() => "updating agwinterm…";
     public void WorkspaceFocus(string op) { }
     public string SessionBackground(string? target, string action, string? path, int opacity, string? mode) => FindSes(target) is not null ? "ok" : "no session";
-    public string SessionSwitch(string op) => ActiveSess?.Name ?? "";
+    public string SessionSwitch(string op) => SessionOperations.IsSwitchOp(op) ? ActiveSess?.Name ?? "" : SessionOperations.UnknownOp(op);
     public string CommandRun(string nameOrCommand, string? mode) => $"{mode ?? "new"}: {nameOrCommand}";
     public string CommandList() => "";
     public string CommandLeader(string op) => "idle";

--- a/tests/conformance/control-api.json
+++ b/tests/conformance/control-api.json
@@ -279,7 +279,7 @@
         "{alpha}"
       ],
       "result": "string",
-      "note": "P6: the mouse-up path (copy-on-select) run from a script; with no selection it answers `finalized (empty)` (the full app: `finalized (copy-on-select off)` when that setting is off - lite has no off switch) and touches no clipboard either."
+      "note": "The mouse-up path (copy-on-select) run from a script; with no selection it answers `finalized (empty)`, or `finalized (copy-on-select off)` when that setting is off in either product, and touches no clipboard."
     },
     {
       "verb": "session.type",
@@ -927,6 +927,14 @@
         "no-such-session-id"
       ],
       "note": "P6: same for session.paste - a paste that silently went nowhere is the worst of the silent-success class (the text was meant for a shell)."
+    },
+    {
+      "args": ["session", "readonly", "on", "--target", "no-such-session-id"],
+      "note": "A missing protection target is refused; success must never imply a nonexistent pane was protected."
+    },
+    {
+      "args": ["session", "search", "needle", "--target", "no-such-session-id"],
+      "note": "A missing search target is refused without opening or changing another pane's search."
     }
   ],
   "$orderComment": [

--- a/tests/integration/navigation-ui-cases.ps1
+++ b/tests/integration/navigation-ui-cases.ps1
@@ -23,6 +23,24 @@ function PixelDifference($a,$b,[int]$x=0,[int]$y=0,[int]$w=0,[int]$h=0){
     }};return $different
 }
 $first=[string](CurrentWs);$beforeText=Rpc 'session.text' @{} $session
+Check 'readonly rejects an unknown operation without changing protection' (-not (Rpc 'session.readonly' @{op='typo'} $session -AllowError).ok -and (Rpc 'session.readonly' @{op='state'} $session)-eq 'off')
+$null=Rpc 'session.readonly' @{op='on'} $session
+Check 'readonly typo cannot remove existing protection' (-not (Rpc 'session.readonly' @{op='typo'} $session -AllowError).ok -and (Rpc 'session.readonly' @{op='get'} $session)-eq 'on')
+$null=Rpc 'session.readonly' @{op='off'} $session
+Check 'missing readonly target refuses' (-not (Rpc 'session.readonly' @{op='on'} 'missing-pane' -AllowError).ok)
+Check 'missing search target refuses' (-not (Rpc 'session.search' @{query='needle'} 'missing-pane' -AllowError).ok)
+Check 'unknown switch operation refuses' (-not (Rpc 'session.switch' @{op='typo'} -NoTarget -AllowError).ok)
+$mixedCommand='Tool --Path C:/CaseSensitive/Project --Key AbC'
+$null=Rpc 'session.bind' @{agent=$mixedCommand} $session
+Check 'binding preserves command case in the saved pane' (NavWait {
+    foreach($file in Get-ChildItem (Join-Path $appDir 'windows') -Filter '*.json') {
+        try {$saved=Get-Content $file.FullName -Raw|ConvertFrom-Json} catch {continue}
+        foreach($ws in $saved.Workspaces){foreach($ses in $ws.Sessions){foreach($pane in $ses.Panes){
+            if($pane.Id-eq $session -and $pane.AgentResume-ceq $mixedCommand){return $true}
+        }}}
+    };return $false
+})
+$null=Rpc 'session.bind' @{agent='NoNe'} $session
 Check 'one workspace navigation refuses' (-not (Rpc 'workspace.go' @{to='next'} -NoTarget -AllowError).ok)
 Check 'last workspace deletion refuses without removing its terminal' (-not (Rpc 'workspace.delete' @{} $first -AllowError).ok -and @(NavTree).Count-eq 1 -and $null-ne (Node $session))
 $second=[string](Rpc 'workspace.new' @{name='P15-empty'})

--- a/tests/integration/navigation-ui-cases.ps1
+++ b/tests/integration/navigation-ui-cases.ps1
@@ -27,8 +27,12 @@ Check 'readonly rejects an unknown operation without changing protection' (-not 
 $null=Rpc 'session.readonly' @{op='on'} $session
 Check 'readonly typo cannot remove existing protection' (-not (Rpc 'session.readonly' @{op='typo'} $session -AllowError).ok -and (Rpc 'session.readonly' @{op='get'} $session)-eq 'on')
 $null=Rpc 'session.readonly' @{op='off'} $session
-Check 'missing readonly target refuses' (-not (Rpc 'session.readonly' @{op='on'} 'missing-pane' -AllowError).ok)
-Check 'missing search target refuses' (-not (Rpc 'session.search' @{query='needle'} 'missing-pane' -AllowError).ok)
+Check 'missing readonly target refuses without protecting the active pane' (-not (Rpc 'session.readonly' @{op='on'} 'missing-pane' -AllowError).ok -and (Rpc 'session.readonly' @{op='state'} $session)-eq 'off')
+$null=Rpc 'session.write' @{text="`r`nSTABILIZATION-SEARCH-MARKER`r`n"} $session
+$findBefore=Rpc 'session.search' @{query='STABILIZATION-SEARCH-MARKER'} $session
+Check 'search mutation guard has a real match' ($findBefore-match 'of [1-9]')
+Check 'missing search target refuses without replacing active query' (-not (Rpc 'session.search' @{query='MISSING-SEARCH-QUERY'} 'missing-pane' -AllowError).ok -and (Rpc 'session.search' @{} $session)-eq $findBefore)
+$null=Rpc 'session.search' @{action='close'} $session
 Check 'unknown switch operation refuses' (-not (Rpc 'session.switch' @{op='typo'} -NoTarget -AllowError).ok)
 $mixedCommand='Tool --Path C:/CaseSensitive/Project --Key AbC'
 $null=Rpc 'session.bind' @{agent=$mixedCommand} $session
@@ -49,6 +53,18 @@ Check 'go reaches empty workspace and reports id' ((Rpc 'workspace.go' @{to='nex
 Check 'empty destination leaves selected terminal intact' ((Rpc 'window.state').activeWorkspace-eq 'P15-empty' -and (Node $session).active)
 $placed=[string](Rpc 'session.new' @{name='P15-placed';wait=$true})
 Check 'new session without caller lands in current empty workspace' (NavWait {@((NavTree|Where-Object id -eq $second).sessions|Where-Object id -eq $placed).Count-eq 1 -and (Node $placed).active})
+foreach($badOp in 'typo',$false,42,$null,@(),@{}) {
+    Check 'invalid switch operation preserves focus with two live sessions' (-not (Rpc 'session.switch' @{op=$badOp} -NoTarget -AllowError).ok -and (Node $placed).active)
+    $null=Rpc 'session.readonly' @{op='on'} $placed
+    Check 'malformed readonly operation preserves protection' (-not (Rpc 'session.readonly' @{op=$badOp} $placed -AllowError).ok -and (Rpc 'session.readonly' @{op='state'} $placed)-eq 'on')
+}
+$null=Rpc 'session.readonly' @{op='off'} $placed
+$refusalName=([string][char]1)+'refuse:valid-name'
+$null=Rpc 'session.rename' @{name=$refusalName} $placed
+$switchReply=Rpc 'session.switch' @{op='begin'} -NoTarget -AllowError
+Check 'valid session name cannot turn switch success into an error' ($switchReply.ok -and $switchReply.result-ceq $refusalName)
+$null=Rpc 'session.switch' @{op='cancel'} -NoTarget
+$null=Rpc 'session.rename' @{name='P15-placed'} $placed
 $null=Rpc 'workspace.collapse' @{} $second
 Check 'collapsed workspace readback' (NavWait {(NavTree|Where-Object id -eq $second).collapsed})
 Check 'previous wraps without skipping collapsed destinations' ((Rpc 'workspace.go' @{to='prev'} -NoTarget)-eq $first -and (Rpc 'workspace.go' @{to='next'} -NoTarget)-eq $second)

--- a/tests/integration/win32-control.ps1
+++ b/tests/integration/win32-control.ps1
@@ -1390,9 +1390,9 @@ for ($i = 0; $i -lt 60; $i++) { & '__CTL__' session overlay resize --size-percen
                 Move-Item -LiteralPath $capStateBak -Destination $capState.FullName -Force
             }
         }
-        Check 'a capture whose state file cannot be written is refused: captured into memory, not on disk, will not survive a restart (#246)' `
+        Check 'a failed capture save reports only that this save did not persist the checkpoint (#246)' `
             ($capNoSave -and (-not $capNoSave.ok) -and ("$($capNoSave.error)" -match 'captured into memory') -and
-             ("$($capNoSave.error)" -match 'could not be written') -and ("$($capNoSave.error)" -match 'will not survive a restart')) `
+             ("$($capNoSave.error)" -match 'could not be written') -and ("$($capNoSave.error)" -match 'this save did not put the checkpoint on disk')) `
             "reply=$($capNoSave | ConvertTo-Json -Compress -Depth 5)"
         Check 'and the slot was left as captured: tree still shows it' `
             ($capNodeNoSave -and ("$($capNodeNoSave.capturedCommands.$survivorId)" -match $pingPattern)) `

--- a/tests/integration/win32-control.ps1
+++ b/tests/integration/win32-control.ps1
@@ -1139,6 +1139,13 @@ for ($i = 0; $i -lt 60; $i++) { & '__CTL__' session overlay resize --size-percen
         }
         $p5After = & $p5Shape (Get-SessionSnapshot $p5Id)
         Check 'and none of them changed the overlay slots' ($p5Before -eq $p5After) "before=$p5Before after=$p5After"
+        # Exercise both production CLI parsers, not just the shared server/parser helper.
+        foreach ($textVerb in @(@('session','text'), @('session','overlay','text'))) {
+            $allRead=Invoke-Ctl ($textVerb + @('--all','--target',$p5Ovl))
+            $largeRead=Invoke-Ctl ($textVerb + @('--lines','2147483648','--target',$p5Ovl))
+            Check "CLI $($textVerb -join ' ') saturates large counts" ($allRead.ok -and $largeRead.ok -and
+                [string]$allRead.result.text -ceq [string]$largeRead.result.text) "all=$($allRead|ConvertTo-Json -Compress) large=$($largeRead|ConvertTo-Json -Compress)"
+        }
         # The slot moves with its pane: a 30/70 divider so the boxes differ, then swap: paneOverlays ["left"], the overlay measures the pane's NEW box.
         Invoke-Ctl @('session', 'resize', '--split-ratio', '0.3', '--target', $p5Id) | Out-Null
         $p5RightBox = $null
@@ -1373,7 +1380,7 @@ for ($i = 0; $i -lt 60; $i++) { & '__CTL__' session overlay resize --size-percen
         Check '--target <id> --target is refused before sending: the last occurrence decides (#246)' `
             ($capDupCode -eq 2 -and ("$capDup" -match 'is empty') -and ("$capDup" -match 'Nothing sent')) "exit $capDupCode, output: $capDup"
         # #246: a capture whose save does not land is REFUSED, saying what it left: the slots are in
-        # memory (tree shows them), the checkpoint is not on disk. The state file is replaced by a
+        # memory (tree shows them), but this save did not persist them; an earlier checkpoint may remain. The state file is replaced by a
         # DIRECTORY of its own name, which the atomic File.Move cannot overwrite; the file goes back
         # afterwards. This is the sandbox's own app-id directory, never the user's.
         $capNoSave = $null; $capNodeNoSave = $null
@@ -1392,7 +1399,8 @@ for ($i = 0; $i -lt 60; $i++) { & '__CTL__' session overlay resize --size-percen
         }
         Check 'a failed capture save reports only that this save did not persist the checkpoint (#246)' `
             ($capNoSave -and (-not $capNoSave.ok) -and ("$($capNoSave.error)" -match 'captured into memory') -and
-             ("$($capNoSave.error)" -match 'could not be written') -and ("$($capNoSave.error)" -match 'this save did not put the checkpoint on disk')) `
+             ("$($capNoSave.error)" -match 'could not be written') -and ("$($capNoSave.error)" -match 'this save did not put the checkpoint on disk') -and
+             ("$($capNoSave.error)" -notmatch 'will not survive|checkpoint is not on disk')) `
             "reply=$($capNoSave | ConvertTo-Json -Compress -Depth 5)"
         Check 'and the slot was left as captured: tree still shows it' `
             ($capNodeNoSave -and ("$($capNodeNoSave.capturedCommands.$survivorId)" -match $pingPattern)) `


### PR DESCRIPTION
First post-P17 stabilization batch. Fixes #254, fixes #257, fixes #259. Also refreshes the canonical P6 finalize note (lite #55) and capture-save wording (lite #36 item 4). Preserves agent command case and clearing semantics; missing readonly/search and invalid readonly/switch operations refuse; decimal line counts saturate at the CLI and server without overflow. Tests: Release solution build; 99 isolated control/type-text tests; conformance validator 16. Added production GUI acceptance for refusal/state and persisted binding bytes. Codex-only independent review and exact-head full CI are pending; draft until both pass. Canonical contract must merge before the Lite mirror; no release/tag/install.