### PR TITLE
Separate known input closure from final host output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
         # hard merge gate.
         run: cargo build --release --manifest-path native/Cargo.toml
 
+      - name: Host resize transaction regressions (no child processes)
+        run: cargo test --manifest-path native/agwinterm-ptyhost/Cargo.toml resize::tests
+
       # The control API is a cross-product contract now: agliteterm ships from its own repository
       # promising to speak this dialect, and its CI runs THIS spec against its own client. Running
       # it here too is what makes "same control API" a gate rather than a claim — a verb reshaped

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,11 +129,13 @@ jobs:
         run: |
           function Invoke-Tests {
             if (Test-Path out.txt) { Remove-Item out.txt, err.txt -ErrorAction SilentlyContinue }
-            $p = Start-Process dotnet -ArgumentList 'test','Agwinterm.slnx','-c','Release','--no-build' `
+            $p = Start-Process dotnet -ArgumentList 'test','Agwinterm.slnx','-c','Release','--no-build','--logger','"console;verbosity=normal"' `
                  -NoNewWindow -PassThru -RedirectStandardOutput out.txt -RedirectStandardError err.txt
             if (-not $p.WaitForExit(360000)) {   # 6 min: the suite is ~30s, so this only trips on a deadlock
               try { $p.Kill($true) } catch {}
-              Write-Host '::warning::test run HUNG (issue #118 deadlock variant) - killed'
+              [void]$p.WaitForExit(10000)
+              Get-Content out.txt, err.txt -Raw -ErrorAction SilentlyContinue | Write-Host
+              Write-Host '::warning::test run exceeded six minutes; killed. Logs above distinguish test progress from a runner hang; #118 is a known possibility, not a diagnosis.'
               return 'retry'
             }
             $out = (Get-Content out.txt, err.txt -Raw -ErrorAction SilentlyContinue) -join "`n"

--- a/docs/plans/2026-09-10-host-input-lifecycle.md
+++ b/docs/plans/2026-09-10-host-input-lifecycle.md
@@ -16,11 +16,13 @@ application-level output/receipt marker and must not blindly retry a possibly pa
 No protobuf version or cross-product ABI changes are needed for this contract.
 
 The #258 exit-ordering test uses two private events: output begins after sink attachment; exit is
-released only after the replica sees the marker. It checks the grid captured by the exit handler.
+released only after the replica sees a readiness marker. The child then prints a second marker and
+immediately exits; that second marker must be in the grid captured by the exit handler.
 The color-reattach test already has the corresponding output-start gate. These are controlled
 ordering tests, not guarantees of lossless output from a process that finishes before first attach,
 or of unbounded ConPTY draining beyond the existing bounded settle window.
 
-Isolated tests exercise early input closure, hosted disconnect without a child-exit claim, rejected
-input while final output remains live, and cancellation. Real host/child scenarios remain in the
+Isolated tests exercise early input-closed states, broadcast failure isolation, actual pane-host
+query replies followed by output, and cancellation of an already-pending read. A real hosted
+supersede test checks EOF without a child-exit claim. Real host/child scenarios remain in the
 isolated Windows CI gate; local execution requires the canonical shared suite token.

--- a/docs/plans/2026-09-10-host-input-lifecycle.md
+++ b/docs/plans/2026-09-10-host-input-lifecycle.md
@@ -1,0 +1,26 @@
+# Host input and output lifecycle (#258, #268)
+
+The input and output halves have different terminal conditions. `InputClosed` means this backend
+knows it can no longer accept input; `HasExited` and `Exited` retain their output-settled meaning.
+In-process child death closes input before the settle window. Hosted clients close input at EOF,
+local detach/disposal or a synchronous write failure, even if the host still reports a living child.
+The host keeps the duplex output channel alive after an input failure until output settlement or
+transport disconnection. A late terminal query cannot abort the output pump by trying to reply to
+already closed input.
+
+The API deliberately keeps its existing unacknowledged input transport. `pasted`, `typed`, and a
+successful send-command reply mean the local transport accepted the write without a synchronous
+error, not that the child read it or executed a command. Neither a host acknowledgment nor a PID
+probe could establish application execution. Automation needing that proof must use an
+application-level output/receipt marker and must not blindly retry a possibly partial write.
+No protobuf version or cross-product ABI changes are needed for this contract.
+
+The #258 exit-ordering test uses two private events: output begins after sink attachment; exit is
+released only after the replica sees the marker. It checks the grid captured by the exit handler.
+The color-reattach test already has the corresponding output-start gate. These are controlled
+ordering tests, not guarantees of lossless output from a process that finishes before first attach,
+or of unbounded ConPTY draining beyond the existing bounded settle window.
+
+Isolated tests exercise early input closure, hosted disconnect without a child-exit claim, rejected
+input while final output remains live, and cancellation. Real host/child scenarios remain in the
+isolated Windows CI gate; local execution requires the canonical shared suite token.

--- a/native/agwinterm-ptyhost/src/main.rs
+++ b/native/agwinterm-ptyhost/src/main.rs
@@ -35,6 +35,7 @@ struct Hosted {
     pty: Mutex<ConPty>,
     term: Mutex<Terminal>,
     data: Mutex<Option<Arc<OvStream>>>,
+    resize: Mutex<()>, // real resize and the complete repaint jiggle share one transaction
     exited: AtomicBool,
     /// Bytes the pump has fed so far; the exit watcher's settle window reads it (#246).
     pump_bytes: AtomicU64,
@@ -173,6 +174,7 @@ fn dispatch(host: &Arc<Host>, req: Request) -> Reply {
             if r.cols == 0 || r.rows == 0 {
                 return err_reply("resize needs cols/rows");
             }
+            let _resize = h.resize.lock().unwrap();
             h.term
                 .lock()
                 .unwrap()
@@ -304,6 +306,7 @@ fn handle_create(host: &Arc<Host>, c: proto::Create) -> Reply {
         term: Mutex::new(Terminal::new(cols as usize, rows as usize)),
         pty: Mutex::new(pty),
         data: Mutex::new(None),
+        resize: Mutex::new(()),
         exited: AtomicBool::new(false),
         pump_bytes: AtomicU64::new(0),
         pump_in_flight: AtomicBool::new(false),
@@ -398,6 +401,7 @@ fn handle_attach(host: &Arc<Host>, a: proto::Attach) -> Reply {
             return;
         }
         if repaint {
+            let _resize = h2.resize.lock().unwrap();
             let (c, r) = h2.pty.lock().unwrap().size();
             h2.term
                 .lock()

--- a/native/agwinterm-ptyhost/src/main.rs
+++ b/native/agwinterm-ptyhost/src/main.rs
@@ -257,8 +257,9 @@ fn handle_create(host: &Arc<Host>, c: proto::Create) -> Reply {
     if c.de_elevate {
         return err_reply("spawn failed: de-elevate unsupported by rust host");
     }
-    let cols = c.cols.clamp(1, 10000) as i64;
-    let rows = c.rows.clamp(1, 10000) as i64;
+    let Some((cols, rows)) = resize::create_dimensions(c.cols, c.rows) else {
+        return err_reply("create cols/rows must not exceed 10000");
+    };
     {
         let sessions = host.sessions.lock().unwrap();
         if sessions.contains_key(&c.id) {

--- a/native/agwinterm-ptyhost/src/main.rs
+++ b/native/agwinterm-ptyhost/src/main.rs
@@ -13,6 +13,7 @@ mod freshenv;
 mod persist;
 mod pipes;
 mod proto;
+mod resize;
 
 use std::collections::HashMap;
 use std::fs::File;
@@ -171,16 +172,17 @@ fn dispatch(host: &Arc<Host>, req: Request) -> Reply {
             ok_reply(None)
         }),
         Some(request::Cmd::Resize(r)) => with_session(host, &r.id, |h| {
-            if r.cols == 0 || r.rows == 0 {
-                return err_reply("resize needs cols/rows");
+            if !resize::valid(r.cols, r.rows) {
+                return err_reply("resize cols/rows must be in 1..10000");
             }
-            let _resize = h.resize.lock().unwrap();
+            resize::transaction(&h.resize, || {
             h.term
                 .lock()
                 .unwrap()
                 .emu
                 .resize(r.cols as usize, r.rows as usize);
             h.pty.lock().unwrap().resize(r.cols as i16, r.rows as i16);
+            });
             ok_reply(None)
         }),
         Some(request::Cmd::Kill(k)) => match host.sessions.lock().unwrap().remove(&k.id) {
@@ -401,7 +403,7 @@ fn handle_attach(host: &Arc<Host>, a: proto::Attach) -> Reply {
             return;
         }
         if repaint {
-            let _resize = h2.resize.lock().unwrap();
+            resize::transaction(&h2.resize, || {
             let (c, r) = h2.pty.lock().unwrap().size();
             h2.term
                 .lock()
@@ -412,6 +414,7 @@ fn handle_attach(host: &Arc<Host>, a: proto::Attach) -> Reply {
             std::thread::sleep(std::time::Duration::from_millis(60));
             h2.term.lock().unwrap().emu.resize(c as usize, r as usize);
             h2.pty.lock().unwrap().resize(c, r);
+            });
         }
         let mut buf = [0u8; 16 * 1024];
         loop {

--- a/native/agwinterm-ptyhost/src/main.rs
+++ b/native/agwinterm-ptyhost/src/main.rs
@@ -38,6 +38,7 @@ struct Hosted {
     data: Mutex<Option<Arc<OvStream>>>,
     resize: Mutex<()>, // real resize and the complete repaint jiggle share one transaction
     exited: AtomicBool,
+    input_closed: AtomicBool, // observed child death/write failure, before output settlement
     /// Bytes the pump has fed so far; the exit watcher's settle window reads it (#246).
     pump_bytes: AtomicU64,
     /// True while a chunk is read but not yet fed + forwarded (the feed can block on `term`).
@@ -310,6 +311,7 @@ fn handle_create(host: &Arc<Host>, c: proto::Create) -> Reply {
         data: Mutex::new(None),
         resize: Mutex::new(()),
         exited: AtomicBool::new(false),
+        input_closed: AtomicBool::new(false),
         pump_bytes: AtomicU64::new(0),
         pump_in_flight: AtomicBool::new(false),
         exit_code: AtomicI32::new(0),
@@ -350,6 +352,7 @@ fn handle_create(host: &Arc<Host>, c: proto::Create) -> Reply {
     let child_h = hosted2.pty.lock().unwrap().child as usize;
     std::thread::spawn(move || {
         let code = conpty::wait_child(child_h);
+        hosted2.input_closed.store(true, Ordering::SeqCst);
         // The child is gone, but what it wrote last may still be in flight: conhost flushes the
         // pseudoconsole's output after the process exits and the pipe never hits EOF, so "exited"
         // is not "complete". Wait until one 50 ms window passes with no new bytes from the pump,
@@ -422,8 +425,9 @@ fn handle_attach(host: &Arc<Host>, a: proto::Attach) -> Reply {
             if n == 0 {
                 break;
             }
-            if !h2.pty.lock().unwrap().write_input(&buf[..n]) {
-                break;
+            if !h2.input_closed.load(Ordering::SeqCst) && !h2.pty.lock().unwrap().write_input(&buf[..n]) {
+                // Keep the output channel until the exit watcher drains it and detaches.
+                h2.input_closed.store(true, Ordering::SeqCst);
             }
         }
         let mut data = h2.data.lock().unwrap();

--- a/native/agwinterm-ptyhost/src/resize.rs
+++ b/native/agwinterm-ptyhost/src/resize.rs
@@ -1,0 +1,59 @@
+use std::sync::Mutex;
+
+pub fn valid(cols: u32, rows: u32) -> bool {
+    (1..=10000).contains(&cols) && (1..=10000).contains(&rows)
+}
+
+// Keep the complete repaint (including its pause) in the same transaction as a real resize.
+pub fn transaction<T>(gate: &Mutex<()>, action: impl FnOnce() -> T) -> T {
+    let _held = gate.lock().unwrap();
+    action()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, mpsc};
+    #[test]
+    fn real_resize_waits_for_repaint_restore() {
+        let gate = Arc::new(Mutex::new(()));
+        let size = Arc::new(Mutex::new((100, 24)));
+        let (jiggled_tx, jiggled_rx) = mpsc::channel();
+        let (restore_tx, restore_rx) = mpsc::channel();
+        let (attempt_tx, attempt_rx) = mpsc::channel();
+        let (done_tx, done_rx) = mpsc::channel();
+        let repaint = {
+            let gate = gate.clone(); let size = size.clone();
+            std::thread::spawn(move || transaction(&gate, || {
+                let original = *size.lock().unwrap();
+                *size.lock().unwrap() = (100, 23);
+                jiggled_tx.send(()).unwrap();
+                restore_rx.recv().unwrap();
+                *size.lock().unwrap() = original;
+            }))
+        };
+        jiggled_rx.recv().unwrap();
+        // Directly prove that the shared gate stays held during the controlled repaint pause.
+        let locked_during_pause = gate.try_lock().is_err();
+        let real = {
+            let gate = gate.clone(); let size = size.clone();
+            std::thread::spawn(move || {
+                attempt_tx.send(()).unwrap();
+                transaction(&gate, || { *size.lock().unwrap() = (132, 40); });
+                done_tx.send(()).unwrap();
+            })
+        };
+        attempt_rx.recv().unwrap();
+        restore_tx.send(()).unwrap();
+        repaint.join().unwrap(); real.join().unwrap(); done_rx.recv().unwrap();
+        assert!(locked_during_pause);
+        assert_eq!(*size.lock().unwrap(), (132, 40));
+    }
+    #[test]
+    fn dimensions_are_bounded_before_allocation() {
+        for (c, r) in [(0,24),(80,0),(10001,24),(80,10001),(u32::MAX,24)] {
+            assert!(!valid(c,r));
+        }
+        assert!(valid(1,1)); assert!(valid(10000,10000));
+    }
+}

--- a/native/agwinterm-ptyhost/src/resize.rs
+++ b/native/agwinterm-ptyhost/src/resize.rs
@@ -4,6 +4,12 @@ pub fn valid(cols: u32, rows: u32) -> bool {
     (1..=10000).contains(&cols) && (1..=10000).contains(&rows)
 }
 
+pub fn create_dimensions(cols: u32, rows: u32) -> Option<(i64, i64)> {
+    if cols > 10000 || rows > 10000 { return None; }
+    Some((if cols == 0 { 120 } else { cols } as i64,
+          if rows == 0 { 30 } else { rows } as i64))
+}
+
 // Keep the complete repaint (including its pause) in the same transaction as a real resize.
 pub fn transaction<T>(gate: &Mutex<()>, action: impl FnOnce() -> T) -> T {
     let _held = gate.lock().unwrap();
@@ -55,5 +61,11 @@ mod tests {
             assert!(!valid(c,r));
         }
         assert!(valid(1,1)); assert!(valid(10000,10000));
+        assert_eq!(create_dimensions(0,0),Some((120,30)));
+        assert_eq!(create_dimensions(0,24),Some((120,24)));
+        assert_eq!(create_dimensions(80,0),Some((80,30)));
+        assert_eq!(create_dimensions(10001,24),None);
+        assert_eq!(create_dimensions(80,10001),None);
+        assert_eq!(create_dimensions(u32::MAX,u32::MAX),None);
     }
 }

--- a/src/Agwinterm.Core/DecodeMailbox.cs
+++ b/src/Agwinterm.Core/DecodeMailbox.cs
@@ -1,0 +1,54 @@
+namespace Agwinterm.Core;
+
+/// <summary>Bound decoded results to current owners. Invalidation drops an already published
+/// payload and prevents an in-flight worker from publishing into a replaced owner's slot.</summary>
+public sealed class DecodeMailbox<TKey, TValue> where TKey : notnull
+{
+    public sealed class Ticket
+    {
+        internal bool Ready;
+        internal TValue? Value;
+    }
+    private readonly Dictionary<TKey, Ticket> _pending = new();
+    public Ticket? Begin(TKey key)
+    {
+        lock (_pending)
+        {
+            if (_pending.ContainsKey(key)) return null;
+            var ticket = new Ticket(); _pending.Add(key, ticket); return ticket;
+        }
+    }
+    public bool Complete(TKey key, Ticket ticket, TValue value)
+    {
+        lock (_pending)
+        {
+            if (!_pending.TryGetValue(key, out var current) || !ReferenceEquals(current, ticket)) return false;
+            ticket.Value = value; ticket.Ready = true; return true;
+        }
+    }
+    public List<(TKey Key, TValue Value)> Drain()
+    {
+        lock (_pending)
+        {
+            var results = new List<(TKey, TValue)>();
+            foreach (var pair in _pending.Where(p => p.Value.Ready).ToArray())
+            {
+                results.Add((pair.Key, pair.Value.Value!));
+                pair.Value.Value = default; _pending.Remove(pair.Key);
+            }
+            return results;
+        }
+    }
+    public void Invalidate(TKey key)
+    {
+        lock (_pending) if (_pending.Remove(key, out var ticket)) ticket.Value = default;
+    }
+    public void Clear()
+    {
+        lock (_pending)
+        {
+            foreach (var ticket in _pending.Values) ticket.Value = default;
+            _pending.Clear();
+        }
+    }
+}

--- a/src/Agwinterm.Pty/AgentSkill.cs
+++ b/src/Agwinterm.Pty/AgentSkill.cs
@@ -169,6 +169,10 @@ public static class AgentSkill
         - `agwintermctl session search --next|--prev|--close`    — step matches / close the find bar
 
         ## Selection & clipboard
+
+        A paste can also refuse with `the pane's input is closed` before clipboard access: no bytes
+        were sent by that request, and this does not assert that the child exited. A send-command
+        failure during broadcast may follow delivery to other panes; never retry it blindly.
         - `agwintermctl selection all [--target <id>]`           — select the whole buffer (scrollback + live grid)
         - `agwintermctl selection copy [--target <id>]`          — copy the current selection to the Windows clipboard
         - `agwintermctl selection clear [--target <id>]`         — clear the selection

--- a/src/Agwinterm.Pty/HostInputPump.cs
+++ b/src/Agwinterm.Pty/HostInputPump.cs
@@ -1,0 +1,21 @@
+namespace Agwinterm.Pty;
+
+internal static class HostInputPump
+{
+    // The output half of this duplex channel must survive a child-input failure until the exit
+    // watcher settles the output and cancels the channel. Closing here would truncate final output.
+    internal static async Task CopyAsync(Stream channel, Action<byte[], int> write, CancellationToken cancellation)
+    {
+        var buffer = new byte[16 * 1024];
+        bool inputClosed = false;
+        while (true)
+        {
+            int n = await channel.ReadAsync(buffer, cancellation).ConfigureAwait(false);
+            if (n <= 0) return;
+            if (inputClosed) continue;
+            try { write(buffer, n); }
+            catch (Exception ex) when (ex is IOException or ObjectDisposedException or InvalidOperationException)
+            { inputClosed = true; }
+        }
+    }
+}

--- a/src/Agwinterm.Pty/ISession.cs
+++ b/src/Agwinterm.Pty/ISession.cs
@@ -60,6 +60,10 @@ public interface ISession : IDisposable
     void Attach(SafeFileHandle conOut, SafeFileHandle conIn, SafeFileHandle signal, IntPtr clientProcess, int pid);
     int? ExitCode { get; }
     bool HasExited { get; }
+    /// <summary>Input is known unavailable, independently of final-output settlement. A false
+    /// value is not a child-liveness guarantee: hosted transports learn disconnect asynchronously.
+    /// A successful Write means transport acceptance, never application consumption/execution.</summary>
+    bool InputClosed => HasExited;
     /// <summary>Raised (background thread) when the child process exits, with its exit code — after
     /// the output it wrote last has settled into the emulator, so a handler that reads the grid reads
     /// a complete one (#246; see <see cref="TerminalSession"/>'s settle window). Not raised for a

--- a/src/Agwinterm.Pty/PtyHostClient.cs
+++ b/src/Agwinterm.Pty/PtyHostClient.cs
@@ -67,6 +67,8 @@ public sealed class PtyHostClient : IDisposable
         string? cwd = null, IReadOnlyDictionary<string, string>? env = null, bool verbatim = false, bool deElevate = false,
         bool freshEnv = true)
     {
+        if (cols < 0 || rows < 0 || cols > 10000 || rows > 10000)
+            throw new ArgumentOutOfRangeException(nameof(cols), "create cols/rows must be in 0..10000 (zero selects defaults)");
         var create = new Create
         {
             Id = id,

--- a/src/Agwinterm.Pty/PtyHostClient.cs
+++ b/src/Agwinterm.Pty/PtyHostClient.cs
@@ -106,7 +106,11 @@ public sealed class PtyHostClient : IDisposable
     }
 
     public void Resize(string id, int cols, int rows)
-        => Request(new Request { Resize = new Resize { Id = id, Cols = (uint)cols, Rows = (uint)rows } });
+    {
+        if (!PtyResizeTransaction.Valid(unchecked((uint)cols), unchecked((uint)rows)))
+            throw new ArgumentOutOfRangeException(nameof(cols), "resize cols/rows must be in 1..10000");
+        Request(new Request { Resize = new Resize { Id = id, Cols = (uint)cols, Rows = (uint)rows } });
+    }
 
     public void Detach(string id)
         => Request(new Request { Detach = new SessionRef { Id = id } });

--- a/src/Agwinterm.Pty/PtyHostServer.cs
+++ b/src/Agwinterm.Pty/PtyHostServer.cs
@@ -258,15 +258,9 @@ public sealed class PtyHostServer : IDisposable
     /// (issue #118).</summary>
     private static async Task PumpInputAsync(Hosted hosted, DataChannel ch)
     {
-        var buf = new byte[16 * 1024];
         try
         {
-            while (true)
-            {
-                int n = await ch.Pipe.ReadAsync(buf, ch.Cancel.Token).ConfigureAwait(false);
-                if (n <= 0) break;
-                try { hosted.S.Write(buf.AsSpan(0, n)); } catch { break; }   // child gone
-            }
+            await HostInputPump.CopyAsync(ch.Pipe, (bytes, length) => hosted.S.Write(bytes.AsSpan(0, length)), ch.Cancel.Token).ConfigureAwait(false);
         }
         catch (OperationCanceledException) { }
         catch (IOException) { }

--- a/src/Agwinterm.Pty/PtyHostServer.cs
+++ b/src/Agwinterm.Pty/PtyHostServer.cs
@@ -39,7 +39,7 @@ public sealed class PtyHostServer : IDisposable
         public required string Id;
         public required TerminalSession S;
         public readonly object DataLock = new();                 // guards Data + writes to it
-        public readonly object ResizeLock = new();               // serializes real resize with repaint jiggle
+        public readonly PtyResizeTransaction Resize = new();     // real resize and the complete repaint jiggle
         public DataChannel? Data;                                // the currently-attached client
     }
 
@@ -150,6 +150,7 @@ public sealed class PtyHostServer : IDisposable
 
     private Reply HandleCreate(Create c)
     {
+        if (c.Cols > 10000 || c.Rows > 10000) return Err("create cols/rows must not exceed 10000");
         string id = c.Id.Length > 0 ? c.Id : Guid.NewGuid().ToString();
         int cols = c.Cols > 0 ? (int)c.Cols : 120;
         int rows = c.Rows > 0 ? (int)c.Rows : 30;
@@ -243,7 +244,7 @@ public sealed class PtyHostServer : IDisposable
                 }
                 return;
             }
-            if (repaint) lock (hosted.ResizeLock) JiggleRepaint(hosted.S);
+            if (repaint) hosted.Resize.Run(() => JiggleRepaint(hosted.S));
             await PumpInputAsync(hosted, ch).ConfigureAwait(false);
         });
 
@@ -296,8 +297,8 @@ public sealed class PtyHostServer : IDisposable
 
     private Reply HandleResize(Resize r) => WithSession(r.Id, h =>
     {
-        if (r.Cols == 0 || r.Rows == 0) return Err("resize needs cols/rows");
-        lock (h.ResizeLock) h.S.Resize((int)r.Cols, (int)r.Rows);
+        if (!PtyResizeTransaction.Valid(r.Cols, r.Rows)) return Err("resize cols/rows must be in 1..10000");
+        h.Resize.Run(() => h.S.Resize((int)r.Cols, (int)r.Rows));
         return Ok();
     });
 

--- a/src/Agwinterm.Pty/PtyHostServer.cs
+++ b/src/Agwinterm.Pty/PtyHostServer.cs
@@ -39,6 +39,7 @@ public sealed class PtyHostServer : IDisposable
         public required string Id;
         public required TerminalSession S;
         public readonly object DataLock = new();                 // guards Data + writes to it
+        public readonly object ResizeLock = new();               // serializes real resize with repaint jiggle
         public DataChannel? Data;                                // the currently-attached client
     }
 
@@ -242,7 +243,7 @@ public sealed class PtyHostServer : IDisposable
                 }
                 return;
             }
-            if (repaint) JiggleRepaint(hosted.S);
+            if (repaint) lock (hosted.ResizeLock) JiggleRepaint(hosted.S);
             await PumpInputAsync(hosted, ch).ConfigureAwait(false);
         });
 
@@ -296,7 +297,7 @@ public sealed class PtyHostServer : IDisposable
     private Reply HandleResize(Resize r) => WithSession(r.Id, h =>
     {
         if (r.Cols == 0 || r.Rows == 0) return Err("resize needs cols/rows");
-        h.S.Resize((int)r.Cols, (int)r.Rows);
+        lock (h.ResizeLock) h.S.Resize((int)r.Cols, (int)r.Rows);
         return Ok();
     });
 

--- a/src/Agwinterm.Pty/PtyResizeTransaction.cs
+++ b/src/Agwinterm.Pty/PtyResizeTransaction.cs
@@ -1,0 +1,9 @@
+namespace Agwinterm.Pty;
+
+/// <summary>A real resize cannot run between the two steps of a reconnect repaint.</summary>
+internal sealed class PtyResizeTransaction
+{
+    private readonly object _gate = new();
+    internal void Run(Action action) { lock (_gate) action(); }
+    internal static bool Valid(uint cols, uint rows) => cols is >= 1 and <= 10000 && rows is >= 1 and <= 10000;
+}

--- a/src/Agwinterm.Pty/ServerSession.cs
+++ b/src/Agwinterm.Pty/ServerSession.cs
@@ -96,6 +96,9 @@ public sealed class ServerSession : ISession
 
     public int? ExitCode { get; private set; }
     public bool HasExited { get; private set; }
+    private volatile bool _inputClosed;
+    public bool InputClosed => _inputClosed || _disposed;
+    internal void MarkInputClosed() => _inputClosed = true;
     public event Action<int>? Exited;
 
     internal ServerSession(ServerSessionBackend backend, string id, int cols, int rows)
@@ -175,7 +178,7 @@ public sealed class ServerSession : ISession
             var msg = $"\r\n\x1b[31m[agwinterm] pty-host session failed to start:\x1b[0m\r\n  {ex.Message}\r\n";
             lock (_sync) Emulator.Feed(System.Text.Encoding.UTF8.GetBytes(msg));
             OutputReceived?.Invoke();
-            ExitCode = 1; HasExited = true;
+            MarkInputClosed(); ExitCode = 1; HasExited = true;
             return;
         }
         _started = true;
@@ -259,6 +262,7 @@ public sealed class ServerSession : ISession
         catch (OperationCanceledException) { }
         catch (IOException) { }
         catch (ObjectDisposedException) { }
+        MarkInputClosed(); // EOF also means detached/superseded; that need not be a child exit.
         try { data.Dispose(); } catch { }                            // safe now: our read is done
         OnStreamEnded();
     }
@@ -298,9 +302,11 @@ public sealed class ServerSession : ISession
 
     public void Write(ReadOnlySpan<byte> bytes)
     {
+        if (InputClosed) throw new IOException("Session input is closed.");
         var data = _data ?? throw new InvalidOperationException("Session not started.");
-        data.Write(bytes);
-        data.Flush();
+        try { data.Write(bytes); data.Flush(); }
+        catch (Exception ex) when (ex is IOException or ObjectDisposedException)
+        { MarkInputClosed(); throw; }
     }
 
     public void Resize(int cols, int rows)

--- a/src/Agwinterm.Pty/ServerSession.cs
+++ b/src/Agwinterm.Pty/ServerSession.cs
@@ -224,6 +224,9 @@ public sealed class ServerSession : ISession
         _started = true;
         _ = Task.Factory.StartNew(ReadLoop, CancellationToken.None,
             TaskCreationOptions.LongRunning, TaskScheduler.Default);
+        // The new UI already reports its desired grid, so its ordinary layout guard will not
+        // detect an old host grid. The reader must be live before resizing (ConPTY may repaint).
+        if (att.Cols != Cols || att.Rows != Rows) Resize(Cols, Rows);
         OutputReceived?.Invoke();
         return true;
     }

--- a/src/Agwinterm.Pty/ServerSession.cs
+++ b/src/Agwinterm.Pty/ServerSession.cs
@@ -85,6 +85,7 @@ public sealed class ServerSession : ISession
     private readonly CancellationTokenSource _readCancel = new();   // unblocks ReadLoop's pending read (#118)
     private int? _childPid;
     private volatile bool _started;
+    private readonly SessionStartFence _startFence = new();
     private volatile bool _disposed;
 
     public ITerminalCore Emulator { get; }
@@ -160,16 +161,19 @@ public sealed class ServerSession : ISession
         {
             await Task.Run(() =>
             {
+                if (_startFence.IsClosed) return;
                 var client = _backend.Client;
                 client.Create(_id, Cols, Rows, app, commandLine, cwd, extraEnv,
                     verbatim: verbatimCommandLine, deElevate: deElevate, freshEnv: freshEnv);
-                var att = client.Attach(_id);
-                _data = att.Data;
-                _childPid = att.ChildPid;
+                if (_startFence.Created()) KillHosted(); // close won while create was in flight
+                if (_startFence.IsClosed) return;
+                try { PublishAttachment(client.Attach(_id)); }
+                catch { if (_startFence.Close(kill: true)) KillHosted(); throw; }
             }, ct).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
+            if (_disposed) return;
             // Same shape as TerminalSession's de-elevate failure: surface it IN the pane instead of
             // leaving a dead surface (or crashing an unobserved fire-and-forget task).
             var msg = $"\r\n\x1b[31m[agwinterm] pty-host session failed to start:\x1b[0m\r\n  {ex.Message}\r\n";
@@ -178,10 +182,22 @@ public sealed class ServerSession : ISession
             ExitCode = 1; HasExited = true;
             return;
         }
-        _started = true;
-        _ = Task.Factory.StartNew(ReadLoop, CancellationToken.None,
-            TaskCreationOptions.LongRunning, TaskScheduler.Default);
     }
+
+    private bool PublishAttachment(PtyHostAttachment att)
+    {
+        bool published = _startFence.Publish(() =>
+        {
+            _data = att.Data; _childPid = att.ChildPid;
+            _started = true; // from here the reader alone owns disposal, even if close cancels it now
+            _ = Task.Factory.StartNew(ReadLoop, CancellationToken.None,
+                TaskCreationOptions.LongRunning, TaskScheduler.Default);
+        });
+        if (!published) att.Dispose(); // no read was ever issued
+        return published;
+    }
+
+    private void KillHosted() { try { _backend.Client.Kill(_id); } catch { } }
 
     public async Task<int> RunAsync(string app, string[] commandLine, bool verbatimCommandLine = false, CancellationToken ct = default)
     {
@@ -198,6 +214,7 @@ public sealed class ServerSession : ISession
     /// fresh; an exited leftover is reaped here so the fresh launch starts clean.</summary>
     public bool TryAdopt()
     {
+        if (_startFence.IsClosed) return false;
         PtyHostAttachment att;
         try { att = _backend.Client.Attach(_id, repaint: true); }
         catch { return false; }                       // no such session (or host unreachable)
@@ -218,12 +235,9 @@ public sealed class ServerSession : ISession
                 Emulator.SeedScrollback(att.Scrollback);
             Emulator.Feed(System.Text.Encoding.UTF8.GetBytes(att.Modes));
         }
-        _data = att.Data;
-        _childPid = att.ChildPid;
+        if (_startFence.Created()) KillHosted();
+        if (!PublishAttachment(att)) return false;
         Adopted = true;
-        _started = true;
-        _ = Task.Factory.StartNew(ReadLoop, CancellationToken.None,
-            TaskCreationOptions.LongRunning, TaskScheduler.Default);
         // The new UI already reports its desired grid, so its ordinary layout guard will not
         // detect an old host grid. The reader must be live before resizing (ConPTY may repaint).
         if (att.Cols != Cols || att.Rows != Rows) Resize(Cols, Rows);
@@ -330,6 +344,7 @@ public sealed class ServerSession : ISession
     /// app-quit path. Never disposes the pipe directly — see ReadLoop's ownership rule (#118).</summary>
     public void Detach()
     {
+        _startFence.Close(kill: false);
         _disposed = true;                                            // EOF now means "we left", not "it died"
         CancelRead();
     }
@@ -337,16 +352,14 @@ public sealed class ServerSession : ISession
     public void Dispose()
     {
         _disposed = true;
-        if (_started)
-            try { _backend.Client.Kill(_id); } catch { }             // explicit close = kill (pane closed)
+        if (_startFence.Close(kill: true)) KillHosted();
         CancelRead();
     }
 
     private void CancelRead()
     {
         try { _readCancel.Cancel(); } catch (ObjectDisposedException) { }
-        // If the loop never started (start failed / never started), there is no pending read and
-        // no owner to close the pipe — do it here, where it is safe for the same reason.
-        if (!_started && _data is { } d) { try { d.Dispose(); } catch { } }
+        // PublishAttachment either assigns the pipe to a reader, or closes the unpublished pipe.
+        // Never inspect _started here to guess whether a concurrent publisher has issued a read.
     }
 }

--- a/src/Agwinterm.Pty/ServerSession.cs
+++ b/src/Agwinterm.Pty/ServerSession.cs
@@ -168,7 +168,7 @@ public sealed class ServerSession : ISession
                 if (_startFence.Created()) KillHosted(); // close won while create was in flight
                 if (_startFence.IsClosed) return;
                 try { PublishAttachment(client.Attach(_id)); }
-                catch { if (_startFence.Close(kill: true)) KillHosted(); throw; }
+                catch { if (_startFence.AttachmentFailed()) KillHosted(); throw; }
             }, ct).ConfigureAwait(false);
         }
         catch (Exception ex)

--- a/src/Agwinterm.Pty/SessionInput.cs
+++ b/src/Agwinterm.Pty/SessionInput.cs
@@ -1,0 +1,21 @@
+namespace Agwinterm.Pty;
+
+/// <summary>Best-effort input for human broadcasts and terminal protocol replies. False means
+/// unavailable or a possibly partial failed write, never proof that a child read the input.</summary>
+public static class SessionInput
+{
+    public static bool TryWrite(ISession session, ReadOnlySpan<byte> bytes)
+    {
+        if (session.InputClosed) return false;
+        try { session.NotifyActivity(); session.Write(bytes); return true; }
+        catch (Exception ex) when (ex is IOException or ObjectDisposedException or InvalidOperationException) { return false; }
+    }
+
+    public static bool Broadcast(IEnumerable<(ISession Session, bool ReadOnly)> panes, ReadOnlySpan<byte> bytes)
+    {
+        bool allAccepted = true;
+        foreach (var pane in panes)
+            if (pane.ReadOnly || !TryWrite(pane.Session, bytes)) allAccepted = false;
+        return allAccepted;
+    }
+}

--- a/src/Agwinterm.Pty/SessionPastes.cs
+++ b/src/Agwinterm.Pty/SessionPastes.cs
@@ -30,6 +30,9 @@ public static class SessionPastes
     /// needs ok:false, not <see cref="Pasted"/> for text that was dropped. Answered before the
     /// clipboard is read.</summary>
     public const string ReadOnlyPane = "pane is read-only";
+    /// <summary>Known input closure is refused before clipboard access, even while output still
+    /// drains or a disconnected host's child-exit status remains unknown. This is not an exit claim.</summary>
+    public const string InputUnavailable = "the pane's input is closed";
     /// <summary>The refusal for a pane whose process has exited (a single-pane session keeps the
     /// exited surface on screen): its input may still take bytes, but no program reads them.
     /// Answered before the clipboard is read, once the host has OBSERVED the exit: the guard is

--- a/src/Agwinterm.Pty/SessionStartFence.cs
+++ b/src/Agwinterm.Pty/SessionStartFence.cs
@@ -1,0 +1,24 @@
+namespace Agwinterm.Pty;
+
+/// <summary>Serializes publication, not host I/O. A close before create completes leaves a kill
+/// obligation; detach leaves the hosted child alive. The caller performs a claimed kill outside the gate.</summary>
+internal sealed class SessionStartFence
+{
+    private readonly object _gate = new();
+    private bool _closed, _killRequested, _created, _killClaimed;
+    public bool IsClosed { get { lock (_gate) return _closed; } }
+    public bool Created() { lock (_gate) { _created = true; return ClaimKill(); } }
+    public bool Close(bool kill)
+    {
+        lock (_gate) { _closed = true; _killRequested |= kill; return ClaimKill(); }
+    }
+    private bool ClaimKill()
+    {
+        if (!_created || !_killRequested || _killClaimed) return false;
+        _killClaimed = true; return true;
+    }
+    public bool Publish(Action publish)
+    {
+        lock (_gate) { if (_closed) return false; publish(); return true; }
+    }
+}

--- a/src/Agwinterm.Pty/SessionStartFence.cs
+++ b/src/Agwinterm.Pty/SessionStartFence.cs
@@ -12,6 +12,15 @@ internal sealed class SessionStartFence
     {
         lock (_gate) { _closed = true; _killRequested |= kill; return ClaimKill(); }
     }
+    public bool AttachmentFailed()
+    {
+        lock (_gate)
+        {
+            // A failed attach is cleanup for a live create, not authority to undo app-quit detach.
+            if (!_closed) { _closed = true; _killRequested = true; }
+            return ClaimKill();
+        }
+    }
     private bool ClaimKill()
     {
         if (!_created || !_killRequested || _killClaimed) return false;

--- a/src/Agwinterm.Pty/TerminalSession.cs
+++ b/src/Agwinterm.Pty/TerminalSession.cs
@@ -126,6 +126,7 @@ public sealed class TerminalSession : ISession
 
         // Wait for the child to exit on a background thread (WaitForExit is blocking).
         await Task.Run(() => _connection.WaitForExit(Timeout.Infinite), ct).ConfigureAwait(false);
+        MarkInputClosed();
 
         // Let the reader drain output already buffered in the pipe, then stop it.
         await Task.Delay(250, ct).ConfigureAwait(false);
@@ -208,7 +209,7 @@ public sealed class TerminalSession : ISession
                 var msg = $"\r\n\x1b[31m[agwinterm] could not start a non-elevated session:\x1b[0m\r\n  {ex.Message}\r\n";
                 lock (_sync) Emulator.Feed(System.Text.Encoding.UTF8.GetBytes(msg));
                 OutputReceived?.Invoke();
-                ExitCode = 1; HasExited = true;
+                MarkInputClosed(); ExitCode = 1; HasExited = true;
                 return;
             }
             _connection = dc;
@@ -216,6 +217,7 @@ public sealed class TerminalSession : ISession
             _ = Task.Run(() =>
             {
                 try { dc.WaitForExit(Timeout.Infinite); } catch { }
+                MarkInputClosed();
                 int code = 0; try { code = dc.ExitCode; } catch { }
                 SettleOutput();
                 ExitCode = code; HasExited = true;
@@ -265,7 +267,7 @@ public sealed class TerminalSession : ISession
             var msg = $"\r\n\x1b[31m[agwinterm] could not start the session:\x1b[0m\r\n  {ex.Message}\r\n";
             lock (_sync) Emulator.Feed(System.Text.Encoding.UTF8.GetBytes(msg));
             OutputReceived?.Invoke();
-            ExitCode = 1; HasExited = true;
+            MarkInputClosed(); ExitCode = 1; HasExited = true;
             return;
         }
         _connection = conn;
@@ -275,6 +277,7 @@ public sealed class TerminalSession : ISession
         _ = Task.Run(() =>
         {
             try { conn.WaitForExit(Timeout.Infinite); } catch { }
+            MarkInputClosed();
             int code = 0; try { code = conn.ExitCode; } catch { }
             SettleOutput();
             ExitCode = code; HasExited = true;
@@ -316,8 +319,9 @@ public sealed class TerminalSession : ISession
         var pump = StartPump(conn.ReaderStream);
         _ = Task.Run(async () =>
         {
-            if (clientProcess != IntPtr.Zero) { await Task.Run(() => conn.WaitForExit(Timeout.Infinite)).ConfigureAwait(false); SettleOutput(); }
+            if (clientProcess != IntPtr.Zero) { await Task.Run(() => conn.WaitForExit(Timeout.Infinite)).ConfigureAwait(false); MarkInputClosed(); SettleOutput(); }
             else await pump.ConfigureAwait(false);   // no client handle → exit when the output pipe hits EOF (already drained)
+            MarkInputClosed();
             int code = 0; try { code = conn.ExitCode; } catch { }
             ExitCode = code; HasExited = true;
             try { Exited?.Invoke(code); } catch { }
@@ -328,6 +332,9 @@ public sealed class TerminalSession : ISession
     /// <summary>The child's exit code once <see cref="HasExited"/> is true (null while still running).</summary>
     public int? ExitCode { get; private set; }
     public bool HasExited { get; private set; }
+    private volatile bool _inputClosed;
+    public bool InputClosed => _inputClosed;
+    internal void MarkInputClosed() => _inputClosed = true;
     /// <summary>Raised (on a background thread) when the child process exits, with its exit code.</summary>
     public event Action<int>? Exited;
 
@@ -390,9 +397,11 @@ public sealed class TerminalSession : ISession
     /// <summary>Send bytes (e.g. keystrokes) to the child's input.</summary>
     public void Write(ReadOnlySpan<byte> bytes)
     {
+        if (InputClosed) throw new IOException("Session input is closed.");
         var stream = _connection?.WriterStream ?? throw new InvalidOperationException("Session not started.");
-        stream.Write(bytes);
-        stream.Flush();
+        try { stream.Write(bytes); stream.Flush(); }
+        catch (Exception ex) when (ex is IOException or ObjectDisposedException)
+        { MarkInputClosed(); throw; }
     }
 
     public void Resize(int cols, int rows)
@@ -421,6 +430,7 @@ public sealed class TerminalSession : ISession
 
     public void Dispose()
     {
+        MarkInputClosed();
         var c = _connection;
         _connection = null;
         try { c?.Kill(); } catch { /* already exited */ }

--- a/src/Agwinterm.Win32/Dashboard.cs
+++ b/src/Agwinterm.Win32/Dashboard.cs
@@ -40,7 +40,12 @@ internal partial class Program
         RequestRedraw();
     }
 
-    private void CloseDashboard() { if (!_dashboardOpen) return; _dashboardOpen = false; RequestRedraw(); }
+    private void CloseDashboard()
+    {
+        bool wasOpen = _dashboardOpen;
+        _dashboardOpen = false; _dashSessions.Clear(); _dashCells.Clear(); _dashSel = 0;
+        if (wasOpen) RequestRedraw();
+    }
 
     private static (int cols, int rows) DashGrid(int n)
     {

--- a/src/Agwinterm.Win32/Program.Chrome.cs
+++ b/src/Agwinterm.Win32/Program.Chrome.cs
@@ -608,7 +608,12 @@ internal partial class Program
             if (_workspaces.Count == 0) _workspaces.Add(new Workspace { Id = Guid.NewGuid().ToString(), Name = "workspace 1" });
         }
         RefreshHudTimer(); // a removed workspace may have owned the last animated HUD
-        foreach (var s in sessions) { try { s.S.Dispose(); } catch { } }
+        if (ReferenceEquals(_editing, ws)) CancelRename();
+        if (ReferenceEquals(_dragItem, ws) || ReferenceEquals(_pressItem, ws))
+        {
+            _dragging = false; _sbPress = false; _dragItem = null; _pressItem = null; ReleaseCapture();
+        }
+        foreach (var s in sessions) DisposeSessionResources(s);
         if (hadActive)
         {
             var next = AllSessions().FirstOrDefault();

--- a/src/Agwinterm.Win32/Program.Chrome.cs
+++ b/src/Agwinterm.Win32/Program.Chrome.cs
@@ -592,9 +592,20 @@ internal partial class Program
         }
     }
 
+    // These surfaces hold objects/actions, not just ids. Invalidate even an empty workspace's
+    // menu before removing it, and do the same for single-session close.
+    private void InvalidateSessionSelectors()
+    {
+        CloseDashboard(); ClosePalette(); CloseMenuWindow();
+        _menuItems.Clear(); _menuSel = -1;
+        _sidebarRows.Clear(); _sidebarNames.Clear();
+        DismissHoverTip(); ClearLinkHover();
+    }
+
     private bool DeleteWorkspace(Workspace ws)
     {
         lock (_workspaces) if (_workspaces.Count <= 1 || !_workspaces.Contains(ws)) return false;
+        InvalidateSessionSelectors();
         List<Ses> sessions;
         bool hadActive = _active is not null && ReferenceEquals(_active.Ws, ws);
         lock (_workspaces)

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -490,12 +490,14 @@ internal partial class Program
     }
 
     // Clone a session by target (agterm #234) — new session, same cwd + profile. Returns its new id.
-    public string DuplicateSession(string? target)
+    public string DuplicateSession(string? target) => InvokeOnUiQueued(() =>
     {
+        var source = FindSesForTarget(target);
+        if (source is null) throw new InvalidOperationException("session not found");
         string id = Guid.NewGuid().ToString();
-        PostVerb(() => DuplicateSession(FindSesForTarget(target), id));
+        if (DuplicateSession(source, id) is null) throw new InvalidOperationException("session not found");
         return id;
-    }
+    });
 
     // Collapse/expand a single workspace by id (agterm #272). target null/empty = the active workspace.
     public bool WorkspaceCollapse(string? target, bool expand)

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -842,12 +842,12 @@ internal partial class Program
     });
 
     public bool SessionScratch(string? target, string op)
-    {
+        => InvokeOnUiQueued(() => {
         var ses = FindSesForTarget(target);
         if (ses is null) return false;
-        PostVerb(() => ScratchOp(ses, op));
+        ScratchOp(ses, op);
         return true;
-    }
+    });
 
     public void Quick(string op) => InvokeOnUiQueued(() => { QuickOp(op, control: true); return 0; });
 

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -813,6 +813,7 @@ internal partial class Program
         // bytes, so a paste into it would answer `pasted` for text that reached no program (round 9
         // of #256): refused, before the clipboard is read, like the read-only pane.
         if (p.S.HasExited) return ISessionHost.RefusePrefix + SessionPastes.ExitedPane;
+        if (p.S.InputClosed) return ISessionHost.RefusePrefix + SessionPastes.InputUnavailable;
         // "text (or the clipboard when text is null/EMPTY)": the CLI always sends text, "" when the
         // caller gave none, so `?? ClipboardGet()` never ran and `session paste` pasted nothing.
         // ClipboardGet answers "" both for a clipboard with no text and for one it could not read.

--- a/src/Agwinterm.Win32/Program.Input.cs
+++ b/src/Agwinterm.Win32/Program.Input.cs
@@ -29,7 +29,7 @@ internal partial class Program
         RequestRedraw();
     }
 
-    private bool BroadcastActive => _broadcast && _cover is null && _active is not null;
+    private bool BroadcastActive => _broadcast && _cover is null && _active is { } active && active.ActivePane.Overlay.Term is null;
 
     private bool Send(string s, bool editing = true)
     {

--- a/src/Agwinterm.Win32/Program.Input.cs
+++ b/src/Agwinterm.Win32/Program.Input.cs
@@ -241,7 +241,7 @@ internal partial class Program
                 // and Send run together on the UI thread; local write failures propagate through
                 // queued CommandRun. Accepted transport input is not proof of child execution (#268).
                 var surface = ActiveSurface();
-                if (surface is null || _session is null || surface.S.HasExited)
+                if (surface is null || _session is null || surface.S.InputClosed)
                     return ISessionHost.RefusePrefix + "no live pane for send command";
                 if (surface.ReadOnly) return ISessionHost.RefusePrefix + "pane is read-only";
                 Send(expanded.Replace("\r", "").Replace("\n", "") + "\r");

--- a/src/Agwinterm.Win32/Program.Input.cs
+++ b/src/Agwinterm.Win32/Program.Input.cs
@@ -29,16 +29,18 @@ internal partial class Program
         RequestRedraw();
     }
 
+    private bool BroadcastActive => _broadcast && _cover is null && _active is not null;
+
     private bool Send(string s, bool editing = true)
     {
         var surf = ActiveSurface();
-        if (surf is { ReadOnly: true }) { ShowToast("pane is read-only"); return false; }   // block input to a protected pane
-        if (editing && surf is not null) { surf.ScrollOffset = 0; surf.ClearSel(); } // modifiers/key-up do not edit the buffer
-        if (_broadcast && _cover is null && _active is not null)
+        if (!BroadcastActive && surf is { ReadOnly: true }) { ShowToast("pane is read-only"); return false; }
+        if (editing && surf is { ReadOnly: false } && !surf.S.InputClosed) { surf.ScrollOffset = 0; surf.ClearSel(); }
+        if (BroadcastActive)
         {
             byte[] bytes = Encoding.UTF8.GetBytes(s);
             List<Pane> panes;
-            lock (_workspaces) panes = _active.Ws.Sessions.SelectMany(x => x.Panes).ToList();
+            lock (_workspaces) panes = _active!.Ws.Sessions.SelectMany(x => x.Panes).ToList();
             return SessionInput.Broadcast(panes.Select(p => (p.S, p.ReadOnly)), bytes);
         }
         return _session is { } session && SessionInput.TryWrite(session, Encoding.UTF8.GetBytes(s));
@@ -239,9 +241,12 @@ internal partial class Program
                 // and Send run together on the UI thread; local write failures propagate through
                 // queued CommandRun. Accepted transport input is not proof of child execution (#268).
                 var surface = ActiveSurface();
-                if (surface is null || _session is null || surface.S.InputClosed)
-                    return ISessionHost.RefusePrefix + "no live pane for send command";
-                if (surface.ReadOnly) return ISessionHost.RefusePrefix + "pane is read-only";
+                if (!BroadcastActive)
+                {
+                    if (surface is null || _session is null || surface.S.InputClosed)
+                        return ISessionHost.RefusePrefix + "no live pane for send command";
+                    if (surface.ReadOnly) return ISessionHost.RefusePrefix + "pane is read-only";
+                }
                 if (!Send(expanded.Replace("\r", "").Replace("\n", "") + "\r"))
                     return ISessionHost.RefusePrefix + "input unavailable on at least one pane; other panes or part of the payload may have received bytes; do not retry blindly";
                 break;

--- a/src/Agwinterm.Win32/Program.Input.cs
+++ b/src/Agwinterm.Win32/Program.Input.cs
@@ -29,21 +29,19 @@ internal partial class Program
         RequestRedraw();
     }
 
-    private void Send(string s, bool editing = true)
+    private bool Send(string s, bool editing = true)
     {
         var surf = ActiveSurface();
-        if (surf is { ReadOnly: true }) { ShowToast("pane is read-only"); return; }   // block input to a protected pane
+        if (surf is { ReadOnly: true }) { ShowToast("pane is read-only"); return false; }   // block input to a protected pane
         if (editing && surf is not null) { surf.ScrollOffset = 0; surf.ClearSel(); } // modifiers/key-up do not edit the buffer
         if (_broadcast && _cover is null && _active is not null)
         {
             byte[] bytes = Encoding.UTF8.GetBytes(s);
             List<Pane> panes;
             lock (_workspaces) panes = _active.Ws.Sessions.SelectMany(x => x.Panes).ToList();
-            foreach (var p in panes) { p.S.NotifyActivity(); p.S.Write(bytes); }
-            return;
+            return SessionInput.Broadcast(panes.Select(p => (p.S, p.ReadOnly)), bytes);
         }
-        _session?.NotifyActivity();
-        _session?.Write(Encoding.UTF8.GetBytes(s));
+        return _session is { } session && SessionInput.TryWrite(session, Encoding.UTF8.GetBytes(s));
     }
 
     /// <summary>Scroll the active pane's scrollback by delta lines (or to top/bottom for ±int.MaxValue).</summary>
@@ -244,7 +242,8 @@ internal partial class Program
                 if (surface is null || _session is null || surface.S.InputClosed)
                     return ISessionHost.RefusePrefix + "no live pane for send command";
                 if (surface.ReadOnly) return ISessionHost.RefusePrefix + "pane is read-only";
-                Send(expanded.Replace("\r", "").Replace("\n", "") + "\r");
+                if (!Send(expanded.Replace("\r", "").Replace("\n", "") + "\r"))
+                    return ISessionHost.RefusePrefix + "input unavailable on at least one pane; other panes or part of the payload may have received bytes; do not retry blindly";
                 break;
         }
         return expanded;

--- a/src/Agwinterm.Win32/Program.Render.cs
+++ b/src/Agwinterm.Win32/Program.Render.cs
@@ -142,14 +142,13 @@ internal partial class Program
         string path = ses.BgPath!;
 
         // Upload anything decoded on background threads (cheap; UI thread only).
-        while (_bgDecoded.TryDequeue(out var d))
+        foreach (var (decodedPath, d) in _backgroundDecodes.Drain())
         {
-            _bgDecoding.Remove(d.path);
-            if (d.bgra is null || _bgCache.ContainsKey(d.path)) continue;
+            if (d.bgra is null || _bgCache.ContainsKey(decodedPath)) continue;
             try
             {
                 var h = GCHandle.Alloc(d.bgra, GCHandleType.Pinned);
-                try { _bgCache[d.path] = _rt.CreateBitmap(new SizeI(d.w, d.h), h.AddrOfPinnedObject(), (uint)(d.w * 4), _bmpProps); }
+                try { _bgCache[decodedPath] = _rt.CreateBitmap(new SizeI(d.w, d.h), h.AddrOfPinnedObject(), (uint)(d.w * 4), _bmpProps); }
                 finally { h.Free(); }
             }
             catch (Exception ex) { Log($"watermark upload FAILED {path}: {ex.Message}"); }
@@ -157,7 +156,7 @@ internal partial class Program
 
         if (!_bgCache.TryGetValue(path, out var bmp))
         {
-            if (_bgDecoding.Add(path)) _ = Task.Run(() => DecodeBackgroundAsync(path));
+            if (_backgroundDecodes.Begin(path) is { } ticket) _ = Task.Run(() => DecodeBackgroundAsync(path, ticket));
             return; // renders on a later frame once uploaded
         }
 
@@ -196,7 +195,7 @@ internal partial class Program
     }
 
     /// <summary>Background: decode a watermark image file to premultiplied BGRA, enqueue for UI upload.</summary>
-    private void DecodeBackgroundAsync(string path)
+    private void DecodeBackgroundAsync(string path, DecodeMailbox<string, (byte[]? bgra, int w, int h)>.Ticket ticket)
     {
         try
         {
@@ -213,12 +212,12 @@ internal partial class Program
                 else for (int y = 0; y < h; y++) Marshal.Copy(data.Scan0 + y * data.Stride, buf, y * w * 4, w * 4);
             }
             finally { gdi.UnlockBits(data); }
-            _bgDecoded.Enqueue((path, buf, w, h));
+            _backgroundDecodes.Complete(path, ticket, (buf, w, h));
         }
         catch (Exception ex)
         {
             Log($"watermark decode FAILED {path}: {ex.Message}");
-            _bgDecoded.Enqueue((path, null, 0, 0)); // stop retrying
+            _backgroundDecodes.Complete(path, ticket, (null, 0, 0));
         }
         finally { RequestRedraw(); }
     }
@@ -228,7 +227,7 @@ internal partial class Program
     {
         if (string.IsNullOrEmpty(path)) return;
         if (_bgCache.Remove(path!, out var bmp)) { try { bmp.Dispose(); } catch { } }
-        _bgDecoding.Remove(path!);
+        _backgroundDecodes.Invalidate(path!);
     }
 
     /// <summary>Background: decode to premultiplied BGRA pixels (no D2D), enqueue for UI upload, ask for a redraw.</summary>
@@ -295,8 +294,7 @@ internal partial class Program
         // Failed uploads may have been caused by the old device, so those exact images may retry.
         foreach (var b in _bgCache.Values) { try { b.Dispose(); } catch { } } // watermark textures are device-bound too
         _bgCache.Clear();
-        _bgDecoding.Clear();
-        while (_bgDecoded.TryDequeue(out _)) { }
+        _backgroundDecodes.Clear();
         try { _brush?.Dispose(); } catch { }
         try { _rt?.Dispose(); } catch { }
         _brush = null; _rt = null;

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -1657,17 +1657,45 @@ internal partial class Program
             makeActive: true, profileName: source.ProfileName);
     }
 
-    private void CloseSessionInternal(Ses ses)
+    /// <summary>Release every surface and UI reference owned by a session, without creating a
+    /// replacement or recording a second closed-history item. Used by both session and workspace close.</summary>
+    private void DisposeSessionResources(Ses ses)
     {
-        CaptureClosedSession(ses);   // remember it so Reopen Closed Session can bring it back
+        if (_mruSnapshot.Contains(ses))
+        {
+            // A deletion invalidates the walk's frozen membership; a later commit/cancel must
+            // never reactivate a disposed session (including a deleted, non-active start pane).
+            _mruWalking = false; _mruSnapshot.Clear(); _mruStart = null;
+        }
+        _selectedIds.Remove(ses.Id);
+        if (_selAnchorId == ses.Id) _selAnchorId = null;
+        if (ReferenceEquals(_focusRow, ses)) _focusRow = null;
+        if (ReferenceEquals(_toastTarget, ses)) _toastTarget = null;
+        if (ReferenceEquals(_editing, ses)) CancelRename();
+        bool ownsSelection = _selPane is { } selected &&
+            (ses.Panes.Any(p => ReferenceEquals(p, selected) || ReferenceEquals(p.Overlay.Term, selected)) ||
+             ReferenceEquals(ses.Scratch, selected) || ReferenceEquals(ses.Overlay.Term, selected));
+        if (ownsSelection) { _selecting = false; _selPane = null; StopSelAutoscroll(); ReleaseCapture(); }
+        if (ReferenceEquals(_active, ses) && _divDragging) { _divDragging = false; ReleaseCapture(); }
+        if (ReferenceEquals(_dragItem, ses) || ReferenceEquals(_pressItem, ses))
+        {
+            _dragging = false; _sbPress = false; _dragItem = null; _pressItem = null; ReleaseCapture();
+        }
         foreach (var p in ses.Panes) { ClosePaneOverlay(ses, p); try { p.S.Dispose(); } catch { } }   // each pane's overlay (P5) dies with its pane
         // Dismiss + dispose this session's scratch cover if it belongs here.
         if (ses.Scratch is not null) { if (_coverKind == 1 && ReferenceEquals(_cover, ses.Scratch)) HideCover(); try { ses.Scratch.S.Dispose(); } catch { } ses.Scratch = null; }
         CloseOverlayOf(ses); // dismiss + dispose this session's session-wide overlay (a no-op on an empty slot)
-        bool wasActive = ReferenceEquals(_active, ses);
         _mru.Remove(ses.Id);
-        EmitEvent("session", ses.Id, "closed"); EmitEvent("tree");   // control-API event log (#273)
+        EmitEvent("session", ses.Id, "closed");
         EvictWatermark(ses.BgPath); SweepBackground(ses.Id); // drop the session's watermark file + texture
+    }
+
+    private void CloseSessionInternal(Ses ses)
+    {
+        CaptureClosedSession(ses);   // remember it so Reopen Closed Session can bring it back
+        bool wasActive = ReferenceEquals(_active, ses);
+        DisposeSessionResources(ses);
+        EmitEvent("tree");   // control-API event log (#273)
         lock (_workspaces) ses.Ws.Sessions.Remove(ses);
         if (wasActive)
         {

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -556,6 +556,9 @@ internal partial class Program
 
     private void SetActive(Ses ses)
     {
+        // Modal selectors and queued callbacks may outlive the object they captured.
+        lock (_workspaces)
+            if (!_workspaces.Contains(ses.Ws) || !ses.Ws.Sessions.Contains(ses)) return;
         _workspaceTarget = null;
         // Navigating to a session outside the multi-selection drops the selection (single-select again).
         if (!_selectedIds.Contains(ses.Id)) _selectedIds.Clear();
@@ -1661,6 +1664,7 @@ internal partial class Program
     /// replacement or recording a second closed-history item. Used by both session and workspace close.</summary>
     private void DisposeSessionResources(Ses ses)
     {
+        InvalidateSessionSelectors();
         if (_mruSnapshot.Contains(ses))
         {
             // A deletion invalidates the walk's frozen membership; a later commit/cancel must

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -298,9 +298,7 @@ internal partial class Program
         {
             // A late terminal query may be parsed while final output is settling after child death.
             // Refusing its reply must not abort the output pump and lose the remaining output.
-            if (_s.InputClosed) return;
-            try { _s.NotifyActivity(); _s.Write(Encoding.UTF8.GetBytes(reply)); }
-            catch (Exception ex) when (ex is IOException or ObjectDisposedException or InvalidOperationException) { }
+            SessionInput.TryWrite(_s, Encoding.UTF8.GetBytes(reply));
         }
         public void Bell() => _app.Post(() => _app.RingBell(_pane));                                     // BEL -> beep/flash per config
         public void Unhandled(string kind, string detail) => VtLog.Write(_pane.Id, kind, detail);       // AGWINTERM_VT_LOG tap

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -294,7 +294,14 @@ internal partial class Program
             if (!Program._config.ClipboardWrite) { VtLog.Write(_pane.Id, "OSC", $"52 clipboard write DENIED by config ({text.Length} chars)"); return; }
             _app.Post(() => _app.ClipboardSet(text));
         }
-        public void Respond(string reply) { _s.NotifyActivity(); _s.Write(Encoding.UTF8.GetBytes(reply)); } // query reply -> PTY
+        public void Respond(string reply)
+        {
+            // A late terminal query may be parsed while final output is settling after child death.
+            // Refusing its reply must not abort the output pump and lose the remaining output.
+            if (_s.InputClosed) return;
+            try { _s.NotifyActivity(); _s.Write(Encoding.UTF8.GetBytes(reply)); }
+            catch (Exception ex) when (ex is IOException or ObjectDisposedException or InvalidOperationException) { }
+        }
         public void Bell() => _app.Post(() => _app.RingBell(_pane));                                     // BEL -> beep/flash per config
         public void Unhandled(string kind, string detail) => VtLog.Write(_pane.Id, kind, detail);       // AGWINTERM_VT_LOG tap
     }

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -401,6 +401,7 @@ internal partial class Program
         string? command = null, bool interactive = false, Dictionary<string, string>? extraEnv = null, string? profileName = null,
         bool deElevate = false, HandoffArgs? handoff = null, bool wait = false, string? paneId = null)
     {
+        lock (_workspaces) if (!_workspaces.Contains(ws)) throw new InvalidOperationException("workspace no longer exists");
         // Elevated profile from a non-elevated app: hand off to a separate elevated window (UAC).
         if (profileName is not null && !IsElevated()
             && _profileCfg.Profiles.FirstOrDefault(p => p.Name.Equals(profileName, StringComparison.OrdinalIgnoreCase)) is { Elevate: true })
@@ -445,6 +446,7 @@ internal partial class Program
     /// <summary>Append an extra pane to an existing session (used by split-layout restore).</summary>
     private Pane AppendPane(Ses ses, string paneId, string? cwd, float fontSize)
     {
+        if (!OwnsSession(ses)) throw new InvalidOperationException("session no longer exists");
         var p = CreatePane(paneId, ses.Ws, cwd, fontSize, profileName: ses.ProfileName);
         lock (_workspaces) ses.Panes.Add(p);
         return p;
@@ -557,8 +559,7 @@ internal partial class Program
     private void SetActive(Ses ses)
     {
         // Modal selectors and queued callbacks may outlive the object they captured.
-        lock (_workspaces)
-            if (!_workspaces.Contains(ses.Ws) || !ses.Ws.Sessions.Contains(ses)) return;
+        if (!OwnsSession(ses)) return;
         _workspaceTarget = null;
         // Navigating to a session outside the multi-selection drops the selection (single-select again).
         if (!_selectedIds.Contains(ses.Id)) _selectedIds.Clear();
@@ -785,6 +786,7 @@ internal partial class Program
     /// <summary>Show a session's scratch terminal (creating it lazily in the session's cwd).</summary>
     private void ShowScratch(Ses ses)
     {
+        if (!OwnsSession(ses)) return;
         ses.Scratch ??= CreatePane(ses.Id + ":scratch:" + Guid.NewGuid().ToString("N")[..6], ses.Ws, CwdOf(ses), ses.FontSize);
         ShowCover(ses.Scratch, 1);
     }
@@ -827,6 +829,8 @@ internal partial class Program
     /// open — the pane arm has its own <see cref="OverlaySlot.LastResult"/>, reset here.</summary>
     private string OverlayOpen(Ses ses, Pane? pane, string command, int sizePercent, bool wait, Dictionary<string, string>? extraEnv = null)
     {
+        if (!OwnsSession(ses) || (pane is not null && !ses.Panes.Contains(pane)))
+            return ISessionHost.RefusePrefix + "session or pane no longer exists";
         OverlaySlot slot;
         string id;
         if (pane is null)
@@ -1195,6 +1199,7 @@ internal partial class Program
             // itself is the authority (it no-ops harmlessly when already current).
             Post(() =>
             {
+                if (!OwnsSession(ses)) { _claudeUpdating = false; return; }
                 OverlayOpen(ses, null, "claude update", 60, wait: true);
                 var ovl = ses.Overlay.Term;
                 if (ovl is null) { _claudeUpdating = false; return; }
@@ -1421,6 +1426,7 @@ internal partial class Program
 
     private void SplitPane(Ses ses)
     {
+        if (!OwnsSession(ses)) return;
         if (ses.Panes.Count >= 2) return;   // agterm model: strictly primary + one split (no 3+ panes)
         var cur = ses.ActivePane;
         string? cwd = string.IsNullOrEmpty(cur.StartCwd) ? null : cur.StartCwd;
@@ -1655,9 +1661,14 @@ internal partial class Program
     private Ses? DuplicateSession(Ses? source, string? id = null)
     {
         source ??= _active;
-        if (source is null) return null;
+        if (source is null || !OwnsSession(source)) return null;
         return CreateSession(id ?? Guid.NewGuid().ToString(), null, CwdOf(source), source.Ws,
             makeActive: true, profileName: source.ProfileName);
+    }
+
+    private bool OwnsSession(Ses ses)
+    {
+        lock (_workspaces) return _workspaces.Contains(ses.Ws) && ses.Ws.Sessions.Contains(ses);
     }
 
     /// <summary>Release every surface and UI reference owned by a session, without creating a

--- a/src/Agwinterm.Win32/Program.WndProc.cs
+++ b/src/Agwinterm.Win32/Program.WndProc.cs
@@ -608,7 +608,7 @@ internal partial class Program
                 // Focus reporting (DECSET ?1004): on a real focus transition, tell the active pane's
                 // app the terminal gained (ESC[I) or lost (ESC[O) focus, so it can pause/resume.
                 if (_windowActive != wasActive && _session is { } fs && fs.Emulator.FocusReporting)
-                    fs.Write(_windowActive ? "\x1b[I"u8.ToArray() : "\x1b[O"u8.ToArray());
+                    SessionInput.TryWrite(fs, _windowActive ? "\x1b[I"u8 : "\x1b[O"u8);
                 if (_config.UnfocusedDim > 0) RequestRedraw();
                 if (_isQuickWindow && !_windowActive && _quickVisible && !_quickPinned
                     && (lParam == IntPtr.Zero || GetAncestor(lParam, 3 /* GA_ROOTOWNER */) != _hwnd)) DismissQuick(blur: true);

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -462,8 +462,7 @@ internal partial class Program : ISessionHost, IWindowHost
     // (one bitmap per distinct image, at native size); decode happens off the UI thread just like
     // the Kitty pipeline, so a background image never stalls rendering — it appears on a later frame.
     private readonly Dictionary<string, ID2D1Bitmap> _bgCache = new();
-    private readonly HashSet<string> _bgDecoding = new();
-    private readonly System.Collections.Concurrent.ConcurrentQueue<(string path, byte[]? bgra, int w, int h)> _bgDecoded = new();
+    private readonly DecodeMailbox<string, (byte[]? bgra, int w, int h)> _backgroundDecodes = new();
 
     // ---- CLI launch args (wt-style, applied to the first window): ----
     //   Agwinterm.Win32.exe [-p|--profile NAME] [-d|--dir PATH] [--maximized] [--fullscreen]

--- a/tests/Agwinterm.Core.Tests/DecodeMailboxTests.cs
+++ b/tests/Agwinterm.Core.Tests/DecodeMailboxTests.cs
@@ -1,0 +1,42 @@
+using Xunit;
+
+namespace Agwinterm.Core.Tests;
+
+public class DecodeMailboxTests
+{
+    [Fact]
+    public void DeletedOwnerRejectsLateDecodeWithoutRetainingPayload()
+    {
+        var mailbox = new DecodeMailbox<string, byte[]>();
+        var ticket = mailbox.Begin("deleted")!;
+        mailbox.Invalidate("deleted");
+        Assert.False(mailbox.Complete("deleted", ticket, new byte[1024]));
+        Assert.Empty(mailbox.Drain());
+    }
+    [Fact]
+    public void ReplaceCannotAcceptOldCompletionOrEraseNewOne()
+    {
+        var mailbox = new DecodeMailbox<string, byte[]>();
+        var old = mailbox.Begin("same-path")!;
+        Assert.Null(mailbox.Begin("same-path"));
+        mailbox.Invalidate("same-path");
+        var fresh = mailbox.Begin("same-path")!;
+        Assert.False(mailbox.Complete("same-path", old, [1]));
+        Assert.True(mailbox.Complete("same-path", fresh, [2]));
+        Assert.Equal(new byte[] { 2 }, Assert.Single(mailbox.Drain()).Value);
+        Assert.Empty(mailbox.Drain());
+    }
+    [Fact]
+    public void InvalidationDropsAlreadyPublishedResultsAndPreservesOtherOwners()
+    {
+        var mailbox = new DecodeMailbox<string, byte[]>();
+        var deleted = mailbox.Begin("deleted")!; var live = mailbox.Begin("live")!;
+        mailbox.Complete("deleted", deleted, [1]); mailbox.Complete("live", live, [2]);
+        mailbox.Invalidate("deleted");
+        Assert.Equal("live", Assert.Single(mailbox.Drain()).Key);
+        var pending = mailbox.Begin("pending")!; var ready = mailbox.Begin("ready")!;
+        mailbox.Complete("ready", ready, [3]); mailbox.Clear();
+        Assert.False(mailbox.Complete("pending", pending, [4]));
+        Assert.Empty(mailbox.Drain());
+    }
+}

--- a/tests/Agwinterm.Pty.Tests/InputLifecycleTests.cs
+++ b/tests/Agwinterm.Pty.Tests/InputLifecycleTests.cs
@@ -14,7 +14,7 @@ public class InputLifecycleTests
     }
 
     [Fact]
-    public void HostedDisconnectRefusesInputWithoutClaimingChildExit()
+    public void HostedInputClosedStateRefusesWithoutClaimingChildExit()
     {
         // Constructor is cheap and never connects; no server or shared resource is started.
         using var backend = new ServerSessionBackend("not-connected", null);
@@ -27,7 +27,7 @@ public class InputLifecycleTests
         session.Detach(); // local cancellation only, no kill/control connection
     }
 
-    private sealed class ScriptedChannel : Stream
+    private class ScriptedChannel : Stream
     {
         internal int Reads; internal bool SawFinalOutput; internal bool Disposed;
         public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken ct = default)
@@ -58,9 +58,23 @@ public class InputLifecycleTests
     [Fact]
     public async Task HostCancellationStillEndsInputPumpWithoutDisposingAnOutstandingRead()
     {
-        using var channel = new ScriptedChannel(); using var cancel = new CancellationTokenSource();
+        using var channel = new PendingChannel(); using var cancel = new CancellationTokenSource();
+        var pump = HostInputPump.CopyAsync(channel, (_, _) => {}, cancel.Token);
+        await channel.Entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
         cancel.Cancel();
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => HostInputPump.CopyAsync(channel, (_, _) => {}, cancel.Token));
-        Assert.False(channel.Disposed); Assert.Equal(0, channel.Reads);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => pump.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.False(channel.Disposed); Assert.True(channel.ReadCompleted);
+    }
+
+    private sealed class PendingChannel : ScriptedChannel
+    {
+        internal readonly TaskCompletionSource Entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        internal bool ReadCompleted;
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken ct = default)
+        {
+            Entered.SetResult();
+            try { await Task.Delay(Timeout.Infinite, ct); return 0; }
+            finally { ReadCompleted = true; }
+        }
     }
 }

--- a/tests/Agwinterm.Pty.Tests/InputLifecycleTests.cs
+++ b/tests/Agwinterm.Pty.Tests/InputLifecycleTests.cs
@@ -1,0 +1,66 @@
+namespace Agwinterm.Pty.Tests;
+
+public class InputLifecycleTests
+{
+    [Fact]
+    public void InProcessInputCanCloseBeforeOutputCompletion()
+    {
+        using var session = new TerminalSession(80, 24);
+        session.MarkInputClosed();
+        Assert.True(session.InputClosed); Assert.False(session.HasExited);
+        Assert.Throws<IOException>(() => session.Write("not consumed"u8));
+        session.Inject("final-output"u8);
+        Assert.Contains("final-output", session.SnapshotRow(0));
+    }
+
+    [Fact]
+    public void HostedDisconnectRefusesInputWithoutClaimingChildExit()
+    {
+        // Constructor is cheap and never connects; no server or shared resource is started.
+        using var backend = new ServerSessionBackend("not-connected", null);
+        var session = new ServerSession(backend, "pane", 80, 24);
+        session.MarkInputClosed();
+        Assert.True(session.InputClosed); Assert.False(session.HasExited);
+        Assert.Throws<IOException>(() => session.Write("not consumed"u8));
+        session.Inject("final-output"u8);
+        Assert.Contains("final-output", session.SnapshotRow(0));
+        session.Detach(); // local cancellation only, no kill/control connection
+    }
+
+    private sealed class ScriptedChannel : Stream
+    {
+        internal int Reads; internal bool SawFinalOutput; internal bool Disposed;
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested(); Reads++;
+            if (Reads == 2) SawFinalOutput = true; // output side finishes AFTER input write refusal
+            if (Reads == 3) return ValueTask.FromResult(0);
+            buffer.Span[0] = 1; return ValueTask.FromResult(1);
+        }
+        protected override void Dispose(bool disposing) { Disposed = true; base.Dispose(disposing); }
+        public override bool CanRead => true; public override bool CanWrite => false; public override bool CanSeek => false;
+        public override long Length => throw new NotSupportedException(); public override long Position { get => 0; set => throw new NotSupportedException(); }
+        public override int Read(byte[] b,int o,int n) => throw new NotSupportedException();
+        public override void Write(byte[] b,int o,int n) => throw new NotSupportedException();
+        public override void Flush() {} public override long Seek(long o,SeekOrigin s) => throw new NotSupportedException();
+        public override void SetLength(long n) => throw new NotSupportedException();
+    }
+
+    [Fact]
+    public async Task ChildInputFailureDoesNotCloseDuplexOutputEarly()
+    {
+        using var channel = new ScriptedChannel(); int attempted = 0;
+        await HostInputPump.CopyAsync(channel, (_, _) => { attempted++; throw new IOException("child input closed"); }, CancellationToken.None);
+        Assert.Equal(1, attempted); Assert.Equal(3, channel.Reads);
+        Assert.True(channel.SawFinalOutput); Assert.False(channel.Disposed);
+    }
+
+    [Fact]
+    public async Task HostCancellationStillEndsInputPumpWithoutDisposingAnOutstandingRead()
+    {
+        using var channel = new ScriptedChannel(); using var cancel = new CancellationTokenSource();
+        cancel.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => HostInputPump.CopyAsync(channel, (_, _) => {}, cancel.Token));
+        Assert.False(channel.Disposed); Assert.Equal(0, channel.Reads);
+    }
+}

--- a/tests/Agwinterm.Pty.Tests/PtyResizeTransactionTests.cs
+++ b/tests/Agwinterm.Pty.Tests/PtyResizeTransactionTests.cs
@@ -5,6 +5,15 @@ namespace Agwinterm.Pty.Tests;
 
 public class PtyResizeTransactionTests
 {
+    [Theory]
+    [InlineData(-1, 24)] [InlineData(80, -1)] [InlineData(10001, 24)] [InlineData(80, 10001)]
+    public void InvalidCreateDimensionsRefuseBeforeAnyTransportAccess(int cols, int rows)
+    {
+        // No constructor/pipe: touching the transport would fail this test for the wrong reason.
+        var client = (PtyHostClient)System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(typeof(PtyHostClient));
+        Assert.Throws<ArgumentOutOfRangeException>(() => client.Create("unused", cols, rows, "cmd.exe", []));
+    }
+
     [Fact]
     public async Task RealResizeCannotInterleaveWithRepaintRestore()
     {

--- a/tests/Agwinterm.Pty.Tests/PtyResizeTransactionTests.cs
+++ b/tests/Agwinterm.Pty.Tests/PtyResizeTransactionTests.cs
@@ -1,0 +1,48 @@
+using System.Reflection;
+using Xunit;
+
+namespace Agwinterm.Pty.Tests;
+
+public class PtyResizeTransactionTests
+{
+    [Fact]
+    public async Task RealResizeCannotInterleaveWithRepaintRestore()
+    {
+        var transaction = new PtyResizeTransaction();
+        using var jiggled = new ManualResetEventSlim();
+        using var restore = new ManualResetEventSlim();
+        using var attempted = new ManualResetEventSlim();
+        var size = (100, 24);
+        var repaint = Task.Run(() => transaction.Run(() =>
+        {
+            var original = size; size = (100, 23); jiggled.Set();
+            if (!restore.Wait(10000)) throw new TimeoutException("restore barrier");
+            size = original;
+        }));
+        Task? real = null;
+        bool heldDuringPause = false;
+        try
+        {
+            Assert.True(jiggled.Wait(10000));
+            var gate = typeof(PtyResizeTransaction).GetField("_gate", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(transaction)!;
+            heldDuringPause = !Monitor.TryEnter(gate);
+            if (!heldDuringPause) Monitor.Exit(gate);
+            real = Task.Run(() => { attempted.Set(); transaction.Run(() => size = (132, 40)); });
+            Assert.True(attempted.Wait(10000));
+        }
+        finally { restore.Set(); await repaint; if (real is not null) await real; }
+        Assert.True(heldDuringPause);
+        Assert.Equal((132, 40), size);
+    }
+
+    [Theory]
+    [InlineData(0u, 24u)] [InlineData(80u, 0u)] [InlineData(10001u, 24u)]
+    [InlineData(80u, 10001u)] [InlineData(uint.MaxValue, 24u)]
+    public void MalformedDimensionsRefuseBeforeAllocation(uint cols, uint rows)
+        => Assert.False(PtyResizeTransaction.Valid(cols, rows));
+
+    [Theory]
+    [InlineData(1u, 1u)] [InlineData(10000u, 10000u)]
+    public void SupportedBoundsRemainAccepted(uint cols, uint rows)
+        => Assert.True(PtyResizeTransaction.Valid(cols, rows));
+}

--- a/tests/Agwinterm.Pty.Tests/RustPtyHostTests.cs
+++ b/tests/Agwinterm.Pty.Tests/RustPtyHostTests.cs
@@ -137,12 +137,15 @@ public class RustPtyHostTests : IDisposable
 
         Thread.Sleep(300);   // let the echo land in the HOST emulator (its snapshot feeds reattach)
         using var second = client.Attach(id, repaint: true);
+        client.Resize(id, 132, 40); // may arrive during the reconnect repaint's two-resize transaction
         bool inHistory = second.Scrollback.Any(l => l.Contains("before-detach"));
         var emu = new TerminalEmulator(second.Cols, second.Rows);
         emu.Feed(System.Text.Encoding.UTF8.GetBytes(second.Modes));   // modes replay parses cleanly
         Assert.True(inHistory || TypeUntilEcho(second.Data, "echo probe", "probe").Length > 0,
             "reattach must hand back a live stream");
         Assert.Contains("after-reattach", TypeUntilEcho(second.Data, "echo after-reattach", "after-reattach"));
+        var resized = Assert.Single(client.List());
+        Assert.Equal((132, 40), (resized.Cols, resized.Rows));
         client.Kill(id);
     }
 

--- a/tests/Agwinterm.Pty.Tests/ServerSessionTests.cs
+++ b/tests/Agwinterm.Pty.Tests/ServerSessionTests.cs
@@ -161,10 +161,17 @@ public class ServerSessionTests : IDisposable
         }
 
         // "UI generation 2": a fresh handle with the SAME pane id adopts it.
-        using var gen2 = (ServerSession)_backend.Create(paneId, 100, 24);
+        using var gen2 = (ServerSession)_backend.Create(paneId, 132, 40);
         Assert.True(gen2.TryAdopt(), "adoption must find the surviving session");
         Assert.True(gen2.Adopted);
         Assert.Equal(pid, gen2.ChildProcessId);                      // SAME child process — the whole point
+        using (var probe = PtyHostClient.Connect(_appId))
+        {
+            Assert.True(WaitFor(() => probe.List().Any(s => s.Id == paneId && s.Attached)));
+            // Old code leaves the host at 100x24 despite the new replica's requested grid.
+            Assert.Equal((132, 40), (gen2.Cols, gen2.Rows));
+            Assert.True(WaitFor(() => probe.List().Any(s => s.Id == paneId && s.Cols == 132 && s.Rows == 40)));
+        }
         Assert.True(WaitFor(() => GridText(gen2).Contains("pre+restart")),
             "pre-restart output missing after adoption; grid:\n" + GridText(gen2));
 
@@ -172,6 +179,11 @@ public class ServerSessionTests : IDisposable
         // repaints via a resize jiggle, and input landing mid-resize is discarded exactly as it is
         // during init (seen in the full suite under parallel load, never in isolation).
         TypeLine(gen2, "echo post+adopt", "post+adopt");
+        using (var probe = PtyHostClient.Connect(_appId))
+        {
+            var info = Assert.Single(probe.List());
+            Assert.Equal((132, 40), (info.Cols, info.Rows)); // repaint must not later restore the old grid
+        }
     }
 
     [Fact]

--- a/tests/Agwinterm.Pty.Tests/ServerSessionTests.cs
+++ b/tests/Agwinterm.Pty.Tests/ServerSessionTests.cs
@@ -118,10 +118,24 @@ public class ServerSessionTests : IDisposable
         await old.StartAsync("cmd.exe", ["/d", "/q"]);
         Assert.True(WaitFor(() => _backend.Client.List().Any(i => i.Id == id && i.Attached)));
         using var replacement = _backend.Client.Attach(id);
-        Assert.True(WaitFor(() => old.InputClosed));
-        Assert.False(old.HasExited);
-        Assert.Throws<IOException>(() => old.Write("must refuse"u8));
-        Assert.False(_backend.Client.List().Single(i => i.Id == id).HasExited);
+        // An attachment is a duplex transport, not just a handle. Keep consuming output as a
+        // real replacement client does; otherwise a prompt can backpressure the host's writer
+        // while List waits for its attachment lock, deadlocking the test's liveness assertion.
+        using var drainCancel = new CancellationTokenSource();
+        var drain = replacement.Data.CopyToAsync(Stream.Null, drainCancel.Token);
+        try
+        {
+            Assert.True(WaitFor(() => old.InputClosed));
+            Assert.False(old.HasExited);
+            Assert.Throws<IOException>(() => old.Write("must refuse"u8));
+            Assert.False(_backend.Client.List().Single(i => i.Id == id).HasExited);
+        }
+        finally
+        {
+            drainCancel.Cancel();
+            try { await drain; } catch (OperationCanceledException) { }
+            // Consume completion before the attachment's using disposes its overlapped handle.
+        }
     }
 
     [Fact]

--- a/tests/Agwinterm.Pty.Tests/ServerSessionTests.cs
+++ b/tests/Agwinterm.Pty.Tests/ServerSessionTests.cs
@@ -98,7 +98,7 @@ public class ServerSessionTests : IDisposable
         var seen = new TaskCompletionSource<(int Code, string Grid)>(TaskCreationOptions.RunContinuationsAsynchronously);
         s.Exited += code => seen.TrySetResult((code, GridText(s)));
         string script = $"$o=[Threading.EventWaitHandle]::OpenExisting('{outputName}'); $x=[Threading.EventWaitHandle]::OpenExisting('{exitName}'); " +
-            "if(-not $o.WaitOne(60000)){exit 41}; 'settle-marker-246'; if(-not $x.WaitOne(60000)){exit 42}; exit 3";
+            "if(-not $o.WaitOne(60000)){exit 41}; 'settle-marker-246'; if(-not $x.WaitOne(60000)){exit 42}; 'FINAL-after-exit-release'; exit 3";
         await s.StartAsync("powershell.exe", new[] { "-NoLogo", "-NoProfile", "-Command", script });
         Assert.True(WaitFor(() => _backend.Client.List().Any(i => i.Id == id && i.Attached), 10000));
         outputGate.Set();
@@ -106,8 +106,22 @@ public class ServerSessionTests : IDisposable
         exitGate.Set();
         var (exit, grid) = await seen.Task.WaitAsync(TimeSpan.FromSeconds(15));
         Assert.Equal(3, exit);
-        Assert.Contains("settle-marker-246", grid);
+        Assert.Contains("FINAL-after-exit-release", grid);
         Assert.True(s.HasExited);
+    }
+
+    [Fact]
+    public async Task SupersedingAttachmentClosesOldInputWithoutClaimingChildExit()
+    {
+        string id = Guid.NewGuid().ToString();
+        using var old = _backend.Create(id, 80, 24);
+        await old.StartAsync("cmd.exe", ["/d", "/q"]);
+        Assert.True(WaitFor(() => _backend.Client.List().Any(i => i.Id == id && i.Attached)));
+        using var replacement = _backend.Client.Attach(id);
+        Assert.True(WaitFor(() => old.InputClosed));
+        Assert.False(old.HasExited);
+        Assert.Throws<IOException>(() => old.Write("must refuse"u8));
+        Assert.False(_backend.Client.List().Single(i => i.Id == id).HasExited);
     }
 
     [Fact]

--- a/tests/Agwinterm.Pty.Tests/ServerSessionTests.cs
+++ b/tests/Agwinterm.Pty.Tests/ServerSessionTests.cs
@@ -83,15 +83,27 @@ public class ServerSessionTests : IDisposable
     /// <summary>#246: "the process has exited" is not "the pane is complete" — conhost flushes the
     /// last output after the child is gone. The host's exit watcher settles the pump before it
     /// closes the data pipe, so the grid an Exited handler reads has the program's last line. A
-    /// regression guard more than a proof (the echo usually lands first anyway): the assert is on
-    /// what the handler saw AT the event, not later.</summary>
+    /// controlled ordering test: first prove the replica has received output, then release the child
+    /// to exit. Cold create/attach scheduling cannot invalidate the premise. The assertion reads
+    /// the grid AT the event, not later; this does not claim lossless output before attachment.</summary>
     [Fact]
     public async Task Exited_FiresAfterTheLastOutputSettled()
     {
-        using var s = _backend.Create(Guid.NewGuid().ToString(), 80, 24);
+        string id = Guid.NewGuid().ToString();
+        using var s = _backend.Create(id, 80, 24);
+        string outputName = @"Local\agwinterm-output-" + Guid.NewGuid().ToString("N");
+        string exitName = @"Local\agwinterm-exit-" + Guid.NewGuid().ToString("N");
+        using var outputGate = new EventWaitHandle(false, EventResetMode.ManualReset, outputName);
+        using var exitGate = new EventWaitHandle(false, EventResetMode.ManualReset, exitName);
         var seen = new TaskCompletionSource<(int Code, string Grid)>(TaskCreationOptions.RunContinuationsAsynchronously);
         s.Exited += code => seen.TrySetResult((code, GridText(s)));
-        await s.StartAsync("cmd.exe", new[] { "/q", "/c", "echo settle-marker-246 & exit 3" }, verbatimCommandLine: true);
+        string script = $"$o=[Threading.EventWaitHandle]::OpenExisting('{outputName}'); $x=[Threading.EventWaitHandle]::OpenExisting('{exitName}'); " +
+            "if(-not $o.WaitOne(60000)){exit 41}; 'settle-marker-246'; if(-not $x.WaitOne(60000)){exit 42}; exit 3";
+        await s.StartAsync("powershell.exe", new[] { "-NoLogo", "-NoProfile", "-Command", script });
+        Assert.True(WaitFor(() => _backend.Client.List().Any(i => i.Id == id && i.Attached), 10000));
+        outputGate.Set();
+        Assert.True(WaitFor(() => GridText(s).Contains("settle-marker-246"), 60000), "output premise never reached replica");
+        exitGate.Set();
         var (exit, grid) = await seen.Task.WaitAsync(TimeSpan.FromSeconds(15));
         Assert.Equal(3, exit);
         Assert.Contains("settle-marker-246", grid);

--- a/tests/Agwinterm.Pty.Tests/SessionInputTests.cs
+++ b/tests/Agwinterm.Pty.Tests/SessionInputTests.cs
@@ -1,0 +1,61 @@
+using Agwinterm.Core;
+using System.Reflection;
+
+namespace Agwinterm.Pty.Tests;
+
+public class SessionInputTests
+{
+    [Fact]
+    public void BroadcastContinuesPastClosedProtectedAndFailingPanes()
+    {
+        using var closed = new InputSession { InputClosed = true };
+        using var failing = new InputSession { FailWrite = true };
+        using var protectedPane = new InputSession(); using var live = new InputSession();
+        Assert.False(SessionInput.Broadcast([(closed, false), (failing, false), (protectedPane, true), (live, false)], "payload"u8));
+        Assert.Equal(0, closed.Attempts); Assert.Equal(1, failing.Attempts); Assert.Equal(0, protectedPane.Attempts);
+        Assert.Equal("payload", live.Input); Assert.Equal(1, live.Attempts);
+    }
+
+    [Theory]
+    [InlineData(false)] [InlineData(true)]
+    public void ActualPaneHostQueryReplyCannotAbortFollowingOutput(bool closed)
+    {
+        using var session = new InputSession { InputClosed = closed, FailWrite = true };
+        string? root = AppContext.BaseDirectory;
+        while (root is not null && !Directory.Exists(Path.Combine(root, "src", "Agwinterm.Win32"))) root = Path.GetDirectoryName(root);
+        var path = Directory.GetFiles(Path.Combine(root!, "src", "Agwinterm.Win32", "bin"), "Agwinterm.Win32.dll", SearchOption.AllDirectories).OrderByDescending(File.GetLastWriteTimeUtc).First();
+        var type = Assembly.LoadFrom(path).GetType("Agwinterm.Win32.Program+PaneHost", true)!;
+        session.Emulator.Host = (IHostActions)Activator.CreateInstance(type, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, null, [null, null, session], null)!;
+        // Kitty flags query requests a real host reply; the marker follows in the SAME Feed call.
+        session.Emulator.Feed("\x1b[?uFINAL-after-query"u8);
+        Assert.Contains("FINAL-after-query", session.Emulator.DumpRow(0));
+        Assert.Equal(closed ? 0 : 1, session.Attempts);
+    }
+
+    private sealed class InputSession : ISession
+    {
+        public bool InputClosed { get; init; }
+        public bool FailWrite; public int Attempts; public string Input = "";
+        public ITerminalCore Emulator { get; } = new TerminalEmulator(80, 24);
+        public int Cols => 80; public int Rows => 24; public int? ChildProcessId => null;
+        public object SyncRoot { get; } = new();
+        public AgentStatus Status => AgentStatus.Idle; public bool Blink => false; public bool AutoReset => false;
+        public long StatusChangedAt => 0; public bool HasExited => false; public int? ExitCode => null;
+        public event Action? OutputReceived { add { } remove { } }
+        public event Action? StatusChanged { add { } remove { } }
+        public event Action<string?>? SoundRequested { add { } remove { } }
+        public event Action<int>? Exited { add { } remove { } }
+        public void NotifyActivity() { }
+        public void SetStatus(AgentStatus status, bool blink = false, bool autoReset = false, bool sound = false, string? soundName = null) { }
+        public void Write(ReadOnlySpan<byte> bytes) { Attempts++; if (FailWrite) throw new IOException("closed during write"); Input += System.Text.Encoding.UTF8.GetString(bytes); }
+        public Task StartAsync(string app, string[] commandLine, bool verbatimCommandLine = false, IReadOnlyDictionary<string, string>? extraEnv = null, string? cwd = null, bool deElevate = false, bool freshEnv = true, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<int> RunAsync(string app, string[] commandLine, bool verbatimCommandLine = false, CancellationToken ct = default) => throw new NotSupportedException();
+        public void Attach(Microsoft.Win32.SafeHandles.SafeFileHandle conOut, Microsoft.Win32.SafeHandles.SafeFileHandle conIn, Microsoft.Win32.SafeHandles.SafeFileHandle signal, IntPtr clientProcess, int pid) => throw new NotSupportedException();
+        public void Inject(ReadOnlySpan<byte> bytes) => Emulator.Feed(bytes);
+        public void MutateLocked(Action<ITerminalCore> mutate) => mutate(Emulator);
+        public void Resize(int cols, int rows) => Emulator.Resize(cols, rows);
+        public string SnapshotRow(int row) => Emulator.DumpRow(row);
+        public (int Row, int Col) SnapshotCursor() => (Emulator.CursorRow, Emulator.CursorCol);
+        public void Detach() { } public void Dispose() { }
+    }
+}

--- a/tests/Agwinterm.Pty.Tests/SessionInputTests.cs
+++ b/tests/Agwinterm.Pty.Tests/SessionInputTests.cs
@@ -5,6 +5,35 @@ namespace Agwinterm.Pty.Tests;
 
 public class SessionInputTests
 {
+    [Theory]
+    [InlineData(false, false)] [InlineData(true, false)]
+    [InlineData(false, true)] [InlineData(true, true)]
+    public void ActualSendBroadcastDoesNotLetActiveProtectionBlockSibling(bool closed, bool command)
+    {
+        using var active = new InputSession { InputClosed = closed };
+        using var live = new InputSession();
+        var program = LoadProgram();
+        // No Program constructor: no HWND, host, timers, or shared state is created.
+        var app = System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(program);
+        object Make(string nested) => Activator.CreateInstance(program.GetNestedType(nested, BindingFlags.NonPublic)!, true)!;
+        static void Set(object o, string name, object value) => o.GetType().GetField(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(o, value);
+        static System.Collections.IList List(object o, string name) => (System.Collections.IList)o.GetType().GetField(name)!.GetValue(o)!;
+        var ws = Make("Workspace"); var ses = Make("Ses");
+        var pane = Make("Pane"); var sibling = Make("Pane");
+        Set(pane, "S", active); Set(pane, "ReadOnly", !closed); Set(pane, "HasSel", true); Set(pane, "ScrollOffset", 5);
+        Set(sibling, "S", live); Set(ses, "Ws", ws);
+        List(ses, "Panes").Add(pane); List(ses, "Panes").Add(sibling); List(ws, "Sessions").Add(ses);
+        Set(app, "_active", ses); Set(app, "_session", active); Set(app, "_broadcast", true);
+        Set(app, "_workspaces", Activator.CreateInstance(program.GetField("_workspaces", BindingFlags.NonPublic | BindingFlags.Instance)!.FieldType)!);
+        var method = program.GetMethod(command ? "RunCommandText" : "Send", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var result = method.Invoke(app, command ? ["payload", "send"] : ["payload", true]);
+        if (command) Assert.Contains("do not retry blindly", Assert.IsType<string>(result));
+        else Assert.False(Assert.IsType<bool>(result));
+        Assert.Equal(0, active.Attempts); Assert.Equal(command ? "payload\r" : "payload", live.Input);
+        Assert.True((bool)pane.GetType().GetField("HasSel")!.GetValue(pane)!);
+        Assert.Equal(5, pane.GetType().GetField("ScrollOffset")!.GetValue(pane));
+    }
+
     [Fact]
     public void BroadcastContinuesPastClosedProtectedAndFailingPanes()
     {
@@ -21,15 +50,20 @@ public class SessionInputTests
     public void ActualPaneHostQueryReplyCannotAbortFollowingOutput(bool closed)
     {
         using var session = new InputSession { InputClosed = closed, FailWrite = true };
-        string? root = AppContext.BaseDirectory;
-        while (root is not null && !Directory.Exists(Path.Combine(root, "src", "Agwinterm.Win32"))) root = Path.GetDirectoryName(root);
-        var path = Directory.GetFiles(Path.Combine(root!, "src", "Agwinterm.Win32", "bin"), "Agwinterm.Win32.dll", SearchOption.AllDirectories).OrderByDescending(File.GetLastWriteTimeUtc).First();
-        var type = Assembly.LoadFrom(path).GetType("Agwinterm.Win32.Program+PaneHost", true)!;
+        var type = LoadProgram().GetNestedType("PaneHost", BindingFlags.NonPublic)!;
         session.Emulator.Host = (IHostActions)Activator.CreateInstance(type, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, null, [null, null, session], null)!;
         // Kitty flags query requests a real host reply; the marker follows in the SAME Feed call.
         session.Emulator.Feed("\x1b[?uFINAL-after-query"u8);
         Assert.Contains("FINAL-after-query", session.Emulator.DumpRow(0));
         Assert.Equal(closed ? 0 : 1, session.Attempts);
+    }
+
+    private static Type LoadProgram()
+    {
+        string? root = AppContext.BaseDirectory;
+        while (root is not null && !Directory.Exists(Path.Combine(root, "src", "Agwinterm.Win32"))) root = Path.GetDirectoryName(root);
+        var path = Directory.GetFiles(Path.Combine(root!, "src", "Agwinterm.Win32", "bin"), "Agwinterm.Win32.dll", SearchOption.AllDirectories).OrderByDescending(File.GetLastWriteTimeUtc).First();
+        return Assembly.LoadFrom(path).GetType("Agwinterm.Win32.Program", true)!;
     }
 
     private sealed class InputSession : ISession

--- a/tests/Agwinterm.Pty.Tests/SessionInputTests.cs
+++ b/tests/Agwinterm.Pty.Tests/SessionInputTests.cs
@@ -46,6 +46,33 @@ public class SessionInputTests
     }
 
     [Theory]
+    [InlineData(false, 0, false)] [InlineData(true, 0, false)]
+    [InlineData(false, 2, false)] [InlineData(true, 2, false)]
+    [InlineData(false, 0, true)] [InlineData(true, 0, true)]
+    [InlineData(false, 1, true)] [InlineData(true, 1, true)]
+    [InlineData(false, 2, true)] [InlineData(true, 2, true)]
+    public void ActualSendKeepsCoversTargetedWhileBroadcastIsOn(bool paneOverlay, int state, bool command)
+    {
+        using var shell = new InputSession(); using var cover = new InputSession { InputClosed = state == 2 };
+        var program = LoadProgram();
+        var app = System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(program);
+        object Make(string name) => Activator.CreateInstance(program.GetNestedType(name, BindingFlags.NonPublic)!, true)!;
+        static void Set(object o, string name, object value) => o.GetType().GetField(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(o, value);
+        var ses = Make("Ses"); var pane = Make("Pane"); var overlay = Make("Pane");
+        Set(pane, "S", shell); Set(overlay, "S", cover); Set(overlay, "ReadOnly", state == 1);
+        ((System.Collections.IList)ses.GetType().GetField("Panes")!.GetValue(ses)!).Add(pane);
+        if (paneOverlay) Set(pane.GetType().GetField("Overlay")!.GetValue(pane)!, "Term", overlay);
+        else Set(app, "_cover", overlay);
+        Set(app, "_active", ses); Set(app, "_session", cover); Set(app, "_broadcast", true);
+        Assert.False((bool)program.GetProperty("BroadcastActive", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(app)!);
+        var result = program.GetMethod(command ? "RunCommandText" : "Send", BindingFlags.NonPublic | BindingFlags.Instance)!.Invoke(app, command ? ["payload", "send"] : ["payload", true]);
+        Assert.Equal(0, shell.Attempts);
+        Assert.Equal(state == 0 ? (command ? "payload\r" : "payload") : "", cover.Input);
+        if (command) Assert.Equal(state != 0, Assert.IsType<string>(result).StartsWith(ISessionHost.RefusePrefix, StringComparison.Ordinal));
+        else Assert.Equal(state == 0, Assert.IsType<bool>(result));
+    }
+
+    [Theory]
     [InlineData(false)] [InlineData(true)]
     public void ActualPaneHostQueryReplyCannotAbortFollowingOutput(bool closed)
     {

--- a/tests/Agwinterm.Pty.Tests/SessionStartFenceTests.cs
+++ b/tests/Agwinterm.Pty.Tests/SessionStartFenceTests.cs
@@ -6,6 +6,16 @@ public class SessionStartFenceTests
 {
     [Theory]
     [InlineData(false)] [InlineData(true)]
+    public void FailedAttachReapsOnlyIfDetachHasNotAlreadyWon(bool detached)
+    {
+        var fence = new SessionStartFence(); Assert.False(fence.Created());
+        if (detached) Assert.False(fence.Close(false));
+        Assert.Equal(!detached, fence.AttachmentFailed());
+        Assert.False(fence.Publish(() => throw new Exception("must not publish failed attach")));
+        Assert.Equal(detached, fence.Close(true)); // explicit Dispose may strengthen detach later
+    }
+    [Theory]
+    [InlineData(false)] [InlineData(true)]
     public void CloseBeforeCreateLeavesTheRightObligation(bool kill)
     {
         var fence = new SessionStartFence();

--- a/tests/Agwinterm.Pty.Tests/SessionStartFenceTests.cs
+++ b/tests/Agwinterm.Pty.Tests/SessionStartFenceTests.cs
@@ -1,0 +1,58 @@
+using Xunit;
+
+namespace Agwinterm.Pty.Tests;
+
+public class SessionStartFenceTests
+{
+    [Theory]
+    [InlineData(false)] [InlineData(true)]
+    public void CloseBeforeCreateLeavesTheRightObligation(bool kill)
+    {
+        var fence = new SessionStartFence();
+        Assert.False(fence.Close(kill)); // no hosted id exists yet
+        Assert.Equal(kill, fence.Created()); // create just completed: close must reap it, detach must not
+        Assert.False(fence.Created());
+        Assert.False(fence.Publish(() => throw new Exception("must not start reader")));
+    }
+
+    [Fact]
+    public void CloseAfterCreateClaimsKillExactlyOnce()
+    {
+        var fence = new SessionStartFence();
+        Assert.False(fence.Created());
+        Assert.True(fence.Publish(() => { }));
+        Assert.True(fence.Close(true));
+        Assert.False(fence.Close(true));
+        Assert.False(fence.Publish(() => throw new Exception("must not republish")));
+    }
+
+    [Fact]
+    public void ExplicitCloseCanStrengthenAnEarlierDetach()
+    {
+        var fence = new SessionStartFence();
+        Assert.False(fence.Created());
+        Assert.False(fence.Close(false));
+        Assert.True(fence.Close(true));
+        Assert.False(fence.Close(true));
+    }
+
+    [Fact]
+    public async Task CloseDoesNotWaitForBlockedCreateAndCompletionCannotPublish()
+    {
+        var fence = new SessionStartFence();
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int kills = 0, publications = 0;
+        var create = Task.Run(async () =>
+        {
+            entered.SetResult(); await release.Task;
+            if (fence.Created()) Interlocked.Increment(ref kills);
+            fence.Publish(() => Interlocked.Increment(ref publications));
+        });
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        try { Assert.False(fence.Close(true)); }
+        finally { release.TrySetResult(); }
+        await create.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(1, kills); Assert.Equal(0, publications);
+    }
+}

--- a/tests/integration/hud-ui.ps1
+++ b/tests/integration/hud-ui.ps1
@@ -43,6 +43,7 @@ public sealed class HudOwnedJob {
     [DllImport("kernel32.dll",CharSet=CharSet.Unicode,SetLastError=true)] static extern IntPtr CreateJobObjectW(IntPtr a,string n);
     [DllImport("kernel32.dll",SetLastError=true)] static extern bool SetInformationJobObject(IntPtr j,int c,ref LIMIT l,int n);
     [DllImport("kernel32.dll",SetLastError=true)] static extern bool QueryInformationJobObject(IntPtr j,int c,out ACCOUNT a,int n,IntPtr r);
+    [DllImport("kernel32.dll",SetLastError=true)] static extern bool QueryInformationJobObject(IntPtr j,int c,IntPtr a,int n,IntPtr r);
     [DllImport("kernel32.dll",CharSet=CharSet.Unicode,SetLastError=true)] static extern bool CreateProcessW(string app,StringBuilder cmd,IntPtr pa,IntPtr ta,bool inherit,uint flags,IntPtr env,string cwd,ref STARTUP si,out PROCESS pi);
     [DllImport("kernel32.dll",SetLastError=true)] static extern bool AssignProcessToJobObject(IntPtr j,IntPtr p);
     [DllImport("kernel32.dll")] static extern uint ResumeThread(IntPtr t);
@@ -84,6 +85,21 @@ public sealed class HudOwnedJob {
     public uint Count() {
         ACCOUNT a; if(!QueryInformationJobObject(job,1,out a,Marshal.SizeOf<ACCOUNT>(),IntPtr.Zero))throw new Exception("Job accounting");
         return a.active;
+    }
+    public string Members() {
+        // Read only members of THIS private job; never infer ownership from a process name.
+        int bytes=65536;IntPtr buffer=Marshal.AllocHGlobal(bytes);
+        try {
+            if(!QueryInformationJobObject(job,3,buffer,bytes,IntPtr.Zero))throw new Exception("Job members: "+Marshal.GetLastWin32Error());
+            int count=Marshal.ReadInt32(buffer,4);var names=new System.Collections.Generic.List<string>();
+            if(count<0||count>(bytes-8)/IntPtr.Size)throw new Exception("Invalid job member count");
+            for(int i=0;i<count;i++){
+                int pid=checked((int)Marshal.ReadIntPtr(buffer,8+i*IntPtr.Size).ToInt64());
+                try{using(var p=System.Diagnostics.Process.GetProcessById(pid)){names.Add(pid+":"+p.ProcessName);}}
+                catch(ArgumentException){names.Add(pid+":exited");}
+            }
+            return string.Join(", ",names);
+        }finally{Marshal.FreeHGlobal(buffer);}
     }
     public void Finish() {
         if(job==IntPtr.Zero)return;

--- a/tests/integration/hud-ui.ps1
+++ b/tests/integration/hud-ui.ps1
@@ -86,20 +86,27 @@ public sealed class HudOwnedJob {
         ACCOUNT a; if(!QueryInformationJobObject(job,1,out a,Marshal.SizeOf<ACCOUNT>(),IntPtr.Zero))throw new Exception("Job accounting");
         return a.active;
     }
-    public string Members() {
+    public int[] MemberIds() {
         // Read only members of THIS private job; never infer ownership from a process name.
         int bytes=65536;IntPtr buffer=Marshal.AllocHGlobal(bytes);
         try {
             if(!QueryInformationJobObject(job,3,buffer,bytes,IntPtr.Zero))throw new Exception("Job members: "+Marshal.GetLastWin32Error());
-            int count=Marshal.ReadInt32(buffer,4);var names=new System.Collections.Generic.List<string>();
+            int count=Marshal.ReadInt32(buffer,4);var ids=new System.Collections.Generic.List<int>();
             if(count<0||count>(bytes-8)/IntPtr.Size)throw new Exception("Invalid job member count");
             for(int i=0;i<count;i++){
                 int pid=checked((int)Marshal.ReadIntPtr(buffer,8+i*IntPtr.Size).ToInt64());
-                try{using(var p=System.Diagnostics.Process.GetProcessById(pid)){names.Add(pid+":"+p.ProcessName);}}
-                catch(ArgumentException){names.Add(pid+":exited");}
+                ids.Add(pid);
             }
-            return string.Join(", ",names);
+            return ids.ToArray();
         }finally{Marshal.FreeHGlobal(buffer);}
+    }
+    public string Members() {
+        var names=new System.Collections.Generic.List<string>();
+        foreach(int pid in MemberIds()){
+            try{using(var p=System.Diagnostics.Process.GetProcessById(pid)){names.Add(pid+":"+p.ProcessName);}}
+            catch(ArgumentException){names.Add(pid+":exited");}
+        }
+        return string.Join(", ",names);
     }
     public void Finish() {
         if(job==IntPtr.Zero)return;

--- a/tests/integration/navigation-ui-cases.ps1
+++ b/tests/integration/navigation-ui-cases.ps1
@@ -23,6 +23,7 @@ function PixelDifference($a,$b,[int]$x=0,[int]$y=0,[int]$w=0,[int]$h=0){
     }};return $different
 }
 $first=[string](CurrentWs);$beforeText=Rpc 'session.text' @{} $session
+. "$PSScriptRoot/workspace-teardown-cases.ps1"
 Check 'readonly rejects an unknown operation without changing protection' (-not (Rpc 'session.readonly' @{op='typo'} $session -AllowError).ok -and (Rpc 'session.readonly' @{op='state'} $session)-eq 'off')
 $null=Rpc 'session.readonly' @{op='on'} $session
 Check 'readonly typo cannot remove existing protection' (-not (Rpc 'session.readonly' @{op='typo'} $session -AllowError).ok -and (Rpc 'session.readonly' @{op='get'} $session)-eq 'on')

--- a/tests/integration/win32-control.ps1
+++ b/tests/integration/win32-control.ps1
@@ -1517,7 +1517,9 @@ function Read-MouseReport([int]$terminator) {
             'session', 'overlay', 'open', $mouseCommand,
             '--size-percent', '50', '--target', $survivorId)
         $mouseOverlayId = [string]$mouseOverlay.result
-        for ($i = 0; $i -lt 40 -and -not (Test-Path -LiteralPath $mouseCellReadyFile); $i++) {
+        # This child compiles its raw-console helper before publishing the ready file. On a
+        # loaded runner that can exceed ten seconds; keep readiness explicit, with a finite bound.
+        for ($i = 0; $i -lt 120 -and -not (Test-Path -LiteralPath $mouseCellReadyFile); $i++) {
             Start-Sleep -Milliseconds 250
         }
 
@@ -1559,7 +1561,8 @@ function Read-MouseReport([int]$terminator) {
         $mouseFixtureReady = $mouseOverlay.ok -and $hwnd -ne [IntPtr]::Zero -and
             (Test-Path -LiteralPath $mouseCellReadyFile) -and $coverMetricsDistinct -and
             $overlayMetrics.result.cols -gt 8 -and $overlayMetrics.result.widthPx -gt 0
-        Check 'the floating cover mouse-reporting fixture becomes ready' $mouseFixtureReady
+        Check 'the floating cover mouse-reporting fixture becomes ready' $mouseFixtureReady `
+            "open=$($mouseOverlay.ok), hwnd=$hwnd, readyFile=$(Test-Path -LiteralPath $mouseCellReadyFile), distinct=$coverMetricsDistinct, cols=$($overlayMetrics.result.cols), width=$($overlayMetrics.result.widthPx)"
 
         if ($mouseFixtureReady) {
             $esc = [char]27

--- a/tests/integration/workspace-teardown-cases.ps1
+++ b/tests/integration/workspace-teardown-cases.ps1
@@ -1,6 +1,7 @@
 # Runs only within hud-ui's private process job and suite-token lifetime.
 if(-not (NavWait {(Node $session).foregroundShell-eq 'cmd'})){throw 'Teardown fixture needs its survivor shell ready'}
 $survivorCount=$job.Count()
+"Teardown baseline: $survivorCount processes; $($job.Members())"
 foreach($finishWalk in 'cancel','commit'){
 foreach($deleteActive in $false,$true){
     $doomedWs=[string](Rpc 'workspace.new' @{name='teardown-owned'})
@@ -32,7 +33,8 @@ foreach($deleteActive in $false,$true){
         $null=Rpc 'workspace.delete' @{} $doomedWs
         $null=Rpc 'session.switch' @{op=$finishWalk} -NoTarget
         NavKey 13 # a stale dashboard must not activate its disposed member
-        Check "workspace deletion releases every owned process (active=$deleteActive, finish=$finishWalk)" (NavWait {$job.Count()-eq $survivorCount})
+        $released=NavWait {$job.Count()-eq $survivorCount}
+        Check "workspace deletion releases every owned process (active=$deleteActive, finish=$finishWalk)" $released "baseline=$survivorCount remaining=$($job.Count()) members=$($job.Members())"
         Check 'deleted session cannot be reactivated by stale switch state' ($null-eq (Node $doomed) -and (Node $session).active)
         Check 'unrelated survivor still accepts control reads' (-not [string]::IsNullOrWhiteSpace([string](Rpc 'session.text' @{} $session)))
         Check 'repeated deletion refuses' (-not (Rpc 'workspace.delete' @{} $doomedWs -AllowError).ok)

--- a/tests/integration/workspace-teardown-cases.ps1
+++ b/tests/integration/workspace-teardown-cases.ps1
@@ -1,14 +1,17 @@
 # Runs only within hud-ui's private process job and suite-token lifetime.
 if(-not (NavWait {(Node $session).foregroundShell-eq 'cmd'})){throw 'Teardown fixture needs its survivor shell ready'}
 $survivorCount=$job.Count()
+foreach($finishWalk in 'cancel','commit'){
 foreach($deleteActive in $false,$true){
     $doomedWs=[string](Rpc 'workspace.new' @{name='teardown-owned'})
     try {
         $null=Rpc 'workspace.select' @{} $doomedWs
         $doomed=[string](Rpc 'session.new' @{name='teardown-split';wait=$true})
+        if(-not (NavWait {$null-ne (Node $doomed)})){throw 'Doomed session did not materialize'}
         $right=[string](Rpc 'session.split' @{op='on'} $doomed)
         if(-not (NavWait {(Node $doomed).foregroundShells.Count-eq 2 -and @((Node $doomed).foregroundShells|Where-Object {$_-ne 'cmd'}).Count-eq 0})){throw 'Split shells not ready'}
         $null=Rpc 'session.scratch' @{op='on'} $doomed
+        $null=Rpc 'config.set' @{key='cursor-blink';value='false'} -NoTarget # waits behind scratch creation
         if(-not (NavWait {([string](Rpc 'session.text' @{})).Contains('>')})){throw 'Scratch shell not ready'}
         $null=Rpc 'session.scratch' @{op='off'} $doomed
         $paneOverlay=[string](Rpc 'session.overlay' @{action='open';pane='left';command='cmd /d /k echo PANE-TEARDOWN-READY'} $doomed)
@@ -19,10 +22,17 @@ foreach($deleteActive in $false,$true){
         if(-not $deleteActive){$null=Rpc 'session.select' @{} $session}
         # Frozen walk membership must not keep a deleted session reachable by commit or cancel.
         $null=Rpc 'session.switch' @{op='begin'} -NoTarget
+        # Preview the doomed member in a fresh walk for EACH finishing operation.
+        if($finishWalk-eq 'commit'){
+            if(-not (Node $doomed).active){$null=Rpc 'session.switch' @{op='next'} -NoTarget}
+            Check 'commit walk previews doomed session before deletion' ((Node $doomed).active)
+        }
+        $null=Rpc 'dashboard' @{ids=$doomed} -NoTarget
+        $null=Rpc 'config.set' @{key='cursor-blink';value='false'} -NoTarget # queued UI barrier
         $null=Rpc 'workspace.delete' @{} $doomedWs
-        $null=Rpc 'session.switch' @{op='cancel'} -NoTarget
-        $null=Rpc 'session.switch' @{op='commit'} -NoTarget
-        Check "workspace deletion releases every owned process (active=$deleteActive)" (NavWait {$job.Count()-eq $survivorCount})
+        $null=Rpc 'session.switch' @{op=$finishWalk} -NoTarget
+        NavKey 13 # a stale dashboard must not activate its disposed member
+        Check "workspace deletion releases every owned process (active=$deleteActive, finish=$finishWalk)" (NavWait {$job.Count()-eq $survivorCount})
         Check 'deleted session cannot be reactivated by stale switch state' ($null-eq (Node $doomed) -and (Node $session).active)
         Check 'unrelated survivor still accepts control reads' (-not [string]::IsNullOrWhiteSpace([string](Rpc 'session.text' @{} $session)))
         Check 'repeated deletion refuses' (-not (Rpc 'workspace.delete' @{} $doomedWs -AllowError).ok)
@@ -30,4 +40,5 @@ foreach($deleteActive in $false,$true){
         if(@(NavTree|Where-Object id -eq $doomedWs).Count){$null=Rpc 'workspace.delete' @{} $doomedWs}
         $null=Rpc 'session.select' @{} $session
     }
+}
 }

--- a/tests/integration/workspace-teardown-cases.ps1
+++ b/tests/integration/workspace-teardown-cases.ps1
@@ -1,0 +1,33 @@
+# Runs only within hud-ui's private process job and suite-token lifetime.
+if(-not (NavWait {(Node $session).foregroundShell-eq 'cmd'})){throw 'Teardown fixture needs its survivor shell ready'}
+$survivorCount=$job.Count()
+foreach($deleteActive in $false,$true){
+    $doomedWs=[string](Rpc 'workspace.new' @{name='teardown-owned'})
+    try {
+        $null=Rpc 'workspace.select' @{} $doomedWs
+        $doomed=[string](Rpc 'session.new' @{name='teardown-split';wait=$true})
+        $right=[string](Rpc 'session.split' @{op='on'} $doomed)
+        if(-not (NavWait {(Node $doomed).foregroundShells.Count-eq 2 -and @((Node $doomed).foregroundShells|Where-Object {$_-ne 'cmd'}).Count-eq 0})){throw 'Split shells not ready'}
+        $null=Rpc 'session.scratch' @{op='on'} $doomed
+        if(-not (NavWait {([string](Rpc 'session.text' @{})).Contains('>')})){throw 'Scratch shell not ready'}
+        $null=Rpc 'session.scratch' @{op='off'} $doomed
+        $paneOverlay=[string](Rpc 'session.overlay' @{action='open';pane='left';command='cmd /d /k echo PANE-TEARDOWN-READY'} $doomed)
+        if(-not (NavWait {([string](Rpc 'session.text' @{} $paneOverlay)).Contains('PANE-TEARDOWN-READY')})){throw 'Pane overlay not ready'}
+        $wholeOverlay=[string](Rpc 'session.overlay' @{action='open';command='cmd /d /k echo SESSION-TEARDOWN-READY'} $doomed)
+        if(-not (NavWait {([string](Rpc 'session.text' @{} $wholeOverlay)).Contains('SESSION-TEARDOWN-READY')})){throw 'Session overlay not ready'}
+        Check 'fixture owns extra live processes before deletion' ($job.Count()-gt $survivorCount)
+        if(-not $deleteActive){$null=Rpc 'session.select' @{} $session}
+        # Frozen walk membership must not keep a deleted session reachable by commit or cancel.
+        $null=Rpc 'session.switch' @{op='begin'} -NoTarget
+        $null=Rpc 'workspace.delete' @{} $doomedWs
+        $null=Rpc 'session.switch' @{op='cancel'} -NoTarget
+        $null=Rpc 'session.switch' @{op='commit'} -NoTarget
+        Check "workspace deletion releases every owned process (active=$deleteActive)" (NavWait {$job.Count()-eq $survivorCount})
+        Check 'deleted session cannot be reactivated by stale switch state' ($null-eq (Node $doomed) -and (Node $session).active)
+        Check 'unrelated survivor still accepts control reads' (-not [string]::IsNullOrWhiteSpace([string](Rpc 'session.text' @{} $session)))
+        Check 'repeated deletion refuses' (-not (Rpc 'workspace.delete' @{} $doomedWs -AllowError).ok)
+    } finally {
+        if(@(NavTree|Where-Object id -eq $doomedWs).Count){$null=Rpc 'workspace.delete' @{} $doomedWs}
+        $null=Rpc 'session.select' @{} $session
+    }
+}

--- a/tests/integration/workspace-teardown-cases.ps1
+++ b/tests/integration/workspace-teardown-cases.ps1
@@ -1,6 +1,6 @@
 # Runs only within hud-ui's private process job and suite-token lifetime.
 if(-not (NavWait {(Node $session).foregroundShell-eq 'cmd'})){throw 'Teardown fixture needs its survivor shell ready'}
-$survivorCount=$job.Count()
+$survivorIds=@($job.MemberIds());$survivorCount=$survivorIds.Count
 "Teardown baseline: $survivorCount processes; $($job.Members())"
 foreach($finishWalk in 'cancel','commit'){
 foreach($deleteActive in $false,$true){
@@ -19,7 +19,7 @@ foreach($deleteActive in $false,$true){
         if(-not (NavWait {([string](Rpc 'session.text' @{} $paneOverlay)).Contains('PANE-TEARDOWN-READY')})){throw 'Pane overlay not ready'}
         $wholeOverlay=[string](Rpc 'session.overlay' @{action='open';command='cmd /d /k echo SESSION-TEARDOWN-READY'} $doomed)
         if(-not (NavWait {([string](Rpc 'session.text' @{} $wholeOverlay)).Contains('SESSION-TEARDOWN-READY')})){throw 'Session overlay not ready'}
-        Check 'fixture owns extra live processes before deletion' ($job.Count()-gt $survivorCount)
+        Check 'fixture owns extra live processes before deletion' (@($job.MemberIds()|Where-Object {$_-notin $survivorIds}).Count-gt 0)
         if(-not $deleteActive){$null=Rpc 'session.select' @{} $session}
         # Frozen walk membership must not keep a deleted session reachable by commit or cancel.
         $null=Rpc 'session.switch' @{op='begin'} -NoTarget
@@ -33,7 +33,9 @@ foreach($deleteActive in $false,$true){
         $null=Rpc 'workspace.delete' @{} $doomedWs
         $null=Rpc 'session.switch' @{op=$finishWalk} -NoTarget
         NavKey 13 # a stale dashboard must not activate its disposed member
-        $released=NavWait {$job.Count()-eq $survivorCount}
+        # Startup helpers in the baseline may exit normally; require every NEW job member gone,
+        # not an unchanged count (or count <= baseline, which could hide a different leaked child).
+        $released=NavWait {@($job.MemberIds()|Where-Object {$_-notin $survivorIds}).Count-eq 0}
         Check "workspace deletion releases every owned process (active=$deleteActive, finish=$finishWalk)" $released "baseline=$survivorCount remaining=$($job.Count()) members=$($job.Members())"
         Check 'deleted session cannot be reactivated by stale switch state' ($null-eq (Node $doomed) -and (Node $session).active)
         $beforeDuplicate=@((NavTree).sessions).Count

--- a/tests/integration/workspace-teardown-cases.ps1
+++ b/tests/integration/workspace-teardown-cases.ps1
@@ -36,6 +36,9 @@ foreach($deleteActive in $false,$true){
         $released=NavWait {$job.Count()-eq $survivorCount}
         Check "workspace deletion releases every owned process (active=$deleteActive, finish=$finishWalk)" $released "baseline=$survivorCount remaining=$($job.Count()) members=$($job.Members())"
         Check 'deleted session cannot be reactivated by stale switch state' ($null-eq (Node $doomed) -and (Node $session).active)
+        $beforeDuplicate=@((NavTree).sessions).Count
+        $duplicate=Rpc 'session.duplicate' @{} $doomed -AllowError
+        Check 'duplicate refuses a removed explicit owner instead of cloning the survivor' (-not $duplicate.ok -and @((NavTree).sessions).Count-eq $beforeDuplicate)
         Check 'unrelated survivor still accepts control reads' (-not [string]::IsNullOrWhiteSpace([string](Rpc 'session.text' @{} $session)))
         Check 'repeated deletion refuses' (-not (Rpc 'workspace.delete' @{} $doomedWs -AllowError).ok)
     } finally {


### PR DESCRIPTION
Closes #268. Closes #258.

Known input closure is independent of output-settled exit. Both hosts keep the output side alive after a child-input failure until settlement/disconnect; late terminal query replies cannot abort final-output parsing. Public success remains transport acceptance, not consumption or execution; no protocol/ABI redesign.

The cold exit-ordering test now uses private attach/output/exit barriers while retaining the exit-handler grid assertion. Existing color-replay test already has the output-start barrier. These tests do not claim lossless pre-attach output.

Native/C# build and four isolated lifecycle checks pass. Broad Codex-only review and exact-head Windows integration CI pending. Stacked on lifecycle #275, which still has its own blockers; do not merge until parent and candidate gates pass.