### PR TITLE
Release agwinterm 0.18.0

### DIFF
--- a/installer/agwinterm.iss
+++ b/installer/agwinterm.iss
@@ -2,7 +2,7 @@
 ; Build via installer\build.ps1 (publishes to stage\ then runs ISCC on this file).
 
 #define AppName    "agwinterm"
-#define AppVersion "0.17.14"
+#define AppVersion "0.18.0"
 #define AppExe     "Agwinterm.Win32.exe"
 #define AppPublisher "Boris Kudriashov"
 ; The main app defaults new sessions to the Rust pty-host as a first-run seed only (it never


### PR DESCRIPTION
Prepare the first 0.18 release after the P1-P17 stabilization series. This changes only the installer version source of truth, consumed by the app/CLI and portable packaging builds. ABI agreement passes (18). Full CI must pass before merge; publishing is held until the final Lite stabilization PR #76 is green and merged. After merge, tag v0.18.0 to build and publish installer, portable executable, native ABI assets and shared CLI using the existing release workflow. No user installation/restart or package-manager override.