### PR TITLE
Fix selection modifiers, wheel routing, help and font fallback

### DIFF
--- a/src/Agwinterm.Core/BuiltinBoxGlyphs.cs
+++ b/src/Agwinterm.Core/BuiltinBoxGlyphs.cs
@@ -1,0 +1,8 @@
+namespace Agwinterm.Core;
+
+/// <summary>The vector renderer's implemented set; other box glyphs use normal styled font rendering.</summary>
+public static class BuiltinBoxGlyphs
+{
+    public static bool Supports(int codepoint) => codepoint is >= 0x2500 and <= 0x2503
+        or >= 0x250C and <= 0x254B or 0x2550 or 0x2551 or >= 0x2580 and <= 0x2593;
+}

--- a/src/Agwinterm.Core/Keymap.cs
+++ b/src/Agwinterm.Core/Keymap.cs
@@ -22,6 +22,10 @@ namespace Agwinterm.Core;
 /// </summary>
 public static class Keymap
 {
+    /// <summary>Modifier-only Win32 events are protocol state, not editing input.</summary>
+    public static bool IsModifierKey(int vk) => vk is 0x10 or 0x11 or 0x12
+        or 0x5B or 0x5C or >= 0xA0 and <= 0xA5;
+
     /// <summary>Built-in action ids and their default chords (overridable by keymap.conf).</summary>
     public static IReadOnlyList<(string Chord, string Action)> DefaultBindings { get; } =
         Array.AsReadOnly<(string Chord, string Action)>(new (string, string)[] {

--- a/src/Agwinterm.Core/TerminalFontFamily.cs
+++ b/src/Agwinterm.Core/TerminalFontFamily.cs
@@ -1,0 +1,13 @@
+namespace Agwinterm.Core;
+
+/// <summary>Resolve missing configured families before DirectWrite can silently substitute a proportional face.</summary>
+public static class TerminalFontFamily
+{
+    public static string Resolve(string configured, Func<string, bool> installed)
+    {
+        if (!string.IsNullOrWhiteSpace(configured) && installed(configured)) return configured;
+        foreach (string fallback in new[] { "Cascadia Mono", "Consolas", "Lucida Console", "Courier New" })
+            if (installed(fallback)) return fallback;
+        throw new InvalidOperationException("No supported monospace fallback font is installed; install Consolas or Cascadia Mono.");
+    }
+}

--- a/src/Agwinterm.Win32/Help.cs
+++ b/src/Agwinterm.Win32/Help.cs
@@ -12,7 +12,7 @@ namespace Agwinterm.Win32;
 /// bindings (keymap.conf included), and an accessibility guide. When a screen reader is attached
 /// the guide is spoken on open and the whole help text is exposed as a modal UIA document, so a
 /// low-vision user gets an audio orientation of what they can do and how.
-/// F1 opens it from the shell prompt; full-screen TUIs (alt screen: Far, vim) keep their own F1.
+/// Plain F1 opens it even while a full-screen terminal application is running.
 /// </summary>
 internal partial class Program
 {
@@ -57,7 +57,7 @@ internal partial class Program
             "",
             "FOCUS & NAVIGATION",
             "F6            move focus between terminal and sidebar (arrows + Enter there)",
-            "F1            this help (at the shell prompt; full-screen apps keep their F1)",
+            "F1            this help (including while full-screen terminal apps run)",
             "Esc           close overlays (help, settings, palettes, search)",
             "",
             "KEY BINDINGS (effective — keymap.conf applied)",

--- a/src/Agwinterm.Win32/Program.Input.cs
+++ b/src/Agwinterm.Win32/Program.Input.cs
@@ -29,11 +29,11 @@ internal partial class Program
         RequestRedraw();
     }
 
-    private void Send(string s)
+    private void Send(string s, bool editing = true)
     {
         var surf = ActiveSurface();
         if (surf is { ReadOnly: true }) { ShowToast("pane is read-only"); return; }   // block input to a protected pane
-        if (surf is not null) { surf.ScrollOffset = 0; surf.ClearSel(); } // typing snaps to bottom, clears selection
+        if (editing && surf is not null) { surf.ScrollOffset = 0; surf.ClearSel(); } // modifiers/key-up do not edit the buffer
         if (_broadcast && _cover is null && _active is not null)
         {
             byte[] bytes = Encoding.UTF8.GetBytes(s);
@@ -513,13 +513,20 @@ internal partial class Program
     /// <summary>Encode a cell or SGR-Pixels mouse event and send it to the child.</summary>
     private void SendMouse(int btn, int dipX, int dipY, int deviceX, int deviceY, bool press)
     {
-        var em = _session?.Emulator;
+        if (ActiveSurface() is { } pane)
+            SendMouseTo(pane, ActivePaneView(), btn, dipX, dipY, deviceX, deviceY, press);
+    }
+
+    private void SendMouseTo(Pane pane, (float ox, float oy, float cw, float ch) view,
+        int btn, int dipX, int dipY, int deviceX, int deviceY, bool press)
+    {
+        var em = pane.S.Emulator;
         if (em is null || !em.MouseReporting) return;
-        var (ox, oy, cw, ch) = ActivePaneView();
+        var (ox, oy, cw, ch) = view;
         string seq = MouseReport.EncodePointer(
             btn, dipX, dipY, deviceX, deviceY, ox, oy, cw, ch, Scale,
             em.Screen.Cols, em.Screen.Rows, press, em.MouseSgr, em.MouseSgrPixels);
-        _session?.Write(Encoding.UTF8.GetBytes(seq));
+        pane.S.Write(Encoding.UTF8.GetBytes(seq));
     }
 
     // ---- Clickable links: Ctrl+hover underlines a URL (hand cursor); Ctrl+click opens it ----
@@ -1183,14 +1190,11 @@ internal partial class Program
         // While the find bar is open it owns the keyboard (Enter/F3 nav, Esc close, Backspace edit).
         if (_searchActive) return SearchKeyDown(vk);
 
-        // F1 help overlay: modal while open; plain F1 opens it from the shell prompt (full-screen
-        // TUIs on the alt screen — Far, vim — keep their own F1).
+        // Plain F1 is the application help gesture, also while an alternate-screen TUI runs.
         if (_helpOpen) return HelpKey(vk);
         if (vk == 0x70 /* F1 */ && !ctrl && !alt && !shift)
         {
-            var helpSurf = ActiveSurface();
-            bool altScreen = helpSurf is not null && helpSurf.S.Emulator.IsAltScreen;
-            if (!altScreen) { OpenHelp(); return true; }
+            OpenHelp(); return true;
         }
 
         // Dashboard grid overlay (agterm #202): Ctrl+Shift+D toggles it; while open it owns the keyboard.
@@ -1299,7 +1303,7 @@ internal partial class Program
         // ConPTY can reconstruct it. Key-DOWN only for now (the common case apps read); WM_CHAR for
         // this pane is swallowed since the character rides in the sequence's Uc field.
         if (ActiveSurface()?.S.Emulator.Win32InputMode == true)
-        { Send(Win32KeySeq(vk, true, ctrl, shift, alt)); _win32KeysDown.Add(vk); return true; }
+        { Send(Win32KeySeq(vk, true, ctrl, shift, alt), editing: !Keymap.IsModifierKey(vk)); _win32KeysDown.Add(vk); return true; }
 
         // Kitty keyboard protocol: when an app has enabled it, encode keys in CSI-u form.
         if ((ActiveSurface()?.S.Emulator.KeyboardFlags ?? 0) != 0 && KittyKeyEncode(vk, ctrl, alt, shift) is { } ku)
@@ -1375,7 +1379,7 @@ internal partial class Program
     {
         if (!_win32KeysDown.Remove(vk)) return;
         if (ActiveSurface()?.S.Emulator.Win32InputMode == true)
-            Send(Win32KeySeq(vk, false, KeyDown(VK_CONTROL), KeyDown(VK_SHIFT), KeyDown(VK_MENU)));
+            Send(Win32KeySeq(vk, false, KeyDown(VK_CONTROL), KeyDown(VK_SHIFT), KeyDown(VK_MENU)), editing: false);
     }
 
     // Kitty keyboard: OnKeyDown encoded this key, so its following WM_CHAR must be dropped (else

--- a/src/Agwinterm.Win32/Program.Render.cs
+++ b/src/Agwinterm.Win32/Program.Render.cs
@@ -482,14 +482,13 @@ internal partial class Program
                     if (cell.Width == 0 || (startBlank && (cell.Attributes & LineMask) == 0)) { c++; continue; }
                     Color runFg = EffectiveFg(cell);
                     CellAttributes runStyle = cell.Attributes & StyleMask;
-                    // Builtin box-drawing / block elements: vector-draw for pixel-perfect borders
-                    // (unhandled codepoints in the range fall back to the font glyph, drawn solo so
-                    // the coalesced run never has to include them).
-                    if (_config.BuiltinGlyphs && cell.Rune is (>= 0x2500 and <= 0x259F) or 0x2571 or 0x2572)
+                    // Only claim the vector renderer's implemented set. Other glyphs retain the
+                    // normal font-fallback, style and clipping rules below.
+                    if (_config.BuiltinGlyphs && BuiltinBoxGlyphs.Supports(cell.Rune))
                     {
                         float bx = ox + c * cw;
                         if (!DrawBoxGlyph(rt, brush, cell.Rune, bx, y, cw, ch, C4(runFg)))
-                        { brush.Color = C4(runFg); rt.DrawText(RuneStr(cell.Rune), fmt, new Rect(bx, y, bx + cw, y + ch), brush); }
+                        { brush.Color = C4(runFg); rt.DrawText(RuneStr(cell.Rune), StyleFmt(fmt, runStyle), new Rect(bx, y, cw, ch), brush, DrawTextOptions.Clip); }
                         c++; continue;
                     }
                     if (cell.Width == 2 || cell.Rune > 0xFFFF || !GridTrue(cell.Rune))

--- a/src/Agwinterm.Win32/Program.Render.cs
+++ b/src/Agwinterm.Win32/Program.Render.cs
@@ -522,7 +522,7 @@ internal partial class Program
                     {
                         Cell cc = CellAt(r, c);
                         if (cc.Width == 2 || cc.Width == 0 || cc.Rune > 0xFFFF) break;
-                        if (_config.BuiltinGlyphs && cc.Rune is (>= 0x2500 and <= 0x259F) or 0x2571 or 0x2572) break; // vector-drawn separately
+                        if (_config.BuiltinGlyphs && BuiltinBoxGlyphs.Supports(cc.Rune)) break; // same consumed set as the outer dispatch
                         bool blank = cc.Rune == ' ' || cc.Rune == '\0';
                         if (!blank && !GridTrue(cc.Rune)) break;   // fallback glyph → its own solo draw
                         // Blanks only need matching decoration lines (bold/italic is invisible on a

--- a/src/Agwinterm.Win32/Program.WndProc.cs
+++ b/src/Agwinterm.Win32/Program.WndProc.cs
@@ -574,27 +574,16 @@ internal partial class Program
                         ChangeFontSize(HiWord(wParam) > 0 ? 1 : -1);
                         return IntPtr.Zero;
                     }
-                    var em = _session?.Emulator;
-                    if (em is not null && em.MouseReporting) // app wants the wheel (forward to the active pane)
+                    // Decide reporting versus history from the hit-tested surface, not keyboard focus.
+                    if (PaneAt(pt.x, pt.y) is { } under)
                     {
-                        if (pt.x >= (int)_sidebarW && pt.y >= (int)TitleBarH)
-                            SendMouse(HiWord(wParam) > 0 ? 64 : 65, pt.x, pt.y, deviceX, deviceY, true);
-                        return IntPtr.Zero;
-                    }
-                    // Otherwise scroll the pane under the cursor through its scrollback history.
-                    if (_cover is not null && pt.x >= (int)_sidebarW && pt.y >= (int)TitleBarH)
-                    {
-                        if (_cover.S.Emulator.IsAltScreen) return IntPtr.Zero;
-                        int hn = _cover.S.Emulator.HistoryCount;
-                        int step = Math.Clamp(_config.ScrollSpeed, 1, 10);
-                        int no = Math.Clamp(_cover.ScrollOffset + (HiWord(wParam) > 0 ? step : -step), 0, hn);
-                        if (no != _cover.ScrollOffset) { _cover.ScrollOffset = no; RequestRedraw(); }
-                        return IntPtr.Zero;
-                    }
-                    if (_active is not null && pt.x >= (int)_sidebarW && pt.y >= (int)TitleBarH &&
-                        PaneAlongAxisAt(_active, pt.x, pt.y) is { } under)   // the pane under the wheel, on either axis
-                    {
-                        var p = SurfaceOf(under.pane);   // its overlay while one is open (P5): the wheel scrolls the SURFACE under the pointer
+                        var p = under.pane;
+                        if (p.S.Emulator.MouseReporting)
+                        {
+                            SendMouseTo(p, (under.ox, under.oy, under.cw, under.ch),
+                                HiWord(wParam) > 0 ? 64 : 65, pt.x, pt.y, deviceX, deviceY, true);
+                            return IntPtr.Zero;
+                        }
                         // The alt screen shows no history: an offset accumulated here would
                         // never be rendered, and silently move where clicks land.
                         if (p.S.Emulator.IsAltScreen) return IntPtr.Zero;

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -757,7 +757,7 @@ internal partial class Program : ISessionHost, IWindowHost
         return f;
     }
 
-    // The configured family's font object, for per-codepoint coverage checks. A glyph that IS in
+    // The resolved terminal family's font object (possibly the installed fallback), for coverage checks. A glyph that IS in
     // the (monospace) family advances exactly one cell — safe to coalesce into text runs. A glyph
     // that falls back to another font (emoji, ⏺/✻ symbols, …) has arbitrary advance and MUST be
     // drawn solo, anchored to its own grid column, or runs drift and overpaint their neighbours
@@ -811,7 +811,7 @@ internal partial class Program : ISessionHost, IWindowHost
         catch { }   // no family match → every non-ASCII glyph draws solo (safe, just slower)
     }
 
-    /// <summary>Whether the configured family itself covers this codepoint (cached).</summary>
+    /// <summary>Whether the resolved terminal family itself covers this codepoint (cached).</summary>
     private static bool FontHasGlyph(int cp)
     {
         if (_glyphInFont.TryGetValue(cp, out bool has)) return has;
@@ -1265,12 +1265,21 @@ internal partial class Program : ISessionHost, IWindowHost
         _metrics.Clear();
         foreach (var f in _styledFmt.Values) { try { f.Dispose(); } catch { } }     // bold/italic variants bake in the family too
         _styledFmt.Clear();
-        MeasureCell();
-        foreach (var s in AllSessions()) RegridSession(s);
-        if (_cover is not null) RegridCover();
-        if (!_isQuickWindow && _quickHost?._cover is not null) _quickHost.RegridCover();
-        if (_fontFallbackNote is { } note) ShowToast(note, 8000);
-        RequestRedraw();
+        // Formats/metrics are process-wide; every open window must adopt their new geometry.
+        // Quick is not part of the persisted library-window index.
+        List<Program> windows;
+        lock (_windowIndex) windows = _byId.Values.ToList();
+        if (!windows.Contains(this)) windows.Add(this);
+        if (_quickHost is { } quick && !windows.Contains(quick)) windows.Add(quick);
+        foreach (var window in windows)
+        {
+            if (window._hwnd == IntPtr.Zero) continue;
+            window.MeasureCell();
+            foreach (var session in window.AllSessions()) window.RegridSession(session);
+            if (window._cover is not null) window.RegridCover();
+            if (_fontFallbackNote is { } note) window.ShowToast(note, 8000);
+            window.RequestRedraw();
+        }
     }
 
     private void MeasureCell()

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -613,6 +613,8 @@ internal partial class Program : ISessionHost, IWindowHost
         // Experimental knobs announce themselves once at startup — never a silent mystery.
         if (_emulatorCoreNote is { } note)
             front!.Post(() => front.ShowToast(note, 6000));
+        if (_fontFallbackNote is { } fontNote)
+            front!.Post(() => front.ShowToast(fontNote, 8000));
         // Server mode is experimental (#105) — say so once at startup, so a flipped knob is never
         // a silent mystery ("why is there a second agwinterm process?").
         if (_sessionBackend is ServerSessionBackend sb)
@@ -734,9 +736,16 @@ internal partial class Program : ISessionHost, IWindowHost
     private static IDWriteTextFormat CreateTextFormat(TerminalConfig cfg)
     {
         float px = (float)cfg.FontSize;
-        try { return NewFormat(cfg.FontFamily, px); }
-        catch { return NewFormat("Consolas", px); }
+        using var fonts = _dwrite.GetSystemFontCollection(false);
+        _terminalFontFamily = TerminalFontFamily.Resolve(cfg.FontFamily,
+            family => fonts.FindFamilyName(family, out _));
+        _fontFallbackNote = string.Equals(cfg.FontFamily, _terminalFontFamily, StringComparison.OrdinalIgnoreCase)
+            ? null : $"Font '{cfg.FontFamily}' is not installed; using {_terminalFontFamily}";
+        return NewFormat(_terminalFontFamily, px);
     }
+
+    private static string _terminalFontFamily = "Consolas";
+    private static string? _fontFallbackNote;
 
     private static IDWriteTextFormat NewFormat(string family, float px,
         FontWeight weight = FontWeight.Normal, FontStyle style = FontStyle.Normal)
@@ -793,7 +802,7 @@ internal partial class Program : ISessionHost, IWindowHost
         try
         {
             using var coll = _dwrite.GetSystemFontCollection(false);
-            if (coll.FindFamilyName(_config.FontFamily, out uint idx))
+            if (coll.FindFamilyName(_terminalFontFamily, out uint idx))
             {
                 using var fam = coll.GetFontFamily(idx);
                 _familyFont = fam.GetFirstMatchingFont(FontWeight.Normal, FontStretch.Normal, FontStyle.Normal);
@@ -822,8 +831,7 @@ internal partial class Program : ISessionHost, IWindowHost
         if (_styledFmt.TryGetValue((px, bold, italic), out var f)) return f;
         var weight = bold ? FontWeight.Bold : FontWeight.Normal;
         var style = italic ? FontStyle.Italic : FontStyle.Normal;
-        try { f = NewFormat(_config.FontFamily, px, weight, style); }
-        catch { f = NewFormat("Consolas", px, weight, style); }
+        f = NewFormat(_terminalFontFamily, px, weight, style);
         _styledFmt[(px, bold, italic)] = f;
         return f;
     }
@@ -1261,6 +1269,7 @@ internal partial class Program : ISessionHost, IWindowHost
         foreach (var s in AllSessions()) RegridSession(s);
         if (_cover is not null) RegridCover();
         if (!_isQuickWindow && _quickHost?._cover is not null) _quickHost.RegridCover();
+        if (_fontFallbackNote is { } note) ShowToast(note, 8000);
         RequestRedraw();
     }
 
@@ -1286,8 +1295,7 @@ internal partial class Program : ISessionHost, IWindowHost
     {
         if (_metrics.TryGetValue(px, out var m)) return m;
         IDWriteTextFormat fmt;
-        try { fmt = NewFormat(_config.FontFamily, px); }
-        catch { fmt = NewFormat("Consolas", px); }
+        fmt = NewFormat(_terminalFontFamily, px);
         using var run = _dwrite.CreateTextLayout(new string('M', 10), fmt, 4096f, 4096f);
         using var one = _dwrite.CreateTextLayout("M", fmt, 4096f, 4096f);
         float cw = run.Metrics.Width / 10f, ch = MathF.Round(one.Metrics.Height);

--- a/tests/Agwinterm.Core.Tests/BuiltinBoxGlyphTests.cs
+++ b/tests/Agwinterm.Core.Tests/BuiltinBoxGlyphTests.cs
@@ -1,0 +1,32 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace Agwinterm.Core.Tests;
+
+public class BuiltinBoxGlyphTests
+{
+    [Fact]
+    public void GateMatchesTheActualRendererSwitch()
+    {
+        var root = AppContext.BaseDirectory;
+        while (root is not null && !Directory.Exists(Path.Combine(root, "src", "Agwinterm.Win32")))
+            root = Path.GetDirectoryName(root);
+        Assert.NotNull(root);
+        var assemblyPath = Directory.GetFiles(Path.Combine(root!, "src", "Agwinterm.Win32", "bin"),
+            "Agwinterm.Win32.dll", SearchOption.AllDirectories).OrderByDescending(File.GetLastWriteTimeUtc).First();
+        var ui = Assembly.LoadFrom(assemblyPath);
+        var program = ui.GetType("Agwinterm.Win32.Program", true)!;
+        var draw = program.GetMethod("DrawBoxGlyph", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var instance = RuntimeHelpers.GetUninitializedObject(program);
+        var color = Activator.CreateInstance(draw.GetParameters()[7].ParameterType);
+        for (int cp = 0x24FF; cp <= 0x25A0; cp++)
+        {
+            // A supported arm immediately uses the brush; an unsupported arm must return false
+            // without touching graphics. Null graphics keep this a headless switch-coverage test.
+            object?[] args = { null, null, cp, 20f, 30f, 8f, 16f, color };
+            if (BuiltinBoxGlyphs.Supports(cp))
+                Assert.IsType<NullReferenceException>(Assert.Throws<TargetInvocationException>(() => draw.Invoke(instance, args)).InnerException);
+            else Assert.Equal(false, draw.Invoke(instance, args));
+        }
+    }
+}

--- a/tests/Agwinterm.Core.Tests/TerminalFontFamilyTests.cs
+++ b/tests/Agwinterm.Core.Tests/TerminalFontFamilyTests.cs
@@ -1,0 +1,35 @@
+namespace Agwinterm.Core.Tests;
+
+public class TerminalFontFamilyTests
+{
+    [Fact]
+    public void InstalledConfiguredFamilyWins()
+        => Assert.Equal("User Mono", TerminalFontFamily.Resolve("User Mono", _ => true));
+
+    [Theory]
+    [InlineData("Cascadia Mono")]
+    [InlineData("Consolas")]
+    [InlineData("Lucida Console")]
+    [InlineData("Courier New")]
+    public void MissingFamilyUsesAnActuallyInstalledMonospaceFace(string installed)
+        => Assert.Equal(installed, TerminalFontFamily.Resolve("Missing", candidate => candidate == installed));
+
+    [Fact]
+    public void FallbackPriorityIsDeterministic()
+        => Assert.Equal("Cascadia Mono", TerminalFontFamily.Resolve("Missing", candidate => candidate != "Missing"));
+
+    [Fact]
+    public void MissingFallbackFailsExplicitlyInsteadOfChoosingAnUnknownFace()
+        => Assert.Throws<InvalidOperationException>(() => TerminalFontFamily.Resolve("Missing", _ => false));
+
+    [Theory]
+    [InlineData(0x10)] [InlineData(0x11)] [InlineData(0x12)]
+    [InlineData(0x5B)] [InlineData(0x5C)]
+    [InlineData(0xA0)] [InlineData(0xA1)] [InlineData(0xA2)]
+    [InlineData(0xA3)] [InlineData(0xA4)] [InlineData(0xA5)]
+    public void ModifierEventsDoNotRepresentEditing(int vk) => Assert.True(Keymap.IsModifierKey(vk));
+
+    [Theory]
+    [InlineData(0x43)] [InlineData(0x0D)] [InlineData(0x70)]
+    public void ActualKeysRemainEditingEvents(int vk) => Assert.False(Keymap.IsModifierKey(vk));
+}

--- a/tests/integration/navigation-ui-cases.ps1
+++ b/tests/integration/navigation-ui-cases.ps1
@@ -277,6 +277,7 @@ $null=Rpc 'session.type' @{text="exit`r"} $session
 Check 'exited shell does not retain shell-name hint' (NavWait {$null-eq (Node $session).foregroundShell})
 
 $fontOriginal=Rpc 'config.get' @{key='font-family'}
+$libraryWindow=[string](@((Rpc 'window.list').windows|Where-Object open)[0].id)
 $installed=[Drawing.Text.InstalledFontCollection]::new()
 try {
     $familyNames=@($installed.Families|ForEach-Object Name)
@@ -300,7 +301,6 @@ try {
     Check 'font-rendered unsupported box glyphs cannot stall the UI' $responsive
     if(-not $responsive){throw 'Render thread stalled; stop before any unbounded screenshot call'}
     $null=NavPixels 'unsupported-box-glyphs'
-    $libraryWindow=[string](@((Rpc 'window.list').windows|Where-Object open)[0].id)
     $fontWindow=[string](Rpc 'window.new' @{name='Font geometry peer'})
     try {
         if(-not (NavWait {@((Rpc 'window.list').windows|Where-Object {$_.id-eq $fontWindow -and $_.open}).Count-eq 1})){throw 'Font peer window did not open'}
@@ -321,4 +321,4 @@ try {
         $null=Rpc 'window.close' @{} $fontWindow
         $null=Rpc 'window.select' @{} $libraryWindow
     }
-} finally {$installed.Dispose();$null=Rpc 'config.set' @{key='font-family';value=$fontOriginal}}
+} finally {$installed.Dispose();$null=Rpc 'config.set' @{key='font-family';value=$fontOriginal} -Window $libraryWindow}

--- a/tests/integration/navigation-ui-cases.ps1
+++ b/tests/integration/navigation-ui-cases.ps1
@@ -23,6 +23,47 @@ function PixelDifference($a,$b,[int]$x=0,[int]$y=0,[int]$w=0,[int]$h=0){
     }};return $different
 }
 $first=[string](CurrentWs);$beforeText=Rpc 'session.text' @{} $session
+$esc=[string][char]27
+$null=Rpc 'config.set' @{key='cursor-blink';value='false'}
+$null=Rpc 'session.write' @{text=($esc+'[?9001hMODIFIER-SELECTION-PROBE')} $session
+$null=Rpc 'selection.all' @{} $session
+$selectedBefore=Rpc 'session.copy' @{} $session
+NavKey 17
+Check 'modifier down preserves selection in Win32 input mode' ((Rpc 'session.copy' @{} $session)-ceq $selectedBefore)
+[void][HudOwnedJob]::SendMessageW($hwnd,0x101,[IntPtr]17,[IntPtr]1)
+Check 'modifier up preserves selection in Win32 input mode' ((Rpc 'session.copy' @{} $session)-ceq $selectedBefore)
+$null=Rpc 'selection.clear' @{} $session
+$null=Rpc 'session.write' @{text=($esc+'[?9001l'+$esc+'[?1049hALT-HELP-PROBE')} $session
+$helpBefore=NavPixels 'alt-help-before';NavKey 112
+$helpShown=NavPixels 'alt-help-shown'
+Check 'F1 opens app help while alternate screen is active' ((PixelDifference $helpBefore $helpShown)-gt 1000)
+NavKey 112
+$helpClosed=NavPixels 'alt-help-closed'
+Check 'F1 closes app help without forwarding it to the terminal' ((PixelDifference $helpBefore $helpClosed)-lt 250)
+$null=Rpc 'session.write' @{text=($esc+'[?1049l')} $session
+Add-Type -TypeDefinition @'
+using System; using System.Runtime.InteropServices;
+public static class NavWheel {
+    [StructLayout(LayoutKind.Sequential)] public struct POINT { public int x,y; }
+    [DllImport("user32.dll")] public static extern bool ClientToScreen(IntPtr hwnd,ref POINT point);
+}
+'@
+$null=Rpc 'sidebar' @{op='hide'}
+$wheelPane=[string](Rpc 'session.split' @{op='on';axis='vertical'} $session)
+$null=Rpc 'session.focus' @{dir='left'}
+$lines=(1..100|ForEach-Object {"WHEEL-LINE-$_"})-join "`r`n"
+$null=Rpc 'session.write' @{text=($esc+'[?1000h')} $session
+$null=Rpc 'session.write' @{text=($esc+'[?1000l'+$lines)} $wheelPane
+$wheelBefore=NavPixels 'wheel-under-pointer-before'
+$wheelPoint=[NavWheel+POINT]::new();$wheelPoint.x=[int]($wheelBefore.width*0.75);$wheelPoint.y=[int]($wheelBefore.height*0.5)
+if(-not [NavWheel]::ClientToScreen($hwnd,[ref]$wheelPoint)){throw 'Wheel coordinate conversion failed'}
+$wheelPosition=[IntPtr]([int64](($wheelPoint.y-band 0xffff)-shl 16)-bor ($wheelPoint.x-band 0xffff))
+[void][HudOwnedJob]::SendMessageW($hwnd,0x20a,[IntPtr](120-shl 16),$wheelPosition)
+$wheelAfter=NavPixels 'wheel-under-pointer-after'
+Check 'wheel scrolls unfocused history while focused sibling reports mouse' ((PixelDifference $wheelBefore $wheelAfter ([int]($wheelBefore.width*0.55)) 80 ([int]($wheelBefore.width*0.4)) ([int]($wheelBefore.height*0.65)))-gt 100)
+$null=Rpc 'session.write' @{text=($esc+'[?1000l')} $session
+$null=Rpc 'session.split.close' @{} $wheelPane
+$null=Rpc 'sidebar' @{op='show'}
 Check 'readonly rejects an unknown operation without changing protection' (-not (Rpc 'session.readonly' @{op='typo'} $session -AllowError).ok -and (Rpc 'session.readonly' @{op='state'} $session)-eq 'off')
 $null=Rpc 'session.readonly' @{op='on'} $session
 Check 'readonly typo cannot remove existing protection' (-not (Rpc 'session.readonly' @{op='typo'} $session -AllowError).ok -and (Rpc 'session.readonly' @{op='get'} $session)-eq 'on')
@@ -191,3 +232,17 @@ Check 'renaming hovered row invalidates tooltip without a move' ((PixelDifferenc
 $null=Rpc 'sidebar' @{op='mode:tree'}
 $null=Rpc 'session.type' @{text="exit`r"} $session
 Check 'exited shell does not retain shell-name hint' (NavWait {$null-eq (Node $session).foregroundShell})
+
+$fontOriginal=Rpc 'config.get' @{key='font-family'}
+$installed=[Drawing.Text.InstalledFontCollection]::new()
+try {
+    $familyNames=@($installed.Families|ForEach-Object Name)
+    $fallback=@('Cascadia Mono','Consolas','Lucida Console','Courier New'|Where-Object {$_-in $familyNames})[0]
+    if(-not $fallback){throw 'No expected monospace face on integration runner'}
+    $null=Rpc 'config.set' @{key='font-family';value=$fallback}
+    $fallbackMetrics=Rpc 'session.metrics' @{} $session|ConvertTo-Json -Compress
+    $missing='Agwinterm-Missing-'+[guid]::NewGuid().ToString('N')
+    $null=Rpc 'config.set' @{key='font-family';value=$missing}
+    Check 'missing font uses the installed monospace fallback metrics' ((Rpc 'session.metrics' @{} $session|ConvertTo-Json -Compress)-eq $fallbackMetrics)
+    Check 'font fallback preserves the requested preference' ((Rpc 'config.get' @{key='font-family'})-eq $missing)
+} finally {$installed.Dispose();$null=Rpc 'config.set' @{key='font-family';value=$fontOriginal}}

--- a/tests/integration/navigation-ui-cases.ps1
+++ b/tests/integration/navigation-ui-cases.ps1
@@ -46,6 +46,8 @@ using System; using System.Runtime.InteropServices;
 public static class NavWheel {
     [StructLayout(LayoutKind.Sequential)] public struct POINT { public int x,y; }
     [DllImport("user32.dll")] public static extern bool ClientToScreen(IntPtr hwnd,ref POINT point);
+    [DllImport("user32.dll",SetLastError=true)] static extern IntPtr SendMessageTimeoutW(IntPtr h,uint m,IntPtr w,IntPtr l,uint flags,uint timeout,out IntPtr result);
+    public static bool Responsive(IntPtr h) { IntPtr result;return SendMessageTimeoutW(h,0,IntPtr.Zero,IntPtr.Zero,3,2000,out result)!=IntPtr.Zero; }
 }
 '@
 $null=Rpc 'sidebar' @{op='hide'}
@@ -62,6 +64,31 @@ $wheelPosition=[IntPtr]([int64](($wheelPoint.y-band 0xffff)-shl 16)-bor ($wheelP
 $wheelAfter=NavPixels 'wheel-under-pointer-after'
 Check 'wheel scrolls unfocused history while focused sibling reports mouse' ((PixelDifference $wheelBefore $wheelAfter ([int]($wheelBefore.width*0.55)) 80 ([int]($wheelBefore.width*0.4)) ([int]($wheelBefore.height*0.65)))-gt 100)
 $null=Rpc 'session.write' @{text=($esc+'[?1000l')} $session
+$wheelReady=Join-Path $artifact 'wheel-reader-ready';$wheelBytes=Join-Path $artifact 'wheel-reader-bytes'
+$wheelScript=@'
+Add-Type -TypeDefinition 'using System; using System.Runtime.InteropServices; public static class RawWheel { [DllImport("kernel32.dll")] public static extern IntPtr GetStdHandle(int n); [DllImport("kernel32.dll")] public static extern bool GetConsoleMode(IntPtr h,out uint m); [DllImport("kernel32.dll")] public static extern bool SetConsoleMode(IntPtr h,uint m); }'
+$inputHandle=[RawWheel]::GetStdHandle(-10);[uint32]$oldMode=0
+if(-not [RawWheel]::GetConsoleMode($inputHandle,[ref]$oldMode)){throw 'GetConsoleMode'}
+if(-not [RawWheel]::SetConsoleMode($inputHandle,($oldMode-band (-bnot 6))-bor 512)){throw 'SetConsoleMode'}
+try {
+    $inputStream=[Console]::OpenStandardInput();$bytes=[Collections.Generic.List[byte]]::new();$one=[byte[]]::new(1)
+    [IO.File]::WriteAllText('__READY__','ready')
+    while($bytes.Count-lt 256 -and $inputStream.Read($one,0,1)-eq 1){$bytes.Add($one[0]);if($one[0]-eq 77){break}}
+    [IO.File]::WriteAllText('__BYTES__',[Text.Encoding]::ASCII.GetString($bytes.ToArray()))
+    Start-Sleep 600
+} finally {[void][RawWheel]::SetConsoleMode($inputHandle,$oldMode)}
+'@
+$wheelScript=$wheelScript.Replace('__READY__',$wheelReady.Replace("'","''")).Replace('__BYTES__',$wheelBytes.Replace("'","''"))
+$wheelEncoded=[Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($wheelScript))
+$null=Rpc 'session.type' @{text="powershell.exe -NoLogo -NoProfile -EncodedCommand $wheelEncoded`r"} $wheelPane
+for($i=0;$i-lt 300 -and -not (Test-Path $wheelReady);$i++){Start-Sleep -Milliseconds 100}
+if(-not (Test-Path $wheelReady)){throw 'Owned raw-input mouse reader was not ready'}
+$null=Rpc 'session.write' @{text=($esc+'[?1000h'+$esc+'[?1006h'+$lines)} $wheelPane
+$reportBefore=NavPixels 'wheel-report-before'
+[void][HudOwnedJob]::SendMessageW($hwnd,0x20a,[IntPtr](120-shl 16),$wheelPosition)
+Check 'wheel report reaches the unfocused raw-input reader' (NavWait {(Test-Path $wheelBytes) -and (Get-Content $wheelBytes -Raw)-match '^\x1b\[<64;[0-9]+;[0-9]+M$'})
+$reportAfter=NavPixels 'wheel-report-after'
+Check 'reported wheel leaves the hovered history viewport unchanged' ((PixelDifference $reportBefore $reportAfter ([int]($reportBefore.width*0.55)) 80 ([int]($reportBefore.width*0.4)) ([int]($reportBefore.height*0.65)))-lt 100)
 $null=Rpc 'session.split.close' @{} $wheelPane
 $null=Rpc 'sidebar' @{op='show'}
 Check 'readonly rejects an unknown operation without changing protection' (-not (Rpc 'session.readonly' @{op='typo'} $session -AllowError).ok -and (Rpc 'session.readonly' @{op='state'} $session)-eq 'off')
@@ -240,9 +267,42 @@ try {
     $fallback=@('Cascadia Mono','Consolas','Lucida Console','Courier New'|Where-Object {$_-in $familyNames})[0]
     if(-not $fallback){throw 'No expected monospace face on integration runner'}
     $null=Rpc 'config.set' @{key='font-family';value=$fallback}
+    $null=Rpc 'session.write' @{text=($esc+'[2J'+$esc+'[H'+$esc+'[1mBOLD FALLBACK 0123456789'+$esc+'[0m'+"`r`n"+$esc+'[3mITALIC FALLBACK 0123456789'+$esc+'[0m')} $session
+    $styledExpected=NavPixels 'fallback-styled-expected'
     $fallbackMetrics=Rpc 'session.metrics' @{} $session|ConvertTo-Json -Compress
     $missing='Agwinterm-Missing-'+[guid]::NewGuid().ToString('N')
     $null=Rpc 'config.set' @{key='font-family';value=$missing}
     Check 'missing font uses the installed monospace fallback metrics' ((Rpc 'session.metrics' @{} $session|ConvertTo-Json -Compress)-eq $fallbackMetrics)
     Check 'font fallback preserves the requested preference' ((Rpc 'config.get' @{key='font-family'})-eq $missing)
+    $styledActual=NavPixels 'fallback-styled-missing'
+    Check 'missing font uses the same bold and italic glyphs' ((PixelDifference $styledExpected $styledActual 0 40 $styledExpected.width 120)-lt 100)
+    # Consolas covers double-line corners; these must enter the text run, not stall it.
+    $null=Rpc 'config.set' @{key='font-family';value='Consolas'}
+    $null=Rpc 'session.write' @{text=($esc+'[2J'+$esc+'[H'+[string][char]0x2554+[string][char]0x2557+[string][char]0x255A+[string][char]0x255D)} $session
+    Start-Sleep -Milliseconds 200
+    $responsive=[NavWheel]::Responsive($hwnd)
+    Check 'font-rendered unsupported box glyphs cannot stall the UI' $responsive
+    if(-not $responsive){throw 'Render thread stalled; stop before any unbounded screenshot call'}
+    $null=NavPixels 'unsupported-box-glyphs'
+    $libraryWindow=[string](@((Rpc 'window.list').windows|Where-Object open)[0].id)
+    $fontWindow=[string](Rpc 'window.new' @{name='Font geometry peer'})
+    try {
+        if(-not (NavWait {@((Rpc 'window.list').windows|Where-Object {$_.id-eq $fontWindow -and $_.open}).Count-eq 1})){throw 'Font peer window did not open'}
+        $null=Rpc 'config.set' @{key='font-family';value='Courier New'} -Window $libraryWindow
+        $sharedMetrics=Rpc 'session.metrics' -Window $fontWindow|ConvertTo-Json -Compress
+        $null=Rpc 'font' @{op='reset'} -Window $fontWindow
+        $null=Rpc 'config.set' @{key='cursor-blink';value='false'} -Window $fontWindow # FIFO UI barrier behind font reset
+        Check 'shared font change already regrids another library window' (NavWait {(Rpc 'session.metrics' -Window $fontWindow|ConvertTo-Json -Compress)-eq $sharedMetrics})
+        # Verify again after another family change, and include the singleton quick surface.
+        $null=Rpc 'quick' @{op='on'} -Window $libraryWindow
+        $null=Rpc 'config.set' @{key='font-family';value='Consolas'} -Window $libraryWindow
+        $quickMetrics=Rpc 'session.metrics' -Window quick|ConvertTo-Json -Compress
+        $null=Rpc 'font' @{op='reset'} -Window quick
+        $null=Rpc 'config.set' @{key='cursor-blink';value='false'} -Window quick
+        Check 'shared font change already regrids quick' (NavWait {(Rpc 'session.metrics' -Window quick|ConvertTo-Json -Compress)-eq $quickMetrics})
+        $null=Rpc 'quick' @{op='off'} -Window $libraryWindow
+    } finally {
+        $null=Rpc 'window.close' @{} $fontWindow
+        $null=Rpc 'window.select' @{} $libraryWindow
+    }
 } finally {$installed.Dispose();$null=Rpc 'config.set' @{key='font-family';value=$fontOriginal}}

--- a/tests/integration/quick-ui-cases.ps1
+++ b/tests/integration/quick-ui-cases.ps1
@@ -70,7 +70,16 @@ $sink=Join-Path $artifact 'quick-survived.txt'
 $null=Rpc 'session.type' @{text="echo %P14_KEEP%>`"$sink`"`r"} -Window quick
 for($i=0;$i-lt 50 -and -not (Test-Path $sink);$i++){Start-Sleep -Milliseconds 100}
 Check 'same shell and environment survive hide/show' ((Test-Path $sink) -and (Get-Content $sink -Raw).Trim()-eq 'alive')
-Check 'explicit quick prefix routes readback from library window' ((Rpc 'session.text' @{} 'quick:')-ceq (Rpc 'session.text' -Window quick))
+# Two sequential snapshots can straddle the shell's next prompt. Prove routing with a completed
+# output line in each surface instead of requiring an asynchronously changing screen to be equal.
+$null=Rpc 'session.type' @{text="echo P14-ROUTE-CHECK`r"} -Window quick
+$routed=$false
+for($i=0;$i-lt 50;$i++){
+    $explicit=[string](Rpc 'session.text' @{} 'quick:');$implicit=[string](Rpc 'session.text' -Window quick)
+    if($explicit-match '(?m)^P14-ROUTE-CHECK\s*$' -and $implicit-match '(?m)^P14-ROUTE-CHECK\s*$'){$routed=$true;break}
+    Start-Sleep -Milliseconds 100
+}
+Check 'explicit quick prefix routes readback from library window' $routed
 $beforeFont=Rpc 'session.metrics' -Window quick
 $null=Rpc 'font' @{op='inc'} -Window quick
 $afterFont=Rpc 'session.metrics' -Window quick


### PR DESCRIPTION
UI stabilization batch, built on PR #273. Fixes #189, fixes #196, fixes #198, fixes #208, fixes #251. Modifier/key-up protocol events preserve selection; F1 always opens application help; wheel routing uses the hit-tested pane and its metrics; missing font families resolve to an installed monospace face with a visible notice while preserving the requested preference; builtin glyph gate matches the actual implemented switch and fallback uses correct styled/clipped bounds. Release build and 30 selected Core tests pass; expanded guarded navigation cases cover modifier/alt-help/wheel/font behavior. Independent Codex-only review and full exact-head CI pending; draft until gates pass and parent273 merges. No release/tag/install.