### PR TITLE
Isolate accessibility providers per window and apply inherited font sizes live

### DIFF
--- a/docs/plans/2026-09-10-window-accessibility-font.md
+++ b/docs/plans/2026-09-10-window-accessibility-font.md
@@ -5,6 +5,7 @@ retains that context; child runtime IDs append their context identity to the HWN
 Session fragments use lifetime tokens, never mutable sidebar ordinals, including queued focus
 resolution. Chrome buttons use per-window action identities; settings rows use per-lifetime tokens,
 not a tab's current row position. Invoke revalidates identity and modal visibility after its queue hop.
+Settings tabs/controls accept UIA keyboard focus; Invoke-only chrome does not advertise focusability.
 A removed session or control cannot redirect a retained fragment to its replacement. UIA snapshot reads
 run on the owning UI thread (inline for reentrant same-thread calls), and posted actions recheck
 closure before touching the window. No provider lock spans app callbacks or UIA event delivery.

--- a/docs/plans/2026-09-10-window-accessibility-font.md
+++ b/docs/plans/2026-09-10-window-accessibility-font.md
@@ -1,7 +1,9 @@
 # Window accessibility and live font defaults (#267, #276)
 
 Each library or quick Program owns its UI Automation context. Every root, fragment and text range
-retains that context; runtime IDs include a process-unique context identity. UIA snapshot reads
+retains that context; child runtime IDs append their context identity to the HWND host identity.
+Session fragments use lifetime tokens, never mutable sidebar ordinals, including queued focus
+resolution. A removed session cannot redirect a retained fragment to its replacement. UIA snapshot reads
 run on the owning UI thread (inline for reentrant same-thread calls), and posted actions recheck
 closure before touching the window. No provider lock spans app callbacks or UIA event delivery.
 Window destruction retires its root COM references and clears callbacks. Retained text ranges
@@ -17,4 +19,9 @@ Validation uses actual built providers in isolated tests, plus the private-job/t
 Accessibility fixture: distinct documents/runtime IDs, owner-local focus and Invoke, and retained
 ranges across closing two windows while quick remains readable. This tests UIA provider behavior,
 not a manual Narrator/NVDA presentation audit. Navigation integration additionally checks live
-font geometry, explicit zoom preservation and reset across library and quick windows.
+font geometry, explicit zoom preservation and reset across library, quick, scratch, pane-overlay
+and session-overlay surfaces. Active-target font commands use the visible surface, not its hidden
+underlying shell. Legacy absent FontZoomed keys remain absent on round-trip; explicit true/false
+values are preserved. The private UIA client may cache an old property when a node retires; tests
+verify it never rebinds that name or a focus request to the replacement, and isolated provider
+tests verify UIA_E_ELEMENTNOTAVAILABLE directly.

--- a/docs/plans/2026-09-10-window-accessibility-font.md
+++ b/docs/plans/2026-09-10-window-accessibility-font.md
@@ -1,0 +1,20 @@
+# Window accessibility and live font defaults (#267, #276)
+
+Each library or quick Program owns its UI Automation context. Every root, fragment and text range
+retains that context; runtime IDs include a process-unique context identity. UIA snapshot reads
+run on the owning UI thread (inline for reentrant same-thread calls), and posted actions recheck
+closure before touching the window. No provider lock spans app callbacks or UIA event delivery.
+Window destruction retires its root COM references and clears callbacks. Retained text ranges
+refuse access after closure instead of finding a different active window.
+
+Font-size inheritance is separate from its numeric value. A live default change updates unzoomed
+normal, scratch, overlay and quick surfaces across windows. Explicit zoom survives even when it
+happens to equal the default; reset resumes inheritance. Pane state records the nullable FontZoomed
+flag: old files infer inheritance from equality with the current default, new files preserve the
+distinction explicitly. An inherited saved size follows the current default on restoration.
+
+Validation uses actual built providers in isolated tests, plus the private-job/token-protected
+Accessibility fixture: distinct documents/runtime IDs, owner-local focus and Invoke, and retained
+ranges across closing two windows while quick remains readable. This tests UIA provider behavior,
+not a manual Narrator/NVDA presentation audit. Navigation integration additionally checks live
+font geometry, explicit zoom preservation and reset across library and quick windows.

--- a/docs/plans/2026-09-10-window-accessibility-font.md
+++ b/docs/plans/2026-09-10-window-accessibility-font.md
@@ -3,7 +3,9 @@
 Each library or quick Program owns its UI Automation context. Every root, fragment and text range
 retains that context; child runtime IDs append their context identity to the HWND host identity.
 Session fragments use lifetime tokens, never mutable sidebar ordinals, including queued focus
-resolution. A removed session cannot redirect a retained fragment to its replacement. UIA snapshot reads
+resolution. Chrome buttons use per-window action identities; settings rows use per-lifetime tokens,
+not a tab's current row position. Invoke revalidates identity and modal visibility after its queue hop.
+A removed session or control cannot redirect a retained fragment to its replacement. UIA snapshot reads
 run on the owning UI thread (inline for reentrant same-thread calls), and posted actions recheck
 closure before touching the window. No provider lock spans app callbacks or UIA event delivery.
 Window destruction retires its root COM references and clears callbacks. Retained text ranges

--- a/src/Agwinterm.Core/PaneFontSize.cs
+++ b/src/Agwinterm.Core/PaneFontSize.cs
@@ -1,0 +1,15 @@
+namespace Agwinterm.Core;
+
+/// <summary>Default-size inheritance is explicit: zooming back to the same number is still a zoom;
+/// only reset resumes inheritance. Legacy state without the flag infers it from the saved size.</summary>
+public static class PaneFontSize
+{
+    public static (float Size, bool Zoomed) Restore(float saved, float currentDefault, bool? zoomed)
+    {
+        bool explicitSize = zoomed ?? (saved > 0 && saved != currentDefault);
+        return (explicitSize && saved > 0 ? saved : currentDefault, explicitSize && saved > 0);
+    }
+
+    public static (float Size, bool Zoomed) Zoom(float size, float currentDefault, int delta)
+        => delta == 0 ? (currentDefault, false) : (Math.Clamp(size + delta, 6f, 48f), true);
+}

--- a/src/Agwinterm.Pty/RestoreState.cs
+++ b/src/Agwinterm.Pty/RestoreState.cs
@@ -42,7 +42,7 @@ namespace Agwinterm.Pty;
 /// <summary>One pane of a session. <c>Command</c> is the captured foreground command (restore-commands;
 /// <c>""</c> = nothing captured), <c>RestoreCommand</c> the explicit pin (independent of the toggle),
 /// <c>AgentResume</c> the bound resumable agent. Cwd/FontSize are per pane since splits.</summary>
-public sealed class PaneState { public string Id { get; set; } = ""; public string Cwd { get; set; } = ""; public float FontSize { get; set; } public bool? FontZoomed { get; set; } public float Ratio { get; set; } = 1f; public string Command { get; set; } = ""; public string? AgentResume { get; set; } public string? RestoreCommand { get; set; } public List<string>? Buffer { get; set; } public string? BufferBlob { get; set; } }
+public sealed class PaneState { public string Id { get; set; } = ""; public string Cwd { get; set; } = ""; public float FontSize { get; set; } [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public bool? FontZoomed { get; set; } public float Ratio { get; set; } = 1f; public string Command { get; set; } = ""; public string? AgentResume { get; set; } public string? RestoreCommand { get; set; } public List<string>? Buffer { get; set; } public string? BufferBlob { get; set; } }
 
 // Cwd/FontSize kept for backward-compat with pre-splits state.json (one pane per session).
 public sealed class SessionState

--- a/src/Agwinterm.Pty/RestoreState.cs
+++ b/src/Agwinterm.Pty/RestoreState.cs
@@ -42,7 +42,7 @@ namespace Agwinterm.Pty;
 /// <summary>One pane of a session. <c>Command</c> is the captured foreground command (restore-commands;
 /// <c>""</c> = nothing captured), <c>RestoreCommand</c> the explicit pin (independent of the toggle),
 /// <c>AgentResume</c> the bound resumable agent. Cwd/FontSize are per pane since splits.</summary>
-public sealed class PaneState { public string Id { get; set; } = ""; public string Cwd { get; set; } = ""; public float FontSize { get; set; } public float Ratio { get; set; } = 1f; public string Command { get; set; } = ""; public string? AgentResume { get; set; } public string? RestoreCommand { get; set; } public List<string>? Buffer { get; set; } public string? BufferBlob { get; set; } }
+public sealed class PaneState { public string Id { get; set; } = ""; public string Cwd { get; set; } = ""; public float FontSize { get; set; } public bool? FontZoomed { get; set; } public float Ratio { get; set; } = 1f; public string Command { get; set; } = ""; public string? AgentResume { get; set; } public string? RestoreCommand { get; set; } public List<string>? Buffer { get; set; } public string? BufferBlob { get; set; } }
 
 // Cwd/FontSize kept for backward-compat with pre-splits state.json (one pane per session).
 public sealed class SessionState

--- a/src/Agwinterm.Win32/Dashboard.cs
+++ b/src/Agwinterm.Win32/Dashboard.cs
@@ -36,7 +36,7 @@ internal partial class Program
         _dashFontPin = fontPin > 0 ? Math.Clamp(fontPin, 4, 40) : 0;
         _dashSel = Math.Max(0, _dashSessions.FindIndex(s => ReferenceEquals(s, _active)));
         _dashboardOpen = true;
-        Uia.Announce($"Dashboard, {_dashSessions.Count} sessions. Arrow keys to move, Enter to open, Escape to close.");
+        _uia.Announce($"Dashboard, {_dashSessions.Count} sessions. Arrow keys to move, Enter to open, Escape to close.");
         RequestRedraw();
     }
 
@@ -147,7 +147,7 @@ internal partial class Program
     {
         if (i < 0 || i >= _dashSessions.Count || i == _dashSel) return;
         _dashSel = i;
-        Uia.Announce(_dashSessions[i].Name);
+        _uia.Announce(_dashSessions[i].Name);
         RequestRedraw();
     }
 

--- a/src/Agwinterm.Win32/Help.cs
+++ b/src/Agwinterm.Win32/Help.cs
@@ -26,14 +26,14 @@ internal partial class Program
     {
         _helpLines = BuildHelpLines();
         _helpOpen = true; _helpScroll = 0;
-        if (Uia.ClientsListening) Uia.Announce(NarratorGuide());
+        if (Uia.ClientsListening) _uia.Announce(NarratorGuide());
         RequestRedraw();
     }
 
     private void CloseHelp()
     {
         _helpOpen = false;
-        Uia.Announce("Help closed");
+        _uia.Announce("Help closed");
         RequestRedraw();
     }
 

--- a/src/Agwinterm.Win32/Program.Chrome.cs
+++ b/src/Agwinterm.Win32/Program.Chrome.cs
@@ -1403,7 +1403,7 @@ internal partial class Program
         if (hit is not null)
         {
             _hotPaint = hit; _hotAlpha = 1f;   // light instantly on hover-in
-            if (Uia.ClientsListening) Uia.Announce(ChromeButtonLabel(hit) + " button");   // speak the hovered button
+            if (Uia.ClientsListening) _uia.Announce(ChromeButtonLabel(hit) + " button");   // speak the hovered button
         }
         else
         {

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -394,15 +394,11 @@ internal partial class Program
         int delta = op switch { "inc" => 1, "dec" => -1, _ => 0 }; // reset otherwise
         if (string.IsNullOrEmpty(target) || target == "active")
         {
-            if (_isQuickWindow) return InvokeOnUiQueued(() =>
+            return InvokeOnUiQueued(() =>
             {
-                if (ActiveSurface() is not { } p) return false;
-                ZoomPane((p, null, true), delta); return true;
+                if (ActiveSurface() is null) return false;
+                ChangeFontSize(delta); return true;
             });
-            var ses = Find(target);
-            if (ses is null) return false;
-            PostVerb(() => ChangeFontSizeOf(ses, delta));
-            return true;
         }
         if (FindControlPane(target) is not { } targetPane) return false;
         PostVerb(() => ZoomPane(targetPane, delta));

--- a/src/Agwinterm.Win32/Program.Services.cs
+++ b/src/Agwinterm.Win32/Program.Services.cs
@@ -46,8 +46,8 @@ internal partial class Program
             }
             text = sb.ToString();
         }
-        Uia.RaiseTextChanged();   // let the reader's text model re-read (navigation)
-        Uia.Announce(text);       // and speak the new lines directly (reliable across readers)
+        _uia.RaiseTextChanged();   // let the reader's text model re-read (navigation)
+        _uia.Announce(text);       // and speak the new lines directly (reliable across readers)
     }
 
     // ---- Notifications (OSC 9 / OSC 777 / notify) ----
@@ -1511,7 +1511,7 @@ internal partial class Program
                                 }
                             }
                             catch { }
-                        ss.Panes.Add(new PaneState { Id = p.Id, Cwd = cwd, FontSize = p.FontSize, Ratio = p.Ratio, Command = cmd, AgentResume = p.AgentResume, RestoreCommand = p.RestoreCommand, Buffer = buf, BufferBlob = blob });
+                        ss.Panes.Add(new PaneState { Id = p.Id, Cwd = cwd, FontSize = p.FontSize, FontZoomed = p.FontZoomed, Ratio = p.Ratio, Command = cmd, AgentResume = p.AgentResume, RestoreCommand = p.RestoreCommand, Buffer = buf, BufferBlob = blob });
                     }
                     // P4: the axis, written only for a split horizontal session (StoreAxis) — a vertical or
                     // single-pane session writes no key, so its bytes are what 0.17.12 wrote.
@@ -1651,7 +1651,7 @@ internal partial class Program
                         string.IsNullOrWhiteSpace(s.Name) ? null : s.Name,
                         string.IsNullOrWhiteSpace(first.Cwd) ? null : first.Cwd,
                         ws, makeActive: s.Id == st.ActiveId,
-                        fontSize: first.FontSize > 0 ? first.FontSize : (float?)null,
+                        fontSize: PaneFontSize.Restore(first.FontSize, (float)_config.FontSize, first.FontZoomed).Size,
                         profileName: string.IsNullOrWhiteSpace(s.Profile) ? null : s.Profile,
                         paneId: StablePaneId(first.Id, s.Id, sid, first: true));
                     // The axis BEFORE the second pane exists (P4). Every pty is spawned at the full content
@@ -1667,11 +1667,12 @@ internal partial class Program
                         AppendPane(ses,
                             StablePaneId(pl[i].Id, s.Id, sid, first: false),   // verbatim: after a swap this is the pane that carries the session id
                             string.IsNullOrWhiteSpace(pl[i].Cwd) ? null : pl[i].Cwd,
-                            pl[i].FontSize > 0 ? pl[i].FontSize : (float)_config.FontSize);
+                            PaneFontSize.Restore(pl[i].FontSize, (float)_config.FontSize, pl[i].FontZoomed).Size);
                     lock (_workspaces)
                     {
                         for (int i = 0; i < pl.Count && i < ses.Panes.Count; i++)
                         {
+                            ses.Panes[i].FontZoomed = PaneFontSize.Restore(pl[i].FontSize, (float)_config.FontSize, pl[i].FontZoomed).Zoomed;
                             ses.Panes[i].Ratio = pl[i].Ratio > 0 ? pl[i].Ratio : 1f;
                             ses.Panes[i].AgentResume = string.IsNullOrWhiteSpace(pl[i].AgentResume) ? null : pl[i].AgentResume;
                             ses.Panes[i].RestoreCommand = string.IsNullOrWhiteSpace(pl[i].RestoreCommand) ? null : pl[i].RestoreCommand;

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -78,7 +78,8 @@ internal partial class Program
         // Under the session lock: with the Rust core this setter now crosses into native code and
         // re-syncs the mirrors, and an ADOPTED session's reader thread is already feeding by now.
         lock (session.SyncRoot) session.Emulator.ScrollbackMax = _config.Scrollback;
-        var pane = new Pane { Id = paneId, S = session, StartCwd = cwd, FontSize = fontSize };
+        var pane = new Pane { Id = paneId, S = session, StartCwd = cwd, FontSize = fontSize,
+            FontZoomed = fontSize != (float)_config.FontSize };
         // New output snaps this pane back to the live bottom when the buffer ACTUALLY scrolled (a line
         // pushed into history) — not on every repaint. TUIs like Claude Code redraw in place without
         // scrolling, so a mouse selection survives those frames. #copy-selection
@@ -782,7 +783,11 @@ internal partial class Program
     /// <summary>Show a session's scratch terminal (creating it lazily in the session's cwd).</summary>
     private void ShowScratch(Ses ses)
     {
-        ses.Scratch ??= CreatePane(ses.Id + ":scratch:" + Guid.NewGuid().ToString("N")[..6], ses.Ws, CwdOf(ses), ses.FontSize);
+        if (ses.Scratch is null)
+        {
+            ses.Scratch = CreatePane(ses.Id + ":scratch:" + Guid.NewGuid().ToString("N")[..6], ses.Ws, CwdOf(ses), ses.FontSize);
+            ses.Scratch.FontZoomed = ses.ActivePane.FontZoomed;
+        }
         ShowCover(ses.Scratch, 1);
     }
 
@@ -842,6 +847,7 @@ internal partial class Program
         }
         var owner = pane ?? ses.ActivePane;
         var term = CreatePane(id, ses.Ws, CwdOf(owner), owner.FontSize, command, shellWrap: true, extraEnv: extraEnv);
+        term.FontZoomed = owner.FontZoomed;
         term.OverlayDone = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
         // The slot's LAST exit is reset by every open, and the new term becomes the slot's overlay in
         // the same locked step: an exit that lands on the pty thread either wrote before this (and is
@@ -986,7 +992,7 @@ internal partial class Program
 
     /// <summary>Change one pane's font zoom (delta 0 = reset to the config default). Caller reflows.</summary>
     private void ChangeFontSizeOfPane(Pane p, int delta)
-        => p.FontSize = delta == 0 ? (float)_config.FontSize : Math.Clamp(p.FontSize + delta, 6f, 48f);
+        => (p.FontSize, p.FontZoomed) = PaneFontSize.Zoom(p.FontSize, (float)_config.FontSize, delta);
 
     /// <summary>Resolve a pane by id across split panes, per-session scratch/overlay, and the quick terminal
     /// (so <c>agwintermctl font --target &lt;paneId&gt;</c> can zoom a specific pane). Null if no pane matches.</summary>
@@ -1396,10 +1402,7 @@ internal partial class Program
     /// <summary>Change the active pane's font zoom (delta 0 = reset to config default), reflow + repaint.</summary>
     private void ChangeFontSizeOf(Ses ses, int delta)
     {
-        float cur = ses.FontSize;
-        float ns = delta == 0 ? (float)_config.FontSize : Math.Clamp(cur + delta, 6f, 48f);
-        if (ns == cur) return;
-        ses.FontSize = ns;               // active pane
+        ChangeFontSizeOfPane(ses.ActivePane, delta);
         RegridSession(ses);
         if (ReferenceEquals(_active, ses)) RequestRedraw();
         SaveState();
@@ -1422,6 +1425,7 @@ internal partial class Program
         var cur = ses.ActivePane;
         string? cwd = string.IsNullOrEmpty(cur.StartCwd) ? null : cur.StartCwd;
         var np = CreatePane(Guid.NewGuid().ToString(), ses.Ws, cwd, cur.FontSize, profileName: ses.ProfileName);
+        np.FontZoomed = cur.FontZoomed;
         float half = cur.Ratio / 2f;
         cur.Ratio = half; np.Ratio = half;
         int idx = ses.Panes.IndexOf(cur);

--- a/src/Agwinterm.Win32/Program.WndProc.cs
+++ b/src/Agwinterm.Win32/Program.WndProc.cs
@@ -49,12 +49,12 @@ internal partial class Program
                 if ((int)wParam == _quickHotkeyId && _quickHotkeyId != 0) QuickOp("toggle", global: true);
                 return IntPtr.Zero;
             }
-            if (msg == WM_DESTROY) { _uiGone.Cancel(); return IntPtr.Zero; }
+            if (msg == WM_DESTROY) { _uia.Dispose(); _uiGone.Cancel(); return IntPtr.Zero; }
         }
         switch (msg)
         {
             case 0x003D: // WM_GETOBJECT — expose the terminal to screen readers (UIA, T2-14)
-                { nint r = Uia.OnGetObject(hwnd, wParam, lParam); if (r != 0) return r; break; }
+                { nint r = _uia.OnGetObject(hwnd, wParam, lParam); if (r != 0) return r; break; }
 
             case WM_NCCALCSIZE:
                 if (wParam != IntPtr.Zero) { AdjustClientRect(hwnd, lParam); return IntPtr.Zero; }
@@ -622,6 +622,7 @@ internal partial class Program
                 return DefWindowProcW(hwnd, msg, wParam, lParam);
 
             case WM_DESTROY:
+                _uia.Dispose();
                 CloseWindowPicker();
                 _uiGone.Cancel();                 // release any pipe thread waiting in InvokeOnUiQueued
                 RemoveTrayIcon();                 // drop the shell tray balloon icon

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -336,6 +336,7 @@ internal partial class Program : ISessionHost, IWindowHost
         // instead, and treats a task that faulted anyway as the same end.
         public Task? Start;
         public float FontSize;     // per-pane font zoom (pt)
+        public bool FontZoomed;   // reset resumes inheritance; equal numeric sizes alone do not
         public float Ratio = 1f;   // this pane's OWN share of the session's extent along its axis (width when vertical, height when horizontal); PaneLayout normalises by the sum
         public int ScrollOffset;   // lines scrolled up from the live bottom (0 = live; clamped to HistoryCount)
         public long LastScrollGen; // emulator ScrollGeneration last seen on output (detects real scroll vs in-place repaint)
@@ -707,6 +708,7 @@ internal partial class Program : ISessionHost, IWindowHost
         DragAcceptFiles(_hwnd, true);   // drop files/folders onto a pane -> quoted paths pasted
 
         CreateRenderTarget();
+        ConfigureUia(); // every library window and the detached quick host
         if (!_isQuickWindow) StartSession();
 
         ApplySystemTheme();   // if "follow Windows light/dark" is on, pick light/dark before the first paint
@@ -1075,7 +1077,7 @@ internal partial class Program : ISessionHost, IWindowHost
         {
             _setTab = index; _setScroll = 0;
             _setFocus = FocusableRows().FirstOrDefault();
-            Uia.Announce($"{SetTabNames[index]} tab");
+            _uia.Announce($"{SetTabNames[index]} tab");
             RequestRedraw();
         }
     }
@@ -1103,13 +1105,13 @@ internal partial class Program : ISessionHost, IWindowHost
     {
         if (_focusRow is null) return;
         int idx = AllSessions().IndexOf(_focusRow);
-        if (idx >= 0) Uia.RaiseFocus(Uia.NodeKind.Session, idx);
+        if (idx >= 0) _uia.RaiseFocus(Uia.NodeKind.Session, idx);
     }
 
     /// <summary>Build the UIA text-pattern snapshot: the active pane's buffer (recent scrollback + the
     /// live screen) flattened into one document, with the caret offset and the mapping from document
-    /// lines to on-screen rows (screen px) so ranges can report bounding rectangles. Runs on the UIA
-    /// thread; locks the session.</summary>
+    /// lines to on-screen rows (screen px) so ranges can report bounding rectangles. Runs on this
+    /// window's UI thread; locks the session while copying terminal data.</summary>
     private Uia.TextSnapshot? BuildUiaTextSnapshot()
     {
         // The one seam: a shown cover, else the focused pane's SURFACE — its overlay term while a pane
@@ -1168,7 +1170,7 @@ internal partial class Program : ISessionHost, IWindowHost
         if (_sidebarW <= 0) ToggleSidebar();   // reveal the sidebar so the focus ring is visible
         _chromeFocus = true;
         _focusRow = _active ?? AllSessions().FirstOrDefault();
-        Uia.Announce("Sidebar");
+        _uia.Announce("Sidebar");
         AnnounceFocusRow();
         RequestRedraw();
     }
@@ -1177,7 +1179,7 @@ internal partial class Program : ISessionHost, IWindowHost
     {
         if (!_chromeFocus) return;
         _chromeFocus = false;
-        if (announce) { Uia.Announce("Terminal"); Uia.RaiseFocus(Uia.NodeKind.Terminal, 0); }
+        if (announce) { _uia.Announce("Terminal"); _uia.RaiseFocus(Uia.NodeKind.Terminal, 0); }
         RequestRedraw();
     }
 
@@ -1189,7 +1191,7 @@ internal partial class Program : ISessionHost, IWindowHost
         bool current = ReferenceEquals(_focusRow, _active);
         int unread = UnreadOf(_focusRow);
         string extra = (current ? ", current" : "") + (unread > 0 ? $", {unread} unread" : "");
-        Uia.Announce($"{_focusRow.Name}, session{extra}");
+        _uia.Announce($"{_focusRow.Name}, session{extra}");
     }
 
     /// <summary>Keyboard handling while the sidebar zone has focus (F6). Up/Down walk sessions, Enter/Space
@@ -1274,6 +1276,18 @@ internal partial class Program : ISessionHost, IWindowHost
         foreach (var window in windows)
         {
             if (window._hwnd == IntPtr.Zero) continue;
+            var surfaces = new HashSet<Pane>();
+            foreach (var session in window.AllSessions())
+            {
+                foreach (var pane in session.Panes)
+                { surfaces.Add(pane); if (pane.Overlay.Term is { } overlay) surfaces.Add(overlay); }
+                if (session.Scratch is { } scratch) surfaces.Add(scratch);
+                if (session.Overlay.Term is { } sessionOverlay) surfaces.Add(sessionOverlay);
+            }
+            if (window._quick is { } quickPane) surfaces.Add(quickPane);
+            if (window._cover is { } cover) surfaces.Add(cover);
+            foreach (var surface in surfaces)
+                if (!surface.FontZoomed) surface.FontSize = (float)_config.FontSize;
             window.MeasureCell();
             foreach (var session in window.AllSessions()) window.RegridSession(session);
             if (window._cover is not null) window.RegridCover();
@@ -1370,6 +1384,34 @@ internal partial class Program : ISessionHost, IWindowHost
 
     private (int cols, int rows) GridSize() => GridSizeFor(ActiveFontSize());
 
+    private readonly Uia _uia = new();
+    private readonly int _uiaThreadId = Environment.CurrentManagedThreadId;
+
+    // UIA may call back synchronously while the UI thread raises an accessibility event.
+    // Queue only foreign-thread reads; queueing and waiting on ourselves would deadlock.
+    private T ReadUia<T>(Func<T> read) => Environment.CurrentManagedThreadId == _uiaThreadId
+        ? read() : InvokeOnUiQueued(read);
+
+    private void ConfigureUia()
+    {
+        _uia.GetVisibleText = () => ReadUia(() =>
+        {
+            _uia.EnsureAlive();
+            var p = ActiveSurface();
+            if (p is null) return "terminal";
+            lock (p.S.SyncRoot)
+            {
+                var em = p.S.Emulator; var sb = new StringBuilder();
+                for (int r = 0; r < em.Screen.Rows; r++) sb.Append(em.DumpRow(r)).Append('\n');
+                return sb.ToString().TrimEnd() is { Length: > 0 } t ? t : "terminal";
+            }
+        });
+        _uia.GetTextSnapshot = () => ReadUia(() => { _uia.EnsureAlive(); return BuildUiaTextSnapshot(); });
+        _uia.GetTree = () => ReadUia(() => { _uia.EnsureAlive(); return BuildUiaTree(); });
+        _uia.OnSetFocus = (kind, index) => Post(() => { if (!_uia.IsClosed) HandleUiaSetFocus(kind, index); });
+        _uia.OnInvoke = (kind, index) => Post(() => { if (!_uia.IsClosed) HandleUiaInvoke(kind, index); });
+    }
+
     private void StartSession()
     {
         // One control server for the whole app (one pipe); it resolves --window through the library.
@@ -1404,25 +1446,6 @@ internal partial class Program : ISessionHost, IWindowHost
             // Dev builds don't register as the default-terminal COM server — that CLSID is owned by the
             // installed release, and a dev instance must not intercept the OS's console handoffs.
             if (!IsDev) { try { DefTerm.RegisterServer(); } catch { /* defterm not registered / unsupported */ } }
-            // UIA (T2-14): expose the active pane's visible text to screen readers.
-            Uia.GetVisibleText = () =>
-            {
-                var p = ActiveSurface();
-                if (p is null) return "terminal";
-                lock (p.S.SyncRoot)
-                {
-                    var em = p.S.Emulator; var sb = new StringBuilder();
-                    for (int r = 0; r < em.Screen.Rows; r++) sb.Append(em.DumpRow(r)).Append('\n');
-                    return sb.ToString().TrimEnd() is { Length: > 0 } t ? t : "terminal";
-                }
-            };
-            // Full text-pattern snapshot (ITextProvider): the flattened buffer document + caret +
-            // visible-line mapping, so Narrator can read/navigate by line/word/char and box the caret.
-            Uia.GetTextSnapshot = BuildUiaTextSnapshot;
-            // Fragment tree (root → terminal + sidebar/sessions) so the reader scans/Tabs the controls.
-            Uia.GetTree = BuildUiaTree;
-            Uia.OnSetFocus = (kind, index) => Post(() => HandleUiaSetFocus(kind, index));
-            Uia.OnInvoke = (kind, index) => Post(() => HandleUiaInvoke(kind, index));
         }
         // CLI args (first window only; consumed so extra windows don't re-apply them).
         string? argProfile = _argProfile, argDir = _argDir;

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -362,6 +362,8 @@ internal partial class Program : ISessionHost, IWindowHost
 
     private sealed class Ses
     {
+        private static int _nextUiaIdentity;
+        public readonly int UiaIdentity = Interlocked.Increment(ref _nextUiaIdentity);
         public required string Id;
         public required string Name;
         public required Workspace Ws;
@@ -1010,7 +1012,7 @@ internal partial class Program : ISessionHost, IWindowHost
             nodes.Add(new Uia.Node
             {
                 Kind = Uia.NodeKind.Session,
-                Index = i,
+                Index = s.UiaIdentity,
                 Name = s.Name,   // the name only — session.context is a note beside it, not a name; a reader gets it from tree --json / the palette line (P3)
                 Parent = list,
                 Focused = _chromeFocus && ReferenceEquals(_focusRow, s),
@@ -1091,11 +1093,11 @@ internal partial class Program : ISessionHost, IWindowHost
             case Uia.NodeKind.Terminal: ExitChromeFocus(announce: false); break;
             case Uia.NodeKind.Sidebar: EnterChromeFocus(); break;
             case Uia.NodeKind.Session:
-                var list = AllSessions();
-                if (index >= 0 && index < list.Count)
+                var session = AllSessions().FirstOrDefault(s => s.UiaIdentity == index);
+                if (session is not null)
                 {
                     if (_sidebarW <= 0) ToggleSidebar();
-                    _chromeFocus = true; _focusRow = list[index]; RequestRedraw();
+                    _chromeFocus = true; _focusRow = session; RequestRedraw();
                 }
                 break;
         }
@@ -1104,8 +1106,7 @@ internal partial class Program : ISessionHost, IWindowHost
     private void RaiseUiaFocusForRow()
     {
         if (_focusRow is null) return;
-        int idx = AllSessions().IndexOf(_focusRow);
-        if (idx >= 0) _uia.RaiseFocus(Uia.NodeKind.Session, idx);
+        if (AllSessions().Contains(_focusRow)) _uia.RaiseFocus(Uia.NodeKind.Session, _focusRow.UiaIdentity);
     }
 
     /// <summary>Build the UIA text-pattern snapshot: the active pane's buffer (recent scrollback + the
@@ -1389,8 +1390,14 @@ internal partial class Program : ISessionHost, IWindowHost
 
     // UIA may call back synchronously while the UI thread raises an accessibility event.
     // Queue only foreign-thread reads; queueing and waiting on ourselves would deadlock.
-    private T ReadUia<T>(Func<T> read) => Environment.CurrentManagedThreadId == _uiaThreadId
-        ? read() : InvokeOnUiQueued(read);
+    private T ReadUia<T>(Func<T> read)
+    {
+        try { return Environment.CurrentManagedThreadId == _uiaThreadId ? read() : InvokeOnUiQueued(read); }
+        catch (Exception) when (_uia.IsClosed || _uiGone.IsCancellationRequested)
+        {
+            throw new COMException("The accessibility window is closed.", unchecked((int)0x80040201));
+        }
+    }
 
     private void ConfigureUia()
     {

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -953,6 +953,7 @@ internal partial class Program : ISessionHost, IWindowHost
                     Parent = grp,
                     Name = SetTabNames[i] + (i == _setTab ? " tab, selected" : " tab"),
                     Selected = i == _setTab,
+                    Focused = _setNav == i,
                     Rect = ScreenRect(_setCard.Left + 8f, _navHit[i * 2], SetNavW - 16f, _navHit[i * 2 + 1] - _navHit[i * 2]),
                 });
             }
@@ -967,7 +968,7 @@ internal partial class Program : ISessionHost, IWindowHost
                     Index = r.UiaIdentity,
                     Parent = grp,
                     Name = SettingsControlName(r),
-                    Focused = ReferenceEquals(r, _setFocus),
+                    Focused = _setNav < 0 && ReferenceEquals(r, _setFocus),
                     Rect = r.Vis ? ScreenRect(r.Hx0, r.Hy0, Math.Max(1, r.Hx1 - r.Hx0), Math.Max(1, r.Hy1 - r.Hy0)) : default,
                 });
             }
@@ -1099,10 +1100,18 @@ internal partial class Program : ISessionHost, IWindowHost
     private void HandleUiaSetFocus(Uia.NodeKind kind, int index)
     {
         if (_nativePick is not null) { _nativePick.FocusIfForeground(); return; }
+        if (Uia.Find(BuildUiaTree(), kind, index) is null) return;
         switch (kind)
         {
             case Uia.NodeKind.Terminal: ExitChromeFocus(announce: false); break;
             case Uia.NodeKind.Sidebar: EnterChromeFocus(); break;
+            case Uia.NodeKind.SettingsControl:
+                var row = FocusableRows().FirstOrDefault(r => r.UiaIdentity == index);
+                if (_setOpen && row is not null) { _setNav = -1; _setFocus = row; _setFocusKb = true; AfterSetFocus(); }
+                break;
+            case Uia.NodeKind.SettingsTab:
+                if (_setOpen && index >= 0 && index < SetTabNames.Length) { _setNav = index; _setFocusKb = true; AfterHeaderFocus(); }
+                break;
             case Uia.NodeKind.Session:
                 var session = AllSessions().FirstOrDefault(s => s.UiaIdentity == index);
                 if (session is not null)

--- a/src/Agwinterm.Win32/Program.cs
+++ b/src/Agwinterm.Win32/Program.cs
@@ -964,7 +964,7 @@ internal partial class Program : ISessionHost, IWindowHost
                 nodes.Add(new Uia.Node
                 {
                     Kind = Uia.NodeKind.SettingsControl,
-                    Index = i,
+                    Index = r.UiaIdentity,
                     Parent = grp,
                     Name = SettingsControlName(r),
                     Focused = ReferenceEquals(r, _setFocus),
@@ -1027,10 +1027,18 @@ internal partial class Program : ISessionHost, IWindowHost
         for (int i = 0; i < btns.Count; i++)
         {
             rootKids.Add(nodes.Count);
-            nodes.Add(new Uia.Node { Kind = Uia.NodeKind.ChromeButton, Index = i, Name = btns[i].label, Parent = 0, Rect = btns[i].rect });
+            nodes.Add(new Uia.Node { Kind = Uia.NodeKind.ChromeButton, Index = ChromeUiaIdentity(btns[i].action), Name = btns[i].label, Parent = 0, Rect = btns[i].rect });
         }
         nodes[0].Children = rootKids.ToArray();
         return new Uia.TreeSnapshot { Nodes = nodes.ToArray() };
+    }
+
+    private readonly Dictionary<string, int> _chromeUiaIdentities = new(StringComparer.Ordinal);
+    private int ChromeUiaIdentity(string action)
+    {
+        if (!_chromeUiaIdentities.TryGetValue(action, out int identity))
+            _chromeUiaIdentities.Add(action, identity = _chromeUiaIdentities.Count + 1);
+        return identity;
     }
 
     /// <summary>Title-bar + footer chrome buttons as (action, spoken label, screen rect) for the UIA tree.</summary>
@@ -1064,15 +1072,19 @@ internal partial class Program : ISessionHost, IWindowHost
     private void HandleUiaInvoke(Uia.NodeKind kind, int index)
     {
         if (_nativePick is not null) return;
+        // Revalidate after the UI-thread queue hop, including modal visibility. A retained element
+        // must never target a different action merely because the current controls were reordered.
+        if (Uia.Find(BuildUiaTree(), kind, index) is null) return;
         if (kind == Uia.NodeKind.ChromeButton)
         {
             var b = ChromeButtonsForUia();
-            if (index >= 0 && index < b.Count) ChromeAction(b[index].action);
+            var action = b.FirstOrDefault(button => ChromeUiaIdentity(button.action) == index).action;
+            if (action is not null) ChromeAction(action);
         }
         else if (kind == Uia.NodeKind.SettingsControl && _setOpen)
         {
-            var rows = FocusableRows();
-            if (index >= 0 && index < rows.Count) { _setFocus = rows[index]; ActivateSetFocus(); }
+            var row = FocusableRows().FirstOrDefault(r => r.UiaIdentity == index);
+            if (row is not null) { _setFocus = row; ActivateSetFocus(); }
         }
         else if (kind == Uia.NodeKind.SettingsTab && _setOpen && index >= 0 && index < SetTabNames.Length)
         {

--- a/src/Agwinterm.Win32/Settings.cs
+++ b/src/Agwinterm.Win32/Settings.cs
@@ -71,14 +71,14 @@ internal partial class Program
         _setOpen = true; _setTab = 0; _setScroll = 0; _ddRow = null; _setDragRow = null;
         _setFocus = FocusableRows().FirstOrDefault();
         _setNav = -1; _setFocusKb = false;   // no focus rectangle until the keyboard is used
-        Uia.Announce("Settings, General tab. Tab to move, Space to change, Escape to close.");
+        _uia.Announce("Settings, General tab. Tab to move, Space to change, Escape to close.");
         RequestRedraw();
     }
 
     private void CloseSettings()
     {
         _setOpen = false; _ddRow = null; _setDragRow = null;
-        Uia.Announce("Settings closed");
+        _uia.Announce("Settings closed");
         RequestRedraw();
     }
 
@@ -565,7 +565,7 @@ internal partial class Program
             else { ConfigSetInternal("blocked-sound", val == "None" ? "" : val); if (val != "None") PlayStatusSound(val); }
         }
         else ConfigSetInternal(r.Key, val);
-        Uia.Announce($"{r.Label}, {r.Opts[_ddFiltered[filteredIdx]]}");
+        _uia.Announce($"{r.Label}, {r.Opts[_ddFiltered[filteredIdx]]}");
         RequestRedraw();
     }
 
@@ -586,7 +586,7 @@ internal partial class Program
         // nav
         if (mx >= _setCard.Left + 8f && mx <= _setCard.Left + SetNavW - 8f)
             for (int i = 0; i < SetTabNames.Length; i++)
-                if (my >= _navHit[i * 2] && my < _navHit[i * 2 + 1]) { _setTab = i; _setScroll = 0; _setFocus = FocusableRows().FirstOrDefault(); _setNav = -1; _setFocusKb = false; Uia.Announce(SetTabNames[i] + " tab"); RequestRedraw(); return; }
+                if (my >= _navHit[i * 2] && my < _navHit[i * 2 + 1]) { _setTab = i; _setScroll = 0; _setFocus = FocusableRows().FirstOrDefault(); _setNav = -1; _setFocusKb = false; _uia.Announce(SetTabNames[i] + " tab"); RequestRedraw(); return; }
         // outside the card → dismiss
         if (mx < _setCard.Left || mx > _setCard.Right || my < _setCard.Top || my > _setCard.Bottom) { CloseSettings(); return; }
         // widgets (only within the visible pane)
@@ -604,14 +604,14 @@ internal partial class Program
                     {
                         bool on = !IsOn(ConfigValue(r.Key));
                         ConfigSetInternal(r.Key, on ? "true" : "false");
-                        Uia.Announce($"{r.Label}, {(on ? "on" : "off")}");
+                        _uia.Announce($"{r.Label}, {(on ? "on" : "off")}");
                         return;
                     }
                 case SW.Slider: _setDragRow = r; SetCapture(_hwnd); SliderTo(r, mx); return;
                 case SW.Dropdown: case SW.Sound: OpenDropdown(r); return;
                 case SW.Color: PickColorKey(r.Key); return;
-                case SW.Profile: SetProfileDefault(r.Key); Uia.Announce($"{r.Key} is now the default profile"); return;
-                case SW.Button: Uia.Announce(r.Label); r.OnClick?.Invoke(); return;
+                case SW.Profile: SetProfileDefault(r.Key); _uia.Announce($"{r.Key} is now the default profile"); return;
+                case SW.Button: _uia.Announce(r.Label); r.OnClick?.Invoke(); return;
             }
         }
     }
@@ -633,7 +633,7 @@ internal partial class Program
     {
         if (_setDragRow is not null)
         {
-            Uia.Announce($"{_setDragRow.Label}, {ConfigValue(_setDragRow.Key)}");
+            _uia.Announce($"{_setDragRow.Label}, {ConfigValue(_setDragRow.Key)}");
             _setDragRow = null; ReleaseCapture(); RequestRedraw();
         }
     }
@@ -735,7 +735,7 @@ internal partial class Program
 
     private void AfterHeaderFocus()
     {
-        Uia.Announce($"{SetTabNames[_setNav]} tab{(_setNav == _setTab ? ", selected" : "")}, press Enter to open");
+        _uia.Announce($"{SetTabNames[_setNav]} tab{(_setNav == _setTab ? ", selected" : "")}, press Enter to open");
         RequestRedraw();
     }
 
@@ -746,7 +746,7 @@ internal partial class Program
         _setTab = _setNav;
         _setScroll = 0;
         _setFocus = FocusableRows().FirstOrDefault();
-        Uia.Announce($"{SetTabNames[_setTab]} tab, selected");
+        _uia.Announce($"{SetTabNames[_setTab]} tab, selected");
         RequestRedraw();
     }
 
@@ -757,7 +757,7 @@ internal partial class Program
         _setTab = (_setTab + dir + SetTabNames.Length) % SetTabNames.Length;
         _setScroll = 0;
         _setFocus = FocusableRows().FirstOrDefault();
-        Uia.Announce($"{SetTabNames[_setTab]} tab");
+        _uia.Announce($"{SetTabNames[_setTab]} tab");
         AfterSetFocus();
     }
 
@@ -792,7 +792,7 @@ internal partial class Program
             SW.Profile => "profile",
             _ => "",
         };
-        Uia.Announce($"{r.Label}{(val.Length > 0 ? ", " + val : "")}, {kind}");
+        _uia.Announce($"{r.Label}{(val.Length > 0 ? ", " + val : "")}, {kind}");
     }
 
     private void ActivateSetFocus()
@@ -804,7 +804,7 @@ internal partial class Program
             case SW.Toggle:
                 bool on = !IsOn(ConfigValue(r.Key));
                 ConfigSetInternal(r.Key, on ? "true" : "false");
-                Uia.Announce($"{r.Label}, {(on ? "on" : "off")}");
+                _uia.Announce($"{r.Label}, {(on ? "on" : "off")}");
                 break;
             case SW.Dropdown: case SW.Sound: OpenDropdown(r); break;
             case SW.Color: PickColorKey(r.Key); break;
@@ -812,8 +812,8 @@ internal partial class Program
                 var d = PickFolder();
                 if (d is not null) { ConfigSetInternal("new-session-dir", d); ConfigSetInternal("new-session-dir-mode", "custom"); }
                 break;
-            case SW.Profile: SetProfileDefault(r.Key); Uia.Announce($"{r.Key} is now the default profile"); break;
-            case SW.Button: Uia.Announce(r.Label); r.OnClick?.Invoke(); break;
+            case SW.Profile: SetProfileDefault(r.Key); _uia.Announce($"{r.Key} is now the default profile"); break;
+            case SW.Button: _uia.Announce(r.Label); r.OnClick?.Invoke(); break;
         }
         RequestRedraw();
     }
@@ -826,7 +826,7 @@ internal partial class Program
         {
             int cur = int.TryParse(ConfigValue(r.Key), out var v) ? v : r.Min;
             int nv = Math.Clamp(cur + dir, r.Min, r.Max);
-            if (nv != cur) { ConfigSetInternal(r.Key, nv.ToString()); Uia.Announce($"{r.Label}, {nv}"); }
+            if (nv != cur) { ConfigSetInternal(r.Key, nv.ToString()); _uia.Announce($"{r.Label}, {nv}"); }
             RequestRedraw();
         }
         else if (r.Kind is SW.Dropdown or SW.Sound) OpenDropdown(r);

--- a/src/Agwinterm.Win32/Settings.cs
+++ b/src/Agwinterm.Win32/Settings.cs
@@ -22,6 +22,8 @@ internal partial class Program
 
     private sealed class SetRow
     {
+        private static int _nextUiaIdentity;
+        public readonly int UiaIdentity = System.Threading.Interlocked.Increment(ref _nextUiaIdentity);
         public SW Kind;
         public int Tab, Min, Max;
         public string Key = "", Label = "";

--- a/src/Agwinterm.Win32/Uia.Text.cs
+++ b/src/Agwinterm.Win32/Uia.Text.cs
@@ -40,8 +40,8 @@ partial class Uia
         }
     }
 
-    internal static Func<TextSnapshot?>? GetTextSnapshot;
-    internal static TextSnapshot Snap() => GetTextSnapshot?.Invoke() ?? EmptySnap;
+    internal Func<TextSnapshot?>? GetTextSnapshot;
+    internal TextSnapshot Snap() { EnsureAlive(); var snap = GetTextSnapshot?.Invoke() ?? EmptySnap; EnsureAlive(); return snap; }
     private static readonly TextSnapshot EmptySnap = new() { Lines = new[] { "" }, LineStart = new[] { 0, 1 } };
 
     internal static readonly Guid IID_ITextProvider = new("3589c92c-63f3-4367-99bb-ada653b77cf2");
@@ -56,10 +56,12 @@ partial class Uia
     }
 
     /// <summary>Notify listeners that the terminal text changed (so a reader re-reads new output).</summary>
-    internal static void RaiseTextChanged()
+    internal void RaiseTextChanged()
     {
-        if (_providerSimple == 0) return;
-        try { UiaRaiseAutomationEvent(_providerSimple, UIA_Text_TextChangedEventId); } catch { }
+        nint provider = BorrowProvider();
+        if (provider == 0) return;
+        try { UiaRaiseAutomationEvent(provider, UIA_Text_TextChangedEventId); } catch { }
+        finally { Marshal.Release(provider); }
     }
 
     private const int UIA_Text_TextChangedEventId = 20015;
@@ -119,33 +121,33 @@ internal partial class UiaTerminal : ITextProvider
 {
     public nint GetSelection()
     {
-        var s = Uia.Snap();
+        var s = Owner.Snap();
         // A degenerate range at the caret — Narrator announces the caret line.
-        return UiaArrays.RangeArray(new[] { new UiaTextRange(s.CaretOffset, s.CaretOffset) });
+        return UiaArrays.RangeArray(new[] { new UiaTextRange(Owner, s.CaretOffset, s.CaretOffset) });
     }
 
     public nint GetVisibleRanges()
     {
-        var s = Uia.Snap();
+        var s = Owner.Snap();
         int firstOff = s.LineStart[Math.Clamp(s.FirstVisibleLine, 0, s.Lines.Length - 1)];
         int lastLine = Math.Clamp(s.FirstVisibleLine + s.VisibleRows - 1, 0, s.Lines.Length - 1);
         int lastOff = s.LineStart[lastLine] + s.Lines[lastLine].Length;
-        return UiaArrays.RangeArray(new[] { new UiaTextRange(firstOff, lastOff) });
+        return UiaArrays.RangeArray(new[] { new UiaTextRange(Owner, firstOff, lastOff) });
     }
 
-    public nint RangeFromChild(nint childElement) => Uia.AsInterface(new UiaTextRange(0, 0), Uia.IID_ITextRangeProvider);
+    public nint RangeFromChild(nint childElement) => Uia.AsInterface(new UiaTextRange(Owner, 0, 0), Uia.IID_ITextRangeProvider);
 
     public nint RangeFromPoint(UiaPoint point)
     {
-        var s = Uia.Snap();
+        var s = Owner.Snap();
         int row = (int)((point.Y - s.ScreenY) / Math.Max(1, s.CellH));
         int col = (int)((point.X - s.ScreenX) / Math.Max(1, s.CellW));
         int line = Math.Clamp(s.FirstVisibleLine + Math.Max(0, row), 0, s.Lines.Length - 1);
         int off = s.LineStart[line] + Math.Clamp(col, 0, s.Lines[line].Length);
-        return Uia.AsInterface(new UiaTextRange(off, off), Uia.IID_ITextRangeProvider);
+        return Uia.AsInterface(new UiaTextRange(Owner, off, off), Uia.IID_ITextRangeProvider);
     }
 
-    public nint GetDocumentRange() => Uia.AsInterface(new UiaTextRange(0, Uia.Snap().TotalLength), Uia.IID_ITextRangeProvider);
+    public nint GetDocumentRange() => Uia.AsInterface(new UiaTextRange(Owner, 0, Owner.Snap().TotalLength), Uia.IID_ITextRangeProvider);
 
     public SupportedTextSelection GetSupportedTextSelection() => SupportedTextSelection.Single;
 }
@@ -155,25 +157,27 @@ internal partial class UiaTerminal : ITextProvider
 [GeneratedComClass]
 internal partial class UiaTextRange : ITextRangeProvider
 {
+    private readonly Uia Owner;
     private int _start, _end;
-    public UiaTextRange(int start, int end) { _start = Math.Min(start, end); _end = Math.Max(start, end); }
+    public UiaTextRange(Uia owner, int start, int end) { Owner = owner; _start = Math.Min(start, end); _end = Math.Max(start, end); }
 
-    private static int ClampOff(int off) { var s = Uia.Snap(); return Math.Clamp(off, 0, s.TotalLength); }
 
-    public nint Clone() => Uia.AsInterface(new UiaTextRange(_start, _end), Uia.IID_ITextRangeProvider);
+    public nint Clone() => Uia.AsInterface(new UiaTextRange(Owner, _start, _end), Uia.IID_ITextRangeProvider);
 
-    public int Compare(ITextRangeProvider range) => range is UiaTextRange r && r._start == _start && r._end == _end ? 1 : 0;
+    public int Compare(ITextRangeProvider range) => range is UiaTextRange r && ReferenceEquals(Owner, r.Owner) && !Owner.IsClosed && r._start == _start && r._end == _end ? 1 : 0;
 
     public int CompareEndpoints(TextPatternRangeEndpoint endpoint, ITextRangeProvider targetRange, TextPatternRangeEndpoint targetEndpoint)
     {
+        Owner.EnsureAlive();
+        if (targetRange is not UiaTextRange r || !ReferenceEquals(Owner, r.Owner)) throw new ArgumentException("Ranges belong to different windows.", nameof(targetRange));
         int a = endpoint == TextPatternRangeEndpoint.Start ? _start : _end;
-        int b = targetRange is UiaTextRange r ? (targetEndpoint == TextPatternRangeEndpoint.Start ? r._start : r._end) : 0;
+        int b = targetEndpoint == TextPatternRangeEndpoint.Start ? r._start : r._end;
         return a.CompareTo(b);
     }
 
     public void ExpandToEnclosingUnit(TextUnit unit)
     {
-        var s = Uia.Snap();
+        var s = Owner.Snap();
         switch (unit)
         {
             case TextUnit.Character:
@@ -207,14 +211,14 @@ internal partial class UiaTextRange : ITextRangeProvider
 
     public nint FindText(string text, int backward, int ignoreCase)
     {
-        var s = Uia.Snap();
+        var s = Owner.Snap();
         string hay = s.Text;
         int from = Math.Clamp(_start, 0, hay.Length), to = Math.Clamp(_end, 0, hay.Length);
         string window = hay.Substring(from, Math.Max(0, to - from));
         var cmp = ignoreCase != 0 ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
         int idx = backward != 0 ? window.LastIndexOf(text ?? "", cmp) : window.IndexOf(text ?? "", cmp);
         if (idx < 0 || string.IsNullOrEmpty(text)) return 0;
-        return Uia.AsInterface(new UiaTextRange(from + idx, from + idx + text.Length), Uia.IID_ITextRangeProvider);
+        return Uia.AsInterface(new UiaTextRange(Owner, from + idx, from + idx + text.Length), Uia.IID_ITextRangeProvider);
     }
 
     public void GetAttributeValue(int attributeId, nint pRetVal)
@@ -226,7 +230,7 @@ internal partial class UiaTextRange : ITextRangeProvider
 
     public nint GetBoundingRectangles()
     {
-        var s = Uia.Snap();
+        var s = Owner.Snap();
         var rects = new List<double>();
         var (l0, c0) = s.LineColOf(_start);
         var (l1, c1) = s.LineColOf(_end);
@@ -245,11 +249,11 @@ internal partial class UiaTextRange : ITextRangeProvider
         return UiaArrays.DoubleArray(rects.ToArray());
     }
 
-    public nint GetEnclosingElement() => Uia.RootProvider();
+    public nint GetEnclosingElement() => Owner.RootProvider();
 
     public string GetText(int maxLength)
     {
-        var s = Uia.Snap();
+        var s = Owner.Snap();
         string hay = s.Text;
         int from = Math.Clamp(_start, 0, hay.Length), to = Math.Clamp(_end, 0, hay.Length);
         string t = hay.Substring(from, Math.Max(0, to - from));
@@ -259,7 +263,7 @@ internal partial class UiaTextRange : ITextRangeProvider
     public int Move(TextUnit unit, int count)
     {
         // Move the whole (collapsed-to-start) range by `count` units; return units actually moved.
-        var s = Uia.Snap();
+        var s = Owner.Snap();
         if (unit == TextUnit.Character)
         {
             int target = Math.Clamp(_start + count, 0, s.TotalLength);
@@ -278,7 +282,7 @@ internal partial class UiaTextRange : ITextRangeProvider
 
     public int MoveEndpointByUnit(TextPatternRangeEndpoint endpoint, TextUnit unit, int count)
     {
-        var s = Uia.Snap();
+        var s = Owner.Snap();
         int cur = endpoint == TextPatternRangeEndpoint.Start ? _start : _end;
         int target;
         if (unit == TextUnit.Character) target = Math.Clamp(cur + count, 0, s.TotalLength);
@@ -296,7 +300,8 @@ internal partial class UiaTextRange : ITextRangeProvider
 
     public void MoveEndpointByRange(TextPatternRangeEndpoint endpoint, ITextRangeProvider targetRange, TextPatternRangeEndpoint targetEndpoint)
     {
-        if (targetRange is not UiaTextRange r) return;
+        Owner.EnsureAlive();
+        if (targetRange is not UiaTextRange r || !ReferenceEquals(Owner, r.Owner)) throw new ArgumentException("Ranges belong to different windows.", nameof(targetRange));
         int v = targetEndpoint == TextPatternRangeEndpoint.Start ? r._start : r._end;
         if (endpoint == TextPatternRangeEndpoint.Start) { _start = v; if (_end < _start) _end = _start; }
         else { _end = v; if (_start > _end) _start = _end; }

--- a/src/Agwinterm.Win32/Uia.Text.cs
+++ b/src/Agwinterm.Win32/Uia.Text.cs
@@ -162,9 +162,9 @@ internal partial class UiaTextRange : ITextRangeProvider
     public UiaTextRange(Uia owner, int start, int end) { Owner = owner; _start = Math.Min(start, end); _end = Math.Max(start, end); }
 
 
-    public nint Clone() => Uia.AsInterface(new UiaTextRange(Owner, _start, _end), Uia.IID_ITextRangeProvider);
+    public nint Clone() { Owner.EnsureAlive(); return Uia.AsInterface(new UiaTextRange(Owner, _start, _end), Uia.IID_ITextRangeProvider); }
 
-    public int Compare(ITextRangeProvider range) => range is UiaTextRange r && ReferenceEquals(Owner, r.Owner) && !Owner.IsClosed && r._start == _start && r._end == _end ? 1 : 0;
+    public int Compare(ITextRangeProvider range) { Owner.EnsureAlive(); return range is UiaTextRange r && ReferenceEquals(Owner, r.Owner) && r._start == _start && r._end == _end ? 1 : 0; }
 
     public int CompareEndpoints(TextPatternRangeEndpoint endpoint, ITextRangeProvider targetRange, TextPatternRangeEndpoint targetEndpoint)
     {

--- a/src/Agwinterm.Win32/Uia.Tree.cs
+++ b/src/Agwinterm.Win32/Uia.Tree.cs
@@ -44,7 +44,7 @@ partial class Uia
     internal sealed class Node
     {
         public NodeKind Kind;
-        public int Index;                 // session lifetime token; per-kind ordinal for fixed controls
+        public int Index;                 // session/row lifetime token or chrome action identity; fixed tab ordinal
         public string Name = "";
         public bool Focused, Selected;
         public UiaRect Rect;              // screen px (all zero → fall back to the host/window rect)
@@ -125,8 +125,8 @@ internal abstract class UiaNodeBase
     protected Uia.Node? Self(Uia.TreeSnapshot t)
     {
         var node = Uia.Find(t, Kind, Index);
-        if (node is null && Kind == Uia.NodeKind.Session)
-            throw new COMException("The accessibility session is closed.", unchecked((int)0x80040201));
+        if (node is null && Kind is Uia.NodeKind.Session or Uia.NodeKind.ChromeButton or Uia.NodeKind.SettingsControl or Uia.NodeKind.SettingsTab)
+            throw new COMException("The accessibility element is no longer available.", unchecked((int)0x80040201));
         return node;
     }
 
@@ -294,7 +294,7 @@ internal partial class UiaButton : UiaNodeBase, IRawElementProviderSimple, IRawE
         var (ct, lct) = Kind == Uia.NodeKind.SettingsTab ? (Uia.CT_TabItem, "tab") : (Uia.CT_Button, "button");
         FillProperty(propertyId, pRetVal, ct, lct, true);
     }
-    public void Invoke() { Owner.EnsureAlive(); Owner.OnInvoke?.Invoke(Kind, Index); }
+    public void Invoke() { Self(Owner.Tree()); Owner.OnInvoke?.Invoke(Kind, Index); }
     [LibraryImport("oleaut32.dll")] private static partial void VariantInit(nint pvarg);
 }
 

--- a/src/Agwinterm.Win32/Uia.Tree.cs
+++ b/src/Agwinterm.Win32/Uia.Tree.cs
@@ -44,7 +44,7 @@ partial class Uia
     internal sealed class Node
     {
         public NodeKind Kind;
-        public int Index;                 // per-kind ordinal (session / button / settings-row index)
+        public int Index;                 // session lifetime token; per-kind ordinal for fixed controls
         public string Name = "";
         public bool Focused, Selected;
         public UiaRect Rect;              // screen px (all zero → fall back to the host/window rect)
@@ -122,7 +122,13 @@ internal abstract class UiaNodeBase
     protected readonly int Index;
     protected UiaNodeBase(Uia owner, Uia.NodeKind kind, int index) { Owner = owner; Kind = kind; Index = index; }
 
-    protected Uia.Node? Self(Uia.TreeSnapshot t) => Uia.Find(t, Kind, Index);
+    protected Uia.Node? Self(Uia.TreeSnapshot t)
+    {
+        var node = Uia.Find(t, Kind, Index);
+        if (node is null && Kind == Uia.NodeKind.Session)
+            throw new COMException("The accessibility session is closed.", unchecked((int)0x80040201));
+        return node;
+    }
 
     public nint Navigate(NavigateDirection direction)
     {
@@ -153,13 +159,18 @@ internal abstract class UiaNodeBase
 
     private nint NodePtr(Uia.TreeSnapshot t, int nodeIdx) => Owner.FragmentPtr(t.Nodes[nodeIdx].Kind, t.Nodes[nodeIdx].Index);
 
-    public nint GetRuntimeId() => UiaArrays.IntArray(new[] { 42, Owner.Identity, (int)Kind, Index });   // stable identity
+    public nint GetRuntimeId()
+    {
+        Owner.EnsureAlive();
+        // HWND roots use the host identity; children append to it (UiaAppendRuntimeId = 3).
+        return Kind == Uia.NodeKind.Root ? 0 : UiaArrays.IntArray(new[] { 3, Owner.Identity, (int)Kind, Index });
+    }
 
     public UiaRect GetBoundingRectangle() { var n = Self(Owner.Tree()); return n?.Rect ?? default; }
 
     public nint GetEmbeddedFragmentRoots() => 0;
 
-    public void SetFocus() { Owner.EnsureAlive(); Owner.OnSetFocus?.Invoke(Kind, Index); }
+    public void SetFocus() { Owner.EnsureAlive(); if (Kind == Uia.NodeKind.Session) Self(Owner.Tree()); Owner.OnSetFocus?.Invoke(Kind, Index); }
 
     public nint GetFragmentRoot() => Owner.FragmentRootPtr();
 

--- a/src/Agwinterm.Win32/Uia.Tree.cs
+++ b/src/Agwinterm.Win32/Uia.Tree.cs
@@ -8,7 +8,7 @@ namespace Agwinterm.Win32;
 //   Root (window) ─┬─ Terminal (Document + Text pattern)
 //                  └─ Sidebar (List) ── Session (ListItem) × N
 // Fragments are lightweight: each holds its (kind,index) identity and re-reads a fresh snapshot
-// (Uia.Tree(), built by the app on the UIA thread) to answer navigation/properties/bounds. Stable
+// (Owner.Tree(), marshaled to the owning UI thread) to answer navigation/properties/bounds. Stable
 // RuntimeIds let UIA correlate the freshly-built fragments across calls.
 
 internal enum NavigateDirection { Parent = 0, NextSibling = 1, PreviousSibling = 2, FirstChild = 3, LastChild = 4 }
@@ -56,11 +56,11 @@ partial class Uia
 
     internal sealed class TreeSnapshot { public required Node[] Nodes; }   // Nodes[0] is the root
 
-    internal static Func<TreeSnapshot>? GetTree;
-    internal static Action<NodeKind, int>? OnSetFocus;   // app moves internal focus when UIA calls SetFocus
+    internal Func<TreeSnapshot>? GetTree;
+    internal Action<NodeKind, int>? OnSetFocus;   // app moves internal focus when UIA calls SetFocus
     private static readonly TreeSnapshot EmptyTree = new()
     { Nodes = new[] { new Node { Kind = NodeKind.Root, Name = "agwinterm" } } };
-    internal static TreeSnapshot Tree() { try { return GetTree?.Invoke() ?? EmptyTree; } catch { return EmptyTree; } }
+    internal TreeSnapshot Tree() { EnsureAlive(); var tree = GetTree?.Invoke() ?? EmptyTree; EnsureAlive(); return tree; }
 
     /// <summary>Find a node by identity (kind + index) in a snapshot; null if it's gone (e.g. closed session).</summary>
     internal static Node? Find(TreeSnapshot t, NodeKind kind, int index)
@@ -71,30 +71,31 @@ partial class Uia
     internal static int IndexOf(TreeSnapshot t, Node n) => Array.IndexOf(t.Nodes, n);
 
     /// <summary>A COM fragment pointer (IRawElementProviderFragment*, AddRef'd) for a node, or 0.</summary>
-    internal static nint FragmentPtr(NodeKind kind, int index)
+    internal nint FragmentPtr(NodeKind kind, int index)
     {
+        EnsureAlive();
         object obj = kind switch
         {
-            NodeKind.Root => new UiaRoot(_treeHwnd),
-            NodeKind.Terminal => new UiaTerminal(_treeHwnd),
-            _ when IsButton(kind) => new UiaButton(kind, index),
-            _ => new UiaFragment(kind, index),
+            NodeKind.Root => new UiaRoot(this, _treeHwnd),
+            NodeKind.Terminal => new UiaTerminal(this),
+            _ when IsButton(kind) => new UiaButton(this, kind, index),
+            _ => new UiaFragment(this, kind, index),
         };
         return AsInterface(obj, IID_IRawElementProviderFragment);
     }
 
-    internal static Action<NodeKind, int>? OnInvoke;   // app activates a button/control when UIA invokes it
+    internal Action<NodeKind, int>? OnInvoke;   // app activates a button/control when UIA invokes it
     internal static readonly Guid IID_IInvokeProvider = new("54fcb24b-e18e-47a2-b4d3-eccbe77599a2");
 
     internal static readonly Guid IID_IRawElementProviderFragment = new("f7063da8-8359-439c-9297-bbc5299a7d87");
     internal static readonly Guid IID_IRawElementProviderFragmentRoot = new("620ce2a5-ab8f-40a9-86cb-de3c75599b58");
-    internal static nint _treeHwnd;   // set in OnGetObject
+    internal nint _treeHwnd;   // set in OnGetObject
 
     /// <summary>Raise a UIA focus-changed event on a tree node (so the reader announces it) — used when
     /// F6 / arrow keys move the internal focus.</summary>
-    internal static void RaiseFocus(NodeKind kind, int index)
+    internal void RaiseFocus(NodeKind kind, int index)
     {
-        if (_providerSimple == 0 || !ClientsListening) return;
+        if (_closed || _providerSimple == 0 || !ClientsListening) return;
         nint frag = 0;
         try { frag = FragmentPtr(kind, index); if (frag != 0) UiaRaiseAutomationEvent(frag, UIA_AutomationFocusChangedEventId); }
         catch { }
@@ -116,22 +117,23 @@ partial class Uia
 /// <summary>Shared property/navigation logic over a tree node identified by (kind,index).</summary>
 internal abstract class UiaNodeBase
 {
+    protected readonly Uia Owner;
     protected readonly Uia.NodeKind Kind;
     protected readonly int Index;
-    protected UiaNodeBase(Uia.NodeKind kind, int index) { Kind = kind; Index = index; }
+    protected UiaNodeBase(Uia owner, Uia.NodeKind kind, int index) { Owner = owner; Kind = kind; Index = index; }
 
     protected Uia.Node? Self(Uia.TreeSnapshot t) => Uia.Find(t, Kind, Index);
 
     public nint Navigate(NavigateDirection direction)
     {
-        var t = Uia.Tree();
+        var t = Owner.Tree();
         var me = Self(t);
         if (me is null) return 0;
         int myIdx = Uia.IndexOf(t, me);
         switch (direction)
         {
             case NavigateDirection.Parent:
-                return me.Parent >= 0 ? Uia.FragmentPtr(t.Nodes[me.Parent].Kind, t.Nodes[me.Parent].Index) : 0;
+                return me.Parent >= 0 ? Owner.FragmentPtr(t.Nodes[me.Parent].Kind, t.Nodes[me.Parent].Index) : 0;
             case NavigateDirection.FirstChild:
                 return me.Children.Length > 0 ? NodePtr(t, me.Children[0]) : 0;
             case NavigateDirection.LastChild:
@@ -149,21 +151,21 @@ internal abstract class UiaNodeBase
         return 0;
     }
 
-    private static nint NodePtr(Uia.TreeSnapshot t, int nodeIdx) => Uia.FragmentPtr(t.Nodes[nodeIdx].Kind, t.Nodes[nodeIdx].Index);
+    private nint NodePtr(Uia.TreeSnapshot t, int nodeIdx) => Owner.FragmentPtr(t.Nodes[nodeIdx].Kind, t.Nodes[nodeIdx].Index);
 
-    public nint GetRuntimeId() => UiaArrays.IntArray(new[] { 42, (int)Kind, Index });   // stable identity
+    public nint GetRuntimeId() => UiaArrays.IntArray(new[] { 42, Owner.Identity, (int)Kind, Index });   // stable identity
 
-    public UiaRect GetBoundingRectangle() { var n = Self(Uia.Tree()); return n?.Rect ?? default; }
+    public UiaRect GetBoundingRectangle() { var n = Self(Owner.Tree()); return n?.Rect ?? default; }
 
     public nint GetEmbeddedFragmentRoots() => 0;
 
-    public void SetFocus() { try { Uia.OnSetFocus?.Invoke(Kind, Index); } catch { } }
+    public void SetFocus() { Owner.EnsureAlive(); Owner.OnSetFocus?.Invoke(Kind, Index); }
 
-    public nint GetFragmentRoot() => Uia.FragmentRootPtr();
+    public nint GetFragmentRoot() => Owner.FragmentRootPtr();
 
     protected void FillProperty(int propertyId, nint pRetVal, int controlType, string localized, bool content)
     {
-        var n = Self(Uia.Tree());
+        var n = Self(Owner.Tree());
         object? val = propertyId switch
         {
             Uia.P_ControlType => controlType,
@@ -182,30 +184,30 @@ internal abstract class UiaNodeBase
 internal partial class UiaRoot : UiaNodeBase, IRawElementProviderSimple, IRawElementProviderFragment, IRawElementProviderFragmentRoot
 {
     private readonly nint _hwnd;
-    public UiaRoot(nint hwnd) : base(Uia.NodeKind.Root, 0) => _hwnd = hwnd;
+    public UiaRoot(Uia owner, nint hwnd) : base(owner, Uia.NodeKind.Root, 0) => _hwnd = hwnd;
 
     public ProviderOptions GetProviderOptions() => ProviderOptions.ServerSideProvider;
     public nint GetPatternProvider(int patternId) => 0;
-    public nint GetHostRawElementProvider() => UiaHostProviderFromHwnd(_hwnd, out nint host) >= 0 ? host : 0;
+    public nint GetHostRawElementProvider() { Owner.EnsureAlive(); return UiaHostProviderFromHwnd(_hwnd, out nint host) >= 0 ? host : 0; }
     public void GetPropertyValue(int propertyId, nint pRetVal) { VariantInit(pRetVal); FillProperty(propertyId, pRetVal, Uia.CT_Pane, "terminal window", true); }
 
     // FragmentRoot
     public nint ElementProviderFromPoint(double x, double y)
     {
-        var t = Uia.Tree();
+        var t = Owner.Tree();
         // deepest node whose rect contains the point (sessions/terminal before the containers)
         for (int i = t.Nodes.Length - 1; i >= 1; i--)
         {
             var r = t.Nodes[i].Rect;
             if (r.Width > 0 && x >= r.Left && x < r.Left + r.Width && y >= r.Top && y < r.Top + r.Height)
-                return Uia.FragmentPtr(t.Nodes[i].Kind, t.Nodes[i].Index);
+                return Owner.FragmentPtr(t.Nodes[i].Kind, t.Nodes[i].Index);
         }
         return 0;
     }
     public nint GetFocus()
     {
-        var t = Uia.Tree();
-        foreach (var n in t.Nodes) if (n.Focused) return Uia.FragmentPtr(n.Kind, n.Index);
+        var t = Owner.Tree();
+        foreach (var n in t.Nodes) if (n.Focused) return Owner.FragmentPtr(n.Kind, n.Index);
         return 0;
     }
 
@@ -216,8 +218,7 @@ internal partial class UiaRoot : UiaNodeBase, IRawElementProviderSimple, IRawEle
 [GeneratedComClass]
 internal partial class UiaTerminal : UiaNodeBase, IRawElementProviderSimple, IRawElementProviderFragment
 {
-    private readonly nint _hwnd;
-    public UiaTerminal(nint hwnd) : base(Uia.NodeKind.Terminal, 0) => _hwnd = hwnd;
+    public UiaTerminal(Uia owner) : base(owner, Uia.NodeKind.Terminal, 0) { }
 
     public ProviderOptions GetProviderOptions() => ProviderOptions.ServerSideProvider;
     public nint GetPatternProvider(int patternId) => patternId == 10014 /* Text */ ? Uia.AsInterface(this, Uia.IID_ITextProvider) : 0;
@@ -228,7 +229,7 @@ internal partial class UiaTerminal : UiaNodeBase, IRawElementProviderSimple, IRa
         // Name = live screen text (so a plain read still speaks the terminal); rest via FillProperty.
         if (propertyId == Uia.P_Name)
         {
-            string t = Uia.GetVisibleText?.Invoke() is { Length: > 0 } v ? v : "terminal";
+            string t = Owner.VisibleText() is { Length: > 0 } v ? v : "terminal";
             Marshal.GetNativeVariantForObject(t, pRetVal);
             return;
         }
@@ -240,7 +241,7 @@ internal partial class UiaTerminal : UiaNodeBase, IRawElementProviderSimple, IRa
 [GeneratedComClass]
 internal partial class UiaFragment : UiaNodeBase, IRawElementProviderSimple, IRawElementProviderFragment
 {
-    public UiaFragment(Uia.NodeKind kind, int index) : base(kind, index) { }
+    public UiaFragment(Uia owner, Uia.NodeKind kind, int index) : base(owner, kind, index) { }
 
     public ProviderOptions GetProviderOptions() => ProviderOptions.ServerSideProvider;
     public nint GetPatternProvider(int patternId) => 0;
@@ -271,7 +272,7 @@ internal partial interface IInvokeProvider { void Invoke(); }
 [GeneratedComClass]
 internal partial class UiaButton : UiaNodeBase, IRawElementProviderSimple, IRawElementProviderFragment, IInvokeProvider
 {
-    public UiaButton(Uia.NodeKind kind, int index) : base(kind, index) { }
+    public UiaButton(Uia owner, Uia.NodeKind kind, int index) : base(owner, kind, index) { }
 
     public ProviderOptions GetProviderOptions() => ProviderOptions.ServerSideProvider;
     public nint GetPatternProvider(int patternId) => patternId == 10000 /* Invoke */ ? Uia.AsInterface(this, Uia.IID_IInvokeProvider) : 0;
@@ -282,7 +283,7 @@ internal partial class UiaButton : UiaNodeBase, IRawElementProviderSimple, IRawE
         var (ct, lct) = Kind == Uia.NodeKind.SettingsTab ? (Uia.CT_TabItem, "tab") : (Uia.CT_Button, "button");
         FillProperty(propertyId, pRetVal, ct, lct, true);
     }
-    public void Invoke() { try { Uia.OnInvoke?.Invoke(Kind, Index); } catch { } }
+    public void Invoke() { Owner.EnsureAlive(); Owner.OnInvoke?.Invoke(Kind, Index); }
     [LibraryImport("oleaut32.dll")] private static partial void VariantInit(nint pvarg);
 }
 

--- a/src/Agwinterm.Win32/Uia.Tree.cs
+++ b/src/Agwinterm.Win32/Uia.Tree.cs
@@ -170,7 +170,14 @@ internal abstract class UiaNodeBase
 
     public nint GetEmbeddedFragmentRoots() => 0;
 
-    public void SetFocus() { Owner.EnsureAlive(); if (Kind == Uia.NodeKind.Session) Self(Owner.Tree()); Owner.OnSetFocus?.Invoke(Kind, Index); }
+    public void SetFocus()
+    {
+        Self(Owner.Tree());
+        if (!KeyboardFocusable) throw new InvalidOperationException("This accessibility element does not accept keyboard focus.");
+        Owner.OnSetFocus?.Invoke(Kind, Index);
+    }
+
+    internal bool KeyboardFocusable => Kind is Uia.NodeKind.Terminal or Uia.NodeKind.Sidebar or Uia.NodeKind.Session or Uia.NodeKind.SettingsControl or Uia.NodeKind.SettingsTab;
 
     public nint GetFragmentRoot() => Owner.FragmentRootPtr();
 
@@ -182,7 +189,8 @@ internal abstract class UiaNodeBase
             Uia.P_ControlType => controlType,
             Uia.P_Name => n?.Name is { Length: > 0 } nm ? nm : localized,
             Uia.P_LocalizedControlType => localized,
-            Uia.P_IsControlElement or Uia.P_IsKeyboardFocusable => true,
+            Uia.P_IsControlElement => true,
+            Uia.P_IsKeyboardFocusable => KeyboardFocusable,
             Uia.P_IsContentElement => content,
             Uia.P_HasKeyboardFocus => n?.Focused == true,
             _ => null,

--- a/src/Agwinterm.Win32/Uia.cs
+++ b/src/Agwinterm.Win32/Uia.cs
@@ -9,47 +9,98 @@ namespace Agwinterm.Win32;
 /// Raw source-generated COM — NO WPF/UIAutomationProvider dependency (which would bloat the exe). A full
 /// ITextProvider (line/caret navigation) is the follow-on stage.
 /// </summary>
-internal static partial class Uia
+internal partial class Uia : IDisposable
 {
     private static readonly StrategyBasedComWrappers ComWrappers = new();
-    private static UiaRoot? _root;           // keep the singleton root alive
-    private static nint _providerSimple;     // QI'd IRawElementProviderSimple* of the root (handed to UIA)
-    private static nint _fragmentRoot;       // QI'd IRawElementProviderFragmentRoot* of the root
+    // One context per Program window. Retained COM fragments/ranges keep this context, never a
+    // process-wide "current window". Closing it severs callbacks and retires its root references.
+    private readonly object _gate = new();
+    private static int _nextIdentity;
+    internal int Identity { get; } = Interlocked.Increment(ref _nextIdentity);
+    private volatile bool _closed;
+    internal bool IsClosed => _closed;
+    private UiaRoot? _root;
+    private nint _providerSimple, _fragmentRoot;
+    internal Func<string>? GetVisibleText;
 
-    /// <summary>Supplies the current visible terminal text (set by the app) for the terminal element's Name.</summary>
-    internal static Func<string>? GetVisibleText;
+    internal void EnsureAlive()
+    {
+        if (_closed) throw new COMException("The accessibility window is closed.", unchecked((int)0x80040201));
+    }
 
-    /// <summary>Handle WM_GETOBJECT: return our root UIA fragment when UIA asks for it.</summary>
-    internal static nint OnGetObject(nint hwnd, nint wParam, nint lParam)
+    internal string VisibleText()
+    {
+        EnsureAlive();
+        string text = GetVisibleText?.Invoke() ?? "terminal";
+        EnsureAlive();
+        return text;
+    }
+
+    /// <summary>Handle WM_GETOBJECT for this window only.</summary>
+    internal nint OnGetObject(nint hwnd, nint wParam, nint lParam)
     {
         if ((int)lParam != UiaRootObjectId) return 0;
-        if (_providerSimple == 0)
+        nint provider;
+        lock (_gate)
         {
-            _treeHwnd = hwnd;
-            _root = new UiaRoot(hwnd);
-            nint unk = ComWrappers.GetOrCreateComInterfaceForObject(_root, CreateComInterfaceFlags.None);
-            try
+            if (_closed) return 0;
+            if (_providerSimple == 0)
             {
-                // Hand UIA a real IRawElementProviderSimple* (not the raw IUnknown* — vtables differ).
-                Guid iid = IID_IRawElementProviderSimple;
-                if (Marshal.QueryInterface(unk, in iid, out _providerSimple) < 0) _providerSimple = 0;
-                Guid fr = IID_IRawElementProviderFragmentRoot;
-                if (Marshal.QueryInterface(unk, in fr, out _fragmentRoot) < 0) _fragmentRoot = 0;
+                _treeHwnd = hwnd;
+                _root = new UiaRoot(this, hwnd);
+                _providerSimple = AsInterface(_root, IID_IRawElementProviderSimple);
+                if (_fragmentRoot == 0) _fragmentRoot = AsInterface(_root, IID_IRawElementProviderFragmentRoot);
             }
-            finally { Marshal.Release(unk); }
+            provider = _providerSimple;
+            if (provider != 0) Marshal.AddRef(provider);
         }
-        return _providerSimple != 0 ? UiaReturnRawElementProvider(hwnd, wParam, lParam, _providerSimple) : 0;
+        // UIA can reenter the provider. Never hold _gate across a UIA call or an app callback.
+        try { return provider != 0 ? UiaReturnRawElementProvider(hwnd, wParam, lParam, provider) : 0; }
+        finally { if (provider != 0) Marshal.Release(provider); }
     }
 
-    /// <summary>The fragment root (IRawElementProviderFragmentRoot*), AddRef'd — each fragment's FragmentRoot.</summary>
-    internal static nint FragmentRootPtr()
+    internal nint FragmentRootPtr()
     {
-        if (_fragmentRoot != 0) Marshal.AddRef(_fragmentRoot);
-        return _fragmentRoot;
+        lock (_gate)
+        {
+            EnsureAlive();
+            if (_fragmentRoot != 0) Marshal.AddRef(_fragmentRoot);
+            return _fragmentRoot;
+        }
     }
 
-    /// <summary>The terminal element (IRawElementProviderSimple*), AddRef'd — text ranges' GetEnclosingElement.</summary>
-    internal static nint RootProvider() => AsInterface(new UiaTerminal(_treeHwnd), IID_IRawElementProviderSimple);
+    internal nint RootProvider()
+    {
+        EnsureAlive();
+        return AsInterface(new UiaTerminal(this), IID_IRawElementProviderSimple);
+    }
+
+    private nint BorrowProvider()
+    {
+        lock (_gate)
+        {
+            if (_closed || _providerSimple == 0) return 0;
+            Marshal.AddRef(_providerSimple);
+            return _providerSimple;
+        }
+    }
+
+    public void Dispose()
+    {
+        nint provider, root;
+        lock (_gate)
+        {
+            if (_closed) return;
+            _closed = true;
+            GetVisibleText = null; GetTree = null; GetTextSnapshot = null;
+            OnSetFocus = null; OnInvoke = null;
+            provider = _providerSimple; root = _fragmentRoot;
+            _providerSimple = _fragmentRoot = _treeHwnd = 0;
+            _root = null;
+        }
+        if (provider != 0) Marshal.Release(provider);
+        if (root != 0) Marshal.Release(root);
+    }
 
     private static readonly Guid IID_IRawElementProviderSimple = new("d6dd68d1-86fd-4332-8666-9abedea2d24c");
     private const int UiaRootObjectId = -25;
@@ -64,15 +115,18 @@ internal static partial class Uia
     /// <summary>Push text to the active screen reader via a UIA notification event (new terminal output,
     /// settings interactions). Cheap alternative to a full ITextProvider: the reader simply speaks the
     /// string. No-op until the provider exists (first WM_GETOBJECT) or when nothing is listening.</summary>
-    internal static void Announce(string text)
+    internal void Announce(string text)
     {
-        if (_providerSimple == 0 || string.IsNullOrWhiteSpace(text)) return;
+        if (string.IsNullOrWhiteSpace(text)) return;
+        nint provider = BorrowProvider();
+        if (provider == 0) return;
         try
         {
             // NotificationKind_Other = 4, NotificationProcessing_All = 2 (queue, don't drop).
-            UiaRaiseNotificationEvent(_providerSimple, 4, 2, text, "agwinterm-announce");
+            UiaRaiseNotificationEvent(provider, 4, 2, text, "agwinterm-announce");
         }
         catch { }
+        finally { Marshal.Release(provider); }
     }
 
     [LibraryImport("uiautomationcore.dll")]

--- a/src/Agwinterm.Win32/Uia.cs
+++ b/src/Agwinterm.Win32/Uia.cs
@@ -6,8 +6,8 @@ namespace Agwinterm.Win32;
 /// <summary>
 /// UIA accessibility (T2-14): a minimal UI Automation provider so screen readers (Narrator, NVDA) can
 /// see agwinterm as a document control and read the visible terminal content. Exposed via WM_GETOBJECT.
-/// Raw source-generated COM — NO WPF/UIAutomationProvider dependency (which would bloat the exe). A full
-/// ITextProvider (line/caret navigation) is the follow-on stage.
+/// Raw source-generated COM — no WPF/UIAutomationProvider dependency. Includes the fragment tree,
+/// invoke pattern and ITextProvider/ITextRangeProvider for line/caret navigation.
 /// </summary>
 internal partial class Uia : IDisposable
 {

--- a/tests/Agwinterm.Core.Tests/PaneFontSizeTests.cs
+++ b/tests/Agwinterm.Core.Tests/PaneFontSizeTests.cs
@@ -1,0 +1,24 @@
+namespace Agwinterm.Core.Tests;
+
+public class PaneFontSizeTests
+{
+    [Fact]
+    public void ZoomReturningToDefaultIsStillExplicitUntilReset()
+    {
+        var up = PaneFontSize.Zoom(14, 14, 1);
+        var back = PaneFontSize.Zoom(up.Size, 14, -1);
+        Assert.Equal((14f, true), back);
+        Assert.Equal((14f, true), PaneFontSize.Restore(back.Size, 20, back.Zoomed));
+        Assert.Equal((20f, false), PaneFontSize.Zoom(back.Size, 20, 0));
+    }
+
+    [Theory]
+    [InlineData(14, 20, false, 20, false)]
+    [InlineData(14, 20, true, 14, true)]
+    [InlineData(20, 20, null, 20, false)]
+    [InlineData(14, 20, null, 14, true)]
+    [InlineData(0, 20, null, 20, false)]
+    [InlineData(0, 20, true, 20, false)]
+    public void RestorePreservesExplicitZoomAndUpdatesInheritedSize(float saved, float def, bool? zoom, float expected, bool expectedZoom)
+        => Assert.Equal((expected, expectedZoom), PaneFontSize.Restore(saved, def, zoom));
+}

--- a/tests/Agwinterm.Core.Tests/UiaContextTests.cs
+++ b/tests/Agwinterm.Core.Tests/UiaContextTests.cs
@@ -36,6 +36,10 @@ public class UiaContextTests
         Set(s, "TotalLength", text.Length); Set(s, "VisibleRows", 1);
         return s;
     }
+    private static void Tree(object owner, Func<object[]> read)
+    {
+        Callback(owner, "GetTree", () => { var t = New("Uia+TreeSnapshot"); var current = read(); var nodes = Array.CreateInstance(Type("Uia+Node"), current.Length); for (int i = 0; i < current.Length; i++) nodes.SetValue(current[i], i); Set(t, "Nodes", nodes); return t; });
+    }
     private static void Closed(Action action)
     {
         var ex = Assert.Throws<TargetInvocationException>(action);
@@ -93,6 +97,8 @@ public class UiaContextTests
         var a = New("Uia"); var b = New("Uia"); int callsA = 0, callsB = 0;
         Callback(a, "OnInvoke", () => { callsA++; return null; }); Callback(b, "OnInvoke", () => { callsB++; return null; });
         var kind = Enum.ToObject(Type("Uia+NodeKind"), 4);
+        var node = New("Uia+Node"); Set(node, "Kind", kind);
+        Tree(a, () => [node]); Tree(b, () => [node]);
         var buttonA = New("UiaButton", a, kind, 0); var buttonB = New("UiaButton", b, kind, 0);
         try
         {
@@ -103,6 +109,39 @@ public class UiaContextTests
             Call(buttonB, "Invoke"); Assert.Equal(1, callsB);
         }
         finally { ((IDisposable)a).Dispose(); ((IDisposable)b).Dispose(); }
+    }
+
+    [Theory]
+    [InlineData(4)] [InlineData(6)] [InlineData(7)]
+    public void RetainedInvokableIdentityCannotMoveToAnotherControl(int nodeKind)
+    {
+        var owner = New("Uia"); var kind = Enum.ToObject(Type("Uia+NodeKind"), nodeKind);
+        object Node(int id, double x) { var n = New("Uia+Node"); Set(n, "Kind", kind); Set(n, "Index", id); var r = New("UiaRect"); Set(r, "Left", x); Set(n, "Rect", r); return n; }
+        var first = Node(1, 10); var retained = Node(2, 20); object[] current = [first, retained];
+        Tree(owner, () => current); int calls = 0; Callback(owner, "OnInvoke", () => { calls++; return null; });
+        var button = New("UiaButton", owner, kind, 2);
+        try
+        {
+            current = [retained, first];
+            var rect = Call(button, "GetBoundingRectangle")!;
+            Assert.Equal(20d, rect.GetType().GetField("Left")!.GetValue(rect));
+            Call(button, "Invoke"); Assert.Equal(1, calls);
+            current = [first]; Closed(() => Call(button, "Invoke")); Closed(() => Call(button, "GetBoundingRectangle"));
+            Assert.Equal(1, calls);
+        }
+        finally { ((IDisposable)owner).Dispose(); }
+    }
+
+    [Fact]
+    public void ProgramChromeIdentityAndSettingsRowsAreNotListOrdinals()
+    {
+        var app = System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(Type("Program"));
+        Set(app, "_chromeUiaIdentities", new Dictionary<string, int>(StringComparer.Ordinal));
+        var scratch = Call(app, "ChromeUiaIdentity", "scratch"); var split = Call(app, "ChromeUiaIdentity", "split");
+        _ = Call(app, "ChromeUiaIdentity", "recent");
+        Assert.Equal(scratch, Call(app, "ChromeUiaIdentity", "scratch")); Assert.NotEqual(scratch, split);
+        var rowA = New("Program+SetRow"); var rowB = New("Program+SetRow");
+        Assert.NotEqual(rowA.GetType().GetField("UiaIdentity", Flags)!.GetValue(rowA), rowB.GetType().GetField("UiaIdentity", Flags)!.GetValue(rowB));
     }
 
     [Theory]

--- a/tests/Agwinterm.Core.Tests/UiaContextTests.cs
+++ b/tests/Agwinterm.Core.Tests/UiaContextTests.cs
@@ -59,11 +59,32 @@ public class UiaContextTests
             Assert.IsType<ArgumentException>(Assert.Throws<TargetInvocationException>(() => Call(ra, "CompareEndpoints", start, rb, start)).InnerException);
             aText = "A-updated"; Assert.Equal(aText, Call(ra, "GetText", -1));
             ((IDisposable)b).Dispose(); Closed(() => Call(rb, "GetText", -1));
+            Closed(() => Call(rb, "Clone")); Closed(() => Call(rb, "Compare", rb));
             Assert.Equal(aText, Call(ra, "GetText", -1)); Assert.Equal("quick-pane", Call(rq, "GetText", -1));
             ((IDisposable)a).Dispose(); Closed(() => Call(ra, "GetText", -1));
             Assert.Equal("quick-pane", Call(rq, "GetText", -1));
         }
         finally { ((IDisposable)a).Dispose(); ((IDisposable)b).Dispose(); ((IDisposable)quick).Dispose(); }
+    }
+
+    [Fact]
+    public void SessionFragmentsKeepTokensAcrossReorderingAndRetireOnRemoval()
+    {
+        var owner = New("Uia"); var kind = Enum.ToObject(Type("Uia+NodeKind"), 3);
+        object Node(int token, double x) { var n = New("Uia+Node"); Set(n, "Kind", kind); Set(n, "Index", token); var r = New("UiaRect"); Set(r, "Left", x); Set(n, "Rect", r); return n; }
+        var first = Node(11, 10); var retained = Node(22, 20);
+        object[] current = [first, retained];
+        Callback(owner, "GetTree", () => { var t = New("Uia+TreeSnapshot"); var nodes = Array.CreateInstance(Type("Uia+Node"), current.Length); for (int i = 0; i < current.Length; i++) nodes.SetValue(current[i], i); Set(t, "Nodes", nodes); return t; });
+        var fragment = New("UiaFragment", owner, kind, 22);
+        try
+        {
+            current = [retained, first];
+            var rect = Call(fragment, "GetBoundingRectangle")!;
+            Assert.Equal(20d, rect.GetType().GetField("Left")!.GetValue(rect));
+            current = [first];
+            Closed(() => Call(fragment, "GetBoundingRectangle")); Closed(() => Call(fragment, "SetFocus"));
+        }
+        finally { ((IDisposable)owner).Dispose(); }
     }
 
     [Fact]

--- a/tests/Agwinterm.Core.Tests/UiaContextTests.cs
+++ b/tests/Agwinterm.Core.Tests/UiaContextTests.cs
@@ -104,4 +104,23 @@ public class UiaContextTests
         }
         finally { ((IDisposable)a).Dispose(); ((IDisposable)b).Dispose(); }
     }
+
+    [Theory]
+    [InlineData(false)] [InlineData(true)]
+    public void ReadUiaMapsClosureFailuresWithoutHidingLiveFailures(bool close)
+    {
+        var program = Type("Program"); var owner = New("Uia");
+        using var gone = new CancellationTokenSource();
+        var app = System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(program);
+        Set(app, "_uia", owner); Set(app, "_uiGone", gone); Set(app, "_uiaThreadId", Environment.CurrentManagedThreadId);
+        Func<int> read = () => { if (close) ((IDisposable)owner).Dispose(); throw new InvalidOperationException("queued read failure"); };
+        var method = program.GetMethod("ReadUia", Flags)!.MakeGenericMethod(typeof(int));
+        try
+        {
+            var error = Assert.Throws<TargetInvocationException>(() => method.Invoke(app, [read])).InnerException;
+            if (close) Assert.Equal(unchecked((int)0x80040201), Assert.IsType<COMException>(error).HResult);
+            else Assert.IsType<InvalidOperationException>(error);
+        }
+        finally { ((IDisposable)owner).Dispose(); }
+    }
 }

--- a/tests/Agwinterm.Core.Tests/UiaContextTests.cs
+++ b/tests/Agwinterm.Core.Tests/UiaContextTests.cs
@@ -1,0 +1,86 @@
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace Agwinterm.Core.Tests;
+
+/// <summary>Actual built providers, without HWNDs, a UI process, or a screen-reader connection.
+/// Tests context/range ownership and callback retirement, not Narrator's presentation.</summary>
+public class UiaContextTests
+{
+    private const BindingFlags Flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+    private static readonly Assembly Ui = LoadUi();
+    private static Assembly LoadUi()
+    {
+        string? root = AppContext.BaseDirectory;
+        while (root is not null && !Directory.Exists(Path.Combine(root, "src", "Agwinterm.Win32"))) root = Path.GetDirectoryName(root);
+        return Assembly.LoadFrom(Directory.GetFiles(Path.Combine(root!, "src", "Agwinterm.Win32", "bin"), "Agwinterm.Win32.dll", SearchOption.AllDirectories).OrderByDescending(File.GetLastWriteTimeUtc).First());
+    }
+    private static Type Type(string name) => Ui.GetType("Agwinterm.Win32." + name, true)!;
+    private static object New(string name, params object[] args) => Activator.CreateInstance(Type(name), Flags, null, args, null)!;
+    private static object? Call(object target, string name, params object[] args) => target.GetType().GetMethod(name, Flags)!.Invoke(target, args);
+    private static void Set(object target, string name, object value) => target.GetType().GetField(name, Flags)!.SetValue(target, value);
+    private static void Callback(object owner, string fieldName, Func<object?> fn)
+    {
+        var field = owner.GetType().GetField(fieldName, Flags)!;
+        var invoke = field.FieldType.GetMethod("Invoke")!;
+        var parameters = invoke.GetParameters().Select(p => Expression.Parameter(p.ParameterType)).ToArray();
+        Expression body = Expression.Invoke(Expression.Constant(fn));
+        body = invoke.ReturnType == typeof(void) ? Expression.Block(body, Expression.Empty()) : Expression.Convert(body, invoke.ReturnType);
+        field.SetValue(owner, Expression.Lambda(field.FieldType, body, parameters).Compile());
+    }
+    private static object Snapshot(string text)
+    {
+        var s = New("Uia+TextSnapshot");
+        Set(s, "Lines", new[] { text }); Set(s, "LineStart", new[] { 0, text.Length + 1 });
+        Set(s, "TotalLength", text.Length); Set(s, "VisibleRows", 1);
+        return s;
+    }
+    private static void Closed(Action action)
+    {
+        var ex = Assert.Throws<TargetInvocationException>(action);
+        Assert.Equal(unchecked((int)0x80040201), Assert.IsType<COMException>(ex.InnerException).HResult);
+    }
+
+    [Fact]
+    public void LibraryAndQuickContextsKeepTheirOwnTextAndRetainedRanges()
+    {
+        var a = New("Uia"); var b = New("Uia"); var quick = New("Uia");
+        string aText = "library-A";
+        Callback(a, "GetTextSnapshot", () => Snapshot(aText));
+        Callback(b, "GetTextSnapshot", () => Snapshot("library-B"));
+        Callback(quick, "GetTextSnapshot", () => Snapshot("quick-pane"));
+        var ra = New("UiaTextRange", a, 0, 100); var rb = New("UiaTextRange", b, 0, 100); var rq = New("UiaTextRange", quick, 0, 100);
+        try
+        {
+            Assert.Equal("library-A", Call(ra, "GetText", -1)); Assert.Equal("library-B", Call(rb, "GetText", -1)); Assert.Equal("quick-pane", Call(rq, "GetText", -1));
+            Assert.Equal(0, Call(ra, "Compare", rb));
+            var start = Enum.ToObject(Type("TextPatternRangeEndpoint"), 0);
+            Assert.IsType<ArgumentException>(Assert.Throws<TargetInvocationException>(() => Call(ra, "CompareEndpoints", start, rb, start)).InnerException);
+            aText = "A-updated"; Assert.Equal(aText, Call(ra, "GetText", -1));
+            ((IDisposable)b).Dispose(); Closed(() => Call(rb, "GetText", -1));
+            Assert.Equal(aText, Call(ra, "GetText", -1)); Assert.Equal("quick-pane", Call(rq, "GetText", -1));
+            ((IDisposable)a).Dispose(); Closed(() => Call(ra, "GetText", -1));
+            Assert.Equal("quick-pane", Call(rq, "GetText", -1));
+        }
+        finally { ((IDisposable)a).Dispose(); ((IDisposable)b).Dispose(); ((IDisposable)quick).Dispose(); }
+    }
+
+    [Fact]
+    public void RetainedButtonsCannotInvokeAnotherWindowOrKeepClosedCallbacks()
+    {
+        var a = New("Uia"); var b = New("Uia"); int callsA = 0, callsB = 0;
+        Callback(a, "OnInvoke", () => { callsA++; return null; }); Callback(b, "OnInvoke", () => { callsB++; return null; });
+        var kind = Enum.ToObject(Type("Uia+NodeKind"), 4);
+        var buttonA = New("UiaButton", a, kind, 0); var buttonB = New("UiaButton", b, kind, 0);
+        try
+        {
+            Assert.NotEqual(a.GetType().GetProperty("Identity", Flags)!.GetValue(a), b.GetType().GetProperty("Identity", Flags)!.GetValue(b));
+            Call(buttonA, "Invoke"); Assert.Equal(1, callsA); Assert.Equal(0, callsB);
+            ((IDisposable)a).Dispose(); Closed(() => Call(buttonA, "Invoke"));
+            foreach (string field in new[] { "GetTree", "GetVisibleText", "GetTextSnapshot", "OnInvoke", "OnSetFocus" }) Assert.Null(a.GetType().GetField(field, Flags)!.GetValue(a));
+            Call(buttonB, "Invoke"); Assert.Equal(1, callsB);
+        }
+        finally { ((IDisposable)a).Dispose(); ((IDisposable)b).Dispose(); }
+    }
+}

--- a/tests/Agwinterm.Core.Tests/UiaContextTests.cs
+++ b/tests/Agwinterm.Core.Tests/UiaContextTests.cs
@@ -127,6 +127,7 @@ public class UiaContextTests
             Assert.Equal(20d, rect.GetType().GetField("Left")!.GetValue(rect));
             Call(button, "Invoke"); Assert.Equal(1, calls);
             current = [first]; Closed(() => Call(button, "Invoke")); Closed(() => Call(button, "GetBoundingRectangle"));
+            Closed(() => Call(button, "SetFocus"));
             Assert.Equal(1, calls);
         }
         finally { ((IDisposable)owner).Dispose(); }
@@ -142,6 +143,23 @@ public class UiaContextTests
         Assert.Equal(scratch, Call(app, "ChromeUiaIdentity", "scratch")); Assert.NotEqual(scratch, split);
         var rowA = New("Program+SetRow"); var rowB = New("Program+SetRow");
         Assert.NotEqual(rowA.GetType().GetField("UiaIdentity", Flags)!.GetValue(rowA), rowB.GetType().GetField("UiaIdentity", Flags)!.GetValue(rowB));
+    }
+
+    [Theory]
+    [InlineData(4, false)] [InlineData(6, true)] [InlineData(7, true)]
+    public void InvokableFocusContractMatchesSupportedKinds(int nodeKind, bool focusable)
+    {
+        var owner = New("Uia"); var kind = Enum.ToObject(Type("Uia+NodeKind"), nodeKind);
+        var node = New("Uia+Node"); Set(node, "Kind", kind); Tree(owner, () => [node]);
+        var button = New("UiaButton", owner, kind, 0); int calls = 0;
+        Callback(owner, "OnSetFocus", () => { calls++; return null; });
+        try
+        {
+            Assert.Equal(focusable, button.GetType().BaseType!.GetProperty("KeyboardFocusable", Flags)!.GetValue(button));
+            if (focusable) { Call(button, "SetFocus"); Assert.Equal(1, calls); }
+            else { Assert.IsType<InvalidOperationException>(Assert.Throws<TargetInvocationException>(() => Call(button, "SetFocus")).InnerException); Assert.Equal(0, calls); }
+        }
+        finally { ((IDisposable)owner).Dispose(); }
     }
 
     [Theory]

--- a/tests/Agwinterm.Pty.Tests/PtyHostTests.cs
+++ b/tests/Agwinterm.Pty.Tests/PtyHostTests.cs
@@ -121,6 +121,10 @@ public class PtyHostTests : IDisposable
             Assert.Contains("before-detach", TypeUntilEcho(first.Data, "echo before-detach", "before-detach"));
         }   // disposing the data pipe = detach; the shell must keep running
 
+        // Closing the client handle signals EOF asynchronously; a control List can overtake
+        // the host data-reader's detach transition. Observe it rather than assuming a barrier.
+        Assert.True(SpinWait.SpinUntil(() => !Assert.Single(client.List()).Attached, 3000),
+            "host did not observe attachment EOF within the detach deadline");
         var info = Assert.Single(client.List());
         Assert.False(info.HasExited);
         Assert.False(info.Attached);

--- a/tests/Agwinterm.Pty.Tests/RestoreStateTests.cs
+++ b/tests/Agwinterm.Pty.Tests/RestoreStateTests.cs
@@ -147,6 +147,18 @@ public class RestoreStateTests
 
     // ---- Context ----
 
+    [Theory]
+    [InlineData(null)] [InlineData(false)] [InlineData(true)]
+    public void FontZoomedPreservesAbsentAndExplicitWireValues(bool? zoomed)
+    {
+        var state = Tree(); state.Workspaces[0].Sessions[0].Panes[0].FontZoomed = zoomed;
+        string json = RestoreState.Serialize(state);
+        Assert.Equal(zoomed, Load(json).Workspaces[0].Sessions[0].Panes[0].FontZoomed);
+        if (zoomed is null) Assert.DoesNotContain("FontZoomed", json);
+        else Assert.Contains("\"FontZoomed\": " + (zoomed.Value ? "true" : "false"), json);
+        Assert.Equal(json, RestoreState.Serialize(Load(json)));
+    }
+
     [Fact]
     public void RoundTrip_PreservesContext()
     {

--- a/tests/integration/hud-ui.ps1
+++ b/tests/integration/hud-ui.ps1
@@ -1,7 +1,7 @@
 # Dedicated P13 fixture: private app-data, no clipboard/registry writes, exact owned job teardown.
 param([string]$Exe="$PSScriptRoot/../../src/Agwinterm.Win32/bin/x64/Release/net10.0-windows/win-x64/Agwinterm.Win32.exe",
       [string]$TokenOwner=$env:AGWINTERM_TEST_OWNER,[switch]$Strict,
-      [ValidateSet('Hud','Quick','Navigation','Picker')][string]$Suite='Hud')
+      [ValidateSet('Hud','Quick','Navigation','Picker','Accessibility')][string]$Suite='Hud')
 $ErrorActionPreference='Stop'
 $PSNativeCommandUseErrorActionPreference=$false
 $root=[IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
@@ -173,7 +173,13 @@ public sealed class HudOwnedJob {
             }finally{$bitmap.UnlockBits($bits)}
         }finally{$graphics.Dispose();$bitmap.Dispose()}
     }
-    if($Suite-eq 'Picker') { . "$PSScriptRoot/picker-ui-cases.ps1" }
+    if($Suite-eq 'Accessibility') {
+        function NavWait([scriptblock]$condition){for($i=0;$i-lt 60;$i++){if(& $condition){return $true};Start-Sleep -Milliseconds 100};return $false}
+        $esc=[string][char]27
+        $libraryWindow=[string](@((Rpc 'window.list').windows|Where-Object open)[0].id)
+        . "$PSScriptRoot/uia-window-cases.ps1"
+    }
+    elseif($Suite-eq 'Picker') { . "$PSScriptRoot/picker-ui-cases.ps1" }
     elseif($Suite-eq 'Navigation') { . "$PSScriptRoot/navigation-ui-cases.ps1" }
     elseif($Suite-eq 'Quick') { . "$PSScriptRoot/quick-ui-cases.ps1" } else {
     $ctl=Join-Path $root 'src/Agwinterm.Ctl/bin/Release/net10.0-windows/agwintermctl.exe'

--- a/tests/integration/navigation-ui-cases.ps1
+++ b/tests/integration/navigation-ui-cases.ps1
@@ -329,6 +329,34 @@ try {
         $null=Rpc 'font' @{op='reset'} -Window $fontWindow
         $null=Rpc 'config.set' @{key='cursor-blink';value='false'} -Window $fontWindow
         Check 'reset resumes current default size' ((Rpc 'session.metrics' -Window $fontWindow).cellHeight-eq (Rpc 'session.metrics' -Window quick).cellHeight)
+        $fontOwner=[string](Rpc 'tree' -Window $fontWindow).workspaces[0].sessions[0].id
+        foreach($surfaceKind in 'scratch','pane overlay','session overlay'){
+            $null=Rpc 'config.set' @{key='font-size';value='20'} -Window $libraryWindow
+            if($surfaceKind-eq 'scratch'){$null=Rpc 'session.scratch' @{op='on'} $fontOwner -Window $fontWindow}
+            else{
+                $overlayArgs=@{action='open';command='cmd /d /k echo FONT-SURFACE-READY'}
+                if($surfaceKind-eq 'pane overlay'){$overlayArgs.pane='left'}
+                $null=Rpc 'session.overlay' $overlayArgs $fontOwner -Window $fontWindow
+            }
+            $null=Rpc 'config.set' @{key='cursor-blink';value='false'} -Window $fontWindow
+            $beforeSurface=Rpc 'session.metrics' -Window $fontWindow
+            $null=Rpc 'config.set' @{key='font-size';value='22'} -Window $libraryWindow
+            Check "inherited $surfaceKind follows live font default" ((Rpc 'session.metrics' -Window $fontWindow).cellHeight-gt $beforeSurface.cellHeight)
+            $null=Rpc 'font' @{op='inc'} -Window $fontWindow
+            $null=Rpc 'config.set' @{key='cursor-blink';value='false'} -Window $fontWindow
+            $surfaceZoom=Rpc 'session.metrics' -Window $fontWindow
+            $null=Rpc 'config.set' @{key='font-size';value='24'} -Window $libraryWindow
+            Check "explicit $surfaceKind zoom survives default change" ((Rpc 'session.metrics' -Window $fontWindow).cellHeight-eq $surfaceZoom.cellHeight)
+            $null=Rpc 'font' @{op='reset'} -Window $fontWindow
+            $null=Rpc 'config.set' @{key='cursor-blink';value='false'} -Window $fontWindow
+            Check "$surfaceKind reset resumes inheritance" ((Rpc 'session.metrics' -Window $fontWindow).cellHeight-eq (Rpc 'session.metrics' -Window quick).cellHeight)
+            if($surfaceKind-eq 'scratch'){$null=Rpc 'session.scratch' @{op='off'} $fontOwner -Window $fontWindow}
+            else{
+                $closeArgs=@{action='close'};if($surfaceKind-eq 'pane overlay'){$closeArgs.pane='left'}
+                $null=Rpc 'session.overlay' $closeArgs $fontOwner -Window $fontWindow
+            }
+            $null=Rpc 'config.set' @{key='cursor-blink';value='false'} -Window $fontWindow
+        }
         $null=Rpc 'quick' @{op='off'} -Window $libraryWindow
     } finally {
         $null=Rpc 'window.close' @{} $fontWindow

--- a/tests/integration/navigation-ui-cases.ps1
+++ b/tests/integration/navigation-ui-cases.ps1
@@ -277,6 +277,7 @@ $null=Rpc 'session.type' @{text="exit`r"} $session
 Check 'exited shell does not retain shell-name hint' (NavWait {$null-eq (Node $session).foregroundShell})
 
 $fontOriginal=Rpc 'config.get' @{key='font-family'}
+$fontSizeOriginal=Rpc 'config.get' @{key='font-size'}
 $libraryWindow=[string](@((Rpc 'window.list').windows|Where-Object open)[0].id)
 $installed=[Drawing.Text.InstalledFontCollection]::new()
 try {
@@ -316,9 +317,26 @@ try {
         $null=Rpc 'font' @{op='reset'} -Window quick
         $null=Rpc 'config.set' @{key='cursor-blink';value='false'} -Window quick
         Check 'shared font change already regrids quick' (NavWait {(Rpc 'session.metrics' -Window quick|ConvertTo-Json -Compress)-eq $quickMetrics})
+        $peerBefore=Rpc 'session.metrics' -Window $fontWindow
+        $quickBefore=Rpc 'session.metrics' -Window quick
+        $null=Rpc 'config.set' @{key='font-size';value=([int]$fontSizeOriginal+3).ToString()} -Window $libraryWindow
+        Check 'live default font size reaches existing peer and quick panes' ((Rpc 'session.metrics' -Window $fontWindow).cellHeight-gt $peerBefore.cellHeight -and (Rpc 'session.metrics' -Window quick).cellHeight-gt $quickBefore.cellHeight)
+        $null=Rpc 'font' @{op='inc'} -Window $fontWindow
+        $null=Rpc 'config.set' @{key='cursor-blink';value='false'} -Window $fontWindow
+        $zoomed=Rpc 'session.metrics' -Window $fontWindow
+        $null=Rpc 'config.set' @{key='font-size';value=([int]$fontSizeOriginal+5).ToString()} -Window $libraryWindow
+        Check 'live default preserves explicit peer zoom' ((Rpc 'session.metrics' -Window $fontWindow).cellHeight-eq $zoomed.cellHeight)
+        $null=Rpc 'font' @{op='reset'} -Window $fontWindow
+        $null=Rpc 'config.set' @{key='cursor-blink';value='false'} -Window $fontWindow
+        Check 'reset resumes current default size' ((Rpc 'session.metrics' -Window $fontWindow).cellHeight-eq (Rpc 'session.metrics' -Window quick).cellHeight)
         $null=Rpc 'quick' @{op='off'} -Window $libraryWindow
     } finally {
         $null=Rpc 'window.close' @{} $fontWindow
         $null=Rpc 'window.select' @{} $libraryWindow
     }
-} finally {$installed.Dispose();$null=Rpc 'config.set' @{key='font-family';value=$fontOriginal} -Window $libraryWindow}
+} finally {
+    $installed.Dispose()
+    $null=Rpc 'config.set' @{key='font-family';value=$fontOriginal} -Window $libraryWindow
+    $null=Rpc 'config.set' @{key='font-size';value=$fontSizeOriginal} -Window $libraryWindow
+}
+. "$PSScriptRoot/uia-window-cases.ps1"

--- a/tests/integration/navigation-ui-cases.ps1
+++ b/tests/integration/navigation-ui-cases.ps1
@@ -98,6 +98,7 @@ Check 'readonly typo cannot remove existing protection' (-not (Rpc 'session.read
 $null=Rpc 'session.readonly' @{op='off'} $session
 Check 'missing readonly target refuses without protecting the active pane' (-not (Rpc 'session.readonly' @{op='on'} 'missing-pane' -AllowError).ok -and (Rpc 'session.readonly' @{op='state'} $session)-eq 'off')
 $null=Rpc 'session.write' @{text="`r`nSTABILIZATION-SEARCH-MARKER`r`n"} $session
+$null=Rpc 'config.set' @{key='cursor-blink';value='false'} # FIFO barrier: search's sent message can overtake the posted write.
 $findBefore=Rpc 'session.search' @{query='STABILIZATION-SEARCH-MARKER'} $session
 Check 'search mutation guard has a real match' ($findBefore-match 'of [1-9]')
 Check 'missing search target refuses without replacing active query' (-not (Rpc 'session.search' @{query='MISSING-SEARCH-QUERY'} 'missing-pane' -AllowError).ok -and (Rpc 'session.search' @{} $session)-eq $findBefore)

--- a/tests/integration/uia-window-cases.ps1
+++ b/tests/integration/uia-window-cases.ps1
@@ -58,6 +58,10 @@ try {
     $settingsCondition=[System.Windows.Automation.PropertyCondition]::new([System.Windows.Automation.AutomationElement]::NameProperty,'Settings')
     $settingsButton=$b.root.FindFirst([System.Windows.Automation.TreeScope]::Children,$settingsCondition)
     if($null-eq $settingsButton){throw 'Owned peer has no UIA Settings button'}
+    $settingsIdentity=$settingsButton.GetRuntimeId()-join ','
+    $null=Rpc 'sidebar' @{op='hide'} -Window $uiaWindows[1]
+    if(-not (NavWait {$null-ne $b.root.FindFirst([System.Windows.Automation.TreeScope]::Children,[System.Windows.Automation.PropertyCondition]::new([System.Windows.Automation.AutomationElement]::NameProperty,'Recent sessions'))})){throw 'Sidebar-hidden chrome did not materialize'}
+    Check 'retained Settings button keeps its action across chrome insertion' ($settingsButton.Current.Name-eq 'Settings' -and ($settingsButton.GetRuntimeId()-join ',')-eq $settingsIdentity)
     ($settingsButton.GetCurrentPattern([System.Windows.Automation.InvokePattern]::Pattern)).Invoke()
     $settingsOpened=NavWait {
         $group=$b.root.FindFirst([System.Windows.Automation.TreeScope]::Children,$settingsCondition)

--- a/tests/integration/uia-window-cases.ps1
+++ b/tests/integration/uia-window-cases.ps1
@@ -1,0 +1,76 @@
+# Actual UI Automation clients, only for HWNDs belonging to hud-ui's owned app/job.
+# This is provider integration, not a claim that Narrator/NVDA presentation was manually tested.
+Add-Type -Path "$env:WINDIR/Microsoft.NET/Framework64/v4.0.30319/WPF/UIAutomationClient.dll"
+Add-Type -Path "$env:WINDIR/Microsoft.NET/Framework64/v4.0.30319/WPF/UIAutomationTypes.dll"
+Add-Type -TypeDefinition @'
+using System;using System.Collections.Generic;using System.Runtime.InteropServices;using System.Text;
+public static class NavUiaWindows {
+ delegate bool Visitor(IntPtr h,IntPtr p);
+ [DllImport("user32.dll")] static extern bool EnumWindows(Visitor f,IntPtr p);
+ [DllImport("user32.dll")] static extern uint GetWindowThreadProcessId(IntPtr h,out uint p);
+ [DllImport("user32.dll",CharSet=CharSet.Unicode)] static extern int GetWindowTextW(IntPtr h,StringBuilder b,int n);
+ [DllImport("user32.dll",CharSet=CharSet.Unicode)] static extern int GetClassNameW(IntPtr h,StringBuilder b,int n);
+ public static IntPtr[] Owned(uint pid,bool quick=false){var found=new List<IntPtr>();EnumWindows((h,p)=>{uint n;GetWindowThreadProcessId(h,out n);if(n==pid){var cls=new StringBuilder(256);GetClassNameW(h,cls,256);if(cls.ToString()!="AgwintermWin32")return true;var text=new StringBuilder(256);GetWindowTextW(h,text,256);if((text.ToString()=="agwinterm quick terminal")==quick)found.Add(h);}return true;},IntPtr.Zero);return found.ToArray();}
+}
+'@
+function UiaDoc([IntPtr]$handle){
+    $root=[System.Windows.Automation.AutomationElement]::FromHandle($handle)
+    $condition=[System.Windows.Automation.PropertyCondition]::new([System.Windows.Automation.AutomationElement]::ControlTypeProperty,[System.Windows.Automation.ControlType]::Document)
+    $document=$root.FindFirst([System.Windows.Automation.TreeScope]::Children,$condition)
+    if($null-eq $document){throw 'Owned window has no UIA document'}
+    return @{root=$root;document=$document;range=($document.GetCurrentPattern([System.Windows.Automation.TextPattern]::Pattern)).DocumentRange}
+}
+$uiaWindows=@();$uiaHandles=@();$uiaSessions=@()
+try {
+    foreach($label in 'A','B'){
+        $beforeHandles=@([NavUiaWindows]::Owned($job.Pid))
+        $window=[string](Rpc 'window.new' @{name="UIA-owned-$label"} -Window $libraryWindow)
+        $uiaWindows+=,$window
+        if(-not (NavWait {@((Rpc 'window.list').windows|Where-Object {$_.id-eq $window -and $_.open}).Count-eq 1})){throw 'UIA peer did not open'}
+        $handles=@([NavUiaWindows]::Owned($job.Pid)|Where-Object {$_-notin $beforeHandles})
+        if($handles.Count-ne 1){throw 'Cannot identify exactly one new owned UIA HWND'}
+        $uiaHandles+=,$handles[0]
+        $sid=[string](Rpc 'tree' -Window $window).workspaces[0].sessions[0].id;$uiaSessions+=,$sid
+        if(-not (NavWait {@((Rpc 'tree' -Window $window).workspaces[0].sessions)[0].foregroundShell-eq 'cmd'})){throw 'UIA shell not ready'}
+        $null=Rpc 'session.write' @{text=($esc+'[2J'+$esc+'[H'+"UIA-ONLY-$label")} $sid -Window $window
+    }
+    $null=Rpc 'quick' @{op='on'} -Window $libraryWindow
+    $q=@([NavUiaWindows]::Owned($job.Pid,$true))
+    if($q.Count-ne 1){throw 'No unique owned quick HWND'}
+    if(-not (NavWait {([string](Rpc 'session.text' -Window quick)).Contains('>')})){throw 'Quick shell did not finish startup'}
+    $null=Rpc 'session.write' @{text=($esc+'[2J'+$esc+'[H'+'UIA-ONLY-QUICK')} -Window quick
+    if(-not (NavWait {([string](Rpc 'session.text' -Window quick)).Contains('UIA-ONLY-QUICK')})){throw 'Quick marker did not reach its owned pane'}
+    $a=UiaDoc $uiaHandles[0];$b=UiaDoc $uiaHandles[1];$quickDoc=UiaDoc $q[0]
+    Check 'two library UIA roots and quick expose separate document text' ($a.range.GetText(-1).Contains('UIA-ONLY-A') -and $b.range.GetText(-1).Contains('UIA-ONLY-B') -and $quickDoc.range.GetText(-1).Contains('UIA-ONLY-QUICK'))
+    Check 'UIA text runtime ids differ across windows' (($a.document.GetRuntimeId()-join ',')-ne ($b.document.GetRuntimeId()-join ',') -and ($a.document.GetRuntimeId()-join ',')-ne ($quickDoc.document.GetRuntimeId()-join ','))
+    $alternate=[string](Rpc 'session.new' @{name='UIA-focus-alternate'} -Window $uiaWindows[0])
+    if(-not (NavWait {@((Rpc 'tree' -Window $uiaWindows[0]).workspaces[0].sessions|Where-Object id -eq $alternate).Count-eq 1})){throw 'UIA focus peer not ready'}
+    $null=Rpc 'session.select' @{} $uiaSessions[0] -Window $uiaWindows[0]
+    $condition=[System.Windows.Automation.PropertyCondition]::new([System.Windows.Automation.AutomationElement]::NameProperty,'UIA-focus-alternate')
+    $focusNode=$a.root.FindFirst([System.Windows.Automation.TreeScope]::Descendants,$condition)
+    if($null-eq $focusNode){throw 'No owned sidebar session for UIA focus'}
+    $focusNode.SetFocus()
+    Check 'UIA session focus routes only to its owning window' (NavWait {$focusNode.Current.HasKeyboardFocus -and $b.range.GetText(-1).Contains('UIA-ONLY-B')})
+    $settingsCondition=[System.Windows.Automation.PropertyCondition]::new([System.Windows.Automation.AutomationElement]::NameProperty,'Settings')
+    $settingsButton=$b.root.FindFirst([System.Windows.Automation.TreeScope]::Children,$settingsCondition)
+    if($null-eq $settingsButton){throw 'Owned peer has no UIA Settings button'}
+    ($settingsButton.GetCurrentPattern([System.Windows.Automation.InvokePattern]::Pattern)).Invoke()
+    Check 'UIA Invoke opens settings in its owner only' (NavWait {
+        $group=$b.root.FindFirst([System.Windows.Automation.TreeScope]::Children,$settingsCondition)
+        $group.Current.ControlType-eq [System.Windows.Automation.ControlType]::Group -and $a.range.GetText(-1).Contains('UIA-ONLY-A')
+    })
+    [void][HudOwnedJob]::SendMessageW($uiaHandles[1],0x100,[IntPtr]27,[IntPtr]1)
+    # Retain ranges across close; neither may attach itself to another library/quick context.
+    foreach($index in 1,0){
+        $null=Rpc 'window.close' @{} $uiaWindows[$index] -Window $libraryWindow
+        if(-not (NavWait {@((Rpc 'window.list').windows|Where-Object {$_.id-eq $uiaWindows[$index] -and $_.open}).Count-eq 0})){throw 'Owned UIA window did not close'}
+        $retired=if($index-eq 1){$b.range}else{$a.range}
+        $refused=$false;try{$null=$retired.GetText(-1)}catch{$refused=$true}
+        Check "retained range refuses after owning window $index closes" $refused
+        Check 'quick UIA remains readable after another window closes' ($quickDoc.range.GetText(-1).Contains('UIA-ONLY-QUICK'))
+    }
+} finally {
+    foreach($window in $uiaWindows){if(@((Rpc 'window.list').windows|Where-Object {$_.id-eq $window -and $_.open}).Count){$null=Rpc 'window.close' @{} $window -Window $libraryWindow}}
+    $null=Rpc 'quick' @{op='off'} -Window $libraryWindow
+    $null=Rpc 'window.select' @{} $libraryWindow -Window $libraryWindow
+}

--- a/tests/integration/uia-window-cases.ps1
+++ b/tests/integration/uia-window-cases.ps1
@@ -36,20 +36,25 @@ try {
         $uiaHandles+=,$handles[0]
         $sid=[string](Rpc 'tree' -Window $window).workspaces[0].sessions[0].id;$uiaSessions+=,$sid
         if(-not (NavWait {@((Rpc 'tree' -Window $window).workspaces[0].sessions)[0].foregroundShell-eq 'cmd'})){throw 'UIA shell not ready'}
-        $null=Rpc 'session.write' @{text=($esc+'[2J'+$esc+'[H'+"UIA-ONLY-$label")} $sid -Window $window
+        if(-not (NavWait {([string](Rpc 'session.text' @{} $sid -Window $window)).Contains('>')})){throw 'UIA command prompt not ready'}
+        # Produce real child output: injected emulator-only text is replaced by ConPTY repaint
+        # after a later session switch/resize and cannot serve as a retained-range oracle.
+        $null=Rpc 'session.type' @{text="echo UIA-ONLY-$label`r"} $sid -Window $window
+        if(-not (NavWait {([string](Rpc 'session.text' @{} $sid -Window $window)).Contains("UIA-ONLY-$label")})){throw 'UIA marker did not reach owned shell'}
     }
     $null=Rpc 'quick' @{op='on'} -Window $libraryWindow
     $q=@([NavUiaWindows]::Owned($job.Pid,$true))
     if($q.Count-ne 1){throw 'No unique owned quick HWND'}
     if(-not (NavWait {([string](Rpc 'session.text' -Window quick)).Contains('>')})){throw 'Quick shell did not finish startup'}
-    $null=Rpc 'session.write' @{text=($esc+'[2J'+$esc+'[H'+'UIA-ONLY-QUICK')} -Window quick
+    $null=Rpc 'session.type' @{text="echo UIA-ONLY-QUICK`r"} -Window quick
     if(-not (NavWait {([string](Rpc 'session.text' -Window quick)).Contains('UIA-ONLY-QUICK')})){throw 'Quick marker did not reach its owned pane'}
     $a=UiaDoc $uiaHandles[0];$b=UiaDoc $uiaHandles[1];$quickDoc=UiaDoc $q[0]
     Check 'two library UIA roots and quick expose separate document text' ($a.range.GetText(-1).Contains('UIA-ONLY-A') -and $b.range.GetText(-1).Contains('UIA-ONLY-B') -and $quickDoc.range.GetText(-1).Contains('UIA-ONLY-QUICK'))
     Check 'UIA text runtime ids differ across windows' (($a.document.GetRuntimeId()-join ',')-ne ($b.document.GetRuntimeId()-join ',') -and ($a.document.GetRuntimeId()-join ',')-ne ($quickDoc.document.GetRuntimeId()-join ','))
-    $alternate=[string](Rpc 'session.new' @{name='UIA-focus-alternate'} -Window $uiaWindows[0])
+    $alternate=[string](Rpc 'session.new' @{name='UIA-focus-alternate';'no-select'=$true} -Window $uiaWindows[0])
     if(-not (NavWait {@((Rpc 'tree' -Window $uiaWindows[0]).workspaces[0].sessions|Where-Object id -eq $alternate).Count-eq 1})){throw 'UIA focus peer not ready'}
     $null=Rpc 'session.select' @{} $uiaSessions[0] -Window $uiaWindows[0]
+    if(-not (NavWait {@((Rpc 'tree' -Window $uiaWindows[0]).workspaces[0].sessions|Where-Object {$_.id-eq $uiaSessions[0] -and $_.active}).Count-eq 1})){throw 'Original UIA session did not become active'}
     $condition=[System.Windows.Automation.PropertyCondition]::new([System.Windows.Automation.AutomationElement]::NameProperty,'UIA-focus-alternate')
     $focusNode=$a.root.FindFirst([System.Windows.Automation.TreeScope]::Descendants,$condition)
     if($null-eq $focusNode){throw 'No owned sidebar session for UIA focus'}
@@ -62,12 +67,21 @@ try {
     $null=Rpc 'sidebar' @{op='hide'} -Window $uiaWindows[1]
     if(-not (NavWait {$null-ne $b.root.FindFirst([System.Windows.Automation.TreeScope]::Children,[System.Windows.Automation.PropertyCondition]::new([System.Windows.Automation.AutomationElement]::NameProperty,'Recent sessions'))})){throw 'Sidebar-hidden chrome did not materialize'}
     Check 'retained Settings button keeps its action across chrome insertion' ($settingsButton.Current.Name-eq 'Settings' -and ($settingsButton.GetRuntimeId()-join ',')-eq $settingsIdentity)
+    Check 'chrome Invoke button does not advertise unsupported keyboard focus' (-not $settingsButton.Current.IsKeyboardFocusable)
     ($settingsButton.GetCurrentPattern([System.Windows.Automation.InvokePattern]::Pattern)).Invoke()
     $settingsOpened=NavWait {
         $group=$b.root.FindFirst([System.Windows.Automation.TreeScope]::Children,$settingsCondition)
         $group.Current.ControlType-eq [System.Windows.Automation.ControlType]::Group -and $a.range.GetText(-1).Contains('UIA-ONLY-A')
     }
     Check 'UIA Invoke opens settings in its owner only' $settingsOpened
+    if($settingsOpened){
+        $tabCondition=[System.Windows.Automation.PropertyCondition]::new([System.Windows.Automation.AutomationElement]::ControlTypeProperty,[System.Windows.Automation.ControlType]::TabItem)
+        $tab=$b.root.FindFirst([System.Windows.Automation.TreeScope]::Descendants,$tabCondition)
+        $tab.SetFocus();Check 'settings tab UIA SetFocus updates actual keyboard focus' (NavWait {$tab.Current.HasKeyboardFocus})
+        $controlCondition=[System.Windows.Automation.PropertyCondition]::new([System.Windows.Automation.AutomationElement]::ControlTypeProperty,[System.Windows.Automation.ControlType]::Button)
+        $control=$b.root.FindFirst([System.Windows.Automation.TreeScope]::Descendants,$controlCondition)
+        $control.SetFocus();Check 'settings control UIA SetFocus moves focus off tab header' (NavWait {$control.Current.HasKeyboardFocus -and -not $tab.Current.HasKeyboardFocus})
+    }
     if(-not $settingsOpened){"UIA invoke diagnostics: A=$($a.range.GetText(-1)) B=$($b.range.GetText(-1)) windows=$($uiaWindows-join ',')"}
     [void][HudOwnedJob]::SendMessageW($uiaHandles[1],0x100,[IntPtr]27,[IntPtr]1)
     # Remove the earlier row; a retained provider must still identify the same session, not its ordinal.

--- a/tests/integration/uia-window-cases.ps1
+++ b/tests/integration/uia-window-cases.ps1
@@ -30,6 +30,7 @@ try {
         $window=[string](Rpc 'window.new' @{name="UIA-owned-$label"} -Window $libraryWindow)
         $uiaWindows+=,$window
         if(-not (NavWait {@((Rpc 'window.list').windows|Where-Object {$_.id-eq $window -and $_.open}).Count-eq 1})){throw 'UIA peer did not open'}
+        if(-not (NavWait {@([NavUiaWindows]::Owned($job.Pid)|Where-Object {$_-notin $beforeHandles}).Count-eq 1})){throw 'New owned UIA HWND did not materialize'}
         $handles=@([NavUiaWindows]::Owned($job.Pid)|Where-Object {$_-notin $beforeHandles})
         if($handles.Count-ne 1){throw 'Cannot identify exactly one new owned UIA HWND'}
         $uiaHandles+=,$handles[0]
@@ -58,10 +59,12 @@ try {
     $settingsButton=$b.root.FindFirst([System.Windows.Automation.TreeScope]::Children,$settingsCondition)
     if($null-eq $settingsButton){throw 'Owned peer has no UIA Settings button'}
     ($settingsButton.GetCurrentPattern([System.Windows.Automation.InvokePattern]::Pattern)).Invoke()
-    Check 'UIA Invoke opens settings in its owner only' (NavWait {
+    $settingsOpened=NavWait {
         $group=$b.root.FindFirst([System.Windows.Automation.TreeScope]::Children,$settingsCondition)
         $group.Current.ControlType-eq [System.Windows.Automation.ControlType]::Group -and $a.range.GetText(-1).Contains('UIA-ONLY-A')
-    })
+    }
+    Check 'UIA Invoke opens settings in its owner only' $settingsOpened
+    if(-not $settingsOpened){"UIA invoke diagnostics: A=$($a.range.GetText(-1)) B=$($b.range.GetText(-1)) windows=$($uiaWindows-join ',')"}
     [void][HudOwnedJob]::SendMessageW($uiaHandles[1],0x100,[IntPtr]27,[IntPtr]1)
     # Remove the earlier row; a retained provider must still identify the same session, not its ordinal.
     $retainedRuntime=$focusNode.GetRuntimeId()-join ','
@@ -72,8 +75,19 @@ try {
     $replacement=[string](Rpc 'session.new' @{name='UIA-unrelated-replacement'} -Window $uiaWindows[0])
     $null=Rpc 'session.close' @{} $alternate -Window $uiaWindows[0]
     $null=Rpc 'config.set' @{key='cursor-blink';value='false'} -Window $uiaWindows[0]
-    $refused=$false;try{$null=$focusNode.Current.Name}catch{$refused=$true}
-    Check 'removed sidebar item refuses instead of describing replacement' $refused
+    # UIA's client broker may retain an old Name/default rather than forward the provider HRESULT.
+    # Test the user-visible invariant: no rebinding, and a stale focus request cannot steal focus.
+    $staleName=$null;try{$staleName=$focusNode.Current.Name}catch{}
+    $sentinel=[string](Rpc 'session.new' @{name='UIA-focus-sentinel'} -Window $uiaWindows[0])
+    $sentinelCondition=[System.Windows.Automation.PropertyCondition]::new([System.Windows.Automation.AutomationElement]::NameProperty,'UIA-focus-sentinel')
+    if(-not (NavWait {$null-ne $a.root.FindFirst([System.Windows.Automation.TreeScope]::Descendants,$sentinelCondition)})){throw 'UIA sentinel not ready'}
+    $sentinelNode=$a.root.FindFirst([System.Windows.Automation.TreeScope]::Descendants,$sentinelCondition)
+    $sentinelNode.SetFocus()
+    if(-not (NavWait {$sentinelNode.Current.HasKeyboardFocus})){throw 'UIA sentinel did not receive focus'}
+    try{$focusNode.SetFocus()}catch{}
+    $null=Rpc 'config.set' @{key='cursor-blink';value='false'} -Window $uiaWindows[0]
+    "Retained UIA check: original=$($uiaSessions[0]) retained=$alternate tree=$(Rpc 'tree' -Window $uiaWindows[0]|ConvertTo-Json -Depth 6 -Compress)"
+    Check 'removed sidebar item cannot rebind name or focus to replacement' ($staleName-ne 'UIA-unrelated-replacement' -and $sentinelNode.Current.HasKeyboardFocus) "broker name='$staleName'"
     # Retain ranges across close; neither may attach itself to another library/quick context.
     foreach($index in 1,0){
         $null=Rpc 'window.close' @{} $uiaWindows[$index] -Window $libraryWindow

--- a/tests/integration/uia-window-cases.ps1
+++ b/tests/integration/uia-window-cases.ps1
@@ -54,7 +54,11 @@ try {
     $alternate=[string](Rpc 'session.new' @{name='UIA-focus-alternate';'no-select'=$true} -Window $uiaWindows[0])
     if(-not (NavWait {@((Rpc 'tree' -Window $uiaWindows[0]).workspaces[0].sessions|Where-Object id -eq $alternate).Count-eq 1})){throw 'UIA focus peer not ready'}
     $null=Rpc 'session.select' @{} $uiaSessions[0] -Window $uiaWindows[0]
-    if(-not (NavWait {@((Rpc 'tree' -Window $uiaWindows[0]).workspaces[0].sessions|Where-Object {$_.id-eq $uiaSessions[0] -and $_.active}).Count-eq 1})){throw 'Original UIA session did not become active'}
+    # A FIFO UI action, unlike a pipe-thread tree read, observes the posted selection landing.
+    $null=Rpc 'config.set' @{key='cursor-blink';value='false'} -Window $uiaWindows[0]
+    if(-not (NavWait {@((Rpc 'tree' -Window $uiaWindows[0]).workspaces[0].sessions|Where-Object {$_.id-eq $uiaSessions[0] -and $_.active}).Count-eq 1})){
+        throw "Original UIA session did not become active: expected=$($uiaSessions[0]), window=$($uiaWindows[0]), tree=$(Rpc 'tree' -Window $uiaWindows[0]|ConvertTo-Json -Depth 8 -Compress)"
+    }
     $condition=[System.Windows.Automation.PropertyCondition]::new([System.Windows.Automation.AutomationElement]::NameProperty,'UIA-focus-alternate')
     $focusNode=$a.root.FindFirst([System.Windows.Automation.TreeScope]::Descendants,$condition)
     if($null-eq $focusNode){throw 'No owned sidebar session for UIA focus'}

--- a/tests/integration/uia-window-cases.ps1
+++ b/tests/integration/uia-window-cases.ps1
@@ -34,7 +34,11 @@ try {
         $handles=@([NavUiaWindows]::Owned($job.Pid)|Where-Object {$_-notin $beforeHandles})
         if($handles.Count-ne 1){throw 'Cannot identify exactly one new owned UIA HWND'}
         $uiaHandles+=,$handles[0]
-        $sid=[string](Rpc 'tree' -Window $window).workspaces[0].sessions[0].id;$uiaSessions+=,$sid
+        # Opening the HWND precedes asynchronous creation/publication of its first session.
+        if(-not (NavWait {@((Rpc 'tree' -Window $window).workspaces[0].sessions|Where-Object { -not [string]::IsNullOrWhiteSpace($_.id) }).Count-eq 1})){throw 'UIA initial session did not materialize'}
+        $sid=[string](Rpc 'tree' -Window $window).workspaces[0].sessions[0].id
+        if([string]::IsNullOrWhiteSpace($sid)){throw 'UIA initial session disappeared before identity capture'}
+        $uiaSessions+=,$sid
         if(-not (NavWait {@((Rpc 'tree' -Window $window).workspaces[0].sessions)[0].foregroundShell-eq 'cmd'})){throw 'UIA shell not ready'}
         if(-not (NavWait {([string](Rpc 'session.text' @{} $sid -Window $window)).Contains('>')})){throw 'UIA command prompt not ready'}
         # Produce real child output: injected emulator-only text is replaced by ConPTY repaint

--- a/tests/integration/uia-window-cases.ps1
+++ b/tests/integration/uia-window-cases.ps1
@@ -1,7 +1,10 @@
 # Actual UI Automation clients, only for HWNDs belonging to hud-ui's owned app/job.
 # This is provider integration, not a claim that Narrator/NVDA presentation was manually tested.
-Add-Type -Path "$env:WINDIR/Microsoft.NET/Framework64/v4.0.30319/WPF/UIAutomationClient.dll"
-Add-Type -Path "$env:WINDIR/Microsoft.NET/Framework64/v4.0.30319/WPF/UIAutomationTypes.dll"
+# PowerShell Core ships its matching desktop assemblies. Mixing Framework 4.x with that
+# runtime can bind Client 10.0 to Types 4.0 and fail only when FromHandle resolves a type.
+$uiaAssemblies=if($PSVersionTable.PSEdition-eq 'Core'){$PSHOME}else{"$env:WINDIR/Microsoft.NET/Framework64/v4.0.30319/WPF"}
+Add-Type -Path "$uiaAssemblies/UIAutomationTypes.dll"
+Add-Type -Path "$uiaAssemblies/UIAutomationClient.dll"
 Add-Type -TypeDefinition @'
 using System;using System.Collections.Generic;using System.Runtime.InteropServices;using System.Text;
 public static class NavUiaWindows {
@@ -60,6 +63,17 @@ try {
         $group.Current.ControlType-eq [System.Windows.Automation.ControlType]::Group -and $a.range.GetText(-1).Contains('UIA-ONLY-A')
     })
     [void][HudOwnedJob]::SendMessageW($uiaHandles[1],0x100,[IntPtr]27,[IntPtr]1)
+    # Remove the earlier row; a retained provider must still identify the same session, not its ordinal.
+    $retainedRuntime=$focusNode.GetRuntimeId()-join ','
+    $null=Rpc 'session.close' @{} $uiaSessions[0] -Window $uiaWindows[0]
+    $null=Rpc 'config.set' @{key='cursor-blink';value='false'} -Window $uiaWindows[0]
+    $focusNode.SetFocus()
+    Check 'retained sidebar item keeps session identity after earlier row closes' (NavWait {$focusNode.Current.Name-eq 'UIA-focus-alternate' -and $focusNode.Current.HasKeyboardFocus -and ($focusNode.GetRuntimeId()-join ',')-eq $retainedRuntime})
+    $replacement=[string](Rpc 'session.new' @{name='UIA-unrelated-replacement'} -Window $uiaWindows[0])
+    $null=Rpc 'session.close' @{} $alternate -Window $uiaWindows[0]
+    $null=Rpc 'config.set' @{key='cursor-blink';value='false'} -Window $uiaWindows[0]
+    $refused=$false;try{$null=$focusNode.Current.Name}catch{$refused=$true}
+    Check 'removed sidebar item refuses instead of describing replacement' $refused
     # Retain ranges across close; neither may attach itself to another library/quick context.
     foreach($index in 1,0){
         $null=Rpc 'window.close' @{} $uiaWindows[$index] -Window $libraryWindow
@@ -67,6 +81,8 @@ try {
         $retired=if($index-eq 1){$b.range}else{$a.range}
         $refused=$false;try{$null=$retired.GetText(-1)}catch{$refused=$true}
         Check "retained range refuses after owning window $index closes" $refused
+        $refused=$false;try{$null=$retired.Clone()}catch{$refused=$true}
+        Check "retained range cannot clone after owning window $index closes" $refused
         Check 'quick UIA remains readable after another window closes' ($quickDoc.range.GetText(-1).Contains('UIA-ONLY-QUICK'))
     }
 } finally {


### PR DESCRIPTION
Closes #267. Closes #276. Per-window UIA roots, fragments, retained ranges and callbacks; explicit font inheritance and persisted zoom distinction. Build and 9 isolated tests pass. Actual UIA integration: 8/8 checks on two library windows plus quick; token generation 125 released after owned-job-zero cleanup. Broad Codex-only review and fresh CI are merge gates; no release/install.