### PR TITLE
Align session command defaults and direct launches with Lite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,11 @@ jobs:
         timeout-minutes: 10
         run: ./tests/integration/win32-control.ps1 -Strict
 
+      - name: Session command parity integration
+        shell: pwsh
+        timeout-minutes: 5
+        run: ./tests/integration/hud-ui.ps1 -Suite Command -Strict
+
       - name: Passive HUD integration
         shell: pwsh
         timeout-minutes: 5

--- a/README.md
+++ b/README.md
@@ -442,3 +442,9 @@ Everything is rebindable in `keymap.conf` (see `F1` for the live list).
 
 [MIT](LICENSE) © 2026 Boris Kudriashov. Bundled theme files retain their upstream (iTerm2-Color-Schemes,
 MIT) licensing.
+
+### Session command launching
+
+`session new --command` runs PowerShell code and leaves an interactive prompt in both terminals.
+Use `--command-mode direct` for executable + arguments without a shell.
+See [command launching and migration](docs/session-commands.md), including `--wait` and portable workbench scripts.

--- a/docs/plans/2026-09-10-session-command-parity.md
+++ b/docs/plans/2026-09-10-session-command-parity.md
@@ -1,0 +1,66 @@
+# Session command launch parity
+
+User request: make `session new --command` behave the same in agwinterm and
+agliteterm after the 0.18.0 releases. The reported workbench command begins with
+PowerShell `Remove-Item`; Full attempts to execute that name, while Lite interprets it.
+
+## Current behavior, verified against both released sources
+
+- Full `Program.ControlHost.NewSession` forwards the command to `CreateSession`.
+  `CreatePane` splits it as executable + arguments. The child exiting leaves an exited standalone pane. With `--wait`, it instead invokes `cmd /c <command> & echo. & pause`.
+- Lite's `session.new` handler launches `powershell.exe -NoExit -Command <command>`.
+  It leaves a PowerShell prompt after the command completes. It currently ignores
+  `args.wait`. This is still true in Lite 0.18.0.
+- Full also has a separate interactive PowerShell launch path for custom commands;
+  overlays have their own launch and exit-status contracts in both products.
+- Both products support explicit shell profiles. Lite uses the shared Full CLI,
+  with a source revision pinned in its CI workflow.
+
+## Accepted direction (user: "ok, continue")
+
+The recommended shared default is PowerShell code, with an interactive prompt
+after the command completes. This matches the reported workbench use case and
+Lite's existing behavior. Explicit `exit` still exits that PowerShell process.
+
+Provide an explicit direct-launch option (`--command-mode direct`) for consumers
+that require executable + arguments and process-exit session lifetime. Default
+`--command-mode powershell` must use identical parsing and lifetime behavior in both
+products. Refuse invalid modes before creating a workspace or session.
+
+`--wait` is accepted in PowerShell mode, retaining its interactive prompt, and
+refused in direct mode. It never changes the interpreter. No new session wrapper
+is added. Standalone exited panes retain output; split-pane exit rules are unchanged.
+
+Implementation and acceptance are now in progress. The user accepted proceeding
+with the recommended PowerShell default and explicit direct option on 2026-09-10.
+
+## Acceptance
+
+- Exercise a bare cmdlet, multiple statements, an ordinary executable, an explicit
+  PowerShell helper script, paths with spaces, quoted and empty arguments, Unicode,
+  and trailing backslashes through both actual launch paths.
+- Verify command completion, explicit exit, launch failure, and the agreed `--wait`
+  behavior. Test that direct mode does not interpret PowerShell metacharacters.
+- Verify the chosen working directory and inherited pane/pipe identity.
+- Test invalid mode, missing command, command/profile conflicts, and Lite's bounded
+  host fields without creating partial workspace/session state.
+- Migrate Full fixtures that depend on direct launching or immediate child exit
+  explicitly; retain their original safety and lifetime assertions.
+- Update shared CLI help, both shipped agent skills, current documentation, and
+  cross-product acceptance coverage. Coordinate Lite's shared CLI pin after the
+  Full candidate is available.
+- Run Codex-only revmux and relevant isolated/local acceptance tests, using the
+  canonical suite token for any GUI/host test. Require exact candidate CI before
+  merging. No new release or installation is included in this follow-up.
+
+## Ownership and recovery
+
+Codex owns both new worktrees:
+
+- `C:/Users/boris/source/agwinterm-command-parity`, branch
+  `fix/session-command-parity`, base `a9cb53af9c79bf232ac780f8585ed31a182d3d67`.
+- `C:/Users/boris/source/agliteterm-command-parity`, branch
+  `fix/session-command-parity`, base `6264982426afcd1581461a225979d9217433e006`.
+
+Existing dirty worktrees and release evidence remain untouched. Build and test receipts
+live in the owned worktrees under `.revmux/`. Delivery follows the existing PR/CI gates.

--- a/docs/session-commands.md
+++ b/docs/session-commands.md
@@ -1,0 +1,49 @@
+# Launching a session command
+
+Both terminals interpret `session new --command` as Windows PowerShell code:
+
+```powershell
+agwintermctl session new --name build --command "Write-Output 'starting'; npm test"
+```
+
+The command runs after the PowerShell profile loads. When it finishes, the pane has
+an interactive PowerShell prompt. `--wait` is accepted and leaves that same prompt
+open; it no longer selects `cmd.exe` or a press-any-key wrapper. An explicit
+PowerShell `exit` ends the interpreter. A standalone exited pane retains its output.
+
+To launch an executable and its arguments with no added shell, use:
+
+```powershell
+agwintermctl session new --name tool --command-mode direct --command 'tool.exe "a b"'
+```
+
+Direct mode uses Windows command-line quoting, including escaped quotes, empty
+arguments, and trailing backslashes. PowerShell cmdlets, variables, pipelines and
+semicolons are not interpreted. Run a shell executable explicitly when you need one.
+`--wait` with direct mode is refused: use the default PowerShell mode for an
+interactive prompt after completion. An exited standalone direct pane retains output
+but has no interpreter accepting further input. Existing split-pane exit rules apply.
+
+The modes are exactly `powershell` (the default) and `direct`. A mode or `--wait`
+requires a nonempty command. A command cannot be combined with `--profile`.
+Invalid launches are refused before creating a workspace or session. To match Lite's
+host protocol, each launch is limited to a 259-byte UTF-8 executable name, 16
+arguments, and 2047 UTF-8 bytes per argument. The PowerShell code is one argument.
+Use a helper script for longer startup sequences.
+
+For a portable `workbench.cmd`, keep startup logic in a `.ps1` beside the batch file:
+
+```cmd
+agwintermctl session new --name Claude --cwd "%~dp0." --command "powershell.exe -NoLogo -NoExit -File .\workbench-pane.ps1 -Agent claude"
+```
+
+The trailing dot in `%~dp0.` avoids a trailing-backslash quoting trap. This explicit
+PowerShell recipe also works with the already-released 0.18.0 applications, whose
+implicit command defaults differ. For a helper filename containing spaces, quote
+it as PowerShell code (single quotes inside the command string).
+
+Migration from agwinterm 0.18.0: add `--command-mode direct` to callers that depend
+on direct process lifetime or argv parsing. Use a matching updated `agwintermctl`
+and terminal; older CLIs do not send the new option. Lite's ordinary PowerShell
+command behavior remains the same. These rules apply to `session new`; overlays,
+shell profiles, custom commands and restore replay retain their separate contracts.

--- a/docs/session-commands.md
+++ b/docs/session-commands.md
@@ -26,7 +26,9 @@ but has no interpreter accepting further input. Existing split-pane exit rules a
 
 The modes are exactly `powershell` (the default) and `direct`. A mode or `--wait`
 requires a nonempty command. A command cannot be combined with `--profile`.
-Invalid launches are refused before creating a workspace or session. To match Lite's
+Invalid command options are refused before creating a workspace or session. If a valid
+command cannot start (for example, its executable is missing), the returned session
+keeps a diagnostic pane with no process accepting input. To match Lite's
 host protocol, each launch is limited to a 259-byte UTF-8 executable name, 16
 arguments, and 2047 UTF-8 bytes per argument. The PowerShell code is one argument.
 Use a helper script for longer startup sequences.
@@ -47,3 +49,6 @@ on direct process lifetime or argv parsing. Use a matching updated `agwintermctl
 and terminal; older CLIs do not send the new option. Lite's ordinary PowerShell
 command behavior remains the same. These rules apply to `session new`; overlays,
 shell profiles, custom commands and restore replay retain their separate contracts.
+In Lite, duplicating or cold-restoring a bare `powershell.exe` direct session adds
+the usual prompt wrapper; exact empty argv currently applies only to its initial launch
+([tracked follow-up](https://github.com/yeroo/agliteterm/issues/79)).

--- a/qa/control-read.md
+++ b/qa/control-read.md
@@ -77,7 +77,7 @@ is at the left margin" and "nothing answered" must not look alike.
 **Steps:** create a session running a program that homes the caret and then prints nothing —
 
 ```powershell
-Send-Ctl $s @('session','new','--name','col0','--no-select','--command',
+Send-Ctl $s @('session','new','--name','col0','--no-select','--command-mode','direct','--command',
               'powershell -NoProfile -Command "Clear-Host; Start-Sleep 120"')
 ```
 

--- a/src/Agwinterm.Ctl/Program.cs
+++ b/src/Agwinterm.Ctl/Program.cs
@@ -254,6 +254,7 @@ switch (area)
                 break;
             }
             case "new":
+                if (bareLast.Contains("command")) { Console.Error.WriteLine("session new: --command needs a value"); return 2; }
                 if (bareLast.Contains("command-mode")) { Console.Error.WriteLine("session new: --command-mode needs a value"); return 2; }
                 if (!Agwinterm.Pty.SessionCommand.TryCreate(Opt("command"), Opt("command-mode"), options.ContainsKey("wait"),
                     Opt("profile"), out _, out var commandError)) { Console.Error.WriteLine(commandError); return 2; }

--- a/src/Agwinterm.Ctl/Program.cs
+++ b/src/Agwinterm.Ctl/Program.cs
@@ -7,7 +7,7 @@ using System.Text.Json;
 //   agwintermctl ping
 //   agwintermctl version [--json]                  (the CLI that ran + the app serving the pipe)
 //   agwintermctl tree [--json]
-//   agwintermctl session new [--cwd DIR] [--name NAME] [--workspace ID|--workspace-name NAME [--create-workspace]] [--no-select]
+//   agwintermctl session new [--command "PowerShell code"] [--command-mode powershell|direct] [--cwd DIR] [--name NAME] [--workspace ID|--workspace-name NAME [--create-workspace]] [--no-select]
 //       (no workspace given = the workspace of the pane running this CLI; the active one only when there is none)
 //                                                  (an unknown workspace is refused, never swapped for the active one)
 //   agwintermctl session select <target>
@@ -254,6 +254,10 @@ switch (area)
                 break;
             }
             case "new":
+                if (bareLast.Contains("command-mode")) { Console.Error.WriteLine("session new: --command-mode needs a value"); return 2; }
+                if (!Agwinterm.Pty.SessionCommand.TryCreate(Opt("command"), Opt("command-mode"), options.ContainsKey("wait"),
+                    Opt("profile"), out _, out var commandError)) { Console.Error.WriteLine(commandError); return 2; }
+                if (Opt("command-mode") is { } commandMode) cargs["command-mode"] = commandMode;
                 if (Opt("cwd") is { } cwd) cargs["cwd"] = cwd;
                 if (Opt("name") is { } name) cargs["name"] = name;
                 if (Opt("workspace") is { } wsp) cargs["workspace"] = wsp;
@@ -262,7 +266,7 @@ switch (area)
                 if (options.ContainsKey("create-workspace")) cargs["create-workspace"] = true;
                 if (Opt("profile") is { } prof) cargs["profile"] = prof;
                 if (options.ContainsKey("no-select")) cargs["no-select"] = true;   // create in background, keep focus
-                if (options.ContainsKey("wait")) cargs["wait"] = true;             // hold on "press any key" after --command exits
+                if (options.ContainsKey("wait")) cargs["wait"] = true;             // PowerShell keeps its interactive prompt; direct mode refuses this flag
                 // Who is asking: the pane this CLI runs in, the same AGWINTERM_SESSION_ID every other
                 // verb defaults its target to. With no --workspace the session lands in THAT pane's
                 // workspace, not in whatever the user last clicked. Sent as `caller`, not as the

--- a/src/Agwinterm.Pty/AgentSkill.cs
+++ b/src/Agwinterm.Pty/AgentSkill.cs
@@ -73,7 +73,7 @@ public static class AgentSkill
           `--no-select` creates the session in the background without stealing focus or changing the current selection.
           `--command` runs PowerShell code and leaves an interactive prompt. `--wait` is accepted in this mode; the prompt stays open either way.
           — create a session (prints its id). `--command-mode direct` launches executable + arguments using Windows quoting, with no added shell; it refuses `--wait`. An exited standalone pane remains visible without an interactive prompt.
-          `--profile NAME` picks a shell profile (default = Windows PowerShell).
+          `--profile NAME` picks a shell profile (default = Windows PowerShell). `--command` and `--profile` are mutually exclusive.
           `--workspace` is a workspace id (or unique id prefix; `tree --json` lists them), `--workspace-name` its sidebar label
           (case-insensitive). **An unknown workspace is refused** (`ok:false`, no session created) — it is never swapped for the
           active workspace: an unknown id, or an unknown name without `--create-workspace`, is an error that names the value.

--- a/src/Agwinterm.Pty/AgentSkill.cs
+++ b/src/Agwinterm.Pty/AgentSkill.cs
@@ -69,10 +69,10 @@ public static class AgentSkill
           from a live one beside it, and no verb reports the stamp per pane. Always present, even
           for an idle session that never set one)
         - `agwintermctl events [--since CURSOR] [--limit N]`      — poll the event log (status/notification/session/tree changes); returns {cursor, events:[{seq,type,session,info}]}. Pass the returned cursor as --since next poll.
-        - `agwintermctl session new [--name N] [--cwd DIR] [--workspace ID|--workspace-name NAME [--create-workspace]] [--command "argv"] [--profile NAME] [--no-select] [--wait]`
+        - `agwintermctl session new [--name N] [--cwd DIR] [--workspace ID|--workspace-name NAME [--create-workspace]] [--command "PowerShell code"] [--command-mode powershell|direct] [--profile NAME] [--no-select] [--wait]`
           `--no-select` creates the session in the background without stealing focus or changing the current selection.
-          `--wait` (with `--command`) holds the session on "press any key" after the command exits, so its final output stays readable.
-          — create a session (prints its id). `--command` runs that program as the session process (argv-style, no shell) instead of the shell.
+          `--command` runs PowerShell code and leaves an interactive prompt. `--wait` is accepted in this mode; the prompt stays open either way.
+          — create a session (prints its id). `--command-mode direct` launches executable + arguments using Windows quoting, with no added shell; it refuses `--wait`. An exited standalone pane remains visible without an interactive prompt.
           `--profile NAME` picks a shell profile (default = Windows PowerShell).
           `--workspace` is a workspace id (or unique id prefix; `tree --json` lists them), `--workspace-name` its sidebar label
           (case-insensitive). **An unknown workspace is refused** (`ok:false`, no session created) — it is never swapped for the

--- a/src/Agwinterm.Pty/ControlServer.cs
+++ b/src/Agwinterm.Pty/ControlServer.cs
@@ -263,9 +263,14 @@ public sealed class ControlServer : IDisposable
                     string? workspace = GetString(args, "workspace"), workspaceName = GetString(args, "workspace-name");
                     if (!string.IsNullOrEmpty(workspace) && !string.IsNullOrEmpty(workspaceName))
                         return Err(SessionNewWorkspaces.TwoSources(workspace, workspaceName));
+                    if (args.TryGetProperty("command-mode", out var modeValue) && modeValue.ValueKind != JsonValueKind.String)
+                        return Err("session.new: command-mode must be powershell or direct; nothing created");
+                    string? commandMode = GetString(args, "command-mode");
+                    if (!SessionCommand.TryCreate(GetString(args, "command"), commandMode, GetBool(args, "wait"),
+                        GetString(args, "profile"), out _, out var commandError)) return Err(commandError);
                     string created = host.NewSession(GetString(args, "name"), GetString(args, "cwd"), workspace,
                         GetString(args, "command"), workspaceName, GetBool(args, "create-workspace"), GetString(args, "profile"), GetBool(args, "no-select"), GetBool(args, "wait"),
-                        caller: GetString(args, "caller"));
+                        caller: GetString(args, "caller"), commandMode: commandMode);
                     return created.StartsWith(ISessionHost.RefusePrefix, StringComparison.Ordinal)
                         ? Err(created[ISessionHost.RefusePrefix.Length..])
                         : Ok(created);

--- a/src/Agwinterm.Pty/ISessionHost.cs
+++ b/src/Agwinterm.Pty/ISessionHost.cs
@@ -104,8 +104,9 @@ public interface ISessionHost
     /// <summary>
     /// Create a session; returns its id. Optionally in a workspace (by id/prefix via
     /// <paramref name="workspace"/>, or by sidebar label via <paramref name="workspaceName"/> +
-    /// <paramref name="createWorkspace"/>), running <paramref name="command"/> as its process
-    /// instead of the shell. A workspace that does not resolve — an unknown id/prefix, or an
+    /// <paramref name="createWorkspace"/>), running <paramref name="command"/> as PowerShell code with an interactive prompt afterward.
+    /// <paramref name="commandMode"/> = direct runs executable + arguments without a shell;
+    /// wait is accepted only in PowerShell mode, whose prompt already stays open. A workspace that does not resolve — an unknown id/prefix, or an
     /// unknown name without <paramref name="createWorkspace"/> — is <b>refused</b> with
     /// <see cref="RefusePrefix"/> + the <see cref="SessionNewWorkspaces"/> wording, and no session
     /// is created; it is never swapped for the active workspace (P2, decision 1). The host resolves
@@ -122,7 +123,7 @@ public interface ISessionHost
     /// </summary>
     string NewSession(string? name, string? cwd, string? workspace, string? command = null,
         string? workspaceName = null, bool createWorkspace = false, string? profile = null, bool noSelect = false, bool wait = false,
-        string? caller = null);
+        string? caller = null, string? commandMode = null);
 
     /// <summary>Clone a session (same cwd + shell profile); returns the new session id. (agterm #234)</summary>
     string DuplicateSession(string? target);
@@ -621,7 +622,7 @@ public sealed class SingleSessionHost : ISessionHost
     public WindowStateSnapshot WindowState() => new(true, false, false, false, "ws", "single");
     public string NewSession(string? name, string? cwd, string? workspace, string? command = null,
         string? workspaceName = null, bool createWorkspace = false, string? profile = null, bool noSelect = false, bool wait = false,
-        string? caller = null) => "single";
+        string? caller = null, string? commandMode = null) => "single";
     public string DuplicateSession(string? target) => "";
     public string ProfilesList() => "Windows PowerShell";
     public string ProfilesReload() => "0 profiles loaded";

--- a/src/Agwinterm.Pty/SessionCommand.cs
+++ b/src/Agwinterm.Pty/SessionCommand.cs
@@ -1,0 +1,63 @@
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Agwinterm.Pty;
+
+/// <summary>The session.new command contract, shared with Lite's session_command.h.</summary>
+public sealed record SessionCommand(string App, string[] Args)
+{
+    // Porta.Pty's automatic quoting changes embedded quotes. Supply Windows-quoted
+    // arguments verbatim; the Rust and managed hosts also accept this representation.
+    public string[] QuotedArgs => Array.ConvertAll(Args, TerminalSession.QuoteArg);
+
+    public static bool TryCreate(string? command, string? mode, bool wait, string? profile,
+        out SessionCommand? launch, out string error)
+    {
+        launch = null;
+        error = "";
+        if (mode is not (null or "powershell" or "direct"))
+            error = "command-mode must be powershell or direct";
+        else if (string.IsNullOrWhiteSpace(command))
+        {
+            if (mode is not null || wait) error = "command-mode and wait require a nonempty command";
+        }
+        else if (profile is not null) error = "command and profile are mutually exclusive";
+        else if (command.Contains('\0')) error = "command must not contain NUL";
+        else if (mode == "direct" && wait) error = "wait requires powershell mode; direct mode does not add a shell";
+        else if (mode == "direct")
+        {
+            // Use Windows argv rules, including escaped quotes, empty arguments and trailing
+            // backslashes. Leading whitespace must not manufacture an empty executable.
+            nint words = CommandLineToArgvW(command.TrimStart(), out int count);
+            if (words == 0) error = "could not parse command";
+            else
+            {
+                try
+                {
+                    var argv = new string[count];
+                    for (int i = 0; i < count; i++)
+                        argv[i] = Marshal.PtrToStringUni(Marshal.ReadIntPtr(words, i * IntPtr.Size))!;
+                    if (count == 0 || argv[0].Length == 0) error = "command requires an executable";
+                    else launch = new(argv[0], argv[1..]);
+                }
+                finally { LocalFree(words); }
+            }
+        }
+        else launch = new("powershell.exe", ["-NoLogo", "-NoExit", "-Command", command]);
+
+        // Lite's native host fields are bounded. Apply the same limits before either host
+        // creates a workspace or session, rather than silently changing a long command.
+        if (launch is not null && (Encoding.UTF8.GetByteCount(launch.App) >= 260 ||
+            launch.Args.Length > 16 || launch.Args.Any(a => Encoding.UTF8.GetByteCount(a) >= 2048)))
+            error = "command exceeds host capacity (app 259 bytes, 16 arguments, 2047 bytes each)";
+        if (error.Length == 0) return true;
+        launch = null;
+        error = "session.new: " + error + "; nothing created";
+        return false;
+    }
+
+    [DllImport("shell32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern nint CommandLineToArgvW(string command, out int count);
+    [DllImport("kernel32.dll")]
+    private static extern nint LocalFree(nint memory);
+}

--- a/src/Agwinterm.Pty/TerminalSession.cs
+++ b/src/Agwinterm.Pty/TerminalSession.cs
@@ -154,7 +154,7 @@ public sealed class TerminalSession : ISession
 
     /// <summary>Quote one argument per the CommandLineToArgvW rules, so a joined command line round-trips
     /// back to the same argv (handles the -Command &lt;multiline script&gt; case).</summary>
-    private static string QuoteArg(string arg)
+    internal static string QuoteArg(string arg)
     {
         if (arg.Length > 0 && arg.IndexOfAny(new[] { ' ', '\t', '\n', '\v', '"' }) < 0) return arg;
         var sb = new System.Text.StringBuilder("\"");

--- a/src/Agwinterm.Win32/Program.ControlHost.cs
+++ b/src/Agwinterm.Win32/Program.ControlHost.cs
@@ -300,8 +300,10 @@ internal partial class Program
     // the active workspace, and that too is read here, synchronously, rather than inside the Post.
     public string NewSession(string? name, string? cwd, string? workspace, string? command = null,
         string? workspaceName = null, bool createWorkspace = false, string? profile = null, bool noSelect = false, bool wait = false,
-        string? caller = null)
+        string? caller = null, string? commandMode = null)
     {
+        if (!SessionCommand.TryCreate(command, commandMode, wait, profile, out var launch, out var error))
+            return ISessionHost.RefusePrefix + error;
         Workspace? ws = null;
         string? newWorkspaceName = null;   // set = create this workspace on the UI thread, then the session in it
         if (!string.IsNullOrEmpty(workspace))
@@ -361,7 +363,7 @@ internal partial class Program
                 target ??= CreateWorkspace(Guid.NewGuid().ToString(), newWorkspaceName!);
             }
             // --no-select creates the session in the background, leaving the current focus/selection (agterm #250).
-            CreateSession(id, name, cwd, target, makeActive: !noSelect, command: command, profileName: profile, wait: wait);
+            CreateSession(id, name, cwd, target, makeActive: !noSelect, profileName: profile, sessionCommand: launch);
         });
         return id;
     }

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -52,7 +52,7 @@ internal partial class Program
     /// When <paramref name="command"/> is set, that argv runs as the pane's process instead of the shell.</summary>
     private Pane CreatePane(string paneId, Workspace ws, string? cwd, float fontSize, string? command = null,
         bool shellWrap = false, bool interactive = false, Dictionary<string, string>? extraEnv = null, string? profileName = null,
-        bool deElevate = false, HandoffArgs? handoff = null, bool wait = false)
+        bool deElevate = false, HandoffArgs? handoff = null, bool wait = false, SessionCommand? sessionCommand = null)
     {
         var (cols, rows) = GridSizeFor(fontSize);
         // The ONLY session creation site (see ISessionBackend). Handoff panes are pinned in-process
@@ -138,6 +138,8 @@ internal partial class Program
                            new Microsoft.Win32.SafeHandles.SafeFileHandle(h.ConIn, true),
                            new Microsoft.Win32.SafeHandles.SafeFileHandle(h.Signal, true), h.Client, h.ClientPid);
         else if (adopted) { /* reattached to the surviving shell — nothing to launch */ }
+        else if (sessionCommand is { } launch)
+            pane.Start = session.StartAsync(launch.App, launch.QuotedArgs, verbatimCommandLine: true, extraEnv: env, cwd: cwd, freshEnv: _config.FreshEnv);
         else if (!string.IsNullOrWhiteSpace(command) && wait)
             // --wait: run the command, then hold on "press any key" so a build/test/deploy's final
             // output (or an early failure) stays readable before the session closes (agterm #255 —
@@ -405,7 +407,7 @@ internal partial class Program
     /// split, a close, a swap or a restore).</summary>
     private Ses CreateSession(string id, string? name, string? cwd, Workspace ws, bool makeActive, float? fontSize = null,
         string? command = null, bool interactive = false, Dictionary<string, string>? extraEnv = null, string? profileName = null,
-        bool deElevate = false, HandoffArgs? handoff = null, bool wait = false, string? paneId = null)
+        bool deElevate = false, HandoffArgs? handoff = null, bool wait = false, string? paneId = null, SessionCommand? sessionCommand = null)
     {
         lock (_workspaces) if (!_workspaces.Contains(ws)) throw new InvalidOperationException("workspace no longer exists");
         // Elevated profile from a non-elevated app: hand off to a separate elevated window (UAC).
@@ -436,7 +438,7 @@ internal partial class Program
         // closing it by any path leaves none (the id then resolves to the focused pane, like a name —
         // the rule by condition is on ISessionHost.SplitClose), and a restore hands the saved pane-0
         // id in — see the summary.
-        ses.Panes.Add(CreatePane(paneId ?? id, ws, cwd, fs, command, interactive: interactive, extraEnv: extraEnv, profileName: profileName, deElevate: deElevate, handoff: handoff, wait: wait));
+        ses.Panes.Add(CreatePane(paneId ?? id, ws, cwd, fs, command, interactive: interactive, extraEnv: extraEnv, profileName: profileName, deElevate: deElevate, handoff: handoff, wait: wait, sessionCommand: sessionCommand));
         ses.Active = 0;
         DetectSessionElevation(ses);   // refine ⚡ from the shell's real integrity once it's running
 

--- a/src/Agwinterm.Win32/Program.Sessions.cs
+++ b/src/Agwinterm.Win32/Program.Sessions.cs
@@ -49,10 +49,10 @@ internal partial class Program
     }
 
     /// <summary>Create one terminal pane (its own ConPTY, env, wiring) sized for the given font.
-    /// When <paramref name="command"/> is set, that argv runs as the pane's process instead of the shell.</summary>
+    /// When <paramref name="sessionCommand"/> is set, its validated application and argv run as the pane's process.</summary>
     private Pane CreatePane(string paneId, Workspace ws, string? cwd, float fontSize, string? command = null,
         bool shellWrap = false, bool interactive = false, Dictionary<string, string>? extraEnv = null, string? profileName = null,
-        bool deElevate = false, HandoffArgs? handoff = null, bool wait = false, SessionCommand? sessionCommand = null)
+        bool deElevate = false, HandoffArgs? handoff = null, SessionCommand? sessionCommand = null)
     {
         var (cols, rows) = GridSizeFor(fontSize);
         // The ONLY session creation site (see ISessionBackend). Handoff panes are pinned in-process
@@ -140,11 +140,6 @@ internal partial class Program
         else if (adopted) { /* reattached to the surviving shell — nothing to launch */ }
         else if (sessionCommand is { } launch)
             pane.Start = session.StartAsync(launch.App, launch.QuotedArgs, verbatimCommandLine: true, extraEnv: env, cwd: cwd, freshEnv: _config.FreshEnv);
-        else if (!string.IsNullOrWhiteSpace(command) && wait)
-            // --wait: run the command, then hold on "press any key" so a build/test/deploy's final
-            // output (or an early failure) stays readable before the session closes (agterm #255 —
-            // the session-surface counterpart of `overlay open --wait`).
-            pane.Start = session.StartAsync("cmd.exe", new[] { "/c", command! + " & echo. & pause" }, verbatimCommandLine: true, extraEnv: env, cwd: cwd, freshEnv: _config.FreshEnv);
         else if (!string.IsNullOrWhiteSpace(command) && interactive)
             // Run the command in a fresh shell that STAYS OPEN afterwards (custom-command "new" mode):
             // the user's profile loads (oh-my-posh etc.), the command runs, then it's an interactive shell.
@@ -154,32 +149,8 @@ internal partial class Program
             // propagates. Verbatim so it becomes exactly `cmd.exe /c <command>` (no extra quoting,
             // which cmd's /c quote-stripping rules would otherwise mangle).
             pane.Start = session.StartAsync("cmd.exe", new[] { "/c", command! }, verbatimCommandLine: true, extraEnv: env, cwd: cwd, freshEnv: _config.FreshEnv);
-        else if (!string.IsNullOrWhiteSpace(command))
-        {
-            var argv = ParseArgv(command);
-            if (argv.Length > 0)
-                pane.Start = session.StartAsync(argv[0], argv[1..], extraEnv: env, cwd: cwd, freshEnv: _config.FreshEnv);
-            else
-                LaunchShell(session, profileName, env, cwd, deElevate);
-        }
         else LaunchShell(session, profileName, env, cwd, deElevate);   // launch the chosen shell profile (default = Windows PowerShell)
         return pane;
-    }
-
-    /// <summary>Minimal argv split (whitespace-separated, double-quotes group). For session --command.</summary>
-    private static string[] ParseArgv(string s)
-    {
-        var args = new List<string>();
-        var cur = new StringBuilder();
-        bool inQuote = false, has = false;
-        foreach (char ch in s)
-        {
-            if (ch == '"') { inQuote = !inQuote; has = true; }
-            else if (char.IsWhiteSpace(ch) && !inQuote) { if (has) { args.Add(cur.ToString()); cur.Clear(); has = false; } }
-            else { cur.Append(ch); has = true; }
-        }
-        if (has) args.Add(cur.ToString());
-        return args.ToArray();
     }
 
     /// <summary>
@@ -407,7 +378,7 @@ internal partial class Program
     /// split, a close, a swap or a restore).</summary>
     private Ses CreateSession(string id, string? name, string? cwd, Workspace ws, bool makeActive, float? fontSize = null,
         string? command = null, bool interactive = false, Dictionary<string, string>? extraEnv = null, string? profileName = null,
-        bool deElevate = false, HandoffArgs? handoff = null, bool wait = false, string? paneId = null, SessionCommand? sessionCommand = null)
+        bool deElevate = false, HandoffArgs? handoff = null, string? paneId = null, SessionCommand? sessionCommand = null)
     {
         lock (_workspaces) if (!_workspaces.Contains(ws)) throw new InvalidOperationException("workspace no longer exists");
         // Elevated profile from a non-elevated app: hand off to a separate elevated window (UAC).
@@ -438,7 +409,7 @@ internal partial class Program
         // closing it by any path leaves none (the id then resolves to the focused pane, like a name —
         // the rule by condition is on ISessionHost.SplitClose), and a restore hands the saved pane-0
         // id in — see the summary.
-        ses.Panes.Add(CreatePane(paneId ?? id, ws, cwd, fs, command, interactive: interactive, extraEnv: extraEnv, profileName: profileName, deElevate: deElevate, handoff: handoff, wait: wait, sessionCommand: sessionCommand));
+        ses.Panes.Add(CreatePane(paneId ?? id, ws, cwd, fs, command, interactive: interactive, extraEnv: extraEnv, profileName: profileName, deElevate: deElevate, handoff: handoff, sessionCommand: sessionCommand));
         ses.Active = 0;
         DetectSessionElevation(ses);   // refine ⚡ from the shell's real integrity once it's running
 

--- a/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
+++ b/tests/Agwinterm.Pty.Tests/FakeSessionHost.cs
@@ -352,7 +352,7 @@ internal sealed class FakeSessionHost : ISessionHost
     // the active workspace — the last answer, not the first (task 5a).
     public string NewSession(string? name, string? cwd, string? workspace, string? command = null,
         string? workspaceName = null, bool createWorkspace = false, string? profile = null, bool noSelect = false, bool wait = false,
-        string? caller = null)
+        string? caller = null, string? commandMode = null)
     {
         Ws? w;
         if (!string.IsNullOrEmpty(workspace))

--- a/tests/Agwinterm.Pty.Tests/SessionCommandTests.cs
+++ b/tests/Agwinterm.Pty.Tests/SessionCommandTests.cs
@@ -1,0 +1,133 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Agwinterm.Pty;
+
+namespace Agwinterm.Pty.Tests;
+
+public class SessionCommandTests
+{
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData("powershell", false)]
+    [InlineData("powershell", true)]
+    public void PowerShellKeepsCodeAndInteractivePrompt(string? mode, bool wait)
+    {
+        const string code = "Remove-Item -LiteralPath 'old file'; Write-Output \"☃ $env:TEMP\" # tail";
+        Assert.True(SessionCommand.TryCreate(code, mode, wait, null, out var launch, out _));
+        Assert.Equal("powershell.exe", launch!.App);
+        Assert.Equal(new[] { "-NoLogo", "-NoExit", "-Command", code }, launch.Args);
+    }
+
+    [Fact]
+    public void DirectUsesWindowsArgumentQuotingWithoutInterpretingShellSyntax()
+    {
+        Assert.True(SessionCommand.TryCreate("  \"C:\\Program Files\\tool.exe\" \"\" \"a b\" \"C:\\tail\\\\\" \"say \\\"hi\\\"\" ; $x &", "direct", false, null,
+            out var launch, out _));
+        Assert.Equal("C:\\Program Files\\tool.exe", launch!.App);
+        Assert.Equal(new[] { "", "a b", "C:\\tail\\", "say \"hi\"", ";", "$x", "&" }, launch.Args);
+        Assert.True(SessionCommand.TryCreate(TerminalSession.QuoteArg(launch.App) + " " + string.Join(' ', launch.QuotedArgs),
+            "direct", false, null, out var roundTrip, out _));
+        Assert.Equal(launch.App, roundTrip!.App);
+        Assert.Equal(launch.Args, roundTrip.Args);
+    }
+
+    [Theory]
+    [InlineData("", "direct", false, null)]
+    [InlineData("  ", null, true, null)]
+    [InlineData("echo ok", "", false, null)]
+    [InlineData("echo ok", "cmd", false, null)]
+    [InlineData("echo ok", "direct", true, null)]
+    [InlineData("echo ok", null, false, "cmd")]
+    [InlineData("\"\" arg", "direct", false, null)]
+    [InlineData("echo\0wrong", null, false, null)]
+    public void InvalidLaunchIsRefused(string command, string? mode, bool wait, string? profile)
+    {
+        Assert.False(SessionCommand.TryCreate(command, mode, wait, profile, out var launch, out var error));
+        Assert.Null(launch);
+        Assert.EndsWith("; nothing created", error);
+    }
+
+    [Fact]
+    public void HostLimitsDoNotTruncateCommands()
+    {
+        Assert.True(SessionCommand.TryCreate(new string('x', 2047), null, false, null, out _, out _));
+        Assert.False(SessionCommand.TryCreate(new string('x', 2048), null, false, null, out _, out _));
+        Assert.False(SessionCommand.TryCreate(new string('☃', 683), null, false, null, out _, out _));
+        Assert.True(SessionCommand.TryCreate("tool " + string.Join(' ', Enumerable.Repeat("x", 16)), "direct", false, null, out _, out _));
+        Assert.False(SessionCommand.TryCreate("tool " + string.Join(' ', Enumerable.Repeat("x", 17)), "direct", false, null, out _, out _));
+    }
+
+    [Theory]
+    [InlineData("\"wrong\"")]
+    [InlineData("null")]
+    [InlineData("true")]
+    [InlineData("{}")]
+    [InlineData("[]")]
+    public void ServerRefusalCannotCreateRequestedWorkspace(string modeJson)
+    {
+        var server = new ControlServer(new FakeSessionHost());
+        string before = server.Dispatch("{\"cmd\":\"tree\"}");
+        string request = "{\"cmd\":\"session.new\",\"args\":{\"command\":\"echo ok\",\"workspace-name\":\"new workspace\",\"create-workspace\":true,\"command-mode\":" + modeJson + "}}";
+        using var response = JsonDocument.Parse(server.Dispatch(request));
+        Assert.False(response.RootElement.GetProperty("ok").GetBoolean());
+        Assert.Equal(before, server.Dispatch("{\"cmd\":\"tree\"}"));
+    }
+
+    [Theory]
+    [InlineData("Write-Output ('COMMAND-' + 'READY'); $v='quoted \"value\"'; Write-Output $v", "quoted \"value\"")]
+    [InlineData("Write-Output ('COMMAND-' + 'READY'); Write-Error 'intentional failure'", null)]
+    public async Task PowerShellCommandCompletesAndAcceptsMoreInput(string command, string? expected)
+    {
+        Assert.True(SessionCommand.TryCreate(command, null, false, null, out var launch, out _));
+        using var child = Start(launch!);
+        var output = child.StandardOutput.ReadToEndAsync();
+        var errors = child.StandardError.ReadToEndAsync();
+        // A second command executes only after the startup command has completed, proving the
+        // startup command was not simply typed into a racing prompt or made the shell exit.
+        await child.StandardInput.WriteLineAsync("Write-Output ('FOLLOWUP-' + 'READY')");
+        await child.StandardInput.WriteLineAsync("exit 0");
+        child.StandardInput.Close();
+        try
+        {
+            await child.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(20));
+            var text = await output;
+            Assert.Contains("COMMAND-READY", text);
+            Assert.Contains("FOLLOWUP-READY", text);
+            if (expected is not null) Assert.Contains(expected, text);
+            else Assert.Contains("intentional failure", await errors);
+            Assert.Equal(0, child.ExitCode);
+        }
+        finally { if (!child.HasExited) { child.Kill(entireProcessTree: true); child.WaitForExit(); } }
+    }
+
+    [Theory]
+    [InlineData("exit 7", null, 7)]
+    [InlineData("cmd.exe /d /c exit 9", "direct", 9)]
+    public async Task ExplicitExitEndsTheProcess(string command, string? mode, int exitCode)
+    {
+        Assert.True(SessionCommand.TryCreate(command, mode, false, null, out var launch, out _));
+        using var child = Start(launch!);
+        var output = child.StandardOutput.ReadToEndAsync();
+        var errors = child.StandardError.ReadToEndAsync();
+        try
+        {
+            await child.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(20));
+            Assert.Equal(exitCode, child.ExitCode);
+            await Task.WhenAll(output, errors);
+        }
+        finally { if (!child.HasExited) { child.Kill(entireProcessTree: true); child.WaitForExit(); } }
+    }
+
+    private static Process Start(SessionCommand launch)
+    {
+        var start = new ProcessStartInfo(launch.App)
+        {
+            UseShellExecute = false, CreateNoWindow = true,
+            RedirectStandardInput = true, RedirectStandardOutput = true, RedirectStandardError = true
+        };
+        // Tests must not execute the user's profile. Preserve the production command/argv.
+        if (launch.App == "powershell.exe") start.ArgumentList.Add("-NoProfile");
+        foreach (var arg in launch.Args) start.ArgumentList.Add(arg);
+        return Process.Start(start)!;
+    }
+}

--- a/tests/integration/hud-ui.ps1
+++ b/tests/integration/hud-ui.ps1
@@ -1,7 +1,7 @@
 # Dedicated P13 fixture: private app-data, no clipboard/registry writes, exact owned job teardown.
 param([string]$Exe="$PSScriptRoot/../../src/Agwinterm.Win32/bin/x64/Release/net10.0-windows/win-x64/Agwinterm.Win32.exe",
       [string]$TokenOwner=$env:AGWINTERM_TEST_OWNER,[switch]$Strict,
-      [ValidateSet('Hud','Quick','Navigation','Picker','Accessibility')][string]$Suite='Hud')
+      [ValidateSet('Hud','Quick','Navigation','Picker','Accessibility','Command')][string]$Suite='Hud')
 $ErrorActionPreference='Stop'
 $PSNativeCommandUseErrorActionPreference=$false
 $root=[IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
@@ -201,6 +201,15 @@ public sealed class HudOwnedJob {
         $esc=[string][char]27
         $libraryWindow=[string](@((Rpc 'window.list').windows|Where-Object open)[0].id)
         . "$PSScriptRoot/uia-window-cases.ps1"
+    }
+    elseif($Suite-eq 'Command') {
+        $commandArtifact=$artifact;$commandPipe=$pipe
+        $commandCtl=Join-Path $root 'src/Agwinterm.Ctl/bin/Release/net10.0-windows/agwintermctl.exe'
+        function CommandRpc([string]$verb,$params,[string]$target,[switch]$AllowError){
+            Rpc $verb $params $target -AllowError:$AllowError
+        }
+        . "$PSScriptRoot/session-command-cases.ps1"
+        Check 'shared command acceptance completed' ($commandChecks-ge 30)
     }
     elseif($Suite-eq 'Picker') { . "$PSScriptRoot/picker-ui-cases.ps1" }
     elseif($Suite-eq 'Navigation') { . "$PSScriptRoot/navigation-ui-cases.ps1" }

--- a/tests/integration/navigation-ui-cases.ps1
+++ b/tests/integration/navigation-ui-cases.ps1
@@ -124,7 +124,7 @@ $second=[string](Rpc 'workspace.new' @{name='P15-empty'})
 Check 'empty workspace created' (NavWait {@(NavTree|Where-Object id -eq $second).Count-eq 1})
 Check 'go reaches empty workspace and reports id' ((Rpc 'workspace.go' @{to='next'} -NoTarget)-eq $second -and (CurrentWs)-eq $second)
 Check 'empty destination leaves selected terminal intact' ((Rpc 'window.state').activeWorkspace-eq 'P15-empty' -and (Node $session).active)
-$placed=[string](Rpc 'session.new' @{name='P15-placed';wait=$true})
+$placed=[string](Rpc 'session.new' @{name='P15-placed'})
 Check 'new session without caller lands in current empty workspace' (NavWait {@((NavTree|Where-Object id -eq $second).sessions|Where-Object id -eq $placed).Count-eq 1 -and (Node $placed).active})
 foreach($badOp in 'typo',$false,42,$null,@(),@{}) {
     Check 'invalid switch operation preserves focus with two live sessions' (-not (Rpc 'session.switch' @{op=$badOp} -NoTarget -AllowError).ok -and (Node $placed).active)

--- a/tests/integration/paste-sink.ps1
+++ b/tests/integration/paste-sink.ps1
@@ -9,9 +9,9 @@
 # it reads, so a pasted line still shows in `session text`. The host-side fix (compare the clipboard
 # to what was proven, capture instead of paste) is #257's; this is the harness's guard.
 #
-# Why a session of its own, started with `session new --command` (New-PasteSinkLaunch):
-# - The control API's --command starts the program DIRECTLY (CreatePane's last arm: ParseArgv, then
-#   StartAsync(argv[0], argv[1..]) — not the UI's `powershell -NoExit -Command` wrap, not `cmd /c`).
+# Why a session of its own, started with `session new --command-mode direct --command` (New-PasteSinkLaunch):
+# - Explicit direct mode starts this sink through StartAsync with Windows-parsed argv, without
+#   the default interactive PowerShell wrapper.
 #   The pane's process tree holds no shell: nothing is typed, nothing is echoed, and when the sink
 #   leaves for any reason (a Ctrl+C in a pasted line, a crash) there is no interpreter for the pane
 #   to fall back to — the app shows the exited surface, and a paste into it reaches no program.
@@ -20,13 +20,13 @@
 # - Readiness (Test-PasteSinkReady) is the marker the sink prints, seen in the pane's text: proof that
 #   the sink STARTED. Nothing is pasted until it is seen. It is not an isolation claim beyond the
 #   process arrangement above.
-# - No `$` in the command: `session new --command` splits it on whitespace with double quotes
-#   grouping (ParseArgv) and passes the pieces verbatim, but a `$` would need escaping should the
+# - No `$` in the command: `session new --command-mode direct --command` uses Windows argv quoting
+#   and passes the pieces verbatim, but a `$` would need escaping should the
 #   line ever be typed into a shell; [void](Read-Host) needs none. Read-Host throws under
 #   -NonInteractive, so the sink runs without it.
 function New-PasteSinkLaunch([string]$marker) {
     [pscustomobject]@{
-        # The `session new --command` value: powershell.exe (always present), the sink as its -Command.
+        # The `session new --command-mode direct --command` value: powershell.exe (always present), the sink as its -Command.
         Command = "powershell -NoProfile -Command `"'$marker-ready'; for(;;){ [void](Read-Host) }`""
         # What the running sink prints.
         Ready   = "$marker-ready"

--- a/tests/integration/session-command-cases.ps1
+++ b/tests/integration/session-command-cases.ps1
@@ -43,6 +43,36 @@ try{
     $spaced=CommandNew @{command=('"'+$tool+'" /d /c echo SPACE-READY');'command-mode'='direct';name='command-space'}
     CommandCheck (CommandWait $spaced 'SPACE-READY') 'direct executable path can contain spaces'
 
+    # Report argv from an actual executable, so neither PowerShell nor cmd can repair it.
+    $argvSource=Join-Path $commandArtifact 'argv helper.cs'
+    $argvExe=Join-Path $commandArtifact 'argv helper.exe'
+    @'
+using System;
+using System.Text;
+class ArgvHelper {
+    static void Main(string[] args) {
+        Console.WriteLine("ARGC=" + args.Length);
+        for (int i = 0; i < args.Length; i++)
+            Console.WriteLine("ARG" + i + "=" + Convert.ToBase64String(Encoding.UTF8.GetBytes(args[i])) + ":END");
+    }
+}
+'@ | Set-Content -LiteralPath $argvSource
+    & "$env:WINDIR/Microsoft.NET/Framework64/v4.0.30319/csc.exe" /nologo /target:exe "/out:$argvExe" $argvSource
+    if($LASTEXITCODE-ne 0){throw 'argv helper compilation failed'}
+    $argvPane=CommandNew @{command=('"'+$argvExe+'" "" "a b" "say \"hi\"" "C:\tail\\" "☃"');'command-mode'='direct';name='command-argv'}
+    CommandCheck (CommandWait $argvPane 'ARGC=5') 'direct host preserves argument count'
+    $expectedArgs=@('', 'a b', 'say "hi"', 'C:\tail\', '☃')
+    for($argIndex=0;$argIndex-lt $expectedArgs.Count;$argIndex++){
+        $encodedArg=[Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($expectedArgs[$argIndex]))
+        CommandCheck (CommandWait $argvPane ("ARG${argIndex}="+$encodedArg+':END')) "direct host preserves exact argument $argIndex"
+    }
+
+    $failedPane=CommandNew @{command='agwinterm-command-fixture-missing.exe';'command-mode'='direct';name='command-failure';'workspace-name'='command-failure-workspace';'create-workspace'=$true}
+    CommandCheck (CommandWait $failedPane 'start') 'failed executable retains a diagnostic pane'
+    CommandCheck (-not (CommandRpc 'session.type' @{text='MUST-NOT-RUN'} $failedPane -AllowError).ok) 'failed executable has no interpreter accepting input'
+    $failedTree=CommandRpc 'tree' @{} ''
+    CommandCheck (@($failedTree.workspaces|Where-Object { $_.name-eq 'command-failure-workspace' -and $_.sessions.id -contains $failedPane }).Count-eq 1) 'failed executable belongs to the requested published workspace'
+
     $sink="[Console]::WriteLine('DIRECT-READY');`$s=[Console]::ReadLine();[Console]::WriteLine('LITERAL='+`$s);exit 7"
     $encoded=[Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($sink))
     $direct=CommandNew @{command=('powershell.exe -NoProfile -EncodedCommand '+$encoded);'command-mode'='direct';name='command-direct'}
@@ -87,6 +117,15 @@ try{
         $beforeIds=@(($before|ConvertFrom-Json).workspaces|ForEach-Object { $_.id; $_.sessions.id })-join ','
         $afterIds=@(($after|ConvertFrom-Json).workspaces|ForEach-Object { $_.id; $_.sessions.id })-join ','
         CommandCheck ($beforeIds-ceq $afterIds) 'refusal creates neither workspace nor session'
+    }
+    foreach($bareFlag in '--command','--command-mode'){
+        $before=CommandRpc 'tree' @{} ''
+        $null=& $commandCtl session new $bareFlag --pipe $commandPipe --no-select --json 2>&1
+        CommandCheck ($LASTEXITCODE-eq 2) "CLI refuses bare $bareFlag"
+        $after=CommandRpc 'tree' @{} ''
+        $beforeIds=@($before.workspaces|ForEach-Object { $_.id; $_.sessions.id })-join ','
+        $afterIds=@($after.workspaces|ForEach-Object { $_.id; $_.sessions.id })-join ','
+        CommandCheck ($beforeIds-ceq $afterIds) 'bare CLI flag creates no workspace or session'
     }
     # Exercise the shared CLI flag, not only handcrafted JSON. The adapter owns its pipe.
     $json=& $commandCtl session new --command-mode direct --command 'cmd.exe /d /c echo CLI-DIRECT-READY' --pipe $commandPipe --no-select --json

--- a/tests/integration/session-command-cases.ps1
+++ b/tests/integration/session-command-cases.ps1
@@ -1,0 +1,99 @@
+# Mirrored in agliteterm/test. Run only inside each product's owned-process supervisor.
+# Adapter: CommandRpc verb args target [AllowError], $commandArtifact and $commandCtl.
+$commandChecks=0;$commandIds=@()
+function CommandCheck([bool]$ok,[string]$name){if(-not $ok){throw $name};$script:commandChecks++;"PASS $name"}
+function CommandText([string]$id){[string](CommandRpc 'session.text' @{all=$true} $id)}
+function CommandWait([string]$id,[string]$text){
+    for($try=0;$try-lt 100;$try++){
+        try{if((CommandText $id).Contains($text)){return $true}}catch{}
+        Start-Sleep -Milliseconds 100
+    }
+    (CommandText $id)|Set-Content -LiteralPath (Join-Path $commandArtifact ('missing-'+$id.Replace(':','_')+'.txt'))
+    return $false
+}
+function CommandNew($args_){
+    $args_['no-select']=$true;$args_['cwd']=$commandArtifact
+    $id=[string](CommandRpc 'session.new' $args_ '')
+    $script:commandIds+=,$id;return $id
+}
+try{
+    $file=Join-Path $commandArtifact 'remove me.txt';'owned fixture'|Set-Content -LiteralPath $file
+    $command="Remove-Item -LiteralPath './remove me.txt'; Write-Output ('CMD-'+'READY'); Write-Output ('CWD='+ (Get-Location).Path); Write-Output ('PANE='+`$env:AGWINTERM_SESSION_ID); Write-Output 'quoted `"value`" ☃'"
+    $id=CommandNew @{command=$command;name='command-default'}
+    CommandCheck (CommandWait $id 'CMD-READY') 'default executes PowerShell cmdlet and statements'
+    CommandCheck (-not (Test-Path -LiteralPath $file)) 'cmdlet uses the requested working directory'
+    CommandCheck (CommandWait $id ('PANE='+$id)) 'command inherits its own pane identity'
+    CommandCheck (CommandWait $id 'quoted "value" ☃') 'PowerShell preserves quotes and Unicode'
+    $null=CommandRpc 'session.type' @{text="Write-Output ('AFTER-'+'READY')`r"} $id
+    CommandCheck (CommandWait $id 'AFTER-READY') 'default leaves a live interactive prompt'
+
+    $held=CommandNew @{command="Write-Output ('WAIT-'+'READY')";wait=$true;name='command-wait'}
+    CommandCheck (CommandWait $held 'WAIT-READY') 'wait uses the same PowerShell interpreter'
+    $null=CommandRpc 'session.type' @{text="Write-Output ('WAIT-AFTER-'+'READY')`r"} $held
+    CommandCheck (CommandWait $held 'WAIT-AFTER-READY') 'wait leaves the interactive prompt available'
+
+    # Explicit helper executable with a spaced relative script path, for portable workbench.cmd.
+    $helper=Join-Path $commandArtifact 'pane helper.ps1'
+    "param([string]`$Value)`nWrite-Output ('HELPER='+`$Value)"|Set-Content -LiteralPath $helper
+    $scriptPane=CommandNew @{command="powershell.exe -NoLogo -NoProfile -File './pane helper.ps1' -Value 'a b'";name='command-helper'}
+    CommandCheck (CommandWait $scriptPane 'HELPER=a b') 'explicit PowerShell helper preserves spaced path and argument'
+
+    $toolDir=Join-Path $commandArtifact 'tool folder';New-Item -ItemType Directory $toolDir|Out-Null
+    $tool=Join-Path $toolDir 'cmd.exe';Copy-Item -LiteralPath "$env:WINDIR/System32/cmd.exe" -Destination $tool
+    $spaced=CommandNew @{command=('"'+$tool+'" /d /c echo SPACE-READY');'command-mode'='direct';name='command-space'}
+    CommandCheck (CommandWait $spaced 'SPACE-READY') 'direct executable path can contain spaces'
+
+    $sink="[Console]::WriteLine('DIRECT-READY');`$s=[Console]::ReadLine();[Console]::WriteLine('LITERAL='+`$s);exit 7"
+    $encoded=[Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($sink))
+    $direct=CommandNew @{command=('powershell.exe -NoProfile -EncodedCommand '+$encoded);'command-mode'='direct';name='command-direct'}
+    CommandCheck (CommandWait $direct 'DIRECT-READY') 'direct mode starts the requested program'
+    $literal='$x; Write-Output SHOULD-NOT-RUN'
+    $null=CommandRpc 'session.type' @{text=($literal+"`r")} $direct
+    CommandCheck (CommandWait $direct ('LITERAL='+$literal)) 'direct program receives literal shell metacharacters'
+    $dead=$false
+    for($try=0;$try-lt 80;$try++){
+        $answer=CommandRpc 'session.type' @{text=' '} $direct -AllowError
+        if(-not $answer.ok){$dead=$true;break};Start-Sleep -Milliseconds 100
+    }
+    CommandCheck $dead 'direct program exit leaves no interactive shell accepting writes'
+    CommandCheck ((CommandText $direct).Contains('LITERAL='+$literal)) 'exited standalone pane retains output'
+
+    $exitPane=CommandNew @{command="Write-Output ('EXIT-'+'READY');exit 7";name='command-exit'}
+    CommandCheck (CommandWait $exitPane 'EXIT-READY') 'explicit PowerShell exit retains preceding output'
+    $dead=$false
+    for($try=0;$try-lt 80;$try++){
+        $answer=CommandRpc 'session.type' @{text=' '} $exitPane -AllowError
+        if(-not $answer.ok){$dead=$true;break};Start-Sleep -Milliseconds 100
+    }
+    CommandCheck $dead 'explicit PowerShell exit ends the interpreter'
+
+    foreach($args_ in @(
+        @{command='echo ok';'command-mode'='invalid'},
+        @{command='echo ok';'command-mode'=$null},
+        @{command='echo ok';'command-mode'=@{}},
+        @{command='echo ok';'command-mode'=@()},
+        @{command='echo ok';'command-mode'='direct';wait=$true},
+        @{'command-mode'='direct'},
+        @{command='echo ok';profile='missing-profile'},
+        @{command=('x'*2048)},
+        @{command='"" arg';'command-mode'='direct'}
+    )){
+        $before=(CommandRpc 'tree' @{} '')|ConvertTo-Json -Compress -Depth 20
+        $args_['workspace-name']='must-not-create';$args_['create-workspace']=$true
+        $answer=CommandRpc 'session.new' $args_ '' -AllowError
+        CommandCheck (-not $answer.ok) 'malformed launch is refused'
+        $after=(CommandRpc 'tree' @{} '')|ConvertTo-Json -Compress -Depth 20
+        # Compare identities; asynchronous status/foreground metadata can change independently.
+        $beforeIds=@(($before|ConvertFrom-Json).workspaces|ForEach-Object { $_.id; $_.sessions.id })-join ','
+        $afterIds=@(($after|ConvertFrom-Json).workspaces|ForEach-Object { $_.id; $_.sessions.id })-join ','
+        CommandCheck ($beforeIds-ceq $afterIds) 'refusal creates neither workspace nor session'
+    }
+    # Exercise the shared CLI flag, not only handcrafted JSON. The adapter owns its pipe.
+    $json=& $commandCtl session new --command-mode direct --command 'cmd.exe /d /c echo CLI-DIRECT-READY' --pipe $commandPipe --no-select --json
+    CommandCheck ($LASTEXITCODE-eq 0) 'shared CLI sends command-mode'
+    $cliId=[string]($json|ConvertFrom-Json).result;$commandIds+=,$cliId
+    CommandCheck (CommandWait $cliId 'CLI-DIRECT-READY') 'CLI direct launch executes in the terminal'
+    "Session command acceptance: $commandChecks checks passed"
+}finally{
+    foreach($id in $commandIds){$null=CommandRpc 'session.close' @{} $id -AllowError}
+}

--- a/tests/integration/win32-control.ps1
+++ b/tests/integration/win32-control.ps1
@@ -231,7 +231,7 @@ try {
     # and the scratch prefix remain. Exact session resolution must win.
     $releaseLiteral = $releaseFile.Replace("'", "''")
     $exitCommand = "powershell.exe -NoLogo -NoProfile -Command `"while (-not (Test-Path -LiteralPath '$releaseLiteral')) { Start-Sleep -Milliseconds 100 }`""
-    $created = Invoke-Ctl @('session', 'new', '--name', 'win32-resolver', '--command', $exitCommand)
+    $created = Invoke-Ctl @('session', 'new', '--name', 'win32-resolver', '--command-mode', 'direct', '--command', $exitCommand)
     $sessionId = [string]$created.result
     $ready = $false
     for ($i = 0; $i -lt 30; $i++) {
@@ -787,7 +787,7 @@ for ($i = 0; $i -lt 60; $i++) { & '__CTL__' session overlay resize --size-percen
         # directory can go, it reports no OSC 7 (cmd), so the overlay is spawned in the dead dir.
         $goneDir = Join-Path ([IO.Path]::GetTempPath()) ("agwinterm-gone-" + [guid]::NewGuid().ToString('N'))
         New-Item -ItemType Directory -Path $goneDir | Out-Null
-        $goneMade = Invoke-Ctl @('session', 'new', '--name', 'p2-227-gone', '--cwd', $goneDir, '--command', 'cmd.exe /c cd /d C:\ & ping -n 60 127.0.0.1 >nul', '--no-select')
+        $goneMade = Invoke-Ctl @('session', 'new', '--name', 'p2-227-gone', '--cwd', $goneDir, '--command-mode', 'direct', '--command', 'cmd.exe /c cd /d C:\ & ping -n 60 127.0.0.1 >nul', '--no-select')
         $goneId = [string]$goneMade.result
         for ($i = 0; $i -lt 30 -and -not (Get-SessionSnapshot $goneId); $i++) { Start-Sleep -Milliseconds 200 }
         $goneRemoved = $false
@@ -959,7 +959,7 @@ for ($i = 0; $i -lt 60; $i++) { & '__CTL__' session overlay resize --size-percen
         # reads, which in the race is someone else's copy — details carry replies, booleans and lengths.
         $p6SinkMarker = 'agw-sink-' + [guid]::NewGuid().ToString('N').Substring(0, 8)
         $p6Launch = New-PasteSinkLaunch $p6SinkMarker
-        $p6SinkMade = Invoke-Ctl @('session', 'new', '--name', 'p6-paste-sink', '--command', $p6Launch.Command, '--no-select')
+        $p6SinkMade = Invoke-Ctl @('session', 'new', '--name', 'p6-paste-sink', '--command-mode', 'direct', '--command', $p6Launch.Command, '--no-select')
         $p6Sink = if ($p6SinkMade.ok) { [string]$p6SinkMade.result } else { $null }   # the session id: a pane-class target (its one pane)
         $p6SinkUp = $false; $p6SinkTextLen = 0
         if ($p6Sink) {
@@ -1068,7 +1068,7 @@ for ($i = 0; $i -lt 60; $i++) { & '__CTL__' session overlay resize --size-percen
         # exit is asynchronous and the refusal lags it by the output-settle window: the poll runs
         # until the EXPECTED refusal — a paste that lands before it is `pasted` (or, in the spawn
         # gap, `paste failed: Session not started.`) and ignored; the last reply is the detail.
-        $p6ExitMade = Invoke-Ctl @('session', 'new', '--name', 'p6-exited', '--command', 'cmd /c exit 0', '--no-select')
+        $p6ExitMade = Invoke-Ctl @('session', 'new', '--name', 'p6-exited', '--command-mode', 'direct', '--command', 'cmd /c exit 0', '--no-select')
         $p6Exited = if ($p6ExitMade.ok) { [string]$p6ExitMade.result } else { $null }
         $p6ExitPaste = $null
         if ($p6Exited) {

--- a/tests/integration/workspace-teardown-cases.ps1
+++ b/tests/integration/workspace-teardown-cases.ps1
@@ -7,7 +7,7 @@ foreach($deleteActive in $false,$true){
     $doomedWs=[string](Rpc 'workspace.new' @{name='teardown-owned'})
     try {
         $null=Rpc 'workspace.select' @{} $doomedWs
-        $doomed=[string](Rpc 'session.new' @{name='teardown-split';wait=$true})
+        $doomed=[string](Rpc 'session.new' @{name='teardown-split'})
         if(-not (NavWait {$null-ne (Node $doomed)})){throw 'Doomed session did not materialize'}
         $right=[string](Rpc 'session.split' @{op='on'} $doomed)
         if(-not (NavWait {(Node $doomed).foregroundShells.Count-eq 2 -and @((Node $doomed).foregroundShells|Where-Object {$_-ne 'cmd'}).Count-eq 0})){throw 'Split shells not ready'}

--- a/tools/profile-memory.ps1
+++ b/tools/profile-memory.ps1
@@ -70,7 +70,7 @@ function ChurnResize([string]$tag) {
 }
 function HeavyOutput([string]$tag) {
     # ~60k lines through one PTY: scrollback fills to its cap; growth beyond one buffer = leak.
-    $id = (& $Ctl session new --name blaster --command 'powershell -NoProfile -Command "1..60000 | ForEach-Object { \"line $_ with some padding text to make it wider\" }; Start-Sleep 2"' | Out-String).Trim()
+    $id = (& $Ctl session new --name blaster --command-mode direct --command 'powershell -NoProfile -Command "1..60000 | ForEach-Object { \"line $_ with some padding text to make it wider\" }; Start-Sleep 2"' | Out-String).Trim()
     Start-Sleep -Seconds 14
     Sample "heavy output (open) $tag"
     & $Ctl session close --target $id 2>$null | Out-Null


### PR DESCRIPTION
A workbench command beginning with `Remove-Item` was interpreted by Lite but treated as an executable name by agwinterm. Both products now interpret `session new --command` as Windows PowerShell code and keep an interactive prompt afterward. `--command-mode direct` selects executable + Windows argv with no added shell; `--wait` is accepted in PowerShell mode and refused in direct mode.

The shared CLI and hosts reject missing command values, invalid modes, command/profile conflicts and host-capacity violations before creating a workspace or session. Full passes correctly quoted argv verbatim through its PTY backends, and callers that depend on direct launches now select that mode explicitly. Standalone exited panes retain output. The companion [Lite PR](https://github.com/yeroo/agliteterm/pull/78) also retains a diagnostic pane when a valid command cannot start.

Validation:

- [Exact-candidate CI](https://github.com/yeroo/agwinterm/actions/runs/34511784036) passed on `83f37b6549b11d337be5dfc2db832e187944b18e`, including all integration suites and Core/Pty tests.
- Release builds, 48 focused .NET tests, and 192 live command checks passed: the same 48 cases through Full in-process, managed host, Rust host, and Lite. Lite's 122 workspace-race checks also passed. Every owned process job cleaned up and the canonical test lease is free.
- Independent Codex review completed with 4/4 broad sources and 2/2 focused confirmation sources, no degradation and no outstanding blocking findings.

Documented follow-ups: [Lite's exact empty PowerShell argv through duplicate/cold restore](https://github.com/yeroo/agliteterm/issues/79), outside the initial session.new contract; and [three local tooltip paint assertions](https://github.com/yeroo/agwinterm/issues/283) that fail identically with released 0.18.0 (the exact CI navigation gate passes). Matching updated CLI/application versions are required. No release or installation is included.
