### PR TITLE
release: agwinterm 0.19.0

### DIFF
--- a/installer/agwinterm.iss
+++ b/installer/agwinterm.iss
@@ -2,7 +2,7 @@
 ; Build via installer\build.ps1 (publishes to stage\ then runs ISCC on this file).
 
 #define AppName    "agwinterm"
-#define AppVersion "0.18.1"
+#define AppVersion "0.19.0"
 #define AppExe     "Agwinterm.Win32.exe"
 #define AppPublisher "Boris Kudriashov"
 ; The main app defaults new sessions to the Rust pty-host as a first-run seed only (it never


### PR DESCRIPTION
Version bump only: `installer/agwinterm.iss` 0.18.1 -> 0.19.0.

**Minor, not patch.** Two published contracts change shape, and a patch number would hide it.

| change | what a caller sees differently |
| --- | --- |
| #288 (#287) | `session.rename` replies `{session,name}` instead of the constant string `"renamed"` — the session the name landed on and the name in effect. A pane id still names the session that pane belongs to; now the reply says which. agliteterm ships the same shape in its own 0.19.0. |
| #286 | `--help` is answered before anything is parsed (it used to travel into a real request — `session close --help` closed the session the user was looking at); `session text` refuses options it does not read instead of silently returning the focused pane with exit 0; a REDIRECTED stdout gets UTF-8 rather than the console code page. |
| #290 | CI only: the navigation suite stopped depending on a `session.write` that can be swallowed (#289). No shipped behaviour. |

Also merged since 0.18.1 and NOT shipped-behaviour: nothing else.

**Known and deliberately not fixed in this release:** #289 — `session.write` can answer `ok` and discard the text when it races the relayout after `session.split.close`. Found during this work, filed with its evidence, left for its own change rather than folded into a release.

Tag `v0.19.0` follows the merge and triggers the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8r6GeqnhTEpuwFCJk347k