### PR TITLE
fix CI: retry the search marker write; main is red on a swallowed session.write (#289)

### DIFF
--- a/tests/integration/navigation-ui-cases.ps1
+++ b/tests/integration/navigation-ui-cases.ps1
@@ -124,7 +124,27 @@ if (-not $ok) {
                  "marker present in session.text of the target: $inPane"
 }
 Check 'search mutation guard has a real match' $ok $searchSaw
-Check 'missing search target refuses without replacing active query' (-not (Rpc 'session.search' @{query='MISSING-SEARCH-QUERY'} 'missing-pane' -AllowError).ok -and (Rpc 'session.search' @{} $session)-eq $findBefore)
+$missingRefused = -not (Rpc 'session.search' @{query='MISSING-SEARCH-QUERY'} 'missing-pane' -AllowError).ok
+$findAfter = Rpc 'session.search' @{} $session
+$stableSaw = ''
+if (-not ($missingRefused -and $findAfter -eq $findBefore)) {
+    $paneText = ''
+    try { $paneText = [string](Rpc 'session.text' @{} $session) } catch { $paneText = "unreadable: $($_.Exception.Message)" }
+    $markerCount = ([regex]::Matches($paneText, 'STABILIZATION-SEARCH-MARKER')).Count
+    $activeSession = ''
+    try { $activeSession = [string](Rpc 'window.state').activeSession } catch { $activeSession = 'unreadable' }
+    # The pane read twice, a second apart: if the two differ the shell is still writing, which is
+    # the one explanation that also covers the runner's other two failures (a shell env echo that
+    # had not arrived, and split shells not ready).
+    Start-Sleep -Seconds 1
+    $paneAgain = ''
+    try { $paneAgain = [string](Rpc 'session.text' @{} $session) } catch { $paneAgain = 'unreadable' }
+    $stableSaw = "missing-target refused: $missingRefused; before=<$findBefore> after=<$findAfter>; " +
+                 "marker occurrences in pane: $markerCount; activeSession=<$activeSession>; " +
+                 "pane still changing 1s later: $($paneAgain -cne $paneText); " +
+                 "pane tail=<$($paneText.Substring([Math]::Max(0,$paneText.Length-300)) -replace '\s+',' ')>"
+}
+Check 'missing search target refuses without replacing active query' ($missingRefused -and $findAfter -eq $findBefore) $stableSaw
 $null=Rpc 'session.search' @{action='close'} $session
 Check 'unknown switch operation refuses' (-not (Rpc 'session.switch' @{op='typo'} -NoTarget -AllowError).ok)
 $mixedCommand='Tool --Path C:/CaseSensitive/Project --Key AbC'

--- a/tests/integration/navigation-ui-cases.ps1
+++ b/tests/integration/navigation-ui-cases.ps1
@@ -120,8 +120,28 @@ if (-not $ok) {
     $paneText = ''
     try { $paneText = [string](Rpc 'session.text' @{} $session) } catch { $paneText = "unreadable: $($_.Exception.Message)" }
     $inPane = $paneText -match 'STABILIZATION-SEARCH-MARKER'
+    # Write it AGAIN. If the retry lands, the first write was lost and this is a race; if it does not,
+    # writes to this pane stopped working, which is a defect and not a timing artefact.
+    $retryLanded = 'not attempted'
+    try {
+        $null = Rpc 'session.write' @{text="`r`nSTABILIZATION-RETRY-MARKER`r`n"} $session
+        Start-Sleep -Milliseconds 800
+        $retryText = [string](Rpc 'session.text' @{} $session)
+        $retryLanded = [string]($retryText -match 'STABILIZATION-RETRY-MARKER')
+    } catch { $retryLanded = "threw: $($_.Exception.Message)" }
+    # What the session looks like structurally: a split left behind by the wheel fixture's
+    # `session.split.close` would mean the write and the read are not on the same pane.
+    $shape = ''
+    try {
+        $node = (Rpc 'tree').workspaces.sessions | Where-Object { $_.id -eq $session }
+        $shape = "paneCount=$($node.paneCount) focusedPane=$($node.focusedPane) paneIds=$($node.paneIds -join ',') active=$($node.active)"
+    } catch { $shape = "unreadable: $($_.Exception.Message)" }
+    $flat = ($paneText -replace '\s+',' ').Trim()
     $searchSaw = "search answered <$findBefore>; window.state activeSession=<$activeSession>; " +
-                 "marker present in session.text of the target: $inPane"
+                 "marker present in session.text of the target: $inPane; retry write landed: $retryLanded; " +
+                 "target session $shape; pane len=$($paneText.Length) head=<" +
+                 $flat.Substring(0,[Math]::Min(200,$flat.Length)) + "> tail=<" +
+                 $flat.Substring([Math]::Max(0,$flat.Length-200)) + ">"
 }
 Check 'search mutation guard has a real match' $ok $searchSaw
 $missingRefused = -not (Rpc 'session.search' @{query='MISSING-SEARCH-QUERY'} 'missing-pane' -AllowError).ok

--- a/tests/integration/navigation-ui-cases.ps1
+++ b/tests/integration/navigation-ui-cases.ps1
@@ -100,10 +100,30 @@ Check 'missing readonly target refuses without protecting the active pane' (-not
 $null=Rpc 'session.write' @{text="`r`nSTABILIZATION-SEARCH-MARKER`r`n"} $session
 # Search uses a sent UI message and can overtake the posted emulator write. A no-change
 # config.set is not an acknowledgement of that write. Wait for the actual search result.
-Check 'search mutation guard has a real match' (NavWait {
+#
+# The failure detail is the point of the rest of this block. `session.search` searches the ACTIVE
+# surface and only accepts `--target` for API shape (Program.ControlHost.SessionSearch says so), so
+# this check silently depends on $session still being the active pane after the wheel fixture's
+# `session.split.close` above. When it went red on GitHub's runner image 20260907.229.1 (green on
+# 20260824.214.3, same code, and green locally) the bare `Check` said only "FAIL ... : " — which
+# rules nothing out. So say what was actually seen: what search answered, which session is active,
+# and whether the marker is in the pane's own text at all. The three together separate "the write
+# never landed" from "search is looking at another pane".
+$searchSaw = ''
+$ok = NavWait {
     $script:findBefore=Rpc 'session.search' @{query='STABILIZATION-SEARCH-MARKER'} $session
     return $script:findBefore-match 'of [1-9]'
-})
+}
+if (-not $ok) {
+    $activeSession = ''
+    try { $activeSession = [string](Rpc 'window.state').activeSession } catch { $activeSession = "unreadable: $($_.Exception.Message)" }
+    $paneText = ''
+    try { $paneText = [string](Rpc 'session.text' @{} $session) } catch { $paneText = "unreadable: $($_.Exception.Message)" }
+    $inPane = $paneText -match 'STABILIZATION-SEARCH-MARKER'
+    $searchSaw = "search answered <$findBefore>; window.state activeSession=<$activeSession>; " +
+                 "marker present in session.text of the target: $inPane"
+}
+Check 'search mutation guard has a real match' $ok $searchSaw
 Check 'missing search target refuses without replacing active query' (-not (Rpc 'session.search' @{query='MISSING-SEARCH-QUERY'} 'missing-pane' -AllowError).ok -and (Rpc 'session.search' @{} $session)-eq $findBefore)
 $null=Rpc 'session.search' @{action='close'} $session
 Check 'unknown switch operation refuses' (-not (Rpc 'session.switch' @{op='typo'} -NoTarget -AllowError).ok)

--- a/tests/integration/navigation-ui-cases.ps1
+++ b/tests/integration/navigation-ui-cases.ps1
@@ -97,74 +97,43 @@ $null=Rpc 'session.readonly' @{op='on'} $session
 Check 'readonly typo cannot remove existing protection' (-not (Rpc 'session.readonly' @{op='typo'} $session -AllowError).ok -and (Rpc 'session.readonly' @{op='get'} $session)-eq 'on')
 $null=Rpc 'session.readonly' @{op='off'} $session
 Check 'missing readonly target refuses without protecting the active pane' (-not (Rpc 'session.readonly' @{op='on'} 'missing-pane' -AllowError).ok -and (Rpc 'session.readonly' @{op='state'} $session)-eq 'off')
-$null=Rpc 'session.write' @{text="`r`nSTABILIZATION-SEARCH-MARKER`r`n"} $session
-# Search uses a sent UI message and can overtake the posted emulator write. A no-change
-# config.set is not an acknowledgement of that write. Wait for the actual search result.
+# The marker has to be RE-WRITTEN until it is observable, not written once and waited for.
 #
-# The failure detail is the point of the rest of this block. `session.search` searches the ACTIVE
-# surface and only accepts `--target` for API shape (Program.ControlHost.SessionSearch says so), so
-# this check silently depends on $session still being the active pane after the wheel fixture's
-# `session.split.close` above. When it went red on GitHub's runner image 20260907.229.1 (green on
-# 20260824.214.3, same code, and green locally) the bare `Check` said only "FAIL ... : " — which
-# rules nothing out. So say what was actually seen: what search answered, which session is active,
-# and whether the marker is in the pane's own text at all. The three together separate "the write
-# never landed" from "search is looking at another pane".
+# Why: the wheel fixture above ends in `session.split.close`, and a write that arrives while the
+# surviving pane is still being re-laid out is dropped — `session.write` answers ok and the text is
+# gone. Proven on GitHub's runner image 20260907.229.1, where this check went red on code that was
+# green on 20260824.214.3 and is green locally: at the moment of failure the marker was absent from
+# the pane, the pane held nothing but a fresh `cmd` banner and prompts, the session was already back
+# to one pane — and writing the very same text again LANDED. So the pane was healthy and one write
+# had been swallowed. Waiting longer cannot recover a write that was dropped; only writing again can.
+#
+# The dropped write is a product defect in its own right (an ok reply for text that was discarded)
+# and is filed separately. This check is about search, so it retries the write and gets on with it.
 $searchSaw = ''
-$ok = NavWait {
-    $script:findBefore=Rpc 'session.search' @{query='STABILIZATION-SEARCH-MARKER'} $session
-    return $script:findBefore-match 'of [1-9]'
+$ok = $false
+for ($attempt = 0; $attempt -lt 12 -and -not $ok; $attempt++) {
+    $null = Rpc 'session.write' @{text="`r`nSTABILIZATION-SEARCH-MARKER`r`n"} $session
+    Start-Sleep -Milliseconds 250
+    $script:findBefore = Rpc 'session.search' @{query='STABILIZATION-SEARCH-MARKER'} $session
+    $ok = $script:findBefore -match 'of [1-9]'
 }
 if (-not $ok) {
     $activeSession = ''
-    try { $activeSession = [string](Rpc 'window.state').activeSession } catch { $activeSession = "unreadable: $($_.Exception.Message)" }
+    try { $activeSession = [string](Rpc 'window.state').activeSession } catch { $activeSession = 'unreadable' }
     $paneText = ''
     try { $paneText = [string](Rpc 'session.text' @{} $session) } catch { $paneText = "unreadable: $($_.Exception.Message)" }
-    $inPane = $paneText -match 'STABILIZATION-SEARCH-MARKER'
-    # Write it AGAIN. If the retry lands, the first write was lost and this is a race; if it does not,
-    # writes to this pane stopped working, which is a defect and not a timing artefact.
-    $retryLanded = 'not attempted'
-    try {
-        $null = Rpc 'session.write' @{text="`r`nSTABILIZATION-RETRY-MARKER`r`n"} $session
-        Start-Sleep -Milliseconds 800
-        $retryText = [string](Rpc 'session.text' @{} $session)
-        $retryLanded = [string]($retryText -match 'STABILIZATION-RETRY-MARKER')
-    } catch { $retryLanded = "threw: $($_.Exception.Message)" }
-    # What the session looks like structurally: a split left behind by the wheel fixture's
-    # `session.split.close` would mean the write and the read are not on the same pane.
-    $shape = ''
-    try {
-        $node = (Rpc 'tree').workspaces.sessions | Where-Object { $_.id -eq $session }
-        $shape = "paneCount=$($node.paneCount) focusedPane=$($node.focusedPane) paneIds=$($node.paneIds -join ',') active=$($node.active)"
-    } catch { $shape = "unreadable: $($_.Exception.Message)" }
     $flat = ($paneText -replace '\s+',' ').Trim()
-    $searchSaw = "search answered <$findBefore>; window.state activeSession=<$activeSession>; " +
-                 "marker present in session.text of the target: $inPane; retry write landed: $retryLanded; " +
-                 "target session $shape; pane len=$($paneText.Length) head=<" +
-                 $flat.Substring(0,[Math]::Min(200,$flat.Length)) + "> tail=<" +
-                 $flat.Substring([Math]::Max(0,$flat.Length-200)) + ">"
+    $searchSaw = "after $attempt write+search attempts: search answered <$findBefore>; " +
+                 "marker in the pane: $($paneText -match 'STABILIZATION-SEARCH-MARKER'); " +
+                 "window.state activeSession=<$activeSession>; pane len=$($paneText.Length) " +
+                 "tail=<" + $flat.Substring([Math]::Max(0,$flat.Length-200)) + ">"
 }
 Check 'search mutation guard has a real match' $ok $searchSaw
+# The pair is still the point: a refused search must not replace the query in effect.
 $missingRefused = -not (Rpc 'session.search' @{query='MISSING-SEARCH-QUERY'} 'missing-pane' -AllowError).ok
 $findAfter = Rpc 'session.search' @{} $session
-$stableSaw = ''
-if (-not ($missingRefused -and $findAfter -eq $findBefore)) {
-    $paneText = ''
-    try { $paneText = [string](Rpc 'session.text' @{} $session) } catch { $paneText = "unreadable: $($_.Exception.Message)" }
-    $markerCount = ([regex]::Matches($paneText, 'STABILIZATION-SEARCH-MARKER')).Count
-    $activeSession = ''
-    try { $activeSession = [string](Rpc 'window.state').activeSession } catch { $activeSession = 'unreadable' }
-    # The pane read twice, a second apart: if the two differ the shell is still writing, which is
-    # the one explanation that also covers the runner's other two failures (a shell env echo that
-    # had not arrived, and split shells not ready).
-    Start-Sleep -Seconds 1
-    $paneAgain = ''
-    try { $paneAgain = [string](Rpc 'session.text' @{} $session) } catch { $paneAgain = 'unreadable' }
-    $stableSaw = "missing-target refused: $missingRefused; before=<$findBefore> after=<$findAfter>; " +
-                 "marker occurrences in pane: $markerCount; activeSession=<$activeSession>; " +
-                 "pane still changing 1s later: $($paneAgain -cne $paneText); " +
-                 "pane tail=<$($paneText.Substring([Math]::Max(0,$paneText.Length-300)) -replace '\s+',' ')>"
-}
-Check 'missing search target refuses without replacing active query' ($missingRefused -and $findAfter -eq $findBefore) $stableSaw
+Check 'missing search target refuses without replacing active query' ($missingRefused -and $findAfter -eq $findBefore) `
+    "missing-target refused: $missingRefused; before=<$findBefore> after=<$findAfter>"
 $null=Rpc 'session.search' @{action='close'} $session
 Check 'unknown switch operation refuses' (-not (Rpc 'session.switch' @{op='typo'} -NoTarget -AllowError).ok)
 $mixedCommand='Tool --Path C:/CaseSensitive/Project --Key AbC'


### PR DESCRIPTION
**`main` is red and this makes it green.** CI on this branch: `build + test (windows)` **success**,
`Navigation-ui: 138 checks, 0 failed`.

It is not a regression. `main`'s code is byte-identical to the last fully green build except one
version string in `installer/agwinterm.iss`. What changed underneath is GitHub's runner image,
`windows-2025-vs2026` **20260824.214.3 → 20260907.229.1**. The same commit is green on my machine,
four runs out of four.

## What was actually wrong

`session.write` **answered `ok` and discarded the text.** Filed as #289.

The check writes a marker into a pane and searches for it. Its entire failure message was

```
FAIL search mutation guard has a real match :
```

which rules nothing out, so I instrumented it in three rounds on the runner itself. Each round
killed a theory:

| round | hypothesis | what the runner said |
| --- | --- | --- |
| 1 | search ignores `--target`, so it searched another pane | check **passed**, the *next* one failed instead — so it is a race, not a fixed defect |
| 2 | the search status is unstable between reads | `marker present in session.text of the target: **False**` — the text was never in the pane |
| 3 | writes to this pane stopped working after `session.split.close` | `retry write landed: **True**` — the pane was healthy and one write had been swallowed |

Round 3 in full:

```
search answered <no matches>; window.state activeSession=<session 1>;
marker present in session.text of the target: False; retry write landed: True;
target session paneCount= focusedPane= paneIds= active=True;
pane len=203 head=<Microsoft Windows [Version 10.0.26100.33296] (c) Microsoft Corporation.
  All rights reserved. C:\Users\runneradmin> C:\Users\runneradmin> ...>
```

Absent `paneCount` means the session was already back to one pane, so the split close had finished.
The pane held a fresh `cmd` banner and prompts and nothing else — the test's *earlier* writes to it
were gone too. And the identical text, written again seconds later to the same target, landed.

So a `session.write` was accepted and thrown away, around the relayout of the surviving pane after
`session.split.close`. The old check wrapped **one** write in a 6-second retry loop around the
**search**, which is why it could only ever fail: waiting longer cannot recover a write that was
dropped.

## What this changes

Only the test. It retries write+search up to 12 times instead of waiting on a single write, and its
failure detail now says what it saw — the search answer, whether the marker is in the pane, the
active session, and the pane's tail — so the next person does not start from a bare `FAIL`.

The dropped write is a product defect and is **not** fixed here. #289 has the evidence and what I
did not establish: which relayout step drops the text, whether the pane's wider content loss is the
same bug or a second one, and whether `session.type` has the same hole.

## Merge order

This first. yeroo/agwinterm#288 and yeroo/agliteterm#83 are both parked behind a red `main` —
#83 additionally cannot pass its cross-repo contract gate until #288 is on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k
