### PR TITLE
Refuse --help and session text's unknown options; UTF-8 on redirected stdout

### DIFF
--- a/src/Agwinterm.Ctl/CtlUsage.cs
+++ b/src/Agwinterm.Ctl/CtlUsage.cs
@@ -1,0 +1,205 @@
+using System.Text;
+
+namespace Agwinterm.Ctl;
+
+/// <summary>
+/// The CLI's own usage text and the two usage refusals that had no home.
+///
+/// <para>Split out of <c>Program.cs</c> (top-level statements, so not directly testable) for the
+/// reason <see cref="FrameShmCli"/> was: the part that has to be right is a decision, and a
+/// decision that cannot be asserted on drifts. <see cref="Long"/> used to be a 96-line COMMENT at
+/// the top of <c>Program.cs</c> that nothing printed, while <c>Help.cs</c> told users to run
+/// <c>agwintermctl --help</c> — a flag the CLI did not have. It is one string now, printed by
+/// <c>--help</c>, so the promise is true and there is no second copy to fall behind.</para>
+/// </summary>
+public static class CtlUsage
+{
+    /// <summary>The one-line summary printed with no arguments at all.</summary>
+    public const string Short = "usage: agwintermctl <ping|version|tree|session|surface|image|install> ... (see README.md, \"Control it from anything\")";
+
+    /// <summary>Every verb and flag, the text <c>--help</c> prints. Moved here from the comment it
+    /// used to be; keep it and the code in step, because this is now what users read.</summary>
+    public const string Long = """
+        agwintermctl — drive agwinterm's control API from the shell (agterm's agtermctl analog).
+        Usage:
+          agwintermctl ping
+          agwintermctl version [--json]                  (the CLI that ran + the app serving the pipe)
+          agwintermctl tree [--json]
+          agwintermctl session new [--command "PowerShell code"] [--command-mode powershell|direct] [--cwd DIR] [--name NAME] [--workspace ID|--workspace-name NAME [--create-workspace]] [--no-select]
+              (no workspace given = the workspace of the pane running this CLI; the active one only when there is none)
+                                                         (an unknown workspace is refused, never swapped for the active one)
+          agwintermctl session select <target>
+          agwintermctl session close [target]
+          agwintermctl session rename <new-name...> [--target ID]
+          agwintermctl session split [on|off|toggle] [--axis vertical|horizontal] [--target ID]
+              (replies with a PANE ID: on/toggle-on = the split pane's, also when the session was already split;
+              off/toggle-off = the survivor's. Default op = toggle. The axis names the ARRANGEMENT, agterm's words:
+              vertical = left/right panes (the default of a session never split), horizontal = top/bottom panes.
+              Omitted = keep the session's orientation; given on an already-split session = re-orient it live)
+          agwintermctl session split close [--target ID]   (close ONE pane, EITHER side: a pane id = that pane; a session
+              name or no target = the session's focused pane, what Ctrl+Shift+W closes; from a pane's own CLI, that pane.
+              Replies with the SURVIVOR's id. A one-pane session is refused — `session close` closes a session)
+          agwintermctl session swap [--target ID]           (exchange the two panes: order reversed, focus follows the pane,
+              axis and ratio sequence kept — the left/top box keeps its size, the contents change places — and EVERY ID
+              kept: a swap moves panes, never ids, so the session id keeps naming the shell it named, now on the other
+              side. Target = a session, either of its panes, or nothing — from a pane's own CLI, that pane's
+              session; otherwise the active one. Replies
+              {session,paneIds,focusedPane,axis} — the tree's split block after the swap. A one-pane session is refused)
+          agwintermctl session focus [primary|split|left|right|top|bottom|other]   (default other; left/right exist on a
+              vertical split only, top/bottom on a horizontal one — the wrong pair is refused naming the axis)
+          agwintermctl session resize [--split-ratio R] [--grow-left N|--grow-right N|--grow-top N|--grow-bottom N]
+              (left/right move a vertical split's divider by N columns, top/bottom a horizontal one's by N rows;
+              the other axis's flags are refused, and the divider does not move)
+          agwintermctl session context <text...> [--target ID]   (one line of "what is this pane for", shown dimmed
+              beside the name and read back in `tree --json` as context; survives a restart. Blank, a control
+              character or more than 200 characters is refused; replies {session,context})
+          agwintermctl session context --clear [--target ID]      (remove it; text beside --clear is refused)
+          agwintermctl session context --stdin [--target ID]      (text = stdin, one trailing newline dropped; an
+              embedded newline is then refused — the context is one line)
+          agwintermctl session seen [--target ID]        (clear the unseen-notification badge)
+          agwintermctl sidebar state                      (read-back: "visible tree 220" = visibility, mode, width)
+          agwintermctl sidebar width [N]                  (read, or set, the sidebar width in DIP; replies {width,visible[,applied]}
+              with the width actually in effect; outside 120..600 is refused, not clamped; set while hidden = remembered)
+          agwintermctl sidebar show|hide|toggle|expand|collapse|mode <tree|flagged|toggle>   (on/off = show/hide; anything
+              else is refused rather than acknowledged)
+          agwintermctl session status <idle|active|blocked|completed> [--sound [name]] [--blink] [--auto-reset] [--target ID]
+          agwintermctl session metrics [<pane-id>] [--json] (live cell + pane pixel metrics)
+          agwintermctl session text [--all|--lines N] [--target ID]   (N reaches into scrollback; --all = the whole
+              buffer, screen + scrollback; default = screen; --all with --lines is refused)
+          agwintermctl session hud [open|update] <message...> [--detail TEXT] [--spinner|--spinner-style STYLE]
+              [--position ANCHOR] [--size-percent N] [--background-color HEX] [--text-color HEX] [--target ID]
+          agwintermctl session hud close [--target ID]   (see docs/session-hud.md)
+          agwintermctl session overlay open <command...> [--pane left|right] [--wait|--block] [--size-percent N] [--target ID]
+          agwintermctl session overlay close|result|copy [--pane left|right] [--target ID]
+          agwintermctl session overlay text [--all|--lines N] [--pane left|right] [--target ID]
+          agwintermctl session overlay resize --size-percent N [--target ID]   (the session-wide overlay only)
+              (copy and text print result.text; --pane names a PANE slot, passed through as typed — the server validates
+              the word; --size-percent beside --pane, and resize --pane, are refused here and nothing is sent: a pane
+              overlay is always full-pane. The rule, quoted from ISessionHost.SessionOverlay — the skill quotes it too:
+              A session has three overlay slots: one session-wide and one per pane. A session-wide overlay
+              covers the whole session (every pane, and any pane overlay under it), as today. A pane overlay
+              covers exactly one pane's box - always the full box, never floating - and the sibling pane stays
+              visible and interactive. --pane left|right names the slot: left is pane 0 and right is pane 1
+              whatever the axis (on a horizontal split left is the top pane), a non-split session accepts
+              --pane left, and the flag omitted means the session-wide slot - today's behaviour, byte for
+              byte. A pane overlay is that pane's surface while it is open: keys typed into the focused pane,
+              the mouse inside the pane's box and --target active reach the overlay; --target with a pane id
+              reaches the shell underneath (agterm: "session text reads the surface underneath"); --target
+              with the overlay's id reaches the overlay from anywhere, and on session overlay itself names
+              that overlay's slot - the same as passing its --pane word - for as long as the id resolves (an
+              overlay that closed is reached by --pane only); with --pane naming the other side it is refused.
+              The slot moves with its pane (a swap, a split close of the other pane) and dies with it (split
+              close, split off, the shell exiting when that removes the pane - a single-pane session keeps an
+              exited shell on screen, and its overlay with it - session close, the window closing).)
+          agwintermctl session type <text...> [--allow-control] [--target ID]   (control bytes refused unless allowed)
+          agwintermctl session type --stdin [--allow-control] [--target ID]     (text = stdin, as bytes: how quotes,
+              newlines, a leading -- or runs of spaces are sent; invalid UTF-8 is refused, nothing sent; one
+              trailing newline is dropped. "quick type" is `session type --target quick:` — the quick pane's id)
+          agwintermctl session write <text...> [--target ID]                    (also takes --stdin)
+          agwintermctl session restore <command...>|none --target PANE          (pin a command re-run on every restart;
+              target mandatory; replies {action,pane,session}; read back in `tree --json` as restoreCommands)
+          agwintermctl restore capture [--target ID]       (capture the foreground command of every real pane — or the one
+              pane/session named — into its restore slot NOW, so a crash or Stop-Process keeps it; replies
+              {captured,replayOnRestore,panes:[{pane,session,captured|null}]}; read back in `tree --json` as
+              capturedCommands; replayOnRestore = the restore-commands toggle, which gates the replay, not the capture)
+          agwintermctl restore clear                       (delete this window's saved session tree)
+          agwintermctl session copy [--target ID]           (returns the selection text)
+          agwintermctl session paste <text...> [--target ID] (pastes text; clipboard if omitted)
+          agwintermctl selection all|copy|clear|finalize [--target ID]
+          agwintermctl surface cursor [--target ID]         (caret column of a pane, as a bare integer)
+          agwintermctl image show <path> [--row R] [--col C] [--id N] [--target ID]
+          agwintermctl image sixel <path> [--row R] [--col C] [--target ID]
+          agwintermctl image frameshm <Local\agwinterm-frame-NAME> [--slot N] [--seq N] [--width N]
+              [--height N] [--stride N] [--format N] [--id N] [--row R] [--col C] [--cols N] [--rows N]
+              [--sx N] [--sy N] [--sw N] [--sh N] [--target ID]
+          agwintermctl image frameshm --images '[{"name":"Local\\agwinterm-frame-x","slot":0,...}]'
+              (several entries applied as one all-or-nothing frame; see docs/specs/image-frameshm.md)
+          agwintermctl install hooks
+        Target defaults to $AGWINTERM_SESSION_ID (the current session) when not given.
+        """;
+
+    /// <summary>
+    /// Is this invocation a request for help rather than a command?
+    ///
+    /// <para>Asked of the RAW argument array, before the splitter runs, and answered before anything
+    /// is sent. The splitter turns every unknown <c>--flag</c> into a dictionary entry that most
+    /// verbs never read (<c>Program.cs</c>, "Split into positionals and --options"), so
+    /// <c>--help</c> used to be INTERPRETED: <c>session close --help</c> built a real
+    /// <c>session.close</c> whose target fell back to <c>"active"</c> and closed the session the
+    /// user was looking at, with exit 0. Four verbs had grown their own allow-lists against exactly
+    /// this (<c>hud</c>, <c>split</c>, <c>swap</c>, <c>restore capture</c>); help is the one spelling
+    /// every verb shares, so it is answered once, here, for all of them.</para>
+    ///
+    /// <para>Only the exact word <c>--help</c> counts. <c>-h</c>, <c>-?</c> and <c>/?</c> do NOT
+    /// start with <c>--</c>, so the splitter files them as POSITIONALS: they are legitimate text for
+    /// <c>session type</c> and a legitimate name for <c>session rename</c>, and swallowing them here
+    /// would break a caller that means them literally. Text that must survive anything goes through
+    /// <c>--stdin</c>, which reads the payload as bytes and never sees this array.</para>
+    /// </summary>
+    public static bool IsHelpRequest(IReadOnlyList<string> args)
+    {
+        for (int i = 0; i < args.Count; i++)
+            if (string.Equals(args[i], "--help", StringComparison.OrdinalIgnoreCase)) return true;
+        return false;
+    }
+
+    /// <summary>What <c>session text</c> accepts: its own two flags plus the global selectors.</summary>
+    private static readonly HashSet<string> TextOptions =
+        new(FrameShmCli.GlobalValuedOptions, StringComparer.OrdinalIgnoreCase) { "all", "lines" };
+
+    /// <summary>
+    /// Refuse an option <c>session text</c> does not read, instead of dropping it.
+    ///
+    /// <para><c>session text</c> read only <c>--all</c> and <c>--lines</c> and dropped the rest, so
+    /// <c>session text --pane right</c> reported success while reading the LEFT pane — the caller
+    /// got the wrong pane's buffer with exit 0 and no way to tell. <c>docs/agterm-parity.md</c>
+    /// states the rule this breaks: an unsupported form is "refused rather than silently widened".
+    /// <c>--pane</c> is real on <c>session overlay</c> only, which is where the mistake comes from,
+    /// so its refusal names the two spellings that do work.</para>
+    /// </summary>
+    public static bool TryTextOptions(IEnumerable<string> keys, out string? refusal)
+    {
+        foreach (var key in keys)
+        {
+            if (TextOptions.Contains(key)) continue;
+            refusal = string.Equals(key, OverlayPanesPaneKey, StringComparison.OrdinalIgnoreCase)
+                ? "session text: --pane is a `session overlay` flag, not a `session text` one — it was DROPPED here, so this call would have read the focused pane and reported success. To read the other pane pass its id: `session text --target <pane-id>` (tree --json lists paneIds). For a pane's overlay use `session overlay text --pane left|right`. Nothing read."
+                : $"session text: unknown option --{key} (it takes --all, --lines and --target). Nothing read.";
+            return false;
+        }
+        refusal = null;
+        return true;
+    }
+
+    /// <summary>The <c>--pane</c> spelling, from the verb that owns it.</summary>
+    private const string OverlayPanesPaneKey = Agwinterm.Pty.OverlayPanes.Key;
+}
+
+/// <summary>
+/// The encoding this CLI's own stdout speaks.
+///
+/// <para>The control pipe is UTF-8 both ways and the CLI decodes it correctly; then it printed with
+/// a bare <c>Console.WriteLine</c>. On Windows .NET initialises <c>Console.OutputEncoding</c> from
+/// <c>GetConsoleOutputCP()</c>, so every reply was RE-ENCODED into the host console's code page —
+/// cp437 on a stock en-US console — for a captured pipe exactly as for a screen. A script reading
+/// <c>session text</c> got box-drawing in cp437 and a silent <c>?</c> for anything cp437 has no
+/// room for. Inside an agwinterm pane it looked fine only because the shell profile runs
+/// <c>chcp 65001</c>.</para>
+///
+/// <para>So: a REDIRECTED stream gets UTF-8, and a console does not. Setting
+/// <c>Console.OutputEncoding</c> would fix the pipe too, but it calls <c>SetConsoleOutputCP</c> on
+/// the console this short-lived process shares with its parent shell — the code page would outlive
+/// the call, like <c>chcp</c>. Replacing the writer changes nothing the parent can see. A human at a
+/// cp437 console keeps the rendering they have; a script gets the bytes the pipe sent.</para>
+/// </summary>
+public static class CtlStdout
+{
+    /// <summary>UTF-8 with no BOM: a leading BOM would be the first thing every caller parsed.</summary>
+    public static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+    /// <summary>A UTF-8 writer over <paramref name="stream"/> when it is redirected, else null —
+    /// null meaning "leave <c>Console.Out</c> alone". Autoflushed: the process exits without
+    /// disposing it.</summary>
+    public static TextWriter? Utf8Writer(Stream stream, bool redirected) =>
+        redirected ? new StreamWriter(stream, Utf8NoBom) { AutoFlush = true } : null;
+}

--- a/src/Agwinterm.Ctl/Program.cs
+++ b/src/Agwinterm.Ctl/Program.cs
@@ -3,108 +3,25 @@ using System.Text;
 using System.Text.Json;
 
 // agwintermctl — drive agwinterm's control API from the shell (agterm's agtermctl analog).
-// Usage:
-//   agwintermctl ping
-//   agwintermctl version [--json]                  (the CLI that ran + the app serving the pipe)
-//   agwintermctl tree [--json]
-//   agwintermctl session new [--command "PowerShell code"] [--command-mode powershell|direct] [--cwd DIR] [--name NAME] [--workspace ID|--workspace-name NAME [--create-workspace]] [--no-select]
-//       (no workspace given = the workspace of the pane running this CLI; the active one only when there is none)
-//                                                  (an unknown workspace is refused, never swapped for the active one)
-//   agwintermctl session select <target>
-//   agwintermctl session close [target]
-//   agwintermctl session rename <new-name...> [--target ID]
-//   agwintermctl session split [on|off|toggle] [--axis vertical|horizontal] [--target ID]
-//       (replies with a PANE ID: on/toggle-on = the split pane's, also when the session was already split;
-//       off/toggle-off = the survivor's. Default op = toggle. The axis names the ARRANGEMENT, agterm's words:
-//       vertical = left/right panes (the default of a session never split), horizontal = top/bottom panes.
-//       Omitted = keep the session's orientation; given on an already-split session = re-orient it live)
-//   agwintermctl session split close [--target ID]   (close ONE pane, EITHER side: a pane id = that pane; a session
-//       name or no target = the session's focused pane, what Ctrl+Shift+W closes; from a pane's own CLI, that pane.
-//       Replies with the SURVIVOR's id. A one-pane session is refused — `session close` closes a session)
-//   agwintermctl session swap [--target ID]           (exchange the two panes: order reversed, focus follows the pane,
-//       axis and ratio sequence kept — the left/top box keeps its size, the contents change places — and EVERY ID
-//       kept: a swap moves panes, never ids, so the session id keeps naming the shell it named, now on the other
-//       side. Target = a session, either of its panes, or nothing — from a pane's own CLI, that pane's
-//       session; otherwise the active one. Replies
-//       {session,paneIds,focusedPane,axis} — the tree's split block after the swap. A one-pane session is refused)
-//   agwintermctl session focus [primary|split|left|right|top|bottom|other]   (default other; left/right exist on a
-//       vertical split only, top/bottom on a horizontal one — the wrong pair is refused naming the axis)
-//   agwintermctl session resize [--split-ratio R] [--grow-left N|--grow-right N|--grow-top N|--grow-bottom N]
-//       (left/right move a vertical split's divider by N columns, top/bottom a horizontal one's by N rows;
-//       the other axis's flags are refused, and the divider does not move)
-//   agwintermctl session context <text...> [--target ID]   (one line of "what is this pane for", shown dimmed
-//       beside the name and read back in `tree --json` as context; survives a restart. Blank, a control
-//       character or more than 200 characters is refused; replies {session,context})
-//   agwintermctl session context --clear [--target ID]      (remove it; text beside --clear is refused)
-//   agwintermctl session context --stdin [--target ID]      (text = stdin, one trailing newline dropped; an
-//       embedded newline is then refused — the context is one line)
-//   agwintermctl session seen [--target ID]        (clear the unseen-notification badge)
-//   agwintermctl sidebar state                      (read-back: "visible tree 220" = visibility, mode, width)
-//   agwintermctl sidebar width [N]                  (read, or set, the sidebar width in DIP; replies {width,visible[,applied]}
-//       with the width actually in effect; outside 120..600 is refused, not clamped; set while hidden = remembered)
-//   agwintermctl sidebar show|hide|toggle|expand|collapse|mode <tree|flagged|toggle>   (on/off = show/hide; anything
-//       else is refused rather than acknowledged)
-//   agwintermctl session status <idle|active|blocked|completed> [--sound [name]] [--blink] [--auto-reset] [--target ID]
-//   agwintermctl session metrics [<pane-id>] [--json] (live cell + pane pixel metrics)
-//   agwintermctl session text [--all|--lines N] [--target ID]   (N reaches into scrollback; --all = the whole
-//       buffer, screen + scrollback; default = screen; --all with --lines is refused)
-//   agwintermctl session hud [open|update] <message...> [--detail TEXT] [--spinner|--spinner-style STYLE]
-//       [--position ANCHOR] [--size-percent N] [--background-color HEX] [--text-color HEX] [--target ID]
-//   agwintermctl session hud close [--target ID]   (see docs/session-hud.md)
-//   agwintermctl session overlay open <command...> [--pane left|right] [--wait|--block] [--size-percent N] [--target ID]
-//   agwintermctl session overlay close|result|copy [--pane left|right] [--target ID]
-//   agwintermctl session overlay text [--all|--lines N] [--pane left|right] [--target ID]
-//   agwintermctl session overlay resize --size-percent N [--target ID]   (the session-wide overlay only)
-//       (copy and text print result.text; --pane names a PANE slot, passed through as typed — the server validates
-//       the word; --size-percent beside --pane, and resize --pane, are refused here and nothing is sent: a pane
-//       overlay is always full-pane. The rule, quoted from ISessionHost.SessionOverlay — the skill quotes it too:
-//       A session has three overlay slots: one session-wide and one per pane. A session-wide overlay
-//       covers the whole session (every pane, and any pane overlay under it), as today. A pane overlay
-//       covers exactly one pane's box - always the full box, never floating - and the sibling pane stays
-//       visible and interactive. --pane left|right names the slot: left is pane 0 and right is pane 1
-//       whatever the axis (on a horizontal split left is the top pane), a non-split session accepts
-//       --pane left, and the flag omitted means the session-wide slot - today's behaviour, byte for
-//       byte. A pane overlay is that pane's surface while it is open: keys typed into the focused pane,
-//       the mouse inside the pane's box and --target active reach the overlay; --target with a pane id
-//       reaches the shell underneath (agterm: "session text reads the surface underneath"); --target
-//       with the overlay's id reaches the overlay from anywhere, and on session overlay itself names
-//       that overlay's slot - the same as passing its --pane word - for as long as the id resolves (an
-//       overlay that closed is reached by --pane only); with --pane naming the other side it is refused.
-//       The slot moves with its pane (a swap, a split close of the other pane) and dies with it (split
-//       close, split off, the shell exiting when that removes the pane - a single-pane session keeps an
-//       exited shell on screen, and its overlay with it - session close, the window closing).)
-//   agwintermctl session type <text...> [--allow-control] [--target ID]   (control bytes refused unless allowed)
-//   agwintermctl session type --stdin [--allow-control] [--target ID]     (text = stdin, as bytes: how quotes,
-//       newlines, a leading -- or runs of spaces are sent; invalid UTF-8 is refused, nothing sent; one
-//       trailing newline is dropped. "quick type" is `session type --target quick:` — the quick pane's id)
-//   agwintermctl session write <text...> [--target ID]                    (also takes --stdin)
-//   agwintermctl session restore <command...>|none --target PANE          (pin a command re-run on every restart;
-//       target mandatory; replies {action,pane,session}; read back in `tree --json` as restoreCommands)
-//   agwintermctl restore capture [--target ID]       (capture the foreground command of every real pane — or the one
-//       pane/session named — into its restore slot NOW, so a crash or Stop-Process keeps it; replies
-//       {captured,replayOnRestore,panes:[{pane,session,captured|null}]}; read back in `tree --json` as
-//       capturedCommands; replayOnRestore = the restore-commands toggle, which gates the replay, not the capture)
-//   agwintermctl restore clear                       (delete this window's saved session tree)
-//   agwintermctl session copy [--target ID]           (returns the selection text)
-//   agwintermctl session paste <text...> [--target ID] (pastes text; clipboard if omitted)
-//   agwintermctl selection all|copy|clear|finalize [--target ID]
-//   agwintermctl surface cursor [--target ID]         (caret column of a pane, as a bare integer)
-//   agwintermctl image show <path> [--row R] [--col C] [--id N] [--target ID]
-//   agwintermctl image sixel <path> [--row R] [--col C] [--target ID]
-//   agwintermctl image frameshm <Local\agwinterm-frame-NAME> [--slot N] [--seq N] [--width N]
-//       [--height N] [--stride N] [--format N] [--id N] [--row R] [--col C] [--cols N] [--rows N]
-//       [--sx N] [--sy N] [--sw N] [--sh N] [--target ID]
-//   agwintermctl image frameshm --images '[{"name":"Local\\agwinterm-frame-x","slot":0,...}]'
-//       (several entries applied as one all-or-nothing frame; see docs/specs/image-frameshm.md)
-//   agwintermctl install hooks
-// Target defaults to $AGWINTERM_SESSION_ID (the current session) when not given.
+// Every verb and flag is in CtlUsage.Long, which `--help` prints. It used to be a 96-line comment
+// right here that nothing printed, while Help.cs told users to run `agwintermctl --help` — a flag
+// this CLI did not have. One copy, and it is the one users read.
+
+// Before any output, PickCli's included: a REDIRECTED stream gets the UTF-8 the control pipe
+// speaks; a console keeps its own code page. See CtlStdout for why not Console.OutputEncoding.
+if (Agwinterm.Ctl.CtlStdout.Utf8Writer(Console.OpenStandardOutput(), Console.IsOutputRedirected) is { } utf8Out) Console.SetOut(utf8Out);
+if (Agwinterm.Ctl.CtlStdout.Utf8Writer(Console.OpenStandardError(), Console.IsErrorRedirected) is { } utf8Err) Console.SetError(utf8Err);
+
+// Help is answered before anything is parsed, targeted or sent: an unread --help used to reach the
+// pipe as a real request, and `session close --help` closed the session the user was looking at.
+if (Agwinterm.Ctl.CtlUsage.IsHelpRequest(args)) { Console.WriteLine(Agwinterm.Ctl.CtlUsage.Long); return 0; }
 
 if (args.Length > 0 && args[0].Equals("pick", StringComparison.OrdinalIgnoreCase))
     return Agwinterm.Ctl.PickCli.Run(args);
 
 if (args.Length == 0)
 {
-    Console.Error.WriteLine("usage: agwintermctl <ping|version|tree|session|surface|image|install> ... (see README.md, \"Control it from anything\")");
+    Console.Error.WriteLine(Agwinterm.Ctl.CtlUsage.Short);
     return 2;
 }
 
@@ -357,6 +274,12 @@ switch (area)
                 cargs["text"] = rest.Count > 0 ? string.Join(' ', rest) : (Opt("select") ?? "");
                 break;
             case "text": // dump the buffer; --lines N reaches back into scrollback, --all takes the whole buffer (default: the visible screen)
+                // An option this verb does not read is refused, not dropped: `session text --pane right`
+                // used to read the FOCUSED pane and report success, which is the one failure a caller
+                // cannot see — it gets a buffer, just the wrong one. docs/agterm-parity.md states the
+                // rule ("refused rather than silently widened"); `split`, `swap` and `restore capture`
+                // already guard their own options this way.
+                if (!Agwinterm.Ctl.CtlUsage.TryTextOptions(options.Keys, out var badTextOpt)) { Console.Error.WriteLine(badTextOpt); return 2; }
                 // The pair is refused here in the server's words (one reader, two verbs — `session overlay
                 // text` refuses it the same way), so nothing is sent for a read that meant two things.
                 if (options.ContainsKey("all") && options.ContainsKey("lines")) { Console.Error.WriteLine(Agwinterm.Pty.OverlayPanes.AllWithLines); return 2; }

--- a/tests/Agwinterm.Pty.Tests/CtlUsageTests.cs
+++ b/tests/Agwinterm.Pty.Tests/CtlUsageTests.cs
@@ -1,0 +1,137 @@
+using System.Text;
+using Agwinterm.Ctl;
+using Xunit;
+
+namespace Agwinterm.Pty.Tests;
+
+/// <summary>
+/// The three ways `agwintermctl` used to answer a caller mistake with success.
+///
+/// `--help` was INTERPRETED, not parsed: the splitter files any unknown --flag in a dictionary that
+/// most verbs never read, so `session close --help` built a real session.close whose target fell
+/// back to "active" and closed the session the user was looking at. `session text --pane right`
+/// dropped --pane and read the focused pane, reporting ok with the WRONG pane's buffer. And a reply
+/// decoded from the UTF-8 pipe was re-encoded into the console code page on the way out, so a script
+/// capturing stdout got cp437 - lossily, for anything cp437 has no room for.
+/// </summary>
+public class CtlUsageTests
+{
+    // ---- --help is answered, never sent ----
+
+    [Theory]
+    [InlineData("--help")]
+    [InlineData("--HELP")]                       // options are matched case-insensitively everywhere else
+    public void HelpIsRecognised(string spelling) =>
+        Assert.True(CtlUsage.IsHelpRequest(new[] { "session", "close", spelling }));
+
+    [Fact]
+    public void HelpIsRecognisedAloneAndFirst()
+    {
+        Assert.True(CtlUsage.IsHelpRequest(new[] { "--help" }));
+        Assert.True(CtlUsage.IsHelpRequest(new[] { "--help", "session", "close" }));
+    }
+
+    [Fact]
+    public void NoArgumentsIsNotHelp() =>
+        Assert.False(CtlUsage.IsHelpRequest(Array.Empty<string>()));
+
+    [Theory]
+    [InlineData("session", "close")]
+    [InlineData("session", "text")]
+    [InlineData("tree", "--json")]
+    public void OrdinaryInvocationsAreNotHelp(string a, string b) =>
+        Assert.False(CtlUsage.IsHelpRequest(new[] { a, b }));
+
+    /// <summary>The short spellings are POSITIONALS to the splitter, which makes them legitimate
+    /// text for `session type` and a legitimate name for `session rename`. Swallowing them here
+    /// would break a caller that means them literally.</summary>
+    [Theory]
+    [InlineData("-h")]
+    [InlineData("-?")]
+    [InlineData("/?")]
+    [InlineData("help")]
+    public void ShortSpellingsStayLiteralText(string word) =>
+        Assert.False(CtlUsage.IsHelpRequest(new[] { "session", "type", word }));
+
+    [Fact]
+    public void HelpTextCoversTheVerbsItPromises()
+    {
+        Assert.False(string.IsNullOrWhiteSpace(CtlUsage.Long));
+        foreach (var verb in new[] { "session new", "session close", "session split", "session text",
+                                     "surface cursor", "install hooks" })
+            Assert.Contains(verb, CtlUsage.Long);
+        Assert.StartsWith("usage: agwintermctl", CtlUsage.Short);
+    }
+
+    // ---- session text refuses what it does not read ----
+
+    [Fact]
+    public void TextAcceptsItsOwnOptionsAndTheGlobalSelectors()
+    {
+        Assert.True(CtlUsage.TryTextOptions(new[] { "all" }, out var r1));
+        Assert.Null(r1);
+        Assert.True(CtlUsage.TryTextOptions(new[] { "lines", "target" }, out var r2));
+        Assert.Null(r2);
+        Assert.True(CtlUsage.TryTextOptions(FrameShmCli.GlobalValuedOptions, out var r3));
+        Assert.Null(r3);
+        Assert.True(CtlUsage.TryTextOptions(Array.Empty<string>(), out var r4));
+        Assert.Null(r4);
+    }
+
+    /// <summary>The one that mattered: --pane is real on `session overlay`, so the refusal names
+    /// both spellings that do work rather than only saying no.</summary>
+    [Fact]
+    public void TextRefusesPaneAndSaysWhatToUseInstead()
+    {
+        Assert.False(CtlUsage.TryTextOptions(new[] { "pane" }, out var refusal));
+        Assert.NotNull(refusal);
+        Assert.Contains("--target <pane-id>", refusal);
+        Assert.Contains("session overlay text --pane", refusal);
+        Assert.Contains("Nothing read.", refusal);
+    }
+
+    [Fact]
+    public void TextRefusesAnyOtherUnknownOptionNamingIt()
+    {
+        Assert.False(CtlUsage.TryTextOptions(new[] { "targt" }, out var refusal));
+        Assert.NotNull(refusal);
+        Assert.Contains("--targt", refusal);
+        Assert.Contains("Nothing read.", refusal);
+    }
+
+    [Fact]
+    public void TextRefusalNamesTheFirstUnknownOptionOnly()
+    {
+        Assert.False(CtlUsage.TryTextOptions(new[] { "all", "pane", "targt" }, out var refusal));
+        Assert.NotNull(refusal);
+        Assert.Contains("--pane", refusal);
+        Assert.DoesNotContain("--targt", refusal);
+    }
+
+    // ---- stdout speaks the pipe's encoding when it is not a console ----
+
+    [Fact]
+    public void RedirectedStdoutIsUtf8WithoutABom()
+    {
+        var buffer = new MemoryStream();
+        var writer = CtlStdout.Utf8Writer(buffer, redirected: true);
+        Assert.NotNull(writer);
+        writer!.Write("─café");                     // a box-drawing dash and an accent
+        Assert.Equal(Encoding.UTF8.GetBytes("─café"), buffer.ToArray());
+    }
+
+    /// <summary>Null means "leave Console.Out alone": a human at a cp437 console keeps the
+    /// rendering they have, and this process never touches the code page its parent shell shares.</summary>
+    [Fact]
+    public void AConsoleIsLeftAlone() =>
+        Assert.Null(CtlStdout.Utf8Writer(new MemoryStream(), redirected: false));
+
+    [Fact]
+    public void Utf8WriterAutoflushesBecauseTheProcessExitsWithoutDisposingIt()
+    {
+        var buffer = new MemoryStream();
+        var writer = CtlStdout.Utf8Writer(buffer, redirected: true);
+        writer!.WriteLine("ok");
+        Assert.NotEmpty(buffer.ToArray());
+    }
+}


### PR DESCRIPTION
Three defects found while driving the control API from a two-agent workbench (Claude Code in one
pane, codex in its split). All three share a shape `qa/control-honesty.md` already names: *a call
that appears to succeed while doing something other than what was asked.*

Found against the installed **0.18.0** client; every line was then re-checked against **v0.18.1**
(`7afca19`), where all three are unchanged.

## 1. `--help` was interpreted, not parsed

`session close --help` **closed the session the user was looking at**, with exit 0. The splitter at
`src/Agwinterm.Ctl/Program.cs` files every unknown `--flag` into `options`, which most verbs never
read, so `--help` travelled as part of a real request; `case "close"` then falls back to
`Opt("target") ?? "active"`, which also *overrides* the `AGWINTERM_SESSION_ID` default — so the
victim is the focused session, not the caller's own pane.

Four verbs had already grown allow-lists against exactly this (`hud`, `split`, `swap`,
`restore capture`); `close`, `select`, `duplicate`, `rename`, `text`, `status` and `paste` had none.
`session split --help` is correctly refused today, which is what made the `close` case surprising.

Separately, `src/Agwinterm.Win32/Help.cs` tells users on screen: "Control API: `agwintermctl
--help`." That flag did not exist — it printed `unknown command ' '`.

**Fix.** Help is answered before anything is parsed, targeted or sent, once, for every verb. What it
prints is the 96-line usage block that was a *comment* at the top of `Program.cs` that nothing
printed, moved verbatim into `CtlUsage.Long`. One copy, it is now the copy users read, and the
promise in `Help.cs` is true.

Only the exact word `--help` counts. `-h`, `-?` and `/?` do not start with `--`, so the splitter
files them as **positionals** — legitimate text for `session type`, a legitimate name for
`session rename` — and swallowing them here would break a caller that means them literally.

## 2. `session text --pane right` read the wrong pane and answered ok

`case "text"` read only `--all` and `--lines` and dropped everything else, so `--pane` vanished and
the call returned the **focused** pane's buffer with exit 0. That is the one failure a caller cannot
detect: it gets a buffer, just not the one it asked for. `--pane` is real on `session overlay`, which
is where the mistake comes from.

`docs/agterm-parity.md` (lines 49-51) already states the rule this broke — an unsupported form is
"refused rather than silently widened … still the rule for the verbs **without** `--pane`."

**Fix.** `session text` refuses any option it does not read. The `--pane` refusal names both
spellings that do work:

```
$ agwintermctl session text --pane right
session text: --pane is a `session overlay` flag, not a `session text` one — it was DROPPED here, so
this call would have read the focused pane and reported success. To read the other pane pass its id:
`session text --target <pane-id>` (tree --json lists paneIds). For a pane's overlay use `session
overlay text --pane left|right`. Nothing read.
$ echo $?
2
```

## 3. Replies were re-encoded into the console code page

The pipe is UTF-8 both ways and the CLI decodes it correctly, then prints with a bare
`Console.WriteLine`. On Windows .NET initialises `Console.OutputEncoding` from
`GetConsoleOutputCP()`, so every reply was re-encoded — cp437 on a stock en-US console — for a
**captured** pipe exactly as for a screen. `Console.OutputEncoding` is never set anywhere in
`Agwinterm.Ctl`. A script reading `session text` got cp437 and a silent `?` for anything cp437 has no
room for. Inside an agwinterm pane it looked right only because the shell profile runs `chcp 65001`.

This is what led to the finding: a Python peer-chat script decoded pane text as cp1252 and got
**0** `U+2500` characters where there were 311, with no error anywhere.

**Fix.** A *redirected* stream gets UTF-8 without a BOM; a console is left alone. Setting
`Console.OutputEncoding` would fix the pipe too, but it calls `SetConsoleOutputCP` on the console
this short-lived process shares with its parent shell, and the code page would outlive the call like
`chcp`. Replacing the writer changes nothing the parent can see. A human at a cp437 console keeps the
rendering they have; a script gets the bytes the pipe sent.

Measured on the `--help` output, 9197 bytes: 13 em-dashes arrive as UTF-8 `e2 80 94`, zero `?`, no
BOM, whole stream decodes as UTF-8. Before, those 13 characters were lost.

## Not filed, deliberately

Three more findings from the same session turned out to be **correct behaviour**, and are recorded
here rather than changed:

- `foregroundShells: [null, null]` with two live agents. `WorkspaceNavigation` returns null when the
  root shell has children, and an agent runs *under* the shell. Pinned by `NavigationTests` and
  documented in `docs/navigation.md` ("Never treat it as proof of an idle prompt"). Intended.
- `session.type refuses control byte 0x7F … pass --allow-control if you mean it`. Exactly right: the
  usual reason a control byte is there is that a caller built the string wrong.
- An untargeted `session split` acting on the caller's own pane. Documented in the agent skill text,
  and `split` already refuses everything that looks like a failed attempt to name a target.

## Where the decisions live

`CtlUsage` and `CtlStdout`, not `Program.cs`, for the reason `FrameShmCli` was split out: top-level
statements are not testable, and a decision that cannot be asserted on drifts.

## Testing

- `CtlUsageTests`: 19 new tests. Green.
- `dotnet test Agwinterm.slnx -c Release`: 370/370 Core, 963/966 Pty.
- The three Pty failures are pre-existing flakes on a loaded desktop, not regressions. Two full runs
  of this branch failed *different* classes (`StartupHostClaims` + `PtyResizeTransaction`, then
  `SessionStartFence` + `ShmFrameLayout`); a full run of `main` failed
  `StartupHostClaims.ClaimAfterHostListButBeforeReapWins`. The one deterministic failure,
  `RustPtyHostTests.CreationTickets_StartupSweepProtectsUnpublishedPane`, fails identically on `main`
  (the Rust native core is not built in this checkout).
- Behaviour verified on the built binary against `--pipe zz-nonexistent-zz`, so nothing live could be
  reached: `session close --help` prints usage and exits 0 without touching the pipe; `--pane right`
  and `--targt s1` exit 2; `session text --lines 5` still reaches the pipe unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
