### PR TITLE
Release agwinterm 0.18.1

### DIFF
--- a/installer/agwinterm.iss
+++ b/installer/agwinterm.iss
@@ -2,7 +2,7 @@
 ; Build via installer\build.ps1 (publishes to stage\ then runs ISCC on this file).
 
 #define AppName    "agwinterm"
-#define AppVersion "0.18.0"
+#define AppVersion "0.18.1"
 #define AppExe     "Agwinterm.Win32.exe"
 #define AppPublisher "Boris Kudriashov"
 ; The main app defaults new sessions to the Rust pty-host as a first-run seed only (it never


### PR DESCRIPTION
Prepare 0.18.1 installers and portable builds containing the reviewed command-launch parity change in #282. `session new --command` now runs PowerShell code by default; `--command-mode direct` preserves direct executable/argv launching.

This release commit changes only the installer version, which also stamps the application and CLI assemblies. Package-manager checkpoint behavior is unchanged. The release will publish the updated shared CLI and native assets before Lite pins them.

Validation: [exact candidate CI](https://github.com/yeroo/agwinterm/actions/runs/34588187965) passed on `7d7978e1b0d92fe76d17495cee11fbbd7af1d252`. Local installer and portable builds passed; version metadata and ABI 18 were verified. The staged application and CLI passed all 48 live command checks with proven process cleanup and lease release ([receipt](https://github.com/yeroo/agwinterm/pull/285#issuecomment-5633005203)). Functional review and 192 cross-product live command checks completed in #282 and yeroo/agliteterm#78.
